### PR TITLE
Use multiple colors in the Jaeger plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#13](https://github.com/kobsio/kobs/pull/13): Add Jaeger plugin to show traces for an Application and to compare traces.
 - [#16](https://github.com/kobsio/kobs/pull/16): Add support for multiple queries in the Prometheus plugin page.
 - [#18](https://github.com/kobsio/kobs/pull/18): Add metrics and logs for the gRPC server.
+- [#19](https://github.com/kobsio/kobs/pull/19): Use multiple colors in the Jaeger plugin. Each service in a trace has a unique color now, which is used for the charts.
 
 ### Fixed
 

--- a/app/src/plugins/jaeger/JaegerPageCompareTrace.tsx
+++ b/app/src/plugins/jaeger/JaegerPageCompareTrace.tsx
@@ -13,7 +13,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { GetTraceRequest, GetTraceResponse, JaegerPromiseClient } from 'proto/jaeger_grpc_web_pb';
-import { ITrace, formatTraceTime, getDuration } from 'plugins/jaeger/helpers';
+import { ITrace, addColorForProcesses, formatTraceTime, getDuration } from 'plugins/jaeger/helpers';
 import JaegerSpans from 'plugins/jaeger/JaegerSpans';
 import { apiURL } from 'utils/constants';
 
@@ -53,7 +53,7 @@ const JaegerPageCompareTrace: React.FunctionComponent<IJaegerPageCompareTracePro
       const getTraceResponse: GetTraceResponse = await jaegerService.getTrace(getTraceRequest, null);
       const trace = JSON.parse(getTraceResponse.toObject().traces).data;
 
-      setData({ error: '', isLoading: false, trace: trace.length === 1 ? trace[0] : undefined });
+      setData({ error: '', isLoading: false, trace: trace.length === 1 ? addColorForProcesses(trace)[0] : undefined });
     } catch (err) {
       setData({ error: err.message, isLoading: false, trace: undefined });
     }

--- a/app/src/plugins/jaeger/JaegerSpan.tsx
+++ b/app/src/plugins/jaeger/JaegerSpan.tsx
@@ -1,7 +1,8 @@
 import { AccordionContent, AccordionItem, AccordionToggle, Badge } from '@patternfly/react-core';
 import React, { useState } from 'react';
+import ExclamationIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
 
-import { IProcesses, ISpan } from 'plugins/jaeger/helpers';
+import { IProcesses, ISpan, doesSpanContainsError } from 'plugins/jaeger/helpers';
 import JaegerSpanLogs from 'plugins/jaeger/JaegerSpanLogs';
 
 import 'plugins/jaeger/jaeger.css';
@@ -27,7 +28,9 @@ const JaegerSpan: React.FunctionComponent<IJaegerSpanProps> = ({ span, processes
     >
       <span
         style={{
-          backgroundColor: 'var(--pf-global--primary-color--100)',
+          backgroundColor: processes[span.processID].color
+            ? processes[span.processID].color
+            : 'var(--pf-global--primary-color--100)',
           height: '5px',
           left: `${span.offset}%`,
           position: 'absolute',
@@ -50,7 +53,15 @@ const JaegerSpan: React.FunctionComponent<IJaegerSpanProps> = ({ span, processes
           <span>
             {processes[span.processID].serviceName}: {span.operationName}
           </span>
-          <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">{span.spanID}</span>
+          <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">
+            {span.spanID}
+            {doesSpanContainsError(span) ? (
+              <ExclamationIcon
+                className="pf-u-ml-sm pf-u-font-size-sm"
+                style={{ color: 'var(--pf-global--danger-color--100)' }}
+              />
+            ) : null}
+          </span>
           <span className="pf-u-font-size-sm pf-u-color-400" style={{ float: 'right' }}>
             {span.duration / 1000}ms
           </span>

--- a/app/src/plugins/jaeger/JaegerSpans.tsx
+++ b/app/src/plugins/jaeger/JaegerSpans.tsx
@@ -21,7 +21,7 @@ const JaegerSpans: React.FunctionComponent<IJaegerSpansProps> = ({ trace }: IJae
         <CardBody>
           <div style={{ height: `100px`, position: 'relative' }}>
             {spans.map((span, index) => (
-              <JaegerSpansChart key={index} span={span} height={100 / trace.spans.length} />
+              <JaegerSpansChart key={index} span={span} processes={trace.processes} height={100 / trace.spans.length} />
             ))}
           </div>
         </CardBody>

--- a/app/src/plugins/jaeger/JaegerSpansChart.tsx
+++ b/app/src/plugins/jaeger/JaegerSpansChart.tsx
@@ -1,15 +1,20 @@
 import {} from '@patternfly/react-core';
 import React from 'react';
 
-import { ISpan } from 'plugins/jaeger/helpers';
+import { IProcesses, ISpan } from 'plugins/jaeger/helpers';
 
 export interface IJaegerSpansChartProps {
   span: ISpan;
+  processes: IProcesses;
   height: number;
 }
 
+// JaegerSpansChart is a single line in the chart to visualize the spans over time. The component requires a span, all
+// processes to set the correct color for the line and a height for the line. The height is calculated by the container
+// height divided by the number of spans.
 const JaegerSpansChart: React.FunctionComponent<IJaegerSpansChartProps> = ({
   span,
+  processes,
   height,
 }: IJaegerSpansChartProps) => {
   return (
@@ -26,7 +31,9 @@ const JaegerSpansChart: React.FunctionComponent<IJaegerSpansChartProps> = ({
         >
           <span
             style={{
-              backgroundColor: 'var(--pf-global--primary-color--100)',
+              backgroundColor: processes[span.processID].color
+                ? processes[span.processID].color
+                : 'var(--pf-global--primary-color--100)',
               height: `${height}px`,
               left: `${span.offset}%`,
               position: 'absolute',
@@ -37,7 +44,9 @@ const JaegerSpansChart: React.FunctionComponent<IJaegerSpansChartProps> = ({
       </div>
 
       {span.childs
-        ? span.childs.map((span, index) => <JaegerSpansChart key={index} span={span} height={height} />)
+        ? span.childs.map((span, index) => (
+            <JaegerSpansChart key={index} span={span} processes={processes} height={height} />
+          ))
         : null}
     </React.Fragment>
   );

--- a/app/src/plugins/jaeger/JaegerTraces.tsx
+++ b/app/src/plugins/jaeger/JaegerTraces.tsx
@@ -2,7 +2,7 @@ import { Alert, AlertActionLink, AlertVariant, Spinner } from '@patternfly/react
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { GetTracesRequest, GetTracesResponse, JaegerPromiseClient } from 'proto/jaeger_grpc_web_pb';
-import { IJaegerOptions, ITrace } from 'plugins/jaeger/helpers';
+import { IJaegerOptions, ITrace, addColorForProcesses, encodeTags } from 'plugins/jaeger/helpers';
 import JaegerTracesChart from 'plugins/jaeger/JaegerTracesChart';
 import JaegerTracesTrace from 'plugins/jaeger/JaegerTracesTrace';
 import { apiURL } from 'utils/constants';
@@ -54,14 +54,14 @@ const JaegerTraces: React.FunctionComponent<IJaegerTracesProps> = ({
       getTracesRequest.setMinduration(minDuration);
       getTracesRequest.setOperation(operation);
       getTracesRequest.setService(service);
-      getTracesRequest.setTags(tags);
+      getTracesRequest.setTags(encodeTags(tags));
       getTracesRequest.setTimeend(timeEnd);
       getTracesRequest.setTimestart(timeStart);
 
       const getTracesResponse: GetTracesResponse = await jaegerService.getTraces(getTracesRequest, null);
       const traces = JSON.parse(getTracesResponse.toObject().traces).data;
 
-      setData({ error: '', isLoading: false, traces: traces });
+      setData({ error: '', isLoading: false, traces: addColorForProcesses(traces) });
     } catch (err) {
       setData({ error: err.message, isLoading: false, traces: [] });
     }

--- a/app/src/plugins/jaeger/JaegerTracesTrace.tsx
+++ b/app/src/plugins/jaeger/JaegerTracesTrace.tsx
@@ -1,7 +1,14 @@
 import { Badge, Card, CardActions, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
+import ExclamationIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
 import React from 'react';
 
-import { ITrace, formatTraceTime, getDuration, getSpansPerServices } from 'plugins/jaeger/helpers';
+import {
+  ITrace,
+  doesTraceContainsError,
+  formatTraceTime,
+  getDuration,
+  getSpansPerServices,
+} from 'plugins/jaeger/helpers';
 import JaegerTrace from 'plugins/jaeger/JaegerTrace';
 
 interface IJaegerTracesTraceProps {
@@ -38,8 +45,16 @@ const JaegerTracesTrace: React.FunctionComponent<IJaegerTracesTraceProps> = ({
     >
       <CardHeader>
         <CardTitle>
-          {rootSpanService}: {rootSpan.operationName}{' '}
-          <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">{trace.traceID}</span>
+          {rootSpanService}: {rootSpan.operationName}
+          <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">
+            {trace.traceID}
+            {doesTraceContainsError(trace) ? (
+              <ExclamationIcon
+                className="pf-u-ml-sm pf-u-font-size-sm"
+                style={{ color: 'var(--pf-global--danger-color--100)' }}
+              />
+            ) : null}
+          </span>
         </CardTitle>
         <CardActions>
           <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">{getDuration(trace.spans)}ms</span>
@@ -51,7 +66,7 @@ const JaegerTracesTrace: React.FunctionComponent<IJaegerTracesTraceProps> = ({
         </Badge>
 
         {getSpansPerServices(trace).map((service, index) => (
-          <Badge className="pf-u-ml-sm" key={index} isRead={false}>
+          <Badge key={index} className="pf-u-ml-sm" style={{ backgroundColor: service.color }}>
             {service.service} ({service.spans})
           </Badge>
         ))}

--- a/pkg/api/plugins/jaeger/jaeger.go
+++ b/pkg/api/plugins/jaeger/jaeger.go
@@ -181,7 +181,7 @@ func (j *Jaeger) GetTraces(ctx context.Context, getTracesRequest *jaegerProto.Ge
 
 	log.WithFields(logrus.Fields{"service": getTracesRequest.Service, "operation": getTracesRequest.Operation, "tags": getTracesRequest.Tags}).Tracef("GetTraces")
 
-	body, err := instance.doRequest(fmt.Sprintf("/api/traces?end=%d&limit=%s&lookback=custom&maxDuration=%s&minDuration=%s&operation=%s&service=%s&start=%d", getTracesRequest.TimeEnd*1000000, getTracesRequest.Limit, getTracesRequest.MaxDuration, getTracesRequest.MinDuration, getTracesRequest.Operation, getTracesRequest.Service, getTracesRequest.TimeStart*1000000))
+	body, err := instance.doRequest(fmt.Sprintf("/api/traces?end=%d&limit=%s&lookback=custom&maxDuration=%s&minDuration=%s&operation=%s&service=%s&start=%d&tags=%s", getTracesRequest.TimeEnd*1000000, getTracesRequest.Limit, getTracesRequest.MaxDuration, getTracesRequest.MinDuration, getTracesRequest.Operation, getTracesRequest.Service, getTracesRequest.TimeStart*1000000, getTracesRequest.Tags))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The Jaeger plugin uses multiple colors now. Right after a trace was
returned from the gRPC service, we loop through all traces and their
processes and asign each process a color. This color is then used in the
list of spans for the service and in the chart of spans and spans view.

This also fixes a bug, where the specified traces where not used in the
API. The tags specified by the user will now be used for the Jaeger API
calls. For that we transform the string into a json object. This object
is then encoded and the encoded string is sent to our gRPC server.

Besides the mentioned changes from above, we also added two function, to
check if a trace/span contains a tag "error=true". If this is the case,
we display a error icon next to the trace/span id in the title.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
