### PR TITLE
Fix VirtualService in Helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 ### Fixed
 
+- [#43](https://github.com/kobsio/kobs/pull/43): Fix `hosts` and `gateways` list for VirtualService in the Helm chart.
+
 ### Changed
 
 ## [v0.2.0](https://github.com/kobsio/kobs/releases/tag/v0.2.0) (2021-04-23)

--- a/deploy/helm/kobs/Chart.yaml
+++ b/deploy/helm/kobs/Chart.yaml
@@ -4,5 +4,5 @@ description: Kubernetes Observability Platform
 type: application
 home: https://kobs.io
 icon: https://kobs.io/assets/images/logo.svg
-version: 0.3.0
+version: 0.3.1
 appVersion: v0.2.0

--- a/deploy/helm/kobs/templates/virtualservice.yaml
+++ b/deploy/helm/kobs/templates/virtualservice.yaml
@@ -6,11 +6,11 @@ metadata:
   labels:
     {{- include "kobs.labels" . | nindent 4 }}
 spec:
-{{- with .Values.istio.hosts }}
+{{- with .Values.istio.virtualService.hosts }}
   hosts:
     {{- toYaml . | nindent 4 }}
 {{- end }}
-{{- with .Values.istio.gateways }}
+{{- with .Values.istio.virtualService.gateways }}
   gateways:
     {{- toYaml . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
The used value in the VirtualService template for hosts and gateways was
wrong.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
