### PR TITLE
Default logo for teams / Improve Prometheus plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 ### Fixed
 
 - [#43](https://github.com/kobsio/kobs/pull/43): Fix `hosts` and `gateways` list for VirtualService in the Helm chart.
+- [#44](https://github.com/kobsio/kobs/pull/44): Add default logo for teams, which is shown when a team doesn't provide a logo and improve metrics lookup for Prometheus plugin.
 
 ### Changed
 

--- a/app/src/components/teams/TeamsItem.tsx
+++ b/app/src/components/teams/TeamsItem.tsx
@@ -12,11 +12,17 @@ interface ITeamsItemProps {
 // TeamsItem renders a single team in a Card component. The Card is wrapped by our LinkWrapper so that the user is
 // redirected to the page of the team, when he clicks on the card.
 const TeamsItem: React.FunctionComponent<ITeamsItemProps> = ({ description, logo, name }: ITeamsItemProps) => {
+  let teamLogo = logo;
+
+  if (teamLogo === '') {
+    teamLogo = '/img/plugins/teams.png';
+  }
+
   return (
     <LinkWrapper link={`/teams/${name}`}>
       <Card style={{ cursor: 'pointer' }} isHoverable={true}>
         <CardHeader>
-          <img src={logo} alt={name} width="27px" style={{ marginRight: '5px' }} />
+          <img src={teamLogo} alt={name} width="27px" style={{ marginRight: '5px' }} />
           <CardTitle>{name}</CardTitle>
         </CardHeader>
         <CardBody>{description}</CardBody>


### PR DESCRIPTION
This commit adds a default logo for each team, which is used when the
"logo" property in a Team CR isn't used.

This commit also improves the "MetricLookup" implementation. We are now
caching the returned metrics for one hour and we had reduced the lookup
interval to one hour.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
