### PR TITLE
Fix fields handling in Elasticsearch plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#43](https://github.com/kobsio/kobs/pull/43): Fix `hosts` and `gateways` list for VirtualService in the Helm chart.
 - [#44](https://github.com/kobsio/kobs/pull/44): Add default logo for teams, which is shown when a team doesn't provide a logo and improve metrics lookup for Prometheus plugin.
 - [#50](https://github.com/kobsio/kobs/pull/50): Fix determination of the root span in the Jaeger plugin.
+- [#54](https://github.com/kobsio/kobs/pull/54): Fix fields handling in Elasticsearch plugin.
 
 ### Changed
 

--- a/app/src/plugins/elasticsearch/ElasticsearchLogs.tsx
+++ b/app/src/plugins/elasticsearch/ElasticsearchLogs.tsx
@@ -107,7 +107,7 @@ const ElasticsearchLogs: React.FunctionComponent<IElasticsearchLogsProps> = ({
           buckets: tmpLogsResponse.bucketsList,
           documents: parsedLogs,
           error: '',
-          fields: getFields(parsedLogs.slice(parsedLogs.length > 10 ? 10 : parsedLogs.length)),
+          fields: getFields(parsedLogs.length > 10 ? parsedLogs.slice(10) : parsedLogs),
           hits: tmpLogsResponse.hits,
           isLoading: false,
           scrollID: tmpLogsResponse.scrollid,

--- a/app/src/plugins/elasticsearch/ElasticsearchPage.tsx
+++ b/app/src/plugins/elasticsearch/ElasticsearchPage.tsx
@@ -25,7 +25,10 @@ const ElasticsearchPage: React.FunctionComponent<IPluginPageProps> = ({ name, de
   // changeOptions is used to change the options for an Elasticsearch query. Instead of directly modifying the options
   // state we change the URL parameters.
   const changeOptions = (opts: IElasticsearchOptions): void => {
-    const fields = opts.fields ? opts.fields.map((field) => `&field=${field}`) : undefined;
+    const params = new URLSearchParams(location.search);
+    const fields = opts.fields
+      ? opts.fields.map((field) => `&field=${field}`)
+      : params.getAll('field').map((field) => `&field=${field}`);
 
     history.push({
       pathname: location.pathname,


### PR DESCRIPTION
Fix a bug, where the selected fields were removed for a new search. Now
we are keeping the fields across multiple searches. For that we are
parsing the location and reuse all existing fields.

Fix a bug, where the fields list wasn't created, when the search
returned less then 10 documents.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
