### PR TITLE
Add Helm chart

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -1,0 +1,66 @@
+name: Helm
+
+on:
+  push:
+    paths:
+      - 'deploy/helm/**'
+
+jobs:
+  helm:
+    name: Helm Chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Lint
+        run: |
+          helm lint deploy/helm/kobs
+
+      - name: Template
+        run: |
+          helm template kobs -n observability deploy/helm/kobs
+
+      - name: Install
+        run: |
+          kind create cluster
+          sleep 60s
+          kubectl create namespace observability
+          sleep 10s
+          helm install --namespace observability kobs deploy/helm/kobs
+
+      - name: Configure SSH
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: webfactory/ssh-agent@v0.5.1
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Configure Git
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          git config --global user.email "admin@kobs.io" && git config --global user.name "kobsio"
+
+      - name: Package Helm Chart
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          helm package ./deploy/helm/kobs
+
+      - name: Clone Helm Repository
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          git clone git@github.com:kobsio/helm-repository.git
+
+      - name: Update Helm Repository
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          mv kobs* ./helm-repository/ && helm repo index helm-repository/ --url https://kobsio.github.io/helm-repository/
+
+      - name: Commit Changes
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          cd helm-repository/ && git add . && git commit -m "Add new release for kobs"
+
+      - name: Push Changes
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          cd helm-repository/ && git push

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,11 @@ name: Test
 
 on:
   push:
+    paths-ignore:
+      - '.github/**'
+      - '.vscode/**'
+      - 'deploy/**'
+      - 'docs/**'
 
 jobs:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#18](https://github.com/kobsio/kobs/pull/18): Add metrics and logs for the gRPC server.
 - [#19](https://github.com/kobsio/kobs/pull/19): Use multiple colors in the Jaeger plugin. Each service in a trace has a unique color now, which is used for the charts.
 - [#21](https://github.com/kobsio/kobs/pull/21): Add preview for Applications via plugins.
+- [#22](https://github.com/kobsio/kobs/pull/22): Add Helm chart.
 
 ### Fixed
 

--- a/deploy/helm/kobs/.helmignore
+++ b/deploy/helm/kobs/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/helm/kobs/Chart.yaml
+++ b/deploy/helm/kobs/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: kobs
+description: Kubernetes Observability Platform
+type: application
+home: https://kobs.io
+icon: https://kobs.io/TODO.svg
+version: 0.1.0
+appVersion: 0.0.1

--- a/deploy/helm/kobs/templates/NOTES.txt
+++ b/deploy/helm/kobs/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kobs.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "kobs.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "kobs.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "kobs.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:15222 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 15222
+{{- end }}

--- a/deploy/helm/kobs/templates/_helpers.tpl
+++ b/deploy/helm/kobs/templates/_helpers.tpl
@@ -1,0 +1,74 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kobs.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kobs.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kobs.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "kobs.labels" -}}
+helm.sh/chart: {{ include "kobs.chart" . }}
+{{ include "kobs.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kobs.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kobs.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kobs.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "kobs.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the cluster role and cluster role binding to use
+*/}}
+{{- define "kobs.rbacName" -}}
+{{- if .Values.rbac.create -}}
+    {{ default (include "kobs.fullname" .) .Values.rbac.name }}
+{{- else -}}
+    {{ default "default" .Values.rbac.name }}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/kobs/templates/clusterrole.yaml
+++ b/deploy/helm/kobs/templates/clusterrole.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kobs.rbacName" . }}
+  labels:
+    {{- include "kobs.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - 'get'
+      - 'watch'
+      - 'list'
+
+  - nonResourceURLs:
+      - '*'
+    verbs:
+      - 'get'
+      - 'watch'
+      - 'list'
+{{- end -}}

--- a/deploy/helm/kobs/templates/clusterrolebinding.yaml
+++ b/deploy/helm/kobs/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "kobs.rbacName" . }}
+  labels:
+    {{- include "kobs.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kobs.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "kobs.rbacName" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/deploy/helm/kobs/templates/configmap.yaml
+++ b/deploy/helm/kobs/templates/configmap.yaml
@@ -1,0 +1,102 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kobs.fullname" . }}
+  labels:
+    {{- include "kobs.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+{{ tpl .Values.kobs.config . | indent 4 }}
+
+{{ if .Values.envoy.enabled }}
+  envoy.yaml: |
+    admin:
+      access_log_path: /dev/null
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 9901
+
+    static_resources:
+      listeners:
+        - name: listener_0
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: 15222
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    codec_type: auto
+                    stat_prefix: ingress_http
+                    access_log:
+                      - name: envoy.access_loggers.file
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                          path: /dev/stdout
+                          format: "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS% %CONNECTION_TERMINATION_DETAILS% \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME% %ROUTE_NAME%\n"
+                    route_config:
+                      name: local_route
+                      virtual_hosts:
+                        - name: local_service
+                          domains: ["*"]
+                          routes:
+                            - match:
+                                prefix: "/clusters."
+                              route:
+                                cluster: api-server
+                                max_stream_duration:
+                                  grpc_timeout_header_max: 0s
+                            - match:
+                                prefix: "/plugins."
+                              route:
+                                cluster: api-server
+                                max_stream_duration:
+                                  grpc_timeout_header_max: 0s
+                            - match:
+                                prefix: "/"
+                              route:
+                                cluster: app-server
+                          cors:
+                            allow_origin_string_match:
+                              - prefix: "*"
+                            allow_methods: GET, PUT, DELETE, POST, OPTIONS
+                            allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                            max_age: "1728000"
+                            expose_headers: custom-header-1,grpc-status,grpc-message
+                    http_filters:
+                      - name: envoy.filters.http.grpc_web
+                      - name: envoy.filters.http.cors
+                      - name: envoy.filters.http.router
+      clusters:
+        - name: api-server
+          connect_timeout: 0.25s
+          type: logical_dns
+          http2_protocol_options: {}
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: cluster_0
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: localhost
+                          port_value: 15220
+        - name: app-server
+          connect_timeout: 0.25s
+          type: logical_dns
+          # http2_protocol_options: {}
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: cluster_0
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: localhost
+                          port_value: 15219
+{{ end }}

--- a/deploy/helm/kobs/templates/customresourcedefinition.yaml
+++ b/deploy/helm/kobs/templates/customresourcedefinition.yaml
@@ -1,4 +1,4 @@
-
+{{- if .Values.crd.create }}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -357,3 +357,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{ end -}}

--- a/deploy/helm/kobs/templates/deployment.yaml
+++ b/deploy/helm/kobs/templates/deployment.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kobs.fullname" . }}
+  labels:
+    {{- include "kobs.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "kobs.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "kobs.selectorLabels" . | nindent 8 }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "kobs.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: kobs
+          securityContext:
+            {{- toYaml .Values.kobs.securityContext | nindent 12 }}
+          image: "{{ .Values.kobs.image.repository }}:{{ .Values.kobs.image.tag }}"
+          imagePullPolicy: {{ .Values.kobs.image.pullPolicy }}
+          args:
+            - --log.level={{ .Values.kobs.settings.logLevel }}
+            - --log.format={{ .Values.kobs.settings.logFormat }}
+          env:
+            {{- with .Values.kobs.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http-web
+              containerPort: 15219
+              protocol: TCP
+            - name: grpc-api
+              containerPort: 15220
+              protocol: TCP
+            - name: http-metrics
+              containerPort: 15221
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http-web
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http-web
+          resources:
+            {{- toYaml .Values.kobs.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /kobs/config.yaml
+              subPath: config.yaml
+              readOnly: true
+        {{ if .Values.envoy.enabled }}
+        - name: envoy
+          securityContext:
+            {{- toYaml .Values.envoy.securityContext | nindent 12 }}
+          image: "{{ .Values.envoy.image.repository }}:{{ .Values.envoy.image.tag }}"
+          imagePullPolicy: {{ .Values.envoy.image.pullPolicy }}
+          ports:
+            - name: http-envoy
+              containerPort: 15222
+              protocol: TCP
+            - name: http-admin
+              containerPort: 9901
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http-admin
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-admin
+          resources:
+            {{- toYaml .Values.envoy.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/envoy/envoy.yaml
+              subPath: envoy.yaml
+              readOnly: true
+        {{ end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "kobs.fullname" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/deploy/helm/kobs/templates/ingress.yaml
+++ b/deploy/helm/kobs/templates/ingress.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "kobs.fullname" . -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "kobs.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: 15222
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/kobs/templates/service.yaml
+++ b/deploy/helm/kobs/templates/service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kobs.fullname" . }}
+  labels:
+    {{- include "kobs.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: 15219
+      targetPort: http-web
+      protocol: TCP
+      name: http-web
+    - port: 15220
+      targetPort: grpc-api
+      protocol: TCP
+      name: grpc-api
+    - port: 15221
+      targetPort: http-metrics
+      protocol: TCP
+      name: http-metrics
+    {{ if .Values.envoy.enabled }}
+    - port: 15222
+      targetPort: http-envoy
+      protocol: TCP
+      name: http-envoy
+    {{ end }}
+  selector:
+    {{- include "kobs.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/kobs/templates/serviceaccount.yaml
+++ b/deploy/helm/kobs/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kobs.serviceAccountName" . }}
+  labels:
+    {{- include "kobs.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/deploy/helm/kobs/templates/tests/test-connection.yaml
+++ b/deploy/helm/kobs/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "kobs.fullname" . }}-test-connection"
+  labels:
+    {{- include "kobs.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "kobs.fullname" . }}:15222/health']
+  restartPolicy: Never

--- a/deploy/helm/kobs/values.yaml
+++ b/deploy/helm/kobs/values.yaml
@@ -1,0 +1,178 @@
+# Default values for kobs.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+nameOverride: ""
+fullnameOverride: ""
+
+replicas: 1
+
+## Specify a list of image pull secrets, to avoid the DockerHub rate limit or to pull the kobs/enovy image from a
+## private registry.
+## See: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+##
+imagePullSecrets: []
+  # - name: regcred
+
+## Specify security settings for the created Pods. To set the security settings for the kobs or envoy Container use the
+## corresponding "securityContext" field.
+## See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+##
+podSecurityContext: {}
+  # fsGroup: 2000
+
+## Specify a map of key-value pairs, to assign the Pods to a specific set of nodes.
+## See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+##
+nodeSelector: {}
+
+## Specify the tolerations for the kobs Pods.
+## See: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+##
+tolerations: []
+
+## Specify a node affinity or inter-pod affinity / anti-affinity for an advanced scheduling of the kobs Pods.
+## See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}
+
+kobs:
+  image:
+    repository: kobsio/kobs
+    tag: main
+    pullPolicy: IfNotPresent
+
+  ##  Specify security settings for the kobs Container. They override settings made at the Pod level via the
+  ## "podSecurityContext" when there is overlap.
+  ## See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ##
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  ## We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This
+  ## also increases chances charts run on environments with little resources, such as Minikube. If you do want to
+  ## specify resources, uncomment the following lines, adjust them as necessary, and remove the curly braces after
+  ## 'resources:'.
+  ##
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  ## Specify additional environment variables for the kobs container.
+  ##
+  env: []
+
+  ## Specify some settings like log level, log format, etc. for kobs.
+  ##
+  settings:
+    logLevel: info
+    logFormat: plain
+
+  ## Set the content of the config.yaml file, which is used by kobs. The configuration file is used to specify the
+  ## cluster providers and the configuration for the plugins.
+  ##
+  config: |
+    clusters:
+      providers:
+        - provider: incluster
+          incluster:
+            name: kobs
+
+## Enable the Envoy sidecar. This is required, because kobs uses gRPC Web for the API requests and Envoy translates the
+## HTTP requests from the frontend into gRPC requests.
+## The Envoy sidecar can be disabled, when you handle the gRPC requests at another level, e.g. Ingress.
+##
+envoy:
+  enabled: true
+
+  image:
+    repository: envoyproxy/envoy
+    tag: v1.17.0
+    pullPolicy: IfNotPresent
+
+  ##  Specify security settings for the kobs Container. They override settings made at the Pod level via the
+  ## "podSecurityContext" when there is overlap.
+  ## See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ##
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  ## We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This
+  ## also increases chances charts run on environments with little resources, such as Minikube. If you do want to
+  ## specify resources, uncomment the following lines, adjust them as necessary, and remove the curly braces after
+  ## 'resources:'.
+  ##
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+## Specifies whether a service account should be created.
+## See: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  create: true
+
+  ## Annotations to add to the service account
+  ##
+  annotations: {}
+
+  ## The name of the service account to use.
+  ## If not set and create is true, a name is generated using the fullname template
+  ##
+  name:
+
+## Specifies whether a cluster role and cluster role binding should be created.
+## The create cluster role and cluster role binding allows kobs read access to all resources.
+## See: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+##
+rbac:
+  create: true
+  # The name of the cluster role and cluster role binding to use.
+  # If not set and create is true, a name is generated using the fullname template.
+  name:
+
+## Specifies whether the custom resource definitions for kobs should be created.
+## The custom resource definitions are used to extend the functionality of kobs.
+##
+crd:
+  create: true
+
+## Set the type for the created service: ClusterIP, NodePort, LoadBalancer.
+## See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+##
+service:
+  type: ClusterIP
+
+## Create an Ingress to expose kobs.
+## See: https://kubernetes.io/docs/concepts/services-networking/ingress/
+##
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local

--- a/pkg/api/plugins/prometheus/proto/prometheus.pb.go
+++ b/pkg/api/plugins/prometheus/proto/prometheus.pb.go
@@ -674,8 +674,7 @@ func (x *Chart) GetQueries() []*Query {
 
 // Query presents a single query to get the data, which should be shown in the chart for the metrics section. A query
 // consists of a query string (e.g. PromQL) and a lable. The query and the label can contain variables via Go templating
-// syntax (e.g. {{ .VARIABLE-NAME }}). For Prometheus the label can also contain a label from the returned series with
-// the same syntax (e.g. {{ .SERIES-LABEL }}).
+// syntax. For Prometheus the label can also contain a label from the returned series with the same syntax.
 type Query struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/proto/prometheus.proto
+++ b/proto/prometheus.proto
@@ -96,8 +96,7 @@ message Chart {
 
 // Query presents a single query to get the data, which should be shown in the chart for the metrics section. A query
 // consists of a query string (e.g. PromQL) and a lable. The query and the label can contain variables via Go templating
-// syntax (e.g. {{ .VARIABLE-NAME }}). For Prometheus the label can also contain a label from the returned series with
-// the same syntax (e.g. {{ .SERIES-LABEL }}).
+// syntax. For Prometheus the label can also contain a label from the returned series with the same syntax.
 message Query {
   string query = 1;
   string label = 2;


### PR DESCRIPTION
Add a Helm chart to deploy kobs into a Kubernetes cluster via Helm. This
is a first very basic version of the Helm chart and should be extended
later.

The Helm chart can be found in the "deploy/helm/kobs" folder. Every time a
file in this folder is changed, we trigger the corresponding GitHub
action to run "helm lint", "helm template" and "helm install" against a
kind cluster.

If the Helm chart is changed on the main branch we automatically trigger
a release and publish a new version of the Helm chart in the
"kobsio/helm-repository" GitHub repository. The Helm chart can then be
used via https://kobsio.github.io/helm-repository/.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
