### PR TITLE
Add Pod annotations and labels for Helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#56](https://github.com/kobsio/kobs/pull/56): Add actions for Elasticsearch plugin to include/exclude and toggle values in the logs view.
 - [#58](https://github.com/kobsio/kobs/pull/58): Add plugin support for Teams. It is now possible to define plugins within a Team CR, which are then added to the teams page in the React UI.
 - [#59](https://github.com/kobsio/kobs/pull/59): Add support for Templates via the new Templates CRD. Templates allows a user to reuse plugin definitions accross Applications, Teams and Kubernetes resources.
+- [#60](https://github.com/kobsio/kobs/pull/60): Add support for additional Pod annotations and labels in the Helm chart via the new `podAnnotations` and `podLabels` values.
 
 ### Fixed
 

--- a/deploy/helm/kobs/Chart.yaml
+++ b/deploy/helm/kobs/Chart.yaml
@@ -4,5 +4,5 @@ description: Kubernetes Observability Platform
 type: application
 home: https://kobs.io
 icon: https://kobs.io/assets/images/logo.svg
-version: 0.3.6
+version: 0.4.0
 appVersion: v0.2.0

--- a/deploy/helm/kobs/templates/_helpers.tpl
+++ b/deploy/helm/kobs/templates/_helpers.tpl
@@ -72,3 +72,21 @@ Create the name of the cluster role and cluster role binding to use
     {{ default "default" .Values.rbac.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Additional annotations for Pods
+*/}}
+{{- define "kobs.podAnnotations" -}}
+{{- if .Values.podAnnotations }}
+{{- toYaml .Values.podAnnotations }}
+{{- end }}
+{{- end }}
+
+{{/*
+Additional labels for Pods
+*/}}
+{{- define "kobs.podLabels" -}}
+{{- if .Values.podLabels }}
+{{- toYaml .Values.podLabels }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/kobs/templates/deployment.yaml
+++ b/deploy/helm/kobs/templates/deployment.yaml
@@ -13,6 +13,11 @@ spec:
     metadata:
       labels:
         {{- include "kobs.selectorLabels" . | nindent 8 }}
+        {{- include "kobs.podLabels" . | nindent 8 }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{ include "kobs.podAnnotations" . | nindent 8 }}
+      {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/deploy/helm/kobs/values.yaml
+++ b/deploy/helm/kobs/values.yaml
@@ -36,6 +36,14 @@ tolerations: []
 ##
 affinity: {}
 
+## Specify additional annotations for the created Pods.
+##
+podAnnotations: {}
+
+## Specify additional labels for the created Pods.
+##
+podLabels: {}
+
 kobs:
   image:
     repository: kobsio/kobs

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -59,6 +59,8 @@ helm upgrade kobs kobs/kobs
 | `nodeSelector` | Specify a map of key-value pairs, to assign the Pods to a specific set of nodes. | `{}` |
 | `tolerations` | Specify the tolerations for the kobs Pods. | `[]` |
 | `affinity` | Specify a node affinity or inter-pod affinity / anti-affinity for an advanced scheduling of the kobs Pods. | `{}` |
+| `podAnnotations` | Specify additional annotations for the created Pods. | `{}` |
+| `podLabels` | Specify additional labels for the created Pods. | `{}` |
 | `kobs.image.repository` | The repository for the Docker image. | `kobsio/kobs` |
 | `kobs.image.tag` | The tag of the Docker image which should be used. | `v0.2.0` |
 | `kobs.image.pullPolicy` | The image pull policy for the Docker image. | `IfNotPresent` |


### PR DESCRIPTION
It is now possible to specify additional annotations and labels for the
created Pods in the Helm chart. For that we added two new values
"podAnnotations" and "podLabels" to the values file.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [x] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
