### PR TITLE
Add command-line flag to forbid resource access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 - [#45](https://github.com/kobsio/kobs/pull/45): Add value mappings for `sparkline` charts in the Prometheus plugin.
 - [#49](https://github.com/kobsio/kobs/pull/49): Add new chart type `table` for Prometheus plugin, which allows a user to render the results of multiple Prometheus queries in ab table.
+- [#50](https://github.com/kobsio/kobs/pull/50): Add new command-line flag to forbid access for resources.
 
 ### Fixed
 

--- a/app/src/components/resources/ResourceEvents.tsx
+++ b/app/src/components/resources/ResourceEvents.tsx
@@ -20,7 +20,7 @@ interface IEventsProps {
 // Events is the component to display the events for a resource. The resource is identified by the cluster, namespace
 // and name. The event must contain the involvedObject.name=<NAME> to be listed for a resource.
 const Events: React.FunctionComponent<IEventsProps> = ({ cluster, namespace, name }: IEventsProps) => {
-  const [events, setEvents] = useState<IRow[]>(emptyState(4, ''));
+  const [events, setEvents] = useState<IRow[]>(emptyState(4, '', false));
 
   // fetchEvents is used to fetch all events to the provided resource. When the API returnes a list of resources, this
   // list is transformed into a the IRow interface, so we can display the events within the Table component.
@@ -55,13 +55,13 @@ const Events: React.FunctionComponent<IEventsProps> = ({ cluster, namespace, nam
 
           setEvents(tmpEvents);
         } else {
-          setEvents(emptyState(4, ''));
+          setEvents(emptyState(4, '', false));
         }
       } else {
-        setEvents(emptyState(4, ''));
+        setEvents(emptyState(4, '', false));
       }
     } catch (err) {
-      setEvents(emptyState(4, err.message));
+      setEvents(emptyState(4, err.message, false));
     }
   }, [cluster, namespace, name]);
 

--- a/app/src/components/resources/ResourcePods.tsx
+++ b/app/src/components/resources/ResourcePods.tsx
@@ -22,7 +22,7 @@ const ResourcePods: React.FunctionComponent<IResourcePodsProps> = ({
   namespace,
   selector,
 }: IResourcePodsProps) => {
-  const [pods, setPods] = useState<IRow[]>(emptyState(resources.pods.columns.length, ''));
+  const [pods, setPods] = useState<IRow[]>(emptyState(resources.pods.columns.length, '', false));
 
   // fetchPods fetches the pods for the given cluster, namespace and label selector.
   const fetchPods = useCallback(async () => {
@@ -41,10 +41,10 @@ const ResourcePods: React.FunctionComponent<IResourcePodsProps> = ({
       if (resourceList.length === 1) {
         setPods(resources.pods.rows(resourceList));
       } else {
-        setPods(emptyState(resources.pods.columns.length, ''));
+        setPods(emptyState(resources.pods.columns.length, '', false));
       }
     } catch (err) {
-      setPods(emptyState(resources.pods.columns.length, err.message));
+      setPods(emptyState(resources.pods.columns.length, err.message, false));
     }
   }, [cluster, namespace, selector]);
 

--- a/app/src/utils/resources.tsx
+++ b/app/src/utils/resources.tsx
@@ -1,4 +1,12 @@
-import { Bullseye, EmptyState, EmptyStateBody, EmptyStateIcon, EmptyStateVariant, Title } from '@patternfly/react-core';
+import {
+  Bullseye,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Spinner,
+  Title,
+} from '@patternfly/react-core';
 import {
   CoreV1EventList,
   V1ClusterRoleBindingList,
@@ -1316,7 +1324,7 @@ export const customResourceDefinition = (crds: CRD.AsObject[]): IResources => {
 
 // emptyState is used to display an empty state in the table for a resource, when the gRPC API call returned an error or
 // no results.
-export const emptyState = (cols: number, error: string): IRow[] => {
+export const emptyState = (cols: number, error: string, isLoading: boolean): IRow[] => {
   return [
     {
       cells: [
@@ -1325,13 +1333,19 @@ export const emptyState = (cols: number, error: string): IRow[] => {
           title: (
             <Bullseye>
               <EmptyState variant={EmptyStateVariant.small}>
-                <EmptyStateIcon icon={SearchIcon} />
-                <Title headingLevel="h2" size="lg">
-                  No results found
-                </Title>
-                <EmptyStateBody>
-                  {error ? error : 'No results match the filter criteria. Select another cluster or namespace.'}
-                </EmptyStateBody>
+                {isLoading ? (
+                  <EmptyStateIcon variant="container" component={Spinner} />
+                ) : (
+                  <React.Fragment>
+                    <EmptyStateIcon icon={SearchIcon} />
+                    <Title headingLevel="h2" size="lg">
+                      {error ? 'An error occured' : 'No results found'}
+                    </Title>
+                    <EmptyStateBody>
+                      {error ? error : 'No results match the filter criteria. Select another cluster or namespace.'}
+                    </EmptyStateBody>
+                  </React.Fragment>
+                )}
               </EmptyState>
             </Bullseye>
           ),

--- a/docs/configuration/getting-started.md
+++ b/docs/configuration/getting-started.md
@@ -14,6 +14,7 @@ The following command-line arguments and environment variables are available.
 | `--clusters.cache-duration.namespaces` | `KOBS_CLUSTERS_CACHE_DURATION_NAMESPACES` | The duration, for how long requests to get the list of namespaces should be cached. | `5m` |
 | `--clusters.cache-duration.teams` | `KOBS_CLUSTERS_CACHE_DURATION_TEAMS` | The duration, for how long the teams data should be cached. | `60m` |
 | `--clusters.cache-duration.topology` | `KOBS_CLUSTERS_CACHE_DURATION_TOPOLOGY` | The duration, for how long the topology data should be cached. | `60m` |
+| `--clusters.forbidden-resources` | `KOBS_CLUSTERS_FORBIDDEN_RESOURCES` | A list of resources, which can not be accessed via kobs. | |
 | `--config` | `KOBS_CONFIG` | Name of the configuration file.  | `config.yaml` |
 | `--log.format` | `KOBS_LOG_FORMAT` | Set the output format of the logs. Must be `plain` or `json`.  | `plain` |
 | `--log.level` | `KOBS_LOG_LEVEL` | Set the log level. Must be `trace`, `debug`, `info`, `warn`, `error`, `fatal` or `panic`.  | `info` |


### PR DESCRIPTION
This commit adds a new command-line flag
"--clusters.forbidden-resources", which can be used to forbid access to
a list of resources. This allow a user to still use RBAC with wildcards
for the permissions of kobs, but do not allow a user to access the
specified resources.

We also adjusted the corresponding React component, so that the error is
now shown to the user. This also  fixes a problem, where the app
crashed, whenn the empty state was clicked in the resources list.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
