### PR TITLE
Add tags as filter in the Jaeger plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#46](https://github.com/kobsio/kobs/pull/46): Support multiple types for the legend in a Prometheus chart and use a custom component to render the legend.
 - [#47](https://github.com/kobsio/kobs/pull/47): Display the legend at the Prometheus page as table and use color of selected metric in chart.
 - [#53](https://github.com/kobsio/kobs/pull/53): Improve Jaeger plugin, by allow filtering of services and operations and adding several actions for traces.
+- [#55](https://github.com/kobsio/kobs/pull/55): Allow a user to add a tag from a span as filter in the Jaeger plugin.
 
 ## [v0.2.0](https://github.com/kobsio/kobs/releases/tag/v0.2.0) (2021-04-23)
 

--- a/app/package.json
+++ b/app/package.json
@@ -161,6 +161,7 @@
     "react-ace": "^9.3.0",
     "react-cytoscapejs": "^1.2.1",
     "react-dom": "^17.0.1",
+    "react-dropzone": "^11.3.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.2",
     "ts-protoc-gen": "^0.14.0",

--- a/app/src/plugins/jaeger/JaegerPageCompare.tsx
+++ b/app/src/plugins/jaeger/JaegerPageCompare.tsx
@@ -1,17 +1,9 @@
-import {
-  Bullseye,
-  Divider,
-  FileUpload,
-  Grid,
-  GridItem,
-  PageSection,
-  PageSectionVariants,
-} from '@patternfly/react-core';
+import { Grid, GridItem } from '@patternfly/react-core';
 import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 
 import { ITrace } from 'plugins/jaeger/helpers';
-import JaegerPageCompareInput from 'plugins/jaeger/JaegerPageCompareInput';
+import JaegerPageCompareSelectTrace from 'plugins/jaeger/JaegerPageCompareSelectTrace';
 import JaegerPageCompareTrace from 'plugins/jaeger/JaegerPageCompareTrace';
 
 interface IJaegerPageCompareParams {
@@ -49,26 +41,20 @@ const JaegerPageCompare: React.FunctionComponent<IJaegerPageCompareProps> = ({ n
   // handleUpload handles the upload of a JSON file, which contains a trace. When the file upload is finished we parse
   // the content of the file and set the uploadedTrace state. This state (trace) is then passed to the first
   // JaegerPageCompareTrace so that the trace can be viewed.
-  const handleUpload = (
-    value: string | File,
-    filename: string,
-    event:
-      | React.DragEvent<HTMLElement>
-      | React.ChangeEvent<HTMLTextAreaElement>
-      | React.MouseEvent<HTMLButtonElement, MouseEvent>,
-  ): void => {
-    if (typeof value === 'string') {
-      try {
-        const traceData = JSON.parse(value).data;
-        setUploadedTrace(traceData[0]);
-        history.push({
-          pathname:
-            location.pathname.slice(-1) === '/'
-              ? `${location.pathname}${traceData[0].traceID}`
-              : `${location.pathname}/${traceData[0].traceID}`,
-        });
-      } catch (err) {}
-    }
+  const handleUpload = (trace: ITrace): void => {
+    setUploadedTrace(trace);
+    history.push({
+      pathname:
+        location.pathname.slice(-1) === '/'
+          ? `${location.pathname}${trace.traceID}`
+          : `${location.pathname}/${trace.traceID}`,
+    });
+
+    // if (typeof value === 'string') {
+    //   try {
+    //     const traceData = JSON.parse(value).data;
+    //   } catch (err) {}
+    // }
   };
 
   // useEffect is used to set the options every time the search location for the current URL changes. The URL is changed
@@ -80,29 +66,7 @@ const JaegerPageCompare: React.FunctionComponent<IJaegerPageCompareProps> = ({ n
   }, [location.search]);
 
   if (!params.traceID) {
-    return (
-      <Bullseye>
-        <Grid>
-          <GridItem sm={12} md={12} lg={12} xl={12} xl2={12}>
-            <PageSection style={{ height: '100%' }} variant={PageSectionVariants.light}>
-              <JaegerPageCompareInput changeCompareTrace={changeCompareTrace} />
-              <p>&nbsp;</p>
-              <Divider />
-              <p>&nbsp;</p>
-              <FileUpload
-                id="upload-trace"
-                type="text"
-                onChange={handleUpload}
-                hideDefaultPreview={true}
-                dropzoneProps={{
-                  accept: '.json',
-                }}
-              />
-            </PageSection>
-          </GridItem>
-        </Grid>
-      </Bullseye>
-    );
+    return <JaegerPageCompareSelectTrace setTraceID={changeCompareTrace} setTrace={handleUpload} />;
   }
 
   return (

--- a/app/src/plugins/jaeger/JaegerPageCompareSelectTrace.tsx
+++ b/app/src/plugins/jaeger/JaegerPageCompareSelectTrace.tsx
@@ -1,0 +1,63 @@
+import { Bullseye, Divider, Grid, GridItem, PageSection, PageSectionVariants } from '@patternfly/react-core';
+import React from 'react';
+import { useDropzone } from 'react-dropzone';
+
+import { ITrace } from 'plugins/jaeger/helpers';
+import JaegerPageCompareInput from 'plugins/jaeger/JaegerPageCompareInput';
+
+interface IJaegerPageCompareSelectTraceProps {
+  setTrace: (trace: ITrace) => void;
+  setTraceID: (traceID: string) => void;
+}
+
+const JaegerPageCompareSelectTrace: React.FunctionComponent<IJaegerPageCompareSelectTraceProps> = ({
+  setTrace,
+  setTraceID,
+}: IJaegerPageCompareSelectTraceProps) => {
+  const { fileRejections, getRootProps, getInputProps } = useDropzone({
+    accept: 'application/json',
+    maxFiles: 1,
+    onDrop: (files) => {
+      if (files.length === 1) {
+        const reader = new FileReader();
+        reader.readAsText(files[0], 'UTF-8');
+        reader.onload = (e): void => {
+          if (e.target && e.target.result && typeof e.target.result === 'string') {
+            const traceData = JSON.parse(e.target.result).data;
+            setTrace(traceData[0]);
+          }
+        };
+      }
+    },
+  });
+
+  const fileRejectionItems = fileRejections.map(({ file, errors }) => (
+    <div key={file.name}>
+      {errors.map((e) => (
+        <span key={e.code}>{e.message}</span>
+      ))}
+    </div>
+  ));
+
+  return (
+    <Bullseye>
+      <Grid>
+        <GridItem sm={12} md={12} lg={12} xl={12} xl2={12}>
+          <PageSection style={{ height: '100%' }} variant={PageSectionVariants.light}>
+            <JaegerPageCompareInput changeCompareTrace={setTraceID} />
+            <p>&nbsp;</p>
+            <Divider />
+            <p>&nbsp;</p>
+            <div {...getRootProps({ className: 'dropzone' })}>
+              <input {...getInputProps()} />
+              <p>Drag &apos;n&apos; drop a Trace here, or click to select a Trace</p>
+              {fileRejectionItems}
+            </div>
+          </PageSection>
+        </GridItem>
+      </Grid>
+    </Bullseye>
+  );
+};
+
+export default JaegerPageCompareSelectTrace;

--- a/app/src/plugins/jaeger/JaegerPageCompareTrace.tsx
+++ b/app/src/plugins/jaeger/JaegerPageCompareTrace.tsx
@@ -134,7 +134,7 @@ const JaegerPageCompareTrace: React.FunctionComponent<IJaegerPageCompareTracePro
 
         <GridItem sm={12} md={12} lg={12} xl={12} xl2={12}>
           <PageSection variant={PageSectionVariants.default}>
-            <JaegerSpans trace={data.trace} />
+            <JaegerSpans name={name} trace={data.trace} />
           </PageSection>
         </GridItem>
       </Grid>

--- a/app/src/plugins/jaeger/JaegerPageToolbar.tsx
+++ b/app/src/plugins/jaeger/JaegerPageToolbar.tsx
@@ -136,6 +136,12 @@ const JaegerPageToolbar: React.FunctionComponent<IJaegerPageToolbarProps> = ({
     fetchOperations();
   }, [fetchOperations]);
 
+  useEffect(() => {
+    setOptions((o) => {
+      return { ...o, tags: tags };
+    });
+  }, [tags]);
+
   if (data.error) {
     return (
       <Alert

--- a/app/src/plugins/jaeger/JaegerSpan.tsx
+++ b/app/src/plugins/jaeger/JaegerSpan.tsx
@@ -1,19 +1,26 @@
-import { AccordionContent, AccordionItem, AccordionToggle, Badge } from '@patternfly/react-core';
+import { AccordionContent, AccordionItem, AccordionToggle } from '@patternfly/react-core';
 import React, { useState } from 'react';
 import { ExclamationIcon } from '@patternfly/react-icons';
 
 import { IProcesses, ISpan, doesSpanContainsError } from 'plugins/jaeger/helpers';
 import JaegerSpanLogs from 'plugins/jaeger/JaegerSpanLogs';
+import JaegerTag from 'plugins/jaeger/JaegerTag';
 
 import 'plugins/jaeger/jaeger.css';
 
 export interface IJaegerSpanProps {
+  name: string;
   span: ISpan;
   processes: IProcesses;
   padding: number;
 }
 
-const JaegerSpan: React.FunctionComponent<IJaegerSpanProps> = ({ span, processes, padding }: IJaegerSpanProps) => {
+const JaegerSpan: React.FunctionComponent<IJaegerSpanProps> = ({
+  name,
+  span,
+  processes,
+  padding,
+}: IJaegerSpanProps) => {
   const [expanded, setExpanded] = useState<boolean>(false);
 
   const time = (
@@ -74,9 +81,7 @@ const JaegerSpan: React.FunctionComponent<IJaegerSpanProps> = ({ span, processes
               <div className="pf-u-pb-md">
                 Process:
                 {processes[span.processID].tags.map((tag, index) => (
-                  <Badge key={index} className="pf-u-ml-sm pf-u-mb-sm" isRead={true}>
-                    {tag.key}: {tag.value}
-                  </Badge>
+                  <JaegerTag key={index} name={name} tag={tag} />
                 ))}
               </div>
             ) : null}
@@ -84,9 +89,7 @@ const JaegerSpan: React.FunctionComponent<IJaegerSpanProps> = ({ span, processes
               <div className="pf-u-pb-md">
                 Tags:
                 {span.tags.map((tag, index) => (
-                  <Badge key={index} className="pf-u-ml-sm pf-u-mb-sm" isRead={true}>
-                    {tag.key}: {tag.value}
-                  </Badge>
+                  <JaegerTag key={index} name={name} tag={tag} />
                 ))}
               </div>
             ) : null}
@@ -104,7 +107,7 @@ const JaegerSpan: React.FunctionComponent<IJaegerSpanProps> = ({ span, processes
 
       {span.childs
         ? span.childs.map((span, index) => (
-            <JaegerSpan key={index} span={span} processes={processes} padding={padding + 16} />
+            <JaegerSpan key={index} name={name} span={span} processes={processes} padding={padding + 16} />
           ))
         : null}
     </React.Fragment>

--- a/app/src/plugins/jaeger/JaegerSpans.tsx
+++ b/app/src/plugins/jaeger/JaegerSpans.tsx
@@ -8,10 +8,11 @@ import JaegerSpansChart from 'plugins/jaeger/JaegerSpansChart';
 import 'plugins/jaeger/jaeger.css';
 
 export interface IJaegerSpansProps {
+  name: string;
   trace: ITrace;
 }
 
-const JaegerSpans: React.FunctionComponent<IJaegerSpansProps> = ({ trace }: IJaegerSpansProps) => {
+const JaegerSpans: React.FunctionComponent<IJaegerSpansProps> = ({ name, trace }: IJaegerSpansProps) => {
   const duration = getDuration(trace.spans);
   const spans: ISpan[] = createSpansTree(trace.spans, trace.spans[0].startTime, duration);
 
@@ -37,7 +38,7 @@ const JaegerSpans: React.FunctionComponent<IJaegerSpansProps> = ({ trace }: IJae
       <Card>
         <Accordion asDefinitionList={false}>
           {spans.map((span, index) => (
-            <JaegerSpan key={index} span={span} processes={trace.processes} padding={16} />
+            <JaegerSpan key={index} name={name} span={span} processes={trace.processes} padding={16} />
           ))}
         </Accordion>
       </Card>

--- a/app/src/plugins/jaeger/JaegerTag.tsx
+++ b/app/src/plugins/jaeger/JaegerTag.tsx
@@ -1,0 +1,74 @@
+import { Button, ButtonVariant, Popover } from '@patternfly/react-core';
+import { Link, useLocation } from 'react-router-dom';
+import React, { useState } from 'react';
+import { PlusIcon } from '@patternfly/react-icons';
+
+import { IKeyValue, getOptionsFromSearch } from 'plugins/jaeger/helpers';
+
+interface IDataState {
+  link: string;
+  value: string | boolean | number;
+}
+
+interface IJaegerTagProps {
+  name: string;
+  tag: IKeyValue;
+}
+
+const JaegerTag: React.FunctionComponent<IJaegerTagProps> = ({ name, tag }: IJaegerTagProps) => {
+  const [isVisible, setIsVisible] = useState<boolean>(false);
+  const [data, setData] = useState<IDataState>({ link: '', value: tag.value });
+  const location = useLocation();
+
+  const show = (): void => {
+    const opts = getOptionsFromSearch(location.search);
+    const link =
+      location.pathname === `/plugins/${name}`
+        ? `${location.pathname}?limit=${opts.limit}&maxDuration=${opts.maxDuration}&minDuration=${opts.minDuration}&operation=${opts.operation}&service=${opts.service}&tags=${tag.key}=${tag.value}&timeEnd=${opts.timeEnd}&timeStart=${opts.timeStart}`
+        : '';
+
+    let value = tag.value;
+    if (typeof value === 'string') {
+      try {
+        value = JSON.stringify(JSON.parse(value), null, 2);
+      } catch (err) {
+        value = tag.value;
+      }
+    }
+
+    setData({ link: link, value: value });
+    setIsVisible(true);
+  };
+
+  return (
+    <Popover
+      aria-label="Tag"
+      isVisible={isVisible}
+      shouldOpen={show}
+      shouldClose={(): void => setIsVisible(false)}
+      headerContent={<div>{tag.key}</div>}
+      bodyContent={
+        <div>
+          <div style={{ maxHeight: '200px', overflow: 'scroll', whiteSpace: 'pre' }}>{data.value}</div>
+        </div>
+      }
+      footerContent={
+        data.link ? (
+          <Link to={data.link}>
+            <Button variant={ButtonVariant.link} isSmall={true} isInline={true} icon={<PlusIcon />}>
+              Filter
+            </Button>
+          </Link>
+        ) : undefined
+      }
+    >
+      <div className="pf-c-chip pf-u-ml-sm pf-u-mb-sm" style={{ cursor: 'pointer', maxWidth: '100%' }}>
+        <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+          {tag.key}: {tag.value}
+        </span>
+      </div>
+    </Popover>
+  );
+};
+
+export default JaegerTag;

--- a/app/src/plugins/jaeger/JaegerTrace.tsx
+++ b/app/src/plugins/jaeger/JaegerTrace.tsx
@@ -42,7 +42,7 @@ const JaegerTrace: React.FunctionComponent<IJaegerTraceProps> = ({ name, trace, 
       <DrawerPanelBody>
         <JaegerTraceHeader trace={trace} rootSpan={rootSpan} />
         <p>&nbsp;</p>
-        <JaegerSpans trace={trace} />
+        <JaegerSpans name={name} trace={trace} />
         <p>&nbsp;</p>
       </DrawerPanelBody>
     </DrawerPanelContent>

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2720,6 +2720,11 @@ attr-accept@^1.1.3:
   dependencies:
     core-js "^2.5.0"
 
+attr-accept@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
+  integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
+
 autoprefixer@^9.6.1:
   version "9.8.6"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.8.6.tgz#3b73594ca1bf9266320c5acf1588d74dea74210f"
@@ -5293,6 +5298,13 @@ file-selector@^0.1.8:
   integrity sha512-kCWw3+Aai8Uox+5tHCNgMFaUdgidxvMnLWO6fM5sZ0hA2wlHP5/DHGF0ECe84BiB95qdJbKNEJhWKVDvMN+JDQ==
   dependencies:
     tslib "^2.0.1"
+
+file-selector@^0.2.2:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.2.4.tgz#7b98286f9dbb9925f420130ea5ed0a69238d4d80"
+  integrity sha512-ZDsQNbrv6qRi1YTDOEWzf5J2KjZ9KMI1Q2SGeTkCJmNNW25Jg4TW4UMcmoqcg4WrAyKRcpBXdbWRxkfrOzVRbA==
+  dependencies:
+    tslib "^2.0.3"
 
 file-uri-to-path@1.0.0:
   version "1.0.0"
@@ -9647,6 +9659,15 @@ react-dropzone@9.0.0:
     file-selector "^0.1.8"
     prop-types "^15.6.2"
     prop-types-extra "^1.1.0"
+
+react-dropzone@^11.3.2:
+  version "11.3.2"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-11.3.2.tgz#2efb6af800a4779a9daa1e7ba1f8d51d0ab862d7"
+  integrity sha512-Z0l/YHcrNK1r85o6RT77Z5XgTARmlZZGfEKBl3tqTXL9fZNQDuIdRx/J0QjvR60X+yYu26dnHeaG2pWU+1HHvw==
+  dependencies:
+    attr-accept "^2.2.1"
+    file-selector "^0.2.2"
+    prop-types "^15.7.2"
 
 react-error-overlay@^6.0.9:
   version "6.0.9"


### PR DESCRIPTION
It is now possible to directly add a tag from a span as filter in the
Jaeger plugin. To do so, a user has to click on the tag and then he must
click on the "Filter" link. In the current logic all existing tags are
replaced by the selected tag.

We also adjusted the compare page, by directly using react-dropzone
instead of the FileUpload component from Patternfly. This allows us to
have a cleaner layout on the page.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
