### PR TITLE
Improve style of various React components

### DIFF
--- a/app/src/components/applications/Applications.tsx
+++ b/app/src/components/applications/Applications.tsx
@@ -90,7 +90,10 @@ const Applications: React.FunctionComponent = () => {
           }
         >
           <DrawerContentBody>
-            <PageSection style={{ height: '100%', minHeight: '100%' }} variant={PageSectionVariants.default}>
+            <PageSection
+              style={data.view === 'topology' ? { height: '100%', minHeight: '100%' } : { minHeight: '100%' }}
+              variant={PageSectionVariants.default}
+            >
               {data.clusters.length === 0 || data.namespaces.length === 0 ? (
                 <Alert variant={AlertVariant.info} title="Select clusters and namespaces">
                   <p>Select a list of clusters and namespaces from the toolbar.</p>

--- a/app/src/components/applications/ApplicationsGallery.tsx
+++ b/app/src/components/applications/ApplicationsGallery.tsx
@@ -62,7 +62,11 @@ const ApplicationsGallery: React.FunctionComponent<IApplicationsGalleryProps> = 
   }, [fetchApplications]);
 
   if (data.isLoading) {
-    return <Spinner style={{ left: '50%', position: 'fixed', top: '50%', transform: 'translate(-50%, -50%)' }} />;
+    return (
+      <div className="pf-u-text-align-center">
+        <Spinner />
+      </div>
+    );
   }
 
   if (data.error) {

--- a/app/src/components/applications/ApplicationsTopology.tsx
+++ b/app/src/components/applications/ApplicationsTopology.tsx
@@ -143,7 +143,11 @@ const ApplicationsTopology: React.FunctionComponent<IApplicationsTopologyProps> 
   }, [fetchApplicationsTopology]);
 
   if (data.isLoading) {
-    return <Spinner style={{ left: '50%', position: 'fixed', top: '50%', transform: 'translate(-50%, -50%)' }} />;
+    return (
+      <div className="pf-u-text-align-center">
+        <Spinner />
+      </div>
+    );
   }
 
   if (data.error) {

--- a/app/src/components/resources/ResourceOverview.tsx
+++ b/app/src/components/resources/ResourceOverview.tsx
@@ -67,7 +67,7 @@ const ResourceOverview: React.FunctionComponent<IResourceOverviewProps> = ({ res
   return (
     <Card isCompact={true}>
       <CardBody>
-        <DescriptionList isHorizontal={true}>
+        <DescriptionList className="pf-u-text-break-word" isHorizontal={true}>
           {resource.name?.title && (
             <DescriptionListGroup>
               <DescriptionListTerm>Name</DescriptionListTerm>

--- a/app/src/plugins/elasticsearch/ElasticsearchLogs.tsx
+++ b/app/src/plugins/elasticsearch/ElasticsearchLogs.tsx
@@ -145,7 +145,11 @@ const ElasticsearchLogs: React.FunctionComponent<IElasticsearchLogsProps> = ({
 
   // When the isLoading property is true, we render a spinner as loading indicator for the user.
   if (data.isLoading) {
-    return <Spinner style={{ left: '50%', position: 'fixed', top: '50%', transform: 'translate(-50%, -50%)' }} />;
+    return (
+      <div className="pf-u-text-align-center">
+        <Spinner />
+      </div>
+    );
   }
 
   // In case of an error, we show an Alert component, with the error message, while the request failed.

--- a/app/src/plugins/jaeger/JaegerPageCompare.tsx
+++ b/app/src/plugins/jaeger/JaegerPageCompare.tsx
@@ -41,7 +41,7 @@ const JaegerPageCompare: React.FunctionComponent<IJaegerPageCompareProps> = ({ n
   return (
     <React.Fragment>
       <Grid>
-        <GridItem span={compareTrace ? 6 : 12}>
+        <GridItem sm={12} md={12} lg={compareTrace ? 6 : 12} xl={compareTrace ? 6 : 12} xl2={compareTrace ? 6 : 12}>
           <JaegerPageCompareTrace
             name={name}
             traceID={params.traceID}
@@ -50,7 +50,7 @@ const JaegerPageCompare: React.FunctionComponent<IJaegerPageCompareProps> = ({ n
         </GridItem>
 
         {compareTrace ? (
-          <GridItem span={compareTrace ? 6 : 12}>
+          <GridItem sm={12} md={12} lg={compareTrace ? 6 : 12} xl={compareTrace ? 6 : 12} xl2={compareTrace ? 6 : 12}>
             <JaegerPageCompareTrace
               name={name}
               traceID={compareTrace}

--- a/app/src/plugins/jaeger/JaegerPageCompareTrace.tsx
+++ b/app/src/plugins/jaeger/JaegerPageCompareTrace.tsx
@@ -66,32 +66,43 @@ const JaegerPageCompareTrace: React.FunctionComponent<IJaegerPageCompareTracePro
 
   // When the loading identicator is true, we show a spinner component.
   if (data.isLoading) {
-    return <Spinner style={{ left: '50%', position: 'fixed', top: '50%', transform: 'translate(-50%, -50%)' }} />;
+    return (
+      <div className="pf-u-text-align-center">
+        <Spinner />
+      </div>
+    );
   }
 
   // When an error occured during the execution of the fetchTrace function, we show the error in an Alert component.
   if (data.error || !data.trace) {
     return (
-      <Alert
-        style={{ left: '50%', position: 'fixed', top: '50%', transform: 'translate(-50%, -50%)' }}
-        variant={AlertVariant.danger}
-        title="Could not get trace"
-        actionLinks={
-          <React.Fragment>
-            <AlertActionLink onClick={(): void => history.push('/')}>Home</AlertActionLink>
-            <AlertActionLink onClick={fetchTrace}>Retry</AlertActionLink>
-          </React.Fragment>
-        }
-      >
-        <p>{data.error ? data.error : 'Trace is undefined'}</p>
-      </Alert>
+      <PageSection variant={PageSectionVariants.default}>
+        <Alert
+          variant={AlertVariant.danger}
+          title="Could not get trace"
+          actionLinks={
+            <React.Fragment>
+              <AlertActionLink onClick={(): void => history.push('/')}>Home</AlertActionLink>
+              <AlertActionLink onClick={fetchTrace}>Retry</AlertActionLink>
+            </React.Fragment>
+          }
+        >
+          <p>{data.error ? data.error : 'Trace is undefined'}</p>
+        </Alert>
+      </PageSection>
     );
   }
 
   return (
     <React.Fragment>
       <Grid>
-        <GridItem span={headerComponent ? 9 : 12}>
+        <GridItem
+          sm={12}
+          md={12}
+          lg={headerComponent ? 9 : 12}
+          xl={headerComponent ? 9 : 12}
+          xl2={headerComponent ? 9 : 12}
+        >
           <PageSection style={{ height: '100%' }} variant={PageSectionVariants.light}>
             <Title className="pf-u-text-nowrap pf-u-text-truncate" headingLevel="h6" size="xl">
               {data.trace.processes[data.trace.spans[0].processID].serviceName}: {data.trace.spans[0].operationName}{' '}
@@ -119,14 +130,20 @@ const JaegerPageCompareTrace: React.FunctionComponent<IJaegerPageCompareTracePro
         </GridItem>
 
         {headerComponent ? (
-          <GridItem span={headerComponent ? 3 : 12}>
+          <GridItem
+            sm={12}
+            md={12}
+            lg={headerComponent ? 3 : 12}
+            xl={headerComponent ? 3 : 12}
+            xl2={headerComponent ? 3 : 12}
+          >
             <PageSection style={{ height: '100%' }} variant={PageSectionVariants.light}>
               {headerComponent}
             </PageSection>
           </GridItem>
         ) : null}
 
-        <GridItem span={12}>
+        <GridItem sm={12} md={12} lg={12} xl={12} xl2={12}>
           <PageSection variant={PageSectionVariants.default}>
             <JaegerSpans trace={data.trace} />
           </PageSection>

--- a/app/src/plugins/jaeger/JaegerTraces.tsx
+++ b/app/src/plugins/jaeger/JaegerTraces.tsx
@@ -72,7 +72,11 @@ const JaegerTraces: React.FunctionComponent<IJaegerTracesProps> = ({
 
   // When the isLoading property is true, we render a spinner as loading indicator for the user.
   if (data.isLoading) {
-    return <Spinner style={{ left: '50%', position: 'fixed', top: '50%', transform: 'translate(-50%, -50%)' }} />;
+    return (
+      <div className="pf-u-text-align-center">
+        <Spinner />
+      </div>
+    );
   }
 
   // In case of an error, we show an Alert component, with the error message, while the request failed.

--- a/app/src/plugins/opsgenie/OpsgeniePageAlert.tsx
+++ b/app/src/plugins/opsgenie/OpsgeniePageAlert.tsx
@@ -133,7 +133,9 @@ const OpsgeniePageAlert: React.FunctionComponent<IOpsgeniePageAlertProps> = ({ n
             <Card isCompact={true}>
               <CardTitle>Description</CardTitle>
               <CardBody>
-                <Text style={{ whiteSpace: 'pre-wrap', wordWrap: 'break-word' }}>{data.alert.description}</Text>
+                <Text className="pf-u-text-break-word" style={{ whiteSpace: 'pre-wrap' }}>
+                  {data.alert.description}
+                </Text>
               </CardBody>
             </Card>
           </GridItem>
@@ -141,7 +143,7 @@ const OpsgeniePageAlert: React.FunctionComponent<IOpsgeniePageAlertProps> = ({ n
             <Card isCompact={true}>
               <CardTitle>Details</CardTitle>
               <CardBody>
-                <DescriptionList isHorizontal={true}>
+                <DescriptionList className="pf-u-text-break-word" isHorizontal={true}>
                   {data.alert.detailsMap.map((detail, index) => (
                     <DescriptionListGroup key={index}>
                       <DescriptionListTerm>{detail[0]}</DescriptionListTerm>

--- a/app/src/plugins/prometheus/PrometheusPage.tsx
+++ b/app/src/plugins/prometheus/PrometheusPage.tsx
@@ -118,7 +118,9 @@ const PrometheusPage: React.FunctionComponent<IPluginPageProps> = ({ name, descr
 
       <PageSection variant={PageSectionVariants.default}>
         {data.isLoading ? (
-          <Spinner style={{ left: '50%', position: 'fixed', top: '50%', transform: 'translate(-50%, -50%)' }} />
+          <div className="pf-u-text-align-center">
+            <Spinner />
+          </div>
         ) : data.error ? (
           <Alert
             variant={AlertVariant.danger}

--- a/pkg/api/plugins/opsgenie/opsgenie.go
+++ b/pkg/api/plugins/opsgenie/opsgenie.go
@@ -127,11 +127,9 @@ func (o *Opsgenie) GetAlert(ctx context.Context, getAlertRequest *opsgenieProto.
 			IdentifierType:  team.Id,
 			IdentifierValue: responder.Id,
 		})
-		if err != nil {
-			return nil, err
+		if err == nil {
+			responders = append(responders, teamRes.Name)
 		}
-
-		responders = append(responders, teamRes.Name)
 	}
 
 	return &opsgenieProto.GetAlertResponse{


### PR DESCRIPTION
This commit improves the style of various React components:

- We are using a consistent style for the Spinner component accross all
  components now. This means that the Spinner component is only rendered
  in the middle of the page, when there are no other components on the
  page. Else we are rendering the Spinner below the parent component,
  horizontal centered.
- We adjust the adjust the style of the PageSection in the Applications
  view. When the user selects the topology option we set a static height
  of 100%. For the gallery the PageSection takes the complete height of
  the page.
- We do not return an error in the page for an alert in the Opsgenie
  plugin. Instead we render the page, without the responders.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [ ] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
