### PR TITLE
Fix time parsing for the datasource options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 ### Fixed
 
 - [#1](https://github.com/kobsio/kobs/pull/1): Fix mobile layout for the cluster and namespace filter by using a Toolbar instead of FlexItems.
+- [#9](https://github.com/kobsio/kobs/pull/9): Fix time parsing for the datasource options.
 
 ### Changed
 

--- a/app/src/app.css
+++ b/app/src/app.css
@@ -63,8 +63,12 @@
   width: 100%;
 }
 
-/* kobsio-options-list-item
- * Apply some padding between the list items for smaller screens. */
+/* kobsio-options-list
+ * Do not center the items vertically and apply some padding between the list items for smaller screens. */
+.kobsio-options-list {
+  align-items: flex-start;
+}
+
 .kobsio-options-list-item {
   padding-bottom: 16px;
 }


### PR DESCRIPTION
The user provided time string wasn't parsed correctly. We used the
provided start time also for the end time by mistak. Also the provided
string was always parsed as UTC date instead of the users current
timezone. Both issues are fixed now.

We also added a new input field for the Prometheus resolution. This
option was already present, but the input field was missing. So that a
user wasn't able to change the resolution. The resolution is displayed
in a fourth column in the options modal. This column should also be used
for other datasources (e.g. max results for Jaeger).

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
