### PR TITLE
Fix determination of the root span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 - [#43](https://github.com/kobsio/kobs/pull/43): Fix `hosts` and `gateways` list for VirtualService in the Helm chart.
 - [#44](https://github.com/kobsio/kobs/pull/44): Add default logo for teams, which is shown when a team doesn't provide a logo and improve metrics lookup for Prometheus plugin.
+- [#50](https://github.com/kobsio/kobs/pull/50): Fix determination of the root span in the Jaeger plugin.
 
 ### Changed
 

--- a/app/src/plugins/jaeger/JaegerPageCompareTrace.tsx
+++ b/app/src/plugins/jaeger/JaegerPageCompareTrace.tsx
@@ -16,6 +16,7 @@ import { GetTraceRequest, GetTraceResponse, JaegerPromiseClient } from 'proto/ja
 import { ITrace, addColorForProcesses, formatTraceTime, getDuration } from 'plugins/jaeger/helpers';
 import JaegerSpans from 'plugins/jaeger/JaegerSpans';
 import { apiURL } from 'utils/constants';
+import { getRootSpan } from 'plugins/jaeger/helpers';
 
 // jaegerService is the gRPC service to get the traces from a Jaeger instance.
 const jaegerService = new JaegerPromiseClient(apiURL, null, null);
@@ -93,6 +94,11 @@ const JaegerPageCompareTrace: React.FunctionComponent<IJaegerPageCompareTracePro
     );
   }
 
+  const rootSpan = data.trace && data.trace.spans.length > 0 ? getRootSpan(data.trace.spans) : undefined;
+  if (!rootSpan) {
+    return null;
+  }
+
   return (
     <React.Fragment>
       <Grid>
@@ -105,7 +111,7 @@ const JaegerPageCompareTrace: React.FunctionComponent<IJaegerPageCompareTracePro
         >
           <PageSection style={{ height: '100%' }} variant={PageSectionVariants.light}>
             <Title className="pf-u-text-nowrap pf-u-text-truncate" headingLevel="h6" size="xl">
-              {data.trace.processes[data.trace.spans[0].processID].serviceName}: {data.trace.spans[0].operationName}{' '}
+              {data.trace.processes[rootSpan.processID].serviceName}: {rootSpan.operationName}
               <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">{data.trace.traceID}</span>
             </Title>
             <p>

--- a/app/src/plugins/jaeger/JaegerTrace.tsx
+++ b/app/src/plugins/jaeger/JaegerTrace.tsx
@@ -11,6 +11,7 @@ import { ITrace, formatTraceTime, getDuration } from 'plugins/jaeger/helpers';
 import JaegerSpans from 'plugins/jaeger/JaegerSpans';
 import JaegerTraceDetailsLink from 'plugins/jaeger/JaegerTraceDetailsLink';
 import Title from 'components/Title';
+import { getRootSpan } from 'plugins/jaeger/helpers';
 
 export interface IJaegerTraceProps {
   name: string;
@@ -19,7 +20,11 @@ export interface IJaegerTraceProps {
 }
 
 const JaegerTrace: React.FunctionComponent<IJaegerTraceProps> = ({ name, trace, close }: IJaegerTraceProps) => {
-  const rootSpan = trace.spans[0];
+  const rootSpan = getRootSpan(trace.spans);
+  if (!rootSpan) {
+    return null;
+  }
+
   const rootSpanProcess = trace.processes[rootSpan.processID];
   const rootSpanService = rootSpanProcess.serviceName;
 

--- a/app/src/plugins/jaeger/JaegerTracesTrace.tsx
+++ b/app/src/plugins/jaeger/JaegerTracesTrace.tsx
@@ -9,6 +9,7 @@ import {
   doesTraceContainsError,
   formatTraceTime,
   getDuration,
+  getRootSpan,
   getSpansPerServices,
 } from 'plugins/jaeger/helpers';
 import JaegerTrace from 'plugins/jaeger/JaegerTrace';
@@ -24,7 +25,11 @@ const JaegerTracesTrace: React.FunctionComponent<IJaegerTracesTraceProps> = ({
   trace,
   setTrace,
 }: IJaegerTracesTraceProps) => {
-  const rootSpan = trace.spans[0];
+  const rootSpan = getRootSpan(trace.spans);
+  if (!rootSpan) {
+    return null;
+  }
+
   const rootSpanProcess = trace.processes[rootSpan.processID];
   const rootSpanService = rootSpanProcess.serviceName;
 

--- a/app/src/plugins/jaeger/helpers.ts
+++ b/app/src/plugins/jaeger/helpers.ts
@@ -268,3 +268,16 @@ export const jsonToProto = (json: any): Plugin.AsObject | undefined => {
 
   return plugin.toObject();
 };
+
+// getRootSpan returns the first span of a trace. Normally this should be the first span, but sometime it can happen,
+// that this isn't the case. So that we have to loop over the spans and then we return the first trace, which doesn't
+// have a reference.
+export const getRootSpan = (spans: ISpan[]): ISpan | undefined => {
+  for (const span of spans) {
+    if (span.references.length === 0 || span.references[0].refType !== 'CHILD_OF') {
+      return span;
+    }
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
This fixes the determination of the root span in the Jaeger plugin. In
some cases it can happen that the first span isn't the root span, so
that we have to loop through all span. Then we return the first one,
which doesn't have any references with an "CHILD_OF" entry.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
