### PR TITLE
Add action for Elasticsearch plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#49](https://github.com/kobsio/kobs/pull/49): Add new chart type `table` for Prometheus plugin, which allows a user to render the results of multiple Prometheus queries in ab table.
 - [#51](https://github.com/kobsio/kobs/pull/51): Add new command-line flag to forbid access for resources.
 - [#52](https://github.com/kobsio/kobs/pull/52): Add option to enter a single trace id in the Jaeger plugin.
+- [#56](https://github.com/kobsio/kobs/pull/56): Add actions for Elasticsearch plugin to include/exclude and toggle values in the logs view.
 
 ### Fixed
 

--- a/app/src/plugins/elasticsearch/ElasticsearchLogs.tsx
+++ b/app/src/plugins/elasticsearch/ElasticsearchLogs.tsx
@@ -39,6 +39,7 @@ interface IElasticsearchLogsProps extends IElasticsearchOptions {
   setDocument?: (document: React.ReactNode) => void;
   setScrollID: (scrollID: string) => void;
   selectField?: (field: string) => void;
+  showActions: boolean;
 }
 
 // ElasticsearchLogs is a wrapper component for the Elasticsearch results view (ElasticsearchLogsGrid), it is used to
@@ -54,6 +55,7 @@ const ElasticsearchLogs: React.FunctionComponent<IElasticsearchLogsProps> = ({
   setDocument,
   setScrollID,
   selectField,
+  showActions,
 }: IElasticsearchLogsProps) => {
   const [data, setData] = useState<IDataState>({
     buckets: [],
@@ -186,6 +188,7 @@ const ElasticsearchLogs: React.FunctionComponent<IElasticsearchLogsProps> = ({
       setDocument={setDocument}
       setScrollID={setScrollID}
       selectField={selectField}
+      showActions={showActions}
     />
   );
 };

--- a/app/src/plugins/elasticsearch/ElasticsearchLogsActions.tsx
+++ b/app/src/plugins/elasticsearch/ElasticsearchLogsActions.tsx
@@ -1,0 +1,84 @@
+import { Button, ButtonVariant } from '@patternfly/react-core';
+import { ColumnsIcon, MinusIcon, PlusIcon } from '@patternfly/react-icons';
+import { useHistory, useLocation } from 'react-router-dom';
+import React from 'react';
+
+import { IKeyValue, getOptionsFromSearch } from 'plugins/elasticsearch/helpers';
+
+interface IElasticsearchLogsActionsProps {
+  field: IKeyValue;
+}
+
+const ElasticsearchLogsActions: React.FunctionComponent<IElasticsearchLogsActionsProps> = ({
+  field,
+}: IElasticsearchLogsActionsProps) => {
+  const history = useHistory();
+  const location = useLocation();
+
+  const adjustQuery = (addition: string): void => {
+    const opts = getOptionsFromSearch(location.search);
+    const fields = opts.fields ? opts.fields.map((field) => `&field=${field}`) : [];
+    const query = `${opts.query} ${addition}`;
+
+    history.push({
+      pathname: location.pathname,
+      search: `?query=${query}${fields && fields.length > 0 ? fields.join('') : ''}&timeEnd=${opts.timeEnd}&timeStart=${
+        opts.timeStart
+      }`,
+    });
+  };
+
+  const adjustFields = (field: string): void => {
+    const opts = getOptionsFromSearch(location.search);
+    let tmpFields = opts.fields ? opts.fields : [];
+
+    if (tmpFields.includes(field)) {
+      tmpFields = tmpFields.filter((f) => f !== field);
+    } else {
+      tmpFields.push(field);
+    }
+
+    const fields = tmpFields ? tmpFields.map((field) => `&field=${field}`) : [];
+
+    history.push({
+      pathname: location.pathname,
+      search: `?query=${opts.query}${fields && fields.length > 0 ? fields.join('') : ''}&timeEnd=${
+        opts.timeEnd
+      }&timeStart=${opts.timeStart}`,
+    });
+  };
+
+  return (
+    <React.Fragment>
+      <Button
+        style={{ fontSize: '10px', padding: '0px 6px' }}
+        variant={ButtonVariant.plain}
+        isSmall={true}
+        aria-label="Include"
+        onClick={(): void => adjustQuery(`AND ${field.key}: ${field.value}`)}
+      >
+        <PlusIcon />
+      </Button>
+      <Button
+        style={{ fontSize: '10px', padding: '0px 6px' }}
+        variant={ButtonVariant.plain}
+        isSmall={true}
+        aria-label="Exclude"
+        onClick={(): void => adjustQuery(`AND NOT ${field.key}: ${field.value}`)}
+      >
+        <MinusIcon />
+      </Button>
+      <Button
+        style={{ fontSize: '10px', padding: '0px 6px' }}
+        variant={ButtonVariant.plain}
+        isSmall={true}
+        aria-label="Toggle"
+        onClick={(): void => adjustFields(field.key)}
+      >
+        <ColumnsIcon />
+      </Button>
+    </React.Fragment>
+  );
+};
+
+export default ElasticsearchLogsActions;

--- a/app/src/plugins/elasticsearch/ElasticsearchLogsDocument.tsx
+++ b/app/src/plugins/elasticsearch/ElasticsearchLogsDocument.tsx
@@ -1,18 +1,24 @@
 import {
+  Card,
   DrawerActions,
   DrawerCloseButton,
   DrawerHead,
   DrawerPanelBody,
   DrawerPanelContent,
+  Tab,
+  TabTitleText,
+  Tabs,
 } from '@patternfly/react-core';
-import React from 'react';
+import React, { useState } from 'react';
 
 import { IDocument, formatTimeWrapper } from 'plugins/elasticsearch/helpers';
 import Editor from 'components/Editor';
+import ElasticsearchLogsDocumentOverview from 'plugins/elasticsearch/ElasticsearchLogsDocumentOverview';
 import Title from 'components/Title';
 
 export interface IElasticsearchLogsDocumentProps {
   document: IDocument;
+  showActions: boolean;
   close: () => void;
 }
 
@@ -20,8 +26,11 @@ export interface IElasticsearchLogsDocumentProps {
 // code view. The highlighting of this JSON document is handled by highlight.js.
 const ElasticsearchLogsDocument: React.FunctionComponent<IElasticsearchLogsDocumentProps> = ({
   document,
+  showActions,
   close,
 }: IElasticsearchLogsDocumentProps) => {
+  const [activeTab, setActiveTab] = useState<string>('overview');
+
   return (
     <DrawerPanelContent minSize="50%">
       <DrawerHead>
@@ -36,8 +45,26 @@ const ElasticsearchLogsDocument: React.FunctionComponent<IElasticsearchLogsDocum
       </DrawerHead>
 
       <DrawerPanelBody>
-        <Editor value={JSON.stringify(document, null, 2)} mode="json" readOnly={true} />
-        <p>&nbsp;</p>
+        <Tabs
+          activeKey={activeTab}
+          onSelect={(event, tabIndex): void => setActiveTab(tabIndex.toString())}
+          className="pf-u-mt-md"
+          isFilled={true}
+          mountOnEnter={true}
+        >
+          <Tab eventKey="overview" title={<TabTitleText>Overview</TabTitleText>}>
+            <div style={{ maxWidth: '100%', overflowX: 'scroll', padding: '24px 24px' }}>
+              <ElasticsearchLogsDocumentOverview document={document} showActions={showActions} />
+            </div>
+          </Tab>
+          <Tab eventKey="json" title={<TabTitleText>JSON</TabTitleText>}>
+            <div style={{ maxWidth: '100%', overflowX: 'scroll', padding: '24px 24px' }}>
+              <Card>
+                <Editor value={JSON.stringify(document, null, 2)} mode="json" readOnly={true} />
+              </Card>
+            </div>
+          </Tab>
+        </Tabs>
       </DrawerPanelBody>
     </DrawerPanelContent>
   );

--- a/app/src/plugins/elasticsearch/ElasticsearchLogsDocumentOverview.tsx
+++ b/app/src/plugins/elasticsearch/ElasticsearchLogsDocumentOverview.tsx
@@ -1,0 +1,45 @@
+import { Card, CardBody, DescriptionList } from '@patternfly/react-core';
+import React from 'react';
+
+import { IDocument, IKeyValue } from 'plugins/elasticsearch/helpers';
+import ElasticsearchLogsDocumentOverviewItem from 'plugins/elasticsearch/ElasticsearchLogsDocumentOverviewItem';
+
+// getKeyValues creates an array with all keys and values of the document.
+const getKeyValues = (obj: IDocument, prefix = ''): IKeyValue[] => {
+  return Object.keys(obj).reduce((res: IKeyValue[], el) => {
+    if (Array.isArray(obj[el])) {
+      return res;
+    } else if (typeof obj[el] === 'object' && obj[el] !== null) {
+      return [...res, ...getKeyValues(obj[el], prefix + el + '.')];
+    }
+    return [...res, { key: prefix + el, value: obj[el] }];
+  }, []);
+};
+
+export interface IElasticsearchLogsDocumentOverviewProps {
+  document: IDocument;
+  showActions: boolean;
+}
+
+// ElasticsearchLogsDocumentOverview renders a list of all keys and their values in a description list. For that we have
+// to generate a fields list via the getKeyValues function first.
+const ElasticsearchLogsDocumentOverview: React.FunctionComponent<IElasticsearchLogsDocumentOverviewProps> = ({
+  document,
+  showActions,
+}: IElasticsearchLogsDocumentOverviewProps) => {
+  const fields = getKeyValues(document['_source']);
+
+  return (
+    <Card>
+      <CardBody>
+        <DescriptionList className="pf-u-text-break-word">
+          {fields.map((field) => (
+            <ElasticsearchLogsDocumentOverviewItem key={field.key} field={field} showActions={showActions} />
+          ))}
+        </DescriptionList>
+      </CardBody>
+    </Card>
+  );
+};
+
+export default ElasticsearchLogsDocumentOverview;

--- a/app/src/plugins/elasticsearch/ElasticsearchLogsDocumentOverviewItem.tsx
+++ b/app/src/plugins/elasticsearch/ElasticsearchLogsDocumentOverviewItem.tsx
@@ -1,0 +1,32 @@
+import { DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from '@patternfly/react-core';
+import React, { useState } from 'react';
+
+import ElasticsearchLogsActions from 'plugins/elasticsearch/ElasticsearchLogsActions';
+import { IKeyValue } from 'plugins/elasticsearch/helpers';
+
+interface IElasticsearchLogsDocumentOverviewItemProps {
+  field: IKeyValue;
+  showActions: boolean;
+}
+
+// Item is the component to render a single field from the generated key/values list. When the user hovers over the
+// title/key of the description list, we will show some actions, which can be used to include/exclude the value from the
+// search or to add it as column to the table.
+const ElasticsearchLogsDocumentOverviewItem: React.FunctionComponent<IElasticsearchLogsDocumentOverviewItemProps> = ({
+  field,
+  showActions,
+}: IElasticsearchLogsDocumentOverviewItemProps) => {
+  const [show, setShow] = useState<boolean>(false);
+
+  return (
+    <DescriptionListGroup>
+      <DescriptionListTerm onMouseEnter={(): void => setShow(true)} onMouseLeave={(): void => setShow(false)}>
+        {field.key}
+        {showActions && show ? <ElasticsearchLogsActions field={field} /> : null}
+      </DescriptionListTerm>
+      <DescriptionListDescription>{field.value}</DescriptionListDescription>
+    </DescriptionListGroup>
+  );
+};
+
+export default ElasticsearchLogsDocumentOverviewItem;

--- a/app/src/plugins/elasticsearch/ElasticsearchLogsDocuments.tsx
+++ b/app/src/plugins/elasticsearch/ElasticsearchLogsDocuments.tsx
@@ -1,13 +1,15 @@
-import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { TableComposable, TableVariant, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
 import { Card } from '@patternfly/react-core';
 import React from 'react';
 
-import { IDocument, formatTimeWrapper, getProperty } from 'plugins/elasticsearch/helpers';
+import ElasticsearchLogsDocumentsItem from 'plugins/elasticsearch/ElasticsearchLogsDocumentsItem';
+import { IDocument } from 'plugins/elasticsearch/helpers';
 
 export interface IElasticsearchLogsDocumentsProps {
   selectedFields: string[];
   documents: IDocument[];
   select?: (doc: IDocument) => void;
+  showActions: boolean;
 }
 
 // ElasticsearchLogsDocuments renders a list of documents. If the user has selected some fields, we will render the
@@ -17,6 +19,7 @@ const ElasticsearchLogsDocuments: React.FunctionComponent<IElasticsearchLogsDocu
   selectedFields,
   documents,
   select,
+  showActions,
 }: IElasticsearchLogsDocumentsProps) => {
   return (
     <Card style={{ maxWidth: '100%', overflowX: 'scroll' }}>
@@ -33,18 +36,13 @@ const ElasticsearchLogsDocuments: React.FunctionComponent<IElasticsearchLogsDocu
         </Thead>
         <Tbody>
           {documents.map((document, index) => (
-            <Tr key={index} onClick={select ? (): void => select(document) : undefined}>
-              <Td dataLabel="Time">{formatTimeWrapper(document['_source']['@timestamp'])}</Td>
-              {selectedFields.length > 0 ? (
-                selectedFields.map((selectedField, index) => (
-                  <Td key={index} dataLabel={selectedField}>
-                    {getProperty(document['_source'], selectedField)}
-                  </Td>
-                ))
-              ) : (
-                <Td dataLabel="_source">{JSON.stringify(document['_source'])}</Td>
-              )}
-            </Tr>
+            <ElasticsearchLogsDocumentsItem
+              key={index}
+              document={document}
+              selectedFields={selectedFields}
+              select={select}
+              showActions={showActions}
+            />
           ))}
         </Tbody>
       </TableComposable>

--- a/app/src/plugins/elasticsearch/ElasticsearchLogsDocumentsItem.tsx
+++ b/app/src/plugins/elasticsearch/ElasticsearchLogsDocumentsItem.tsx
@@ -1,0 +1,41 @@
+import { TableText, Td, Tr } from '@patternfly/react-table';
+import React from 'react';
+
+import { IDocument, formatTimeWrapper } from 'plugins/elasticsearch/helpers';
+import ElasticsearchLogsDocumentsItemField from 'plugins/elasticsearch/ElasticsearchLogsDocumentsItemField';
+
+export interface IElasticsearchLogsDocumentsItemProps {
+  selectedFields: string[];
+  document: IDocument;
+  select?: (doc: IDocument) => void;
+  showActions: boolean;
+}
+
+const ElasticsearchLogsDocumentsItem: React.FunctionComponent<IElasticsearchLogsDocumentsItemProps> = ({
+  selectedFields,
+  document,
+  select,
+  showActions,
+}: IElasticsearchLogsDocumentsItemProps) => {
+  return (
+    <Tr>
+      <Td dataLabel="Time" onClick={select ? (): void => select(document) : undefined}>
+        <TableText wrapModifier="nowrap"> {formatTimeWrapper(document['_source']['@timestamp'])}</TableText>
+      </Td>
+      {selectedFields.length > 0 ? (
+        selectedFields.map((selectedField, index) => (
+          <ElasticsearchLogsDocumentsItemField
+            key={index}
+            document={document}
+            selectedField={selectedField}
+            showActions={showActions}
+          />
+        ))
+      ) : (
+        <Td dataLabel="_source">{JSON.stringify(document['_source'])}</Td>
+      )}
+    </Tr>
+  );
+};
+
+export default ElasticsearchLogsDocumentsItem;

--- a/app/src/plugins/elasticsearch/ElasticsearchLogsDocumentsItemField.tsx
+++ b/app/src/plugins/elasticsearch/ElasticsearchLogsDocumentsItemField.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { Td } from '@patternfly/react-table';
+
+import { IDocument, getProperty } from 'plugins/elasticsearch/helpers';
+import ElasticsearchLogsActions from 'plugins/elasticsearch/ElasticsearchLogsActions';
+
+export interface IElasticsearchLogsDocumentsItemFieldProps {
+  selectedField: string;
+  document: IDocument;
+  select?: (doc: IDocument) => void;
+  showActions: boolean;
+}
+
+const ElasticsearchLogsDocumentsItemField: React.FunctionComponent<IElasticsearchLogsDocumentsItemFieldProps> = ({
+  document,
+  selectedField,
+  showActions,
+}: IElasticsearchLogsDocumentsItemFieldProps) => {
+  const [show, setShow] = useState<boolean>(false);
+  const value = getProperty(document['_source'], selectedField);
+
+  return (
+    <Td dataLabel={selectedField} onMouseEnter={(): void => setShow(true)} onMouseLeave={(): void => setShow(false)}>
+      {value}
+      {showActions && show ? <ElasticsearchLogsActions field={{ key: selectedField, value: value as string }} /> : null}
+    </Td>
+  );
+};
+
+export default ElasticsearchLogsDocumentsItemField;

--- a/app/src/plugins/elasticsearch/ElasticsearchLogsGrid.tsx
+++ b/app/src/plugins/elasticsearch/ElasticsearchLogsGrid.tsx
@@ -25,6 +25,7 @@ interface IElasticsearchLogsGridProps {
   setDocument?: (document: React.ReactNode) => void;
   setScrollID: (scrollID: string) => void;
   selectField?: (field: string) => void;
+  showActions: boolean;
 }
 
 // ElasticsearchLogsGrid renders a grid, for the Elasticsearch results. The grid contains a list of fields and selected
@@ -46,6 +47,7 @@ const ElasticsearchLogsGrid: React.FunctionComponent<IElasticsearchLogsGridProps
   setDocument,
   setScrollID,
   selectField,
+  showActions,
 }: IElasticsearchLogsGridProps) => {
   // showFields is used to define if we want to show the fields list in the grid or not. If the queryName isn't present,
   // which can only happen in the page view, we show the logs. In that way we can save some space in the plugin view,
@@ -83,9 +85,16 @@ const ElasticsearchLogsGrid: React.FunctionComponent<IElasticsearchLogsGridProps
             select={
               setDocument
                 ? (doc: IDocument): void =>
-                    setDocument(<ElasticsearchLogsDocument document={doc} close={(): void => setDocument(undefined)} />)
+                    setDocument(
+                      <ElasticsearchLogsDocument
+                        document={doc}
+                        showActions={showActions}
+                        close={(): void => setDocument(undefined)}
+                      />,
+                    )
                 : undefined
             }
+            showActions={showActions}
           />
         ) : null}
 

--- a/app/src/plugins/elasticsearch/ElasticsearchPage.tsx
+++ b/app/src/plugins/elasticsearch/ElasticsearchPage.tsx
@@ -99,6 +99,7 @@ const ElasticsearchPage: React.FunctionComponent<IPluginPageProps> = ({ name, de
                   setDocument={setDocument}
                   setScrollID={setScrollID}
                   selectField={selectField}
+                  showActions={true}
                 />
               ) : null}
             </PageSection>

--- a/app/src/plugins/elasticsearch/ElasticsearchPageToolbar.tsx
+++ b/app/src/plugins/elasticsearch/ElasticsearchPageToolbar.tsx
@@ -9,7 +9,7 @@ import {
   ToolbarToggleGroup,
 } from '@patternfly/react-core';
 import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import Options, { IAdditionalFields } from 'components/Options';
 import { IElasticsearchOptions } from 'plugins/elasticsearch/helpers';
@@ -63,6 +63,14 @@ const ElasticsearchPageToolbar: React.FunctionComponent<IElasticsearchPageToolba
       setOptions(data);
     }
   };
+
+  // useEffect is triggered when the query property is changed. This is needed because, the query can also be changed,
+  // via the actions of a field in the document (include/exclude the value of a field).
+  useEffect(() => {
+    setData((d) => {
+      return { ...d, query: query };
+    });
+  }, [query]);
 
   return (
     <Toolbar id="elasticsearch-toolbar" style={{ paddingBottom: '0px', zIndex: 300 }}>

--- a/app/src/plugins/elasticsearch/ElasticsearchPlugin.tsx
+++ b/app/src/plugins/elasticsearch/ElasticsearchPlugin.tsx
@@ -74,6 +74,7 @@ const ElasticsearchPlugin: React.FunctionComponent<IPluginProps> = ({
           timeStart={options.timeStart}
           setDocument={showDetails}
           setScrollID={setScrollID}
+          showActions={false}
         />
       ) : null}
     </React.Fragment>

--- a/app/src/plugins/elasticsearch/helpers.ts
+++ b/app/src/plugins/elasticsearch/helpers.ts
@@ -23,6 +23,12 @@ export interface IDocument {
   [key: string]: any;
 }
 
+// IKeyValue is the interface for a single field in a document, with it's key and value.
+export interface IKeyValue {
+  key: string;
+  value: string;
+}
+
 // getOptionsFromSearch is used to get the Elasticsearch options from a given search location.
 export const getOptionsFromSearch = (search: string): IElasticsearchOptions => {
   const params = new URLSearchParams(search);

--- a/app/src/plugins/jaeger/JaegerPageToolbar.tsx
+++ b/app/src/plugins/jaeger/JaegerPageToolbar.tsx
@@ -136,6 +136,8 @@ const JaegerPageToolbar: React.FunctionComponent<IJaegerPageToolbarProps> = ({
     fetchOperations();
   }, [fetchOperations]);
 
+  // useEffect is triggered when the tags property is changed. This is needed because, tags can also be set by clicking
+  // on a tag and selecting the filter option.
   useEffect(() => {
     setOptions((o) => {
       return { ...o, tags: tags };

--- a/pkg/api/plugins/elasticsearch/elasticsearch.go
+++ b/pkg/api/plugins/elasticsearch/elasticsearch.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	elasticsearchProto "github.com/kobsio/kobs/pkg/api/plugins/elasticsearch/proto"
 	pluginsProto "github.com/kobsio/kobs/pkg/api/plugins/plugins/proto"
@@ -111,7 +112,7 @@ func (e *Elasticsearch) GetLogs(ctx context.Context, getLogsRequest *elasticsear
 
 	if getLogsRequest.ScrollID == "" {
 		url = fmt.Sprintf("%s/_search?scroll=15m", instance.address)
-		body = []byte(fmt.Sprintf(`{"size":100,"sort":[{"@timestamp":{"order":"desc"}}],"query":{"bool":{"must":[{"range":{"@timestamp":{"gte":"%d","lte":"%d"}}},{"query_string":{"query":"%s"}}]}},"aggs":{"logcount":{"auto_date_histogram":{"field":"@timestamp","buckets":30}}}}`, getLogsRequest.TimeStart*1000, getLogsRequest.TimeEnd*1000, getLogsRequest.Query.Query))
+		body = []byte(fmt.Sprintf(`{"size":100,"sort":[{"@timestamp":{"order":"desc"}}],"query":{"bool":{"must":[{"range":{"@timestamp":{"gte":"%d","lte":"%d"}}},{"query_string":{"query":"%s"}}]}},"aggs":{"logcount":{"auto_date_histogram":{"field":"@timestamp","buckets":30}}}}`, getLogsRequest.TimeStart*1000, getLogsRequest.TimeEnd*1000, strings.ReplaceAll(getLogsRequest.Query.Query, "\"", "\\\"")))
 	} else {
 		url = fmt.Sprintf("%s/_search/scroll", instance.address)
 		body = []byte(`{"scroll" : "15m", "scroll_id" : "` + getLogsRequest.ScrollID + `"}`)


### PR DESCRIPTION
The new actions for the Elasticsearch plugin can be used to
include/exclude a value from the search and to toggle a field in the
table view. These actions are only available in the page view of the
Elasticsearch plugin and not within the Applications view.

We also fixed a small bug, where double quotes were not escaped
correctly in the request against the Elasticsearch API.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
