### PR TITLE
Add overview and Pods tab for resource details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#32](https://github.com/kobsio/kobs/pull/32): Add support for container logs via the Kubernetes API.
 - [#34](https://github.com/kobsio/kobs/pull/34): Add a new Custom Resource Definition for Teams. Teams can be used to define the ownership for Applications and other Kubernetes resources. :warning: *Breaking change:* :warning: We are now using the `apiextensions.k8s.io/v1` API for the Custom Resource Definitions of kobs.
 - [#39](https://github.com/kobsio/kobs/pull/39): Add Opsgenie plugin to view alerts within an Application.
-- [#40](https://github.com/kobsio/kobs/pull/39): Prometheus plugin metric name suggestions.
+- [#40](https://github.com/kobsio/kobs/pull/40): Add metric name suggestions for Prometheus plugin.
+- [#41](https://github.com/kobsio/kobs/pull/41): Add overview and Pods tab for resource details.
 
 ### Fixed
 

--- a/app/src/components/resources/ResourceDetails.tsx
+++ b/app/src/components/resources/ResourceDetails.tsx
@@ -31,6 +31,8 @@ import { Plugin as IPlugin } from 'proto/plugins_grpc_web_pb';
 import Plugin from 'components/plugins/Plugin';
 import ResourceEvents from 'components/resources/ResourceEvents';
 import ResourceLogs from 'components/resources/ResourceLogs';
+import ResourceOverview from 'components/resources/ResourceOverview';
+import ResourcePods from 'components/resources/ResourcePods';
 import Title from 'components/Title';
 import { plugins as pluginsDefinition } from 'utils/plugins';
 
@@ -65,6 +67,27 @@ const interpolate = (str: string, resource: any, interpolator: string[] = ['<<',
     .join('');
 };
 
+// getSelector is used to get the label selector for various resources as string. The returned string can be used in
+// a Kubernetes API request to get the all pods, which are matching the label selector.
+const getSelector = (resource: IRow): string => {
+  if (resource.props && resource.props.apiVersion && resource.props.kind) {
+    if (
+      (resource.props.apiVersion === 'apps/v1' && resource.props.kind === 'Deployment') ||
+      (resource.props.apiVersion === 'apps/v1' && resource.props.kind === 'DaemonSet') ||
+      (resource.props.apiVersion === 'apps/v1' && resource.props.kind === 'StatefulSet') ||
+      (resource.props.apiVersion === 'batch/v1' && resource.props.kind === 'Job')
+    ) {
+      return resource.props?.spec?.selector?.matchLabels
+        ? Object.keys(resource.props.spec.selector.matchLabels)
+            .map((key) => `${key}=${resource.props.spec.selector.matchLabels[key]}`)
+            .join(',')
+        : '';
+    }
+  }
+
+  return '';
+};
+
 interface IApplications {
   namespace?: string;
   name: string;
@@ -84,8 +107,10 @@ const ResourceDetails: React.FunctionComponent<IResourceDetailsProps> = ({
   resource,
   close,
 }: IResourceDetailsProps) => {
-  const [activeTab, setActiveTab] = useState<string>('yaml');
+  const [activeTab, setActiveTab] = useState<string>('overview');
   const pluginsContext = useContext<IPluginsContext>(PluginsContext);
+
+  const podSelector = getSelector(resource);
 
   let applications: IApplications[] = [];
   let teams: string[] = [];
@@ -226,6 +251,12 @@ const ResourceDetails: React.FunctionComponent<IResourceDetailsProps> = ({
           isFilled={true}
           mountOnEnter={true}
         >
+          <Tab eventKey="overview" title={<TabTitleText>Overview</TabTitleText>}>
+            <div style={{ maxWidth: '100%', overflowX: 'scroll', padding: '24px 24px' }}>
+              <ResourceOverview resource={resource} />
+            </div>
+          </Tab>
+
           <Tab eventKey="yaml" title={<TabTitleText>Yaml</TabTitleText>}>
             <div style={{ maxWidth: '100%', overflowX: 'scroll', padding: '24px 24px' }}>
               <Card>
@@ -233,6 +264,7 @@ const ResourceDetails: React.FunctionComponent<IResourceDetailsProps> = ({
               </Card>
             </div>
           </Tab>
+
           <Tab eventKey="events" title={<TabTitleText>Events</TabTitleText>}>
             <div style={{ maxWidth: '100%', overflowX: 'scroll', padding: '24px 24px' }}>
               <ResourceEvents
@@ -251,6 +283,18 @@ const ResourceDetails: React.FunctionComponent<IResourceDetailsProps> = ({
                   namespace={resource.namespace ? resource.namespace.title : ''}
                   name={resource.name.title}
                   pod={resource.props}
+                />
+              </div>
+            </Tab>
+          ) : null}
+
+          {podSelector ? (
+            <Tab eventKey="pods" title={<TabTitleText>Pods</TabTitleText>}>
+              <div style={{ maxWidth: '100%', overflowX: 'scroll', padding: '24px 24px' }}>
+                <ResourcePods
+                  cluster={resource.cluster.title}
+                  namespace={resource.namespace ? resource.namespace.title : ''}
+                  selector={podSelector}
                 />
               </div>
             </Tab>

--- a/app/src/components/resources/ResourceOverview.tsx
+++ b/app/src/components/resources/ResourceOverview.tsx
@@ -1,0 +1,152 @@
+import {
+  Card,
+  CardBody,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+} from '@patternfly/react-core';
+import { IRow } from '@patternfly/react-table';
+import React from 'react';
+import { V1OwnerReference } from '@kubernetes/client-node';
+
+import Conditions from 'components/resources/overview/Conditions';
+import CronJob from 'components/resources/overview/CronJob';
+import DaemonSet from 'components/resources/overview/DaemonSet';
+import Deployment from 'components/resources/overview/Deployment';
+import Job from 'components/resources/overview/Job';
+import Pod from 'components/resources/overview/Pod';
+import StatefulSet from 'components/resources/overview/StatefulSet';
+import { timeDifference } from 'utils/helpers';
+
+interface IResourceOverviewProps {
+  resource: IRow;
+}
+
+// ResourceOverview is the overview tab for a resource. It shows the metadata of a resource in a clear way. We can also
+// add some additional fields on a per resource basis.
+const ResourceOverview: React.FunctionComponent<IResourceOverviewProps> = ({ resource }: IResourceOverviewProps) => {
+  // additions contains a React component with additional details for a resource. The default component just renders the
+  // conditions of a resource.
+  let additions =
+    resource.props && resource.props.status && resource.props.status.conditions ? (
+      <Conditions conditions={resource.props.status.conditions} />
+    ) : null;
+
+  // Overwrite the additions for several resources.
+  if (resource.props && resource.props.apiVersion && resource.props.kind) {
+    if (resource.props.apiVersion === 'v1' && resource.props.kind === 'Pod') {
+      additions = <Pod pod={resource.props} />;
+    } else if (resource.props.apiVersion === 'apps/v1' && resource.props.kind === 'Deployment') {
+      additions = (
+        <Deployment
+          cluster={resource.cluster?.title}
+          namespace={resource.namespace?.title}
+          deployment={resource.props}
+        />
+      );
+    } else if (resource.props.apiVersion === 'apps/v1' && resource.props.kind === 'DaemonSet') {
+      additions = (
+        <DaemonSet cluster={resource.cluster?.title} namespace={resource.namespace?.title} daemonSet={resource.props} />
+      );
+    } else if (resource.props.apiVersion === 'apps/v1' && resource.props.kind === 'StatefulSet') {
+      additions = (
+        <StatefulSet
+          cluster={resource.cluster?.title}
+          namespace={resource.namespace?.title}
+          statefulSet={resource.props}
+        />
+      );
+    } else if (resource.props.apiVersion === 'batch/v1beta1' && resource.props.kind === 'CronJob') {
+      additions = <CronJob cronJob={resource.props} />;
+    } else if (resource.props.apiVersion === 'batch/v1' && resource.props.kind === 'Job') {
+      additions = <Job cluster={resource.cluster?.title} namespace={resource.namespace?.title} job={resource.props} />;
+    }
+  }
+
+  return (
+    <Card isCompact={true}>
+      <CardBody>
+        <DescriptionList isHorizontal={true}>
+          {resource.name?.title && (
+            <DescriptionListGroup>
+              <DescriptionListTerm>Name</DescriptionListTerm>
+              <DescriptionListDescription>{resource.name?.title}</DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
+          {resource.namespace?.title && (
+            <DescriptionListGroup>
+              <DescriptionListTerm>Namespace</DescriptionListTerm>
+              <DescriptionListDescription>{resource.namespace?.title}</DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
+          {resource.cluster?.title && (
+            <DescriptionListGroup>
+              <DescriptionListTerm>Cluster</DescriptionListTerm>
+              <DescriptionListDescription>{resource.cluster?.title}</DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
+          {resource.props?.metadata?.labels && (
+            <DescriptionListGroup>
+              <DescriptionListTerm>Labels</DescriptionListTerm>
+              <DescriptionListDescription>
+                {Object.keys(resource.props?.metadata?.labels).map((key) => (
+                  <div key={key} className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+                    <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+                      {key}: {resource.props?.metadata?.labels[key]}
+                    </span>
+                  </div>
+                ))}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
+          {resource.props?.metadata?.annotations && (
+            <DescriptionListGroup>
+              <DescriptionListTerm>Annotations</DescriptionListTerm>
+              <DescriptionListDescription>
+                {Object.keys(resource.props?.metadata?.annotations).map((key) => (
+                  <div key={key} className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+                    <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+                      {key}: {resource.props?.metadata?.annotations[key]}
+                    </span>
+                  </div>
+                ))}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
+          {resource.props?.metadata?.creationTimestamp && (
+            <DescriptionListGroup>
+              <DescriptionListTerm>Age</DescriptionListTerm>
+              <DescriptionListDescription>
+                {timeDifference(
+                  new Date().getTime(),
+                  new Date(resource.props.metadata.creationTimestamp.toString()).getTime(),
+                )}
+                <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">
+                  ({resource.props.metadata.creationTimestamp})
+                </span>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
+          {resource.props?.metadata?.ownerReferences && (
+            <DescriptionListGroup>
+              <DescriptionListTerm>Crontrolled By</DescriptionListTerm>
+              <DescriptionListDescription>
+                {resource.props?.metadata?.ownerReferences.map((owner: V1OwnerReference, index: number) => (
+                  <div key={index}>
+                    {owner.kind}
+                    <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">({owner.name})</span>
+                  </div>
+                ))}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
+
+          {additions}
+        </DescriptionList>
+      </CardBody>
+    </Card>
+  );
+};
+
+export default ResourceOverview;

--- a/app/src/components/resources/ResourcePods.tsx
+++ b/app/src/components/resources/ResourcePods.tsx
@@ -1,0 +1,76 @@
+import { Card, Flex, FlexItem } from '@patternfly/react-core';
+import { IRow, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { ClustersPromiseClient, GetResourcesRequest, GetResourcesResponse } from 'proto/clusters_grpc_web_pb';
+import { emptyState, resources } from 'utils/resources';
+import { apiURL } from 'utils/constants';
+
+// clustersService is the Clusters gRPC service, which is used to get a list of pods.
+const clustersService = new ClustersPromiseClient(apiURL, null, null);
+
+interface IResourcePodsProps {
+  cluster: string;
+  namespace: string;
+  selector: string;
+}
+
+// ResourcePods is the pods tab for various resources. It can be used to show the pods for a deployment, statefulset,
+// etc. within the tabs.
+const ResourcePods: React.FunctionComponent<IResourcePodsProps> = ({
+  cluster,
+  namespace,
+  selector,
+}: IResourcePodsProps) => {
+  const [pods, setPods] = useState<IRow[]>(emptyState(resources.pods.columns.length, ''));
+
+  // fetchPods fetches the pods for the given cluster, namespace and label selector.
+  const fetchPods = useCallback(async () => {
+    try {
+      const getResourcesRequest = new GetResourcesRequest();
+      getResourcesRequest.setClustersList([cluster]);
+      getResourcesRequest.setNamespacesList([namespace]);
+      getResourcesRequest.setPath(resources.pods.path);
+      getResourcesRequest.setResource(resources.pods.resource);
+      getResourcesRequest.setParamname('labelSelector');
+      getResourcesRequest.setParam(selector);
+
+      const getResourcesResponse: GetResourcesResponse = await clustersService.getResources(getResourcesRequest, null);
+      const resourceList = getResourcesResponse.getResourcesList();
+
+      if (resourceList.length === 1) {
+        setPods(resources.pods.rows(resourceList));
+      } else {
+        setPods(emptyState(resources.pods.columns.length, ''));
+      }
+    } catch (err) {
+      setPods(emptyState(resources.pods.columns.length, err.message));
+    }
+  }, [cluster, namespace, selector]);
+
+  useEffect(() => {
+    fetchPods();
+  }, [fetchPods]);
+
+  return (
+    <Card>
+      <Flex direction={{ default: 'column' }}>
+        <FlexItem>
+          <Table
+            aria-label="pods"
+            variant="compact"
+            borders={false}
+            isStickyHeader={false}
+            cells={resources.pods.columns}
+            rows={pods}
+          >
+            <TableHeader />
+            <TableBody />
+          </Table>
+        </FlexItem>
+      </Flex>
+    </Card>
+  );
+};
+
+export default ResourcePods;

--- a/app/src/components/resources/ResourcesToolbar.tsx
+++ b/app/src/components/resources/ResourcesToolbar.tsx
@@ -17,18 +17,27 @@ import ToolbarItemNamespaces from 'components/resources/ToolbarItemNamespaces';
 import ToolbarItemResources from 'components/resources/ToolbarItemResources';
 
 interface IResourcesToolbarProps {
+  resources: IResources;
   setResources: (resources: IResources) => void;
 }
 
 // ResourcesToolbar is the toolbar where the user can select a list of clusters, namespaces and resource. When the user
 // clicks the search button the setResources function is called with the selected clusters, namespaces and resources.
 const ResourcesToolbar: React.FunctionComponent<IResourcesToolbarProps> = ({
+  resources,
   setResources,
 }: IResourcesToolbarProps) => {
+  const initialResources = resources.resources.length === 1 ? resources.resources[0] : undefined;
   const clustersContext = useContext<IClusterContext>(ClustersContext);
-  const [selectedClusters, setSelectedClusters] = useState<string[]>([clustersContext.clusters[0]]);
-  const [selectedResources, setSelectedResources] = useState<string[]>([]);
-  const [selectedNamespaces, setSelectedNamespaces] = useState<string[]>([]);
+  const [selectedClusters, setSelectedClusters] = useState<string[]>(
+    resources.clusters.length > 0 ? resources.clusters : [clustersContext.clusters[0]],
+  );
+  const [selectedResources, setSelectedResources] = useState<string[]>(
+    initialResources ? initialResources.kindsList : [],
+  );
+  const [selectedNamespaces, setSelectedNamespaces] = useState<string[]>(
+    initialResources ? initialResources.namespacesList : [],
+  );
 
   // selectCluster adds/removes the given cluster to the list of selected clusters. When the cluster value is an empty
   // string the selected clusters list is cleared.

--- a/app/src/components/resources/overview/Conditions.tsx
+++ b/app/src/components/resources/overview/Conditions.tsx
@@ -1,0 +1,59 @@
+import { DescriptionListDescription, DescriptionListGroup, DescriptionListTerm, Tooltip } from '@patternfly/react-core';
+import {
+  V1DeploymentCondition,
+  V1JobCondition,
+  V1NodeCondition,
+  V1PersistentVolumeClaimCondition,
+  V1PodCondition,
+  V1ReplicaSetCondition,
+  V1ReplicationControllerCondition,
+  V1StatefulSetCondition,
+} from '@kubernetes/client-node';
+import React from 'react';
+
+export type TCondition =
+  | V1DeploymentCondition
+  | V1JobCondition
+  | V1NodeCondition
+  | V1PodCondition
+  | V1PersistentVolumeClaimCondition
+  | V1ReplicaSetCondition
+  | V1ReplicationControllerCondition
+  | V1StatefulSetCondition;
+
+interface IConditionsProps {
+  conditions: TCondition[];
+}
+
+const Conditions: React.FunctionComponent<IConditionsProps> = ({ conditions }: IConditionsProps) => {
+  return (
+    <DescriptionListGroup>
+      <DescriptionListTerm>Conditions</DescriptionListTerm>
+      <DescriptionListDescription>
+        {conditions.map(
+          (condition, index) =>
+            condition.status === 'True' && (
+              <Tooltip
+                key={index}
+                content={
+                  <div>
+                    {condition.lastTransitionTime}
+                    {condition.reason ? ` - ${condition.reason}` : ''}
+                    {condition.message ? <div>{condition.message}</div> : ''}
+                  </div>
+                }
+              >
+                <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+                  <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+                    {condition.type}
+                  </span>
+                </div>
+              </Tooltip>
+            ),
+        )}
+      </DescriptionListDescription>
+    </DescriptionListGroup>
+  );
+};
+
+export default Conditions;

--- a/app/src/components/resources/overview/Container.tsx
+++ b/app/src/components/resources/overview/Container.tsx
@@ -1,0 +1,189 @@
+import { DescriptionListDescription, DescriptionListGroup, DescriptionListTerm, Title } from '@patternfly/react-core';
+import { V1Container, V1ContainerState, V1ContainerStatus, V1EnvVarSource, V1Probe } from '@kubernetes/client-node';
+import React from 'react';
+
+const getContainerStatus = (state: V1ContainerState): string => {
+  if (state.running) {
+    return `Started at ${state.running.startedAt}`;
+  } else if (state.waiting) {
+    return `Waiting: ${state.waiting.message}`;
+  } else if (state.terminated) {
+    return `Terminated with ${state.terminated.exitCode} at ${state.terminated.finishedAt}: ${state.terminated.reason}`;
+  }
+
+  return 'Indeterminate';
+};
+
+const getValueFrom = (valueFrom: V1EnvVarSource): string => {
+  if (valueFrom.configMapKeyRef) {
+    return `configMapKeyRef(${valueFrom.configMapKeyRef.name}: ${valueFrom.configMapKeyRef.key})`;
+  }
+
+  if (valueFrom.fieldRef) {
+    return `fieldRef(${valueFrom.fieldRef.apiVersion}: ${valueFrom.fieldRef.fieldPath})`;
+  }
+
+  if (valueFrom.secretKeyRef) {
+    return `secretKeyRef(${valueFrom.secretKeyRef.name}: ${valueFrom.secretKeyRef.key})`;
+  }
+
+  return '-';
+};
+
+const getPrope = (title: string, probe: V1Probe): JSX.Element => {
+  return (
+    <DescriptionListGroup>
+      <DescriptionListTerm>{title}</DescriptionListTerm>
+      <DescriptionListDescription>
+        {probe.exec && (
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              {probe.exec.command?.join(' ')}
+            </span>
+          </div>
+        )}
+        {probe.httpGet && (
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              {probe.httpGet.scheme?.toLowerCase()}://
+              {probe.httpGet.host}:{probe.httpGet.port}
+              {probe.httpGet.path}
+            </span>
+          </div>
+        )}
+        {probe.initialDelaySeconds && (
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              delay={probe.initialDelaySeconds}s
+            </span>
+          </div>
+        )}
+        {probe.timeoutSeconds && (
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              timeout={probe.timeoutSeconds}s
+            </span>
+          </div>
+        )}
+        {probe.periodSeconds && (
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              period={probe.periodSeconds}s
+            </span>
+          </div>
+        )}
+        {probe.successThreshold && (
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              #success={probe.successThreshold}
+            </span>
+          </div>
+        )}
+        {probe.failureThreshold && (
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              #failure={probe.failureThreshold}
+            </span>
+          </div>
+        )}
+      </DescriptionListDescription>
+    </DescriptionListGroup>
+  );
+};
+
+interface IContainerProps {
+  container: V1Container;
+  containerStatus?: V1ContainerStatus;
+}
+
+const Container: React.FunctionComponent<IContainerProps> = ({ container, containerStatus }: IContainerProps) => {
+  return (
+    <React.Fragment>
+      <Title headingLevel="h4" size="lg">
+        {container.name}
+      </Title>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Status</DescriptionListTerm>
+        <DescriptionListDescription>
+          {containerStatus && containerStatus.state ? getContainerStatus(containerStatus.state) : '-'}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Ready</DescriptionListTerm>
+        <DescriptionListDescription>
+          {containerStatus && containerStatus.ready ? 'True' : 'False'}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Image</DescriptionListTerm>
+        <DescriptionListDescription>{container.image}</DescriptionListDescription>
+      </DescriptionListGroup>
+      {container.command && (
+        <DescriptionListGroup>
+          <DescriptionListTerm>Command</DescriptionListTerm>
+          <DescriptionListDescription>{container.command}</DescriptionListDescription>
+        </DescriptionListGroup>
+      )}
+      {container.command && (
+        <DescriptionListGroup>
+          <DescriptionListTerm>Command</DescriptionListTerm>
+          <DescriptionListDescription>{container.command.join(' ')}</DescriptionListDescription>
+        </DescriptionListGroup>
+      )}
+      {container.args && (
+        <DescriptionListGroup>
+          <DescriptionListTerm>Command</DescriptionListTerm>
+          <DescriptionListDescription>{container.args.join(' ')}</DescriptionListDescription>
+        </DescriptionListGroup>
+      )}
+      {container.ports && (
+        <DescriptionListGroup>
+          <DescriptionListTerm>Ports</DescriptionListTerm>
+          <DescriptionListDescription>
+            {container.ports.map((port, index) => (
+              <div key={index} className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+                <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+                  {port.containerPort}
+                  {port.protocol ? `/${port.protocol}` : ''}
+                  {port.name ? ` (${port.name})` : ''}
+                </span>
+              </div>
+            ))}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      )}
+      {container.env && (
+        <DescriptionListGroup>
+          <DescriptionListTerm>Environment</DescriptionListTerm>
+          <DescriptionListDescription>
+            {container.env.map((env, index) => (
+              <div key={index}>
+                {env.name}:
+                <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">
+                  {env.value ? env.value : env.valueFrom ? getValueFrom(env.valueFrom) : '-'}
+                </span>
+              </div>
+            ))}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      )}
+      {container.volumeMounts && (
+        <DescriptionListGroup>
+          <DescriptionListTerm>Mounts</DescriptionListTerm>
+          <DescriptionListDescription>
+            {container.volumeMounts.map((mount, index) => (
+              <div key={index}>
+                {mount.name}:<span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">{mount.mountPath}</span>
+              </div>
+            ))}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      )}
+      {container.livenessProbe && getPrope('Liveness Probe', container.livenessProbe)}
+      {container.readinessProbe && getPrope('Readiness Probe', container.readinessProbe)}
+      {container.startupProbe && getPrope('Startup Probe', container.startupProbe)}
+    </React.Fragment>
+  );
+};
+
+export default Container;

--- a/app/src/components/resources/overview/CronJob.tsx
+++ b/app/src/components/resources/overview/CronJob.tsx
@@ -1,0 +1,56 @@
+import { DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from '@patternfly/react-core';
+import React from 'react';
+import { V1beta1CronJob } from '@kubernetes/client-node';
+
+import { timeDifference } from 'utils/helpers';
+
+interface ICronJobProps {
+  cronJob: V1beta1CronJob;
+}
+
+const CronJob: React.FunctionComponent<ICronJobProps> = ({ cronJob }: ICronJobProps) => {
+  return (
+    <React.Fragment>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Schedule</DescriptionListTerm>
+        <DescriptionListDescription>{cronJob.spec?.schedule ? cronJob.spec?.schedule : '-'}</DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Suspend</DescriptionListTerm>
+        <DescriptionListDescription>{cronJob.spec?.suspend ? 'True' : 'False'}</DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>History Limit</DescriptionListTerm>
+        <DescriptionListDescription>
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              success={cronJob.spec?.successfulJobsHistoryLimit ? cronJob.spec?.successfulJobsHistoryLimit : 0}
+            </span>
+          </div>
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              failed={cronJob.spec?.failedJobsHistoryLimit ? cronJob.spec?.failedJobsHistoryLimit : 0}
+            </span>
+          </div>
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Active</DescriptionListTerm>
+        <DescriptionListDescription>{cronJob.status?.active ? 'True' : 'False'}</DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Last Schedule</DescriptionListTerm>
+        {cronJob.status?.lastScheduleTime ? (
+          <DescriptionListDescription>
+            {timeDifference(new Date().getTime(), new Date(cronJob.status.lastScheduleTime.toString()).getTime())}
+            <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">({cronJob.status.lastScheduleTime})</span>
+          </DescriptionListDescription>
+        ) : (
+          <DescriptionListDescription>-</DescriptionListDescription>
+        )}
+      </DescriptionListGroup>
+    </React.Fragment>
+  );
+};
+
+export default CronJob;

--- a/app/src/components/resources/overview/DaemonSet.tsx
+++ b/app/src/components/resources/overview/DaemonSet.tsx
@@ -1,0 +1,71 @@
+import { DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from '@patternfly/react-core';
+import React from 'react';
+import { V1DaemonSet } from '@kubernetes/client-node';
+
+import Conditions from 'components/resources/overview/Conditions';
+import Selector from 'components/resources/overview/Selector';
+
+interface IDaemonSetProps {
+  cluster: string;
+  namespace: string;
+  daemonSet: V1DaemonSet;
+}
+
+const DaemonSet: React.FunctionComponent<IDaemonSetProps> = ({ cluster, namespace, daemonSet }: IDaemonSetProps) => {
+  return (
+    <React.Fragment>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Replicas</DescriptionListTerm>
+        <DescriptionListDescription>
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              {daemonSet.status?.desiredNumberScheduled ? daemonSet.status?.desiredNumberScheduled : 0} desired
+            </span>
+          </div>
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              {daemonSet.status?.currentNumberScheduled ? daemonSet.status?.currentNumberScheduled : 0} current
+            </span>
+          </div>
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              {daemonSet.status?.numberMisscheduled ? daemonSet.status?.numberMisscheduled : 0} misscheduled
+            </span>
+          </div>
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              {daemonSet.status?.numberReady ? daemonSet.status?.numberReady : 0} ready
+            </span>
+          </div>
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              {daemonSet.status?.updatedNumberScheduled ? daemonSet.status?.updatedNumberScheduled : 0} updated
+            </span>
+          </div>
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              {daemonSet.status?.numberAvailable ? daemonSet.status?.numberAvailable : 0} available
+            </span>
+          </div>
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              {daemonSet.status?.numberUnavailable ? daemonSet.status?.numberUnavailable : 0} unavailable
+            </span>
+          </div>
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      {daemonSet.spec?.updateStrategy?.type && (
+        <DescriptionListGroup>
+          <DescriptionListTerm>Strategy</DescriptionListTerm>
+          <DescriptionListDescription>{daemonSet.spec.updateStrategy.type}</DescriptionListDescription>
+        </DescriptionListGroup>
+      )}
+      {daemonSet.spec?.selector && (
+        <Selector cluster={cluster} namespace={namespace} selector={daemonSet.spec.selector} />
+      )}
+      {daemonSet.status?.conditions && <Conditions conditions={daemonSet.status.conditions} />}
+    </React.Fragment>
+  );
+};
+
+export default DaemonSet;

--- a/app/src/components/resources/overview/Deployment.tsx
+++ b/app/src/components/resources/overview/Deployment.tsx
@@ -1,0 +1,65 @@
+import { DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from '@patternfly/react-core';
+import React from 'react';
+import { V1Deployment } from '@kubernetes/client-node';
+
+import Conditions from 'components/resources/overview/Conditions';
+import Selector from 'components/resources/overview/Selector';
+
+interface IDeploymentProps {
+  cluster: string;
+  namespace: string;
+  deployment: V1Deployment;
+}
+
+const Deployment: React.FunctionComponent<IDeploymentProps> = ({
+  cluster,
+  namespace,
+  deployment,
+}: IDeploymentProps) => {
+  return (
+    <React.Fragment>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Replicas</DescriptionListTerm>
+        <DescriptionListDescription>
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              {deployment.status?.replicas ? deployment.status?.replicas : 0} desired
+            </span>
+          </div>
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              {deployment.status?.updatedReplicas ? deployment.status?.updatedReplicas : 0} updated
+            </span>
+          </div>
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              {deployment.status?.readyReplicas ? deployment.status?.readyReplicas : 0} ready
+            </span>
+          </div>
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              {deployment.status?.availableReplicas ? deployment.status?.availableReplicas : 0} available
+            </span>
+          </div>
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              {deployment.status?.unavailableReplicas ? deployment.status?.unavailableReplicas : 0} unavailable
+            </span>
+          </div>
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      {deployment.spec?.strategy?.type && (
+        <DescriptionListGroup>
+          <DescriptionListTerm>Strategy</DescriptionListTerm>
+          <DescriptionListDescription>{deployment.spec.strategy.type}</DescriptionListDescription>
+        </DescriptionListGroup>
+      )}
+      {deployment.spec?.selector && (
+        <Selector cluster={cluster} namespace={namespace} selector={deployment.spec.selector} />
+      )}
+      {deployment.status?.conditions && <Conditions conditions={deployment.status.conditions} />}
+    </React.Fragment>
+  );
+};
+
+export default Deployment;

--- a/app/src/components/resources/overview/Job.tsx
+++ b/app/src/components/resources/overview/Job.tsx
@@ -1,0 +1,54 @@
+import { DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from '@patternfly/react-core';
+import React from 'react';
+import { V1Job } from '@kubernetes/client-node';
+
+import Conditions from 'components/resources/overview/Conditions';
+import Selector from 'components/resources/overview/Selector';
+
+interface IJobProps {
+  cluster: string;
+  namespace: string;
+  job: V1Job;
+}
+
+const Job: React.FunctionComponent<IJobProps> = ({ cluster, namespace, job }: IJobProps) => {
+  return (
+    <React.Fragment>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Completions</DescriptionListTerm>
+        <DescriptionListDescription>{job.spec?.completions ? job.spec?.completions : 0}</DescriptionListDescription>
+      </DescriptionListGroup>
+
+      <DescriptionListGroup>
+        <DescriptionListTerm>Backoff Limit</DescriptionListTerm>
+        <DescriptionListDescription>{job.spec?.backoffLimit ? job.spec?.backoffLimit : 0}</DescriptionListDescription>
+      </DescriptionListGroup>
+
+      <DescriptionListGroup>
+        <DescriptionListTerm>Active</DescriptionListTerm>
+        <DescriptionListDescription>{job.status?.active ? 'True' : 'False'}</DescriptionListDescription>
+      </DescriptionListGroup>
+
+      <DescriptionListGroup>
+        <DescriptionListTerm>Status</DescriptionListTerm>
+        <DescriptionListDescription>
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              succeeded={job.status?.succeeded ? job.status?.succeeded : 0}
+            </span>
+          </div>
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              failed={job.status?.failed ? job.status?.failed : 0}
+            </span>
+          </div>
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+
+      {job.spec?.selector && <Selector cluster={cluster} namespace={namespace} selector={job.spec.selector} />}
+      {job.status?.conditions && <Conditions conditions={job.status.conditions} />}
+    </React.Fragment>
+  );
+};
+
+export default Job;

--- a/app/src/components/resources/overview/Pod.tsx
+++ b/app/src/components/resources/overview/Pod.tsx
@@ -1,0 +1,144 @@
+import { DescriptionListDescription, DescriptionListGroup, DescriptionListTerm, Tooltip } from '@patternfly/react-core';
+import { V1ContainerStatus, V1Pod } from '@kubernetes/client-node';
+import React from 'react';
+import yaml from 'js-yaml';
+
+import Conditions from 'components/resources/overview/Conditions';
+import Container from 'components/resources/overview/Container';
+
+const getContainerStatus = (name: string, status?: V1ContainerStatus[]): V1ContainerStatus | undefined => {
+  if (!status) {
+    return undefined;
+  }
+
+  for (const s of status) {
+    if (s.name === name) {
+      return s;
+    }
+  }
+
+  return undefined;
+};
+
+interface IPodProps {
+  pod: V1Pod;
+}
+
+const Pod: React.FunctionComponent<IPodProps> = ({ pod }: IPodProps) => {
+  const phase = pod.status && pod.status.phase ? pod.status.phase : 'Unknown';
+  let reason = pod.status && pod.status.reason ? pod.status.reason : '';
+  let shouldReady = 0;
+  let isReady = 0;
+  let restarts = 0;
+
+  if (pod.status && pod.status.containerStatuses) {
+    for (const container of pod.status.containerStatuses) {
+      shouldReady = shouldReady + 1;
+      if (container.ready) {
+        isReady = isReady + 1;
+      }
+
+      restarts = restarts + container.restartCount;
+
+      if (container.state && container.state.waiting) {
+        reason = container.state.waiting.reason ? container.state.waiting.reason : '';
+        break;
+      }
+
+      if (container.state && container.state.terminated) {
+        reason = container.state.terminated.reason ? container.state.terminated.reason : '';
+        break;
+      }
+    }
+  }
+
+  return (
+    <React.Fragment>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Ready</DescriptionListTerm>
+        <DescriptionListDescription>
+          {isReady}/{shouldReady}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Restarts</DescriptionListTerm>
+        <DescriptionListDescription>{restarts}</DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Status</DescriptionListTerm>
+        <DescriptionListDescription>{reason ? reason : phase}</DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Priority Class</DescriptionListTerm>
+        <DescriptionListDescription>
+          {pod.spec && pod.spec.priorityClassName ? pod.spec.priorityClassName : '-'}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>QoS Class</DescriptionListTerm>
+        <DescriptionListDescription>
+          {pod.status && pod.status.qosClass ? pod.status.qosClass : '-'}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Node</DescriptionListTerm>
+        <DescriptionListDescription>{pod.spec?.nodeName ? pod.spec.nodeName : '-'}</DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Tolerations</DescriptionListTerm>
+        <DescriptionListDescription>
+          {pod.spec && pod.spec.tolerations ? (
+            <Tooltip
+              content={
+                <div>
+                  {pod.spec.tolerations.map((toleration, index) => (
+                    <div key={index}>{yaml.dump(toleration)}</div>
+                  ))}
+                </div>
+              }
+            >
+              <span>{pod.spec.tolerations.length}</span>
+            </Tooltip>
+          ) : (
+            0
+          )}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Affinities</DescriptionListTerm>
+        <DescriptionListDescription>
+          {pod.spec && pod.spec.affinity ? (
+            <Tooltip
+              content={
+                <div>
+                  <div>{yaml.dump(pod.spec.affinity)}</div>
+                </div>
+              }
+            >
+              <span>Yes</span>
+            </Tooltip>
+          ) : (
+            'No'
+          )}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      {pod.status?.conditions && <Conditions conditions={pod.status.conditions} />}
+      {pod.spec?.initContainers?.map((container, index) => (
+        <Container
+          key={index}
+          container={container}
+          containerStatus={getContainerStatus(container.name, pod.status?.initContainerStatuses)}
+        />
+      ))}
+      {pod.spec?.containers?.map((container, index) => (
+        <Container
+          key={index}
+          container={container}
+          containerStatus={getContainerStatus(container.name, pod.status?.containerStatuses)}
+        />
+      ))}
+    </React.Fragment>
+  );
+};
+
+export default Pod;

--- a/app/src/components/resources/overview/Selector.tsx
+++ b/app/src/components/resources/overview/Selector.tsx
@@ -1,0 +1,37 @@
+import { DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import React from 'react';
+import { V1LabelSelector } from '@kubernetes/client-node';
+
+interface ISelectorProps {
+  cluster: string;
+  namespace: string;
+  selector: V1LabelSelector;
+}
+
+const Selector: React.FunctionComponent<ISelectorProps> = ({ cluster, namespace, selector }: ISelectorProps) => {
+  return (
+    <DescriptionListGroup>
+      <DescriptionListTerm>Selector</DescriptionListTerm>
+      <DescriptionListDescription>
+        {selector.matchLabels &&
+          Object.keys(selector.matchLabels).map((key) => (
+            <Link
+              key={key}
+              to={`/resources?selector=${key}=${
+                selector.matchLabels ? selector.matchLabels[key] : ''
+              }&cluster=${cluster}&namespace=${namespace}&kind=pods`}
+            >
+              <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+                <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+                  {key}={selector.matchLabels ? selector.matchLabels[key] : ''}
+                </span>
+              </div>
+            </Link>
+          ))}
+      </DescriptionListDescription>
+    </DescriptionListGroup>
+  );
+};
+
+export default Selector;

--- a/app/src/components/resources/overview/StatefulSet.tsx
+++ b/app/src/components/resources/overview/StatefulSet.tsx
@@ -1,0 +1,60 @@
+import { DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from '@patternfly/react-core';
+import React from 'react';
+import { V1StatefulSet } from '@kubernetes/client-node';
+
+import Conditions from 'components/resources/overview/Conditions';
+import Selector from 'components/resources/overview/Selector';
+
+interface IStatefulSetProps {
+  cluster: string;
+  namespace: string;
+  statefulSet: V1StatefulSet;
+}
+
+const StatefulSet: React.FunctionComponent<IStatefulSetProps> = ({
+  cluster,
+  namespace,
+  statefulSet,
+}: IStatefulSetProps) => {
+  return (
+    <React.Fragment>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Replicas</DescriptionListTerm>
+        <DescriptionListDescription>
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              {statefulSet.status?.replicas ? statefulSet.status?.replicas : 0} desired
+            </span>
+          </div>
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              {statefulSet.status?.currentReplicas ? statefulSet.status?.currentReplicas : 0} current
+            </span>
+          </div>
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              {statefulSet.status?.readyReplicas ? statefulSet.status?.readyReplicas : 0} ready
+            </span>
+          </div>
+          <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+            <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+              {statefulSet.status?.updatedReplicas ? statefulSet.status?.updatedReplicas : 0} updated
+            </span>
+          </div>
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      {statefulSet.spec?.updateStrategy?.type && (
+        <DescriptionListGroup>
+          <DescriptionListTerm>Strategy</DescriptionListTerm>
+          <DescriptionListDescription>{statefulSet.spec.updateStrategy.type}</DescriptionListDescription>
+        </DescriptionListGroup>
+      )}
+      {statefulSet.spec?.selector && (
+        <Selector cluster={cluster} namespace={namespace} selector={statefulSet.spec.selector} />
+      )}
+      {statefulSet.status?.conditions && <Conditions conditions={statefulSet.status.conditions} />}
+    </React.Fragment>
+  );
+};
+
+export default StatefulSet;

--- a/app/src/plugins/prometheus/PrometheusPage.tsx
+++ b/app/src/plugins/prometheus/PrometheusPage.tsx
@@ -13,8 +13,6 @@ import { useHistory, useLocation } from 'react-router-dom';
 import {
   GetMetricsRequest,
   GetMetricsResponse,
-  MetricLookupRequest,
-  MetricLookupResponse,
   Metrics,
   PrometheusPromiseClient,
   Query,
@@ -81,15 +79,6 @@ const PrometheusPage: React.FunctionComponent<IPluginPageProps> = ({ name, descr
         getMetricsRequest.setTimestart(options.timeStart);
         getMetricsRequest.setResolution(options.resolution);
         getMetricsRequest.setQueriesList(queries);
-
-        const metricLookupRequest = new MetricLookupRequest();
-        metricLookupRequest.setName(name);
-        metricLookupRequest.setMatcher(options.queries[0]);
-        const metricLookupResponse: MetricLookupResponse = await prometheusService.metricLookup(
-          metricLookupRequest,
-          null,
-        );
-        console.log(metricLookupResponse.getNamesList());
 
         const getMetricsResponse: GetMetricsResponse = await prometheusService.getMetrics(getMetricsRequest, null);
         setData({ error: '', isLoading: false, metrics: getMetricsResponse.toObject().metricsList });

--- a/app/src/utils/resources.tsx
+++ b/app/src/utils/resources.tsx
@@ -71,7 +71,7 @@ export interface IResource {
 // resources is the list of Kubernetes standard resources. To generate the rows for a resource, we have to pass the
 // result from the gRPC API call to the rows function. The returned rows are mostly the same as they are also retunred
 // by kubectl.
-const resources: IResources = {
+export const resources: IResources = {
   // eslint-disable-next-line sort-keys
   cronjobs: {
     columns: ['Name', 'Namespace', 'Cluster', 'Schedule', 'Suspend', 'Active', 'Last Schedule', 'Age'],
@@ -108,7 +108,7 @@ const resources: IResources = {
               lastSchedule,
               age,
             ],
-            props: cronJob,
+            props: { apiVersion: 'batch/v1beta1', kind: 'CronJob', ...cronJob },
           });
         }
       }
@@ -172,7 +172,7 @@ const resources: IResources = {
               nodeSelector.join(', '),
               age,
             ],
-            props: daemonSet,
+            props: { apiVersion: 'apps/v1', kind: 'DaemonSet', ...daemonSet },
           });
         }
       }
@@ -216,7 +216,7 @@ const resources: IResources = {
               available,
               age,
             ],
-            props: deployment,
+            props: { apiVersion: 'apps/v1', kind: 'Deployment', ...deployment },
           });
         }
       }
@@ -262,7 +262,7 @@ const resources: IResources = {
               duration,
               age,
             ],
-            props: job,
+            props: { apiVersion: 'batch/v1', kind: 'Job', ...job },
           });
         }
       }
@@ -410,7 +410,7 @@ const resources: IResources = {
               upToDate,
               age,
             ],
-            props: statefulSet,
+            props: { apiVersion: 'apps/v1', kind: 'StatefulSet', ...statefulSet },
           });
         }
       }


### PR DESCRIPTION
This commit adds a new overview tab for all resources in the details
drawer. The overview tab shows the metadata and other important fields
of a resource in a clear way. It should help the user to get a faster
overview of the current status of a resource.

For other resources, like Deployments, StatefulSets, etc. we also add a
Pods tab. The Pods tab shows the pods for a resource, which are matching
the specified label selector.

Last but not least, we are adjusting the query parameters in the
resource view, when the user selects a cluster, namespace or resource,
so that a user can share the url with other users. This also allows us
to link to specific resource by providing a cluster, namespace, resource
and selector in the URL.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
