### PR TITLE
Fix resources tab of an application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#1](https://github.com/kobsio/kobs/pull/1): Fix mobile layout for the cluster and namespace filter by using a Toolbar instead of FlexItems.
 - [#9](https://github.com/kobsio/kobs/pull/9): Fix time parsing for the datasource options.
 - [#14](https://github.com/kobsio/kobs/pull/14): Fix loading of Jaeger services, when a user opend the Jaeger plugin, where the `service` query parameter was already present.
+- [#15](https://github.com/kobsio/kobs/pull/15): Fix resources tab of an Application, where resources were loaded multiple times.
 
 ### Changed
 

--- a/app/src/components/resources/ResourcesListItem.tsx
+++ b/app/src/components/resources/ResourcesListItem.tsx
@@ -1,5 +1,5 @@
 import { IRow, Table, TableBody, TableHeader } from '@patternfly/react-table';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { memo, useCallback, useEffect, useState } from 'react';
 
 import { ClustersPromiseClient, GetResourcesRequest, GetResourcesResponse } from 'proto/clusters_grpc_web_pb';
 import { IResource, emptyState } from 'utils/resources';
@@ -77,4 +77,6 @@ const ResourcesListItem: React.FunctionComponent<IResourcesListItemProps> = ({
   );
 };
 
-export default ResourcesListItem;
+export default memo(ResourcesListItem, () => {
+  return true;
+});


### PR DESCRIPTION
The specified resources of an application were loaded multiple times. We
are using React.memo for the ResourcesListItem component, to avoid that
the resources are loaded multiple times. Now the fetchResources function
of the component is only triggered, when the properties of the component
are changing.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
