### PR TITLE
Use location to load applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,4 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 - [#7](https://github.com/kobsio/kobs/pull/7): Share datasource options between components and allow sharing of URLs.
 - [#11](https://github.com/kobsio/kobs/pull/11): :warning: *Breaking change:* :warning: Refactor cluster and application handling.
+- [#17](https://github.com/kobsio/kobs/pull/17): Use location to load applications, which allows user to share their applications view.

--- a/app/src/components/applications/ApplicationsToolbar.tsx
+++ b/app/src/components/applications/ApplicationsToolbar.tsx
@@ -12,22 +12,27 @@ import FilterIcon from '@patternfly/react-icons/dist/js/icons/filter-icon';
 import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
 
 import { ClustersContext, IClusterContext } from 'context/ClustersContext';
-import { IScope } from 'components/applications/Applications';
 import ToolbarItemClusters from 'components/resources/ToolbarItemClusters';
 import ToolbarItemNamespaces from 'components/resources/ToolbarItemNamespaces';
 
 interface IApplicationsToolbarProps {
-  setScope: (scope: IScope) => void;
+  clusters: string[];
+  namespaces: string[];
+  changeData: (clusters: string[], namespaces: string[]) => void;
 }
 
 // ApplicationsToolbar is the toolbar, where the user can select a list of clusters and namespaces. When the user clicks
 // the search button the setScope function is called with the list of selected clusters and namespaces.
 const ApplicationsToolbar: React.FunctionComponent<IApplicationsToolbarProps> = ({
-  setScope,
+  clusters,
+  namespaces,
+  changeData,
 }: IApplicationsToolbarProps) => {
   const clustersContext = useContext<IClusterContext>(ClustersContext);
-  const [selectedClusters, setSelectedClusters] = useState<string[]>([clustersContext.clusters[0]]);
-  const [selectedNamespaces, setSelectedNamespaces] = useState<string[]>([]);
+  const [selectedClusters, setSelectedClusters] = useState<string[]>(
+    clusters.length > 0 ? clusters : [clustersContext.clusters[0]],
+  );
+  const [selectedNamespaces, setSelectedNamespaces] = useState<string[]>(namespaces);
 
   // selectCluster adds/removes the given cluster to the list of selected clusters. When the cluster value is an empty
   // string the selected clusters list is cleared.
@@ -80,12 +85,7 @@ const ApplicationsToolbar: React.FunctionComponent<IApplicationsToolbarProps> = 
               <Button
                 variant={ButtonVariant.primary}
                 icon={<SearchIcon />}
-                onClick={(): void =>
-                  setScope({
-                    clusters: selectedClusters,
-                    namespaces: selectedNamespaces,
-                  })
-                }
+                onClick={(): void => changeData(selectedClusters, selectedNamespaces)}
               >
                 Search
               </Button>

--- a/app/src/components/resources/Resources.tsx
+++ b/app/src/components/resources/Resources.tsx
@@ -49,18 +49,12 @@ const Resources: React.FunctionComponent = () => {
         >
           <DrawerContentBody>
             <PageSection style={{ minHeight: '100%' }} variant={PageSectionVariants.default}>
-              {!resources ? (
+              {!resources ||
+              resources.clusters.length === 0 ||
+              resources.namespaces.length === 0 ||
+              resources.resources.length === 0 ? (
                 <Alert variant={AlertVariant.info} title="Select clusters, resources and namespaces">
                   <p>Select a list of clusters, resources and namespaces from the toolbar.</p>
-                </Alert>
-              ) : resources.clusters.length === 0 ||
-                resources.namespaces.length === 0 ||
-                resources.resources.length === 0 ? (
-                <Alert variant={AlertVariant.danger} title="Select clusters, resources and namespaces">
-                  <p>
-                    You have to select a minimum of one cluster, resource and namespace from the toolbar to search for
-                    resources.
-                  </p>
                 </Alert>
               ) : (
                 <ResourcesList resources={resources} selectResource={setSelectedResource} />


### PR DESCRIPTION
Similar to the plugins, we do not load the applications directly anymore
after the user clicked the search button. Instead we change the
location.search parameter for the applications page. For each change to
the location the "fetchApplications" function is triggered to load the
applications. This allows a user to share his current selection of
clusters and namespaces with other users.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
