### PR TITLE
Fix GitHub Action for Docker

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,11 +1,14 @@
 name: Docker
 
+# on:
+#   push:
+#     branches:
+#       - main
+#     tags:
+#       - v*
+
 on:
   push:
-    branches:
-      - main
-    tags:
-      - v*
 
 jobs:
   docker:
@@ -45,6 +48,6 @@ jobs:
         with:
           push: true
           context: .
-          file: ./cmd/server/Dockerfile
+          file: ./cmd/kobs/Dockerfile
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8
           tags: kobsio/kobs:${{ steps.tag.outputs.tag }}

--- a/cmd/kobs/Dockerfile
+++ b/cmd/kobs/Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 node:14 as app
 WORKDIR /kobs
 COPY app/package.json app/yarn.lock /kobs/
-RUN yarn install
+RUN yarn install --frozen-lockfile --network-timeout 3600000
 COPY app /kobs/
 RUN yarn build
 


### PR DESCRIPTION
Fix the GitHub Action, which is used to build and push the Docker image for kobs.

- [ ] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
