### PR TITLE
✨ add resource overview tab with metadata, spec and status description

### DIFF
--- a/app/src/components/resources/MetaDataDescriptionList.tsx
+++ b/app/src/components/resources/MetaDataDescriptionList.tsx
@@ -1,0 +1,75 @@
+import {
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  SimpleList,
+  SimpleListItem,
+} from '@patternfly/react-core';
+import React, { memo } from 'react';
+
+import { timeDifference } from 'utils/helpers';
+
+export interface IMetadata {
+  annotations?: Record<string, string>;
+  creationTimestamp: string;
+  labels?: Record<string, string>;
+  name: string;
+  namespace: string;
+}
+
+export interface IMetaDataDescriptionListProps {
+  metadata: IMetadata;
+}
+
+interface IObjectEntryListProps {
+  object: Record<string, string>;
+}
+
+const ObjectEntryList = ({ object }: IObjectEntryListProps): JSX.Element => {
+  return (
+    <SimpleList>
+      {Object.entries(object).map(([key, value]: string[]) => {
+        return (
+          <SimpleListItem key={`${key}: ${value}`}>
+            <b>{key}: </b>
+            {value}
+          </SimpleListItem>
+        );
+      })}
+    </SimpleList>
+  );
+};
+
+export default memo(function metaDataDescriptionList({ metadata }: IMetaDataDescriptionListProps): JSX.Element {
+  return (
+    <DescriptionList>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Name</DescriptionListTerm>
+        <DescriptionListDescription>{metadata.name}</DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Namespace</DescriptionListTerm>
+        <DescriptionListDescription>{metadata.namespace}</DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Labels</DescriptionListTerm>
+        <DescriptionListDescription>
+          {metadata.labels ? <ObjectEntryList object={metadata.labels} /> : '-'}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Annotations</DescriptionListTerm>
+        <DescriptionListDescription>
+          {metadata.annotations ? <ObjectEntryList object={metadata.annotations} /> : '-'}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Age</DescriptionListTerm>
+        <DescriptionListDescription>
+          {timeDifference(new Date().getTime(), new Date(metadata.creationTimestamp.toString()).getTime())}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+    </DescriptionList>
+  );
+});

--- a/app/src/components/resources/ResourceDetails.tsx
+++ b/app/src/components/resources/ResourceDetails.tsx
@@ -17,6 +17,9 @@ import {
   TabTitleText,
   Tabs,
 } from '@patternfly/react-core';
+
+import { ResourceOverview } from './ResourceOverview';
+
 import React, { useContext, useState } from 'react';
 import { TopologyIcon, UsersIcon } from '@patternfly/react-icons';
 import { IRow } from '@patternfly/react-table';
@@ -84,7 +87,8 @@ const ResourceDetails: React.FunctionComponent<IResourceDetailsProps> = ({
   resource,
   close,
 }: IResourceDetailsProps) => {
-  const [activeTab, setActiveTab] = useState<string>('yaml');
+  const [activeTab, setActiveTab] = useState<string>('overview');
+
   const pluginsContext = useContext<IPluginsContext>(PluginsContext);
 
   let applications: IApplications[] = [];
@@ -226,6 +230,9 @@ const ResourceDetails: React.FunctionComponent<IResourceDetailsProps> = ({
           isFilled={true}
           mountOnEnter={true}
         >
+          <Tab eventKey="overview" title={<TabTitleText>Overview</TabTitleText>}>
+            <ResourceOverview resource={resource} />
+          </Tab>
           <Tab eventKey="yaml" title={<TabTitleText>Yaml</TabTitleText>}>
             <div style={{ maxWidth: '100%', overflowX: 'scroll', padding: '24px 24px' }}>
               <Card>

--- a/app/src/components/resources/ResourceOverview.tsx
+++ b/app/src/components/resources/ResourceOverview.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+
+import { Tab, TabTitleText, Tabs } from '@patternfly/react-core';
+import { IRow } from '@patternfly/react-table';
+import MetaDataDescriptionList from './MetaDataDescriptionList';
+
+interface IResourceOverviewProps {
+  resource: IRow;
+}
+
+export const ResourceOverview = ({ resource }: IResourceOverviewProps): JSX.Element => {
+  const [activeSubTab, setActiveSubTab] = useState<string>('metadata');
+
+  return (
+    <Tabs
+      activeKey={activeSubTab}
+      isSecondary
+      onSelect={(event, tabIndex: number | string): void => setActiveSubTab(tabIndex.toString())}
+    >
+      <Tab eventKey="metadata" title={<TabTitleText>metadata</TabTitleText>}>
+        <div style={{ maxWidth: '100%', overflowX: 'scroll', padding: '24px 24px' }}>
+          <MetaDataDescriptionList metadata={resource.props.metadata} />
+        </div>
+      </Tab>
+    </Tabs>
+  );
+};


### PR DESCRIPTION
This PR adds an overview tab to the resource details drawer. The idea is to present resource metadata in a more digestible way than "just" showing the raw yaml. 

TODO's:
- [x] sub-tab for the metadata to the overview tab
- [ ] add a sub-tab for the specs to the overview tab
- [ ] add a sub-tab for the status to the overview tab
- [ ] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
