### PR TITLE
Fix mobile layout for cluster and namespace filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,6 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 ### Fixed
 
+- [#1](https://github.com/kobsio/kobs/pull/1): Fix mobile layout for the cluster and namespace filter by using a Toolbar instead of FlexItems.
+
 ### Changed

--- a/app/src/app.css
+++ b/app/src/app.css
@@ -26,8 +26,23 @@
 }
 
 /* kobs-code
- **/
+ * Set the maximum width to the width of the parend component and the scrolling bahaviour, when we display code. */
 .kobs-code {
   max-width: 100%;
   overflow-x: scroll;
+}
+
+/* kobsio-pagesection-toolbar
+ * Is used to display the toolbar within a page section. For that we have to adjust the z-index, so that the toolbar is
+ * always displayed above the other components. We also remove the bottom, because the padding is already applied by the
+ * PageSection component.
+ * We also remove the padding for the ToolbarContent component, so that the ToolbarItems are aligned with the other
+ * content in the PageSection. */
+.kobsio-pagesection-toolbar {
+  padding-bottom: 0px;
+  z-index: 300;
+}
+
+.kobsio-pagesection-toolbar .pf-c-toolbar__content {
+  padding: 0px;
 }

--- a/app/src/components/resources/Filter.tsx
+++ b/app/src/components/resources/Filter.tsx
@@ -9,8 +9,14 @@ import {
   Select,
   SelectOption,
   SelectVariant,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+  ToolbarToggleGroup,
 } from '@patternfly/react-core';
 import React, { useCallback, useEffect, useState } from 'react';
+import FilterIcon from '@patternfly/react-icons/dist/js/icons/filter-icon';
 
 import {
   GetClustersRequest,
@@ -86,6 +92,7 @@ const Filter: React.FunctionComponent<FilterProps> = ({ isLoading, onFilter }: F
           setError('No namespaces were found.');
         } else {
           setNamespaces(tmpNamespaces);
+          setError('');
         }
       } catch (err) {
         setError(`Could not load namespaces: ${err.message}`);
@@ -106,7 +113,7 @@ const Filter: React.FunctionComponent<FilterProps> = ({ isLoading, onFilter }: F
 
   if (error) {
     return (
-      <Flex direction={{ default: 'column' }}>
+      <Flex className="pf-u-mt-md" direction={{ default: 'column' }}>
         <FlexItem>
           <Alert
             variant={AlertVariant.danger}
@@ -126,52 +133,56 @@ const Filter: React.FunctionComponent<FilterProps> = ({ isLoading, onFilter }: F
   }
 
   return (
-    <Flex>
-      <FlexItem>
-        <Select
-          variant={SelectVariant.typeaheadMulti}
-          typeAheadAriaLabel="Select clusters"
-          placeholderText="Select clusters"
-          onToggle={(): void => setShowClusters(!showClusters)}
-          onSelect={(e, value): void => onSelectCluster(value as string)}
-          onClear={(): void => setSelectedClusters([])}
-          selections={selectedClusters}
-          isOpen={showClusters}
-        >
-          {clusters.map((cluster, index) => (
-            <SelectOption key={index} value={cluster} />
-          ))}
-        </Select>
-      </FlexItem>
-
-      <FlexItem>
-        <Select
-          variant={SelectVariant.typeaheadMulti}
-          typeAheadAriaLabel="Select namespaces"
-          placeholderText="Select namespaces"
-          onToggle={(): void => setShowNamespaces(!showNamespaces)}
-          onSelect={(e, value): void => onSelectNamespace(value as string)}
-          onClear={(): void => setSelectedNamespaces([])}
-          selections={selectedNamespaces}
-          isOpen={showNamespaces}
-        >
-          {namespaces.map((namespace, index) => (
-            <SelectOption key={index} value={namespace} />
-          ))}
-        </Select>
-      </FlexItem>
-
-      <FlexItem>
-        <Button
-          variant={ButtonVariant.primary}
-          spinnerAriaValueText={isLoading ? 'Loading' : undefined}
-          isLoading={isLoading}
-          onClick={(): void => onFilter(selectedClusters, selectedNamespaces)}
-        >
-          Filter
-        </Button>
-      </FlexItem>
-    </Flex>
+    <Toolbar id="filter" className="kobsio-pagesection-toolbar">
+      <ToolbarContent>
+        <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="lg">
+          <ToolbarGroup>
+            <ToolbarItem>
+              <Select
+                variant={SelectVariant.typeaheadMulti}
+                typeAheadAriaLabel="Select clusters"
+                placeholderText="Select clusters"
+                onToggle={(): void => setShowClusters(!showClusters)}
+                onSelect={(e, value): void => onSelectCluster(value as string)}
+                onClear={(): void => setSelectedClusters([])}
+                selections={selectedClusters}
+                isOpen={showClusters}
+              >
+                {clusters.map((cluster, index) => (
+                  <SelectOption key={index} value={cluster} />
+                ))}
+              </Select>
+            </ToolbarItem>
+            <ToolbarItem>
+              <Select
+                variant={SelectVariant.typeaheadMulti}
+                typeAheadAriaLabel="Select namespaces"
+                placeholderText="Select namespaces"
+                onToggle={(): void => setShowNamespaces(!showNamespaces)}
+                onSelect={(e, value): void => onSelectNamespace(value as string)}
+                onClear={(): void => setSelectedNamespaces([])}
+                selections={selectedNamespaces}
+                isOpen={showNamespaces}
+              >
+                {namespaces.map((namespace, index) => (
+                  <SelectOption key={index} value={namespace} />
+                ))}
+              </Select>
+            </ToolbarItem>
+            <ToolbarItem>
+              <Button
+                variant={ButtonVariant.primary}
+                spinnerAriaValueText={isLoading ? 'Loading' : undefined}
+                isLoading={isLoading}
+                onClick={(): void => onFilter(selectedClusters, selectedNamespaces)}
+              >
+                Filter
+              </Button>
+            </ToolbarItem>
+          </ToolbarGroup>
+        </ToolbarToggleGroup>
+      </ToolbarContent>
+    </Toolbar>
   );
 };
 

--- a/app/src/components/resources/Resource.tsx
+++ b/app/src/components/resources/Resource.tsx
@@ -27,7 +27,12 @@ const Resource: React.FunctionComponent<IResourceProps> = ({ resource, columns, 
   return (
     <DrawerPanelContent minSize="50%">
       <DrawerHead>
-        <span className="pf-m-lg pf-u-font-weight-bold">{resource.name.title}</span>
+        <span>
+          <span className="pf-c-title pf-m-lg">{resource.name.title}</span>
+          <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-200">
+            {resource.namespace.title} ({resource.cluster.title})
+          </span>
+        </span>
         <DrawerActions className="kobs-drawer-actions">
           <DrawerCloseButton onClick={close} />
         </DrawerActions>

--- a/app/src/components/resources/Resources.tsx
+++ b/app/src/components/resources/Resources.tsx
@@ -97,7 +97,7 @@ const Resources: React.FunctionComponent = () => {
         <Title headingLevel="h6" size="xl">
           {resources[params.kind].title}
         </Title>
-        <p className="pf-u-mb-xl">{resources[params.kind].description}</p>
+        <p>{resources[params.kind].description}</p>
         <Filter isLoading={isLoading} onFilter={fetchResources} />
       </PageSection>
 


### PR DESCRIPTION
The cluster and namespace filter wasn't displayed correctly on mobile
devices and takes a lot of the available space.

We are using the Toolbar component instead of FlexItems now, so that the
filters can be toggled on mobile devices.

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
