### PR TITLE
Add option to enter a single trace id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 - [#45](https://github.com/kobsio/kobs/pull/45): Add value mappings for `sparkline` charts in the Prometheus plugin.
 - [#49](https://github.com/kobsio/kobs/pull/49): Add new chart type `table` for Prometheus plugin, which allows a user to render the results of multiple Prometheus queries in ab table.
-- [#50](https://github.com/kobsio/kobs/pull/50): Add new command-line flag to forbid access for resources.
+- [#51](https://github.com/kobsio/kobs/pull/51): Add new command-line flag to forbid access for resources.
+- [#52](https://github.com/kobsio/kobs/pull/52): Add option to enter a single trace id in the Jaeger plugin.
 
 ### Fixed
 

--- a/app/src/plugins/jaeger/JaegerPage.tsx
+++ b/app/src/plugins/jaeger/JaegerPage.tsx
@@ -13,7 +13,7 @@ const JaegerPage: React.FunctionComponent<IPluginPageProps> = ({ name, descripti
       <Route exact={true} path={`/plugins/${name}`}>
         <JaegerPageTraces name={name} description={description} />
       </Route>
-      <Route exact={true} path={`/plugins/${name}/trace/:traceID`}>
+      <Route exact={true} path={`/plugins/${name}/trace/:traceID?`}>
         <JaegerPageCompare name={name} />
       </Route>
     </Switch>

--- a/app/src/plugins/jaeger/JaegerPageTraces.tsx
+++ b/app/src/plugins/jaeger/JaegerPageTraces.tsx
@@ -6,8 +6,8 @@ import {
   PageSectionVariants,
   Title,
 } from '@patternfly/react-core';
+import { Link, useHistory, useLocation } from 'react-router-dom';
 import React, { useEffect, useState } from 'react';
-import { useHistory, useLocation } from 'react-router-dom';
 
 import { IJaegerOptions, getOptionsFromSearch } from 'plugins/jaeger/helpers';
 import { IPluginPageProps } from 'utils/plugins';
@@ -40,6 +40,9 @@ const JaegerPageTraces: React.FunctionComponent<IPluginPageProps> = ({ name, des
       <PageSection variant={PageSectionVariants.light}>
         <Title headingLevel="h6" size="xl">
           {name}
+          <span className="pf-u-font-size-md pf-u-font-weight-normal" style={{ float: 'right' }}>
+            <Link to={`/plugins/${name}/trace`}>Compare Traces</Link>
+          </span>
         </Title>
         <p>{description}</p>
         <JaegerPageToolbar


### PR DESCRIPTION
The Jaeger plugin contains a link to the compare traces page now. When
the link is clicked the user is redirected to the compare traces page,
without the traceID parameter. When this parameter isn't present the
user can enter a trace id to view the corresponding trace.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
