### PR TITLE
Change Helm repository url

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Update Helm Repository
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
-          mv kobs* ./helm-repository/ && helm repo index helm-repository/ --url https://kobsio.github.io/helm-repository/
+          mv kobs* ./helm-repository/ && helm repo index helm-repository/ --url https://helm.kobs.io/
 
       - name: Commit Changes
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,4 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#11](https://github.com/kobsio/kobs/pull/11): :warning: *Breaking change:* :warning: Refactor cluster and application handling.
 - [#17](https://github.com/kobsio/kobs/pull/17): Use location to load applications, which allows user to share their applications view.
 - [#20](https://github.com/kobsio/kobs/pull/20): Rework usage of icons, links handling and drawer layout.
+- [#25](https://github.com/kobsio/kobs/pull/25): Change the URL for the Helm repository to [helm.kobs.io](https://helm.kobs.io).

--- a/deploy/helm/kobs/Chart.yaml
+++ b/deploy/helm/kobs/Chart.yaml
@@ -3,6 +3,6 @@ name: kobs
 description: Kubernetes Observability Platform
 type: application
 home: https://kobs.io
-icon: https://kobs.io/TODO.svg
-version: 0.1.0
+icon: https://kobs.io/assets/images/logo.svg
+version: 0.1.1
 appVersion: 0.0.1

--- a/deploy/helm/kobs/values.yaml
+++ b/deploy/helm/kobs/values.yaml
@@ -42,7 +42,7 @@ kobs:
     tag: main
     pullPolicy: IfNotPresent
 
-  ##  Specify security settings for the kobs Container. They override settings made at the Pod level via the
+  ## Specify security settings for the kobs Container. They override settings made at the Pod level via the
   ## "podSecurityContext" when there is overlap.
   ## See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ##
@@ -99,7 +99,7 @@ envoy:
     tag: v1.17.0
     pullPolicy: IfNotPresent
 
-  ##  Specify security settings for the kobs Container. They override settings made at the Pod level via the
+  ## Specify security settings for the wnvoy Container. They override settings made at the Pod level via the
   ## "podSecurityContext" when there is overlap.
   ## See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ##
@@ -169,9 +169,9 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths: []
+  hosts: []
+    # - host: chart-example.local
+    #   paths: []
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -7,14 +7,14 @@
 To install kobs using Helm you have to add our Helm repository:
 
 ```sh
-helm repo add kobsio https://kobsio.github.io/helm-repository
+helm repo add kobs https://helm.kobs.io
 helm repo list
 ```
 
 When you have added the Helm repository, you can install kobs:
 
 ```sh
-helm install kobs kobsio/kobs
+helm install kobs kobs/kobs
 ```
 
 When the installation was successful you shoud see a message like the following:
@@ -38,13 +38,13 @@ To update the Helm repository and to show all available versions of the Helm cha
 
 ```sh
 helm repo update
-helm search repo -l kobsio/
+helm search repo -l kobs/
 ```
 
 To update your deployed Helm chart run:
 
 ```sh
-helm upgrade kobs kobsio/kobs
+helm upgrade kobs kobs/kobs
 ```
 
 ## Values


### PR DESCRIPTION
The Helm repository is now available at http://helm.kobs.io.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [x] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
