### PR TITLE
Fix topology chart for invalid dependency data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 ### Fixed
 
+- [#33](https://github.com/kobsio/kobs/pull/33): Fix the topology graph, which crashes, when an Application has a dependency to an Application, which doesn't exists.
+
 ### Changed
 
 - [#30](https://github.com/kobsio/kobs/pull/30): Support multiple versions of a CRD and allow the specification of namespaces in the Applications resources list.

--- a/pkg/api/plugins/clusters/topology.go
+++ b/pkg/api/plugins/clusters/topology.go
@@ -80,7 +80,17 @@ func (c *Clusters) generateTopology() {
 			}
 		}
 
-		c.edges = edges
+		// Loop through all edges and remove the edge, when the source or target node doesn't exists. This is needed, so
+		// that we only have edges were the source and target nodes exists, because the topology component in the React
+		// UI will crash when it founds an edge but no corresponding node.
+		var filterEdges []*clustersProto.Edge
+		for _, edge := range edges {
+			if doesNodeExists(nodes, edge.Source) && doesNodeExists(nodes, edge.Target) {
+				filterEdges = append(filterEdges, edge)
+			}
+		}
+
+		c.edges = filterEdges
 		c.nodes = nodes
 
 		time.Sleep(sleep)
@@ -107,4 +117,15 @@ func appendNodeIfMissing(nodes []*clustersProto.Node, node *clustersProto.Node) 
 	}
 
 	return append(nodes, node)
+}
+
+// doesNodeExists checks if the given node id exists in a slice of node.
+func doesNodeExists(nodes []*clustersProto.Node, nodeID string) bool {
+	for _, node := range nodes {
+		if node.Id == nodeID {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
When an application has an non existing application defined as
dependency, the topology component in the React UI crashed. To avoid
this we loop through all edges, when we have collected all data for the
topology chart and remove all edges, which do not contain a valid source
or target.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
