### PR TITLE
Add example templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#55](https://github.com/kobsio/kobs/pull/55): Allow a user to add a tag from a span as filter in the Jaeger plugin.
 - [#57](https://github.com/kobsio/kobs/pull/57): Visualize the offset of spans in the Jaeger plugin.
 - [#61](https://github.com/kobsio/kobs/pull/61): Improve caching logic, by generating the teams and topology graph only when it is requested and not via an additional goroutine.
+- [#62](https://github.com/kobsio/kobs/pull/62): Show the name of a variable within the select box in the Prometheus dashboards.
 
 ## [v0.2.0](https://github.com/kobsio/kobs/releases/tag/v0.2.0) (2021-04-23)
 

--- a/app/src/plugins/prometheus/PrometheusVariable.tsx
+++ b/app/src/plugins/prometheus/PrometheusVariable.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Select, SelectOption, SelectOptionObject, SelectVariant } from '@patternfly/react-core';
+import { Select, SelectGroup, SelectOption, SelectOptionObject, SelectVariant } from '@patternfly/react-core';
 
 import { Variable } from 'proto/prometheus_grpc_web_pb';
 
@@ -26,6 +26,14 @@ const PrometheusVariable: React.FunctionComponent<IPrometheusVariableProps> = ({
     setShow(false);
   };
 
+  const group = [
+    <SelectGroup label={variable.name} key="variable">
+      {variable.valuesList.map((value, index) => (
+        <SelectOption key={index} value={value} />
+      ))}
+    </SelectGroup>,
+  ];
+
   return (
     <Select
       variant={SelectVariant.single}
@@ -36,9 +44,7 @@ const PrometheusVariable: React.FunctionComponent<IPrometheusVariableProps> = ({
       selections={variable.value}
       isOpen={show}
     >
-      {variable.valuesList.map((value, index) => (
-        <SelectOption key={index} value={value} />
-      ))}
+      {group}
     </Select>
   );
 };

--- a/deploy/templates/elasticsearch-application-and-istio-logs.yaml
+++ b/deploy/templates/elasticsearch-application-and-istio-logs.yaml
@@ -1,0 +1,30 @@
+apiVersion: kobs.io/v1alpha1
+kind: Template
+metadata:
+  name: elasticsearch-application-and-istio-logs
+spec:
+  description: Display the logs of your Application and the Istio Sidecar via Elasticsearch.
+  variables:
+    - name: name
+      description: The name of your Application.
+    - name: namespace
+      description: The namespace of your Application.
+  plugin:
+    name: Elasticsearch
+    elasticsearch:
+      queries:
+        - name: Application Logs
+          query: "kubernetes.namespace: << namespace >> AND kubernetes.labels.app: << name >> AND NOT kubernetes.container.name: istio-proxy"
+        - name: Istio Sidecar Logs
+          query: "kubernetes.namespace: << namespace >> AND kubernetes.labels.app: << name >> AND kubernetes.container.name: istio-proxy"
+          fields:
+            - "kubernetes.pod.name"
+            - "content.authority"
+            - "content.route_name"
+            - "content.protocol"
+            - "content.method"
+            - "content.path"
+            - "content.response_code"
+            - "content.upstream_service_time"
+            - "content.bytes_received"
+            - "content.bytes_sent"

--- a/deploy/templates/prometheus-istio-workload-http.yaml
+++ b/deploy/templates/prometheus-istio-workload-http.yaml
@@ -1,0 +1,226 @@
+---
+apiVersion: kobs.io/v1alpha1
+kind: Template
+metadata:
+  name: prometheus-istio-workload-http
+spec:
+  description: Istio Workload Dashboard for HTTP traffic, similar to the one provided for Grafana https://grafana.com/grafana/dashboards/7630.
+  variables:
+    - name: namespace
+      description: The workload namespace.
+    - name: workload
+      description: The workload name.
+  plugin:
+    name: Prometheus
+    prometheus:
+      variables:
+        - name: Reporter
+          label: reporter
+          query: istio_requests_total{destination_workload="<< workload >>", destination_workload_namespace=~"<< namespace >>"}
+          allowAll: false
+        - name: Source Workload Namespace
+          label: source_workload_namespace
+          query: istio_requests_total{reporter="{{ .Reporter }}", destination_workload="<< workload >>", destination_workload_namespace=~"<< namespace >>"}
+          allowAll: true
+        - name: Source Workload
+          label: source_workload
+          query: istio_requests_total{reporter="{{ .Reporter }}", destination_workload="<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}
+          allowAll: true
+        - name: Destination Service
+          label: destination_service
+          query: istio_requests_total{reporter="source", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>"}
+          allowAll: true
+      charts:
+        - title: Incoming Request Volume
+          type: sparkline
+          unit: req/s
+          size: 6
+          queries:
+            - label: Incoming Request Volume
+              query: round(sum(irate(istio_requests_total{reporter="{{ .Reporter }}",destination_workload_namespace=~"<< namespace >>",destination_workload=~"<< workload >>"}[5m])), 0.001)
+        - title: Incoming Success Rate
+          type: sparkline
+          unit: "%"
+          size: 6
+          queries:
+            - label: Incoming Success Rate
+              query: sum(irate(istio_requests_total{reporter="{{ .Reporter }}",destination_workload_namespace=~"<< namespace >>",destination_workload=~"<< workload >>",response_code!~"5.*"}[5m])) / sum(irate(istio_requests_total{reporter="{{ .Reporter }}",destination_workload_namespace=~"<< namespace >>",destination_workload=~"<< workload >>"}[5m])) * 100
+        - title: Request Duration
+          type: line
+          unit: ms
+          size: 12
+          queries:
+            - label: P50
+              query: histogram_quantile(0.50, sum(irate(istio_request_duration_milliseconds_bucket{reporter="{{ .Reporter }}",destination_workload_namespace=~"<< namespace >>",destination_workload=~"<< workload >>"}[1m])) by (le))
+            - label: P90
+              query: histogram_quantile(0.90, sum(irate(istio_request_duration_milliseconds_bucket{reporter="{{ .Reporter }}",destination_workload_namespace=~"<< namespace >>",destination_workload=~"<< workload >>"}[1m])) by (le))
+            - label: P99
+              query: histogram_quantile(0.99, sum(irate(istio_request_duration_milliseconds_bucket{reporter="{{ .Reporter }}",destination_workload_namespace=~"<< namespace >>",destination_workload=~"<< workload >>"}[1m])) by (le))
+
+        - title: Inbound Workloads
+          type: divider
+        - title: Incoming Requests By Source And Response Code
+          type: line
+          unit: req/s
+          size: 6
+          queries:
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} : {{ .response_code }} (🔐 mTLS)"
+              query: round(sum(irate(istio_requests_total{connection_security_policy="mutual_tls", destination_workload_namespace=~"<< namespace >>", destination_workload=~"<< workload >>", reporter="{{ .Reporter }}", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[5m])) by (source_workload, source_workload_namespace, response_code), 0.001)
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} : {{ .response_code }}"
+              query: round(sum(irate(istio_requests_total{connection_security_policy!="mutual_tls", destination_workload_namespace=~"<< namespace >>", destination_workload=~"<< workload >>", reporter="{{ .Reporter }}", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[5m])) by (source_workload, source_workload_namespace, response_code), 0.001)
+        - title: Incoming Success Rate (non-5xx responses) By Source
+          type: line
+          unit: "%"
+          size: 6
+          queries:
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} (🔐 mTLS)"
+              query: sum(irate(istio_requests_total{reporter="{{ .Reporter }}", connection_security_policy="mutual_tls", destination_workload_namespace=~"<< namespace >>", destination_workload=~"<< workload >>",response_code!~"5.*", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[5m])) by (source_workload, source_workload_namespace) / sum(irate(istio_requests_total{reporter="{{ .Reporter }}", connection_security_policy="mutual_tls", destination_workload_namespace=~"<< namespace >>", destination_workload=~"<< workload >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[5m])) by (source_workload, source_workload_namespace) * 100
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }}"
+              query: sum(irate(istio_requests_total{reporter="{{ .Reporter }}", connection_security_policy!="mutual_tls", destination_workload_namespace=~"<< namespace >>", destination_workload=~"<< workload >>",response_code!~"5.*", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[5m])) by (source_workload, source_workload_namespace) / sum(irate(istio_requests_total{reporter="{{ .Reporter }}", connection_security_policy!="mutual_tls", destination_workload_namespace=~"<< namespace >>", destination_workload=~"<< workload >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[5m])) by (source_workload, source_workload_namespace) * 100
+        - title: Incoming Request Duration By Source
+          type: line
+          unit: ms
+          size: 4
+          queries:
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} P50 (🔐 m TLS)"
+              query: histogram_quantile(0.50, sum(irate(istio_request_duration_milliseconds_bucket{reporter="{{ .Reporter }}", connection_security_policy="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} P90 (🔐 mTLS)"
+              query: histogram_quantile(0.90, sum(irate(istio_request_duration_milliseconds_bucket{reporter="{{ .Reporter }}", connection_security_policy="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} P95 (🔐 mTLS)"
+              query: histogram_quantile(0.95, sum(irate(istio_request_duration_milliseconds_bucket{reporter="{{ .Reporter }}", connection_security_policy="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} P99 (🔐 mTLS)"
+              query: histogram_quantile(0.99, sum(irate(istio_request_duration_milliseconds_bucket{reporter="{{ .Reporter }}", connection_security_policy="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} P50"
+              query: histogram_quantile(0.50, sum(irate(istio_request_duration_milliseconds_bucket{reporter="{{ .Reporter }}", connection_security_policy!="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} P90"
+              query: histogram_quantile(0.90, sum(irate(istio_request_duration_milliseconds_bucket{reporter="{{ .Reporter }}", connection_security_policy!="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} P95"
+              query: histogram_quantile(0.95, sum(irate(istio_request_duration_milliseconds_bucket{reporter="{{ .Reporter }}", connection_security_policy!="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} P99"
+              query: histogram_quantile(0.99, sum(irate(istio_request_duration_milliseconds_bucket{reporter="{{ .Reporter }}", connection_security_policy!="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+        - title: Incoming Request Size By Source
+          type: line
+          unit: bytes
+          size: 4
+          queries:
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} P50 (🔐 mTLS)"
+              query: histogram_quantile(0.50, sum(irate(istio_request_bytes_bucket{reporter="{{ .Reporter }}", connection_security_policy="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }}  P90 (🔐 mTLS)"
+              query: histogram_quantile(0.90, sum(irate(istio_request_bytes_bucket{reporter="{{ .Reporter }}", connection_security_policy="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} P95 (🔐 mTLS)"
+              query: histogram_quantile(0.95, sum(irate(istio_request_bytes_bucket{reporter="{{ .Reporter }}", connection_security_policy="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }}  P99 (🔐 mTLS)"
+              query: histogram_quantile(0.99, sum(irate(istio_request_bytes_bucket{reporter="{{ .Reporter }}", connection_security_policy="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} P50"
+              query: histogram_quantile(0.50, sum(irate(istio_request_bytes_bucket{reporter="{{ .Reporter }}", connection_security_policy!="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} P90"
+              query: histogram_quantile(0.90, sum(irate(istio_request_bytes_bucket{reporter="{{ .Reporter }}", connection_security_policy!="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} P95"
+              query: histogram_quantile(0.95, sum(irate(istio_request_bytes_bucket{reporter="{{ .Reporter }}", connection_security_policy!="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} P99"
+              query: histogram_quantile(0.99, sum(irate(istio_request_bytes_bucket{reporter="{{ .Reporter }}", connection_security_policy!="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+        - title: Response Size By Source
+          type: line
+          unit: bytes
+          size: 4
+          queries:
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} P50 (🔐 mTLS)"
+              query: histogram_quantile(0.50, sum(irate(istio_response_bytes_bucket{reporter="{{ .Reporter }}", connection_security_policy="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }}  P90 (🔐 mTLS)"
+              query: histogram_quantile(0.90, sum(irate(istio_response_bytes_bucket{reporter="{{ .Reporter }}", connection_security_policy="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} P95 (🔐 mTLS)"
+              query: histogram_quantile(0.95, sum(irate(istio_response_bytes_bucket{reporter="{{ .Reporter }}", connection_security_policy="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }}  P99 (🔐 mTLS)"
+              query: histogram_quantile(0.99, sum(irate(istio_response_bytes_bucket{reporter="{{ .Reporter }}", connection_security_policy="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} P50"
+              query: histogram_quantile(0.50, sum(irate(istio_response_bytes_bucket{reporter="{{ .Reporter }}", connection_security_policy!="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} P90"
+              query: histogram_quantile(0.90, sum(irate(istio_response_bytes_bucket{reporter="{{ .Reporter }}", connection_security_policy!="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} P95"
+              query: histogram_quantile(0.95, sum(irate(istio_response_bytes_bucket{reporter="{{ .Reporter }}", connection_security_policy!="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} P99"
+              query: histogram_quantile(0.99, sum(irate(istio_response_bytes_bucket{reporter="{{ .Reporter }}", connection_security_policy!="mutual_tls", destination_workload=~"<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace, le))
+
+        - title: Outbound Workloads
+          type: divider
+        - title: Outgoing Requests By Destination And Response Code
+          type: line
+          unit: req/s
+          size: 6
+          queries:
+            - label: "{{ .destination_service }} : {{ .response_code }} (🔐 mTLS)"
+              query: round(sum(irate(istio_requests_total{connection_security_policy="mutual_tls", source_workload_namespace=~"<< namespace >>", source_workload=~"<< workload >>", reporter="source", destination_service=~"{{ index . "Destination Service" }}"}[5m])) by (destination_service, response_code), 0.001)
+            - label: "{{ .destination_service }} : {{ .response_code }}"
+              query: round(sum(irate(istio_requests_total{connection_security_policy!="mutual_tls", source_workload_namespace=~"<< namespace >>", source_workload=~"<< workload >>", reporter="source", destination_service=~"{{ index . "Destination Service" }}"}[5m])) by (destination_service, response_code), 0.001)
+        - title: Outgoing Success Rate (non-5xx responses) By Destination
+          type: line
+          unit: "%"
+          size: 6
+          queries:
+            - label: "{{ .destination_service }} (🔐 mTLS)"
+              query: sum(irate(istio_requests_total{reporter="source", connection_security_policy="mutual_tls", source_workload_namespace=~"<< namespace >>", source_workload=~"<< workload >>",response_code!~"5.*", destination_service=~"{{ index . "Destination Service" }}"}[5m])) by (destination_service) / sum(irate(istio_requests_total{reporter="source", connection_security_policy="mutual_tls", source_workload_namespace=~"<< namespace >>", source_workload=~"<< workload >>", destination_service=~"{{ index . "Destination Service" }}"}[5m])) by (destination_service) * 100
+            - label: "{{ .destination_service }}"
+              query: sum(irate(istio_requests_total{reporter="source", connection_security_policy!="mutual_tls", source_workload_namespace=~"<< namespace >>", source_workload=~"<< workload >>",response_code!~"5.*", destination_service=~"{{ index . "Destination Service" }}"}[5m])) by (destination_service) / sum(irate(istio_requests_total{reporter="source", connection_security_policy!="mutual_tls", source_workload_namespace=~"<< namespace >>", source_workload=~"<< workload >>", destination_service=~"{{ index . "Destination Service" }}"}[5m])) by (destination_service) * 100
+        - title: Outgoing Request Duration By Destination
+          type: line
+          unit: ms
+          size: 4
+          queries:
+            - label: "{{ .destination_service }} P50 (🔐 mTLS)"
+              query: histogram_quantile(0.50, sum(irate(istio_request_duration_milliseconds_bucket{reporter="source", connection_security_policy="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+            - label: "{{ .destination_service }} P90 (🔐 mTLS)"
+              query: histogram_quantile(0.90, sum(irate(istio_request_duration_milliseconds_bucket{reporter="source", connection_security_policy="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+            - label: "{{ .destination_service }} P95 (🔐 mTLS)"
+              query: histogram_quantile(0.95, sum(irate(istio_request_duration_milliseconds_bucket{reporter="source", connection_security_policy="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+            - label: "{{ .destination_service }} P99 (🔐 mTLS)"
+              query: histogram_quantile(0.99, sum(irate(istio_request_duration_milliseconds_bucket{reporter="source", connection_security_policy="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+            - label: "{{ .destination_service }} P50"
+              query: histogram_quantile(0.50, sum(irate(istio_request_duration_milliseconds_bucket{reporter="source", connection_security_policy!="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+            - label: "{{ .destination_service }} P90"
+              query: histogram_quantile(0.90, sum(irate(istio_request_duration_milliseconds_bucket{reporter="source", connection_security_policy!="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+            - label: "{{ .destination_service }} P95"
+              query: histogram_quantile(0.95, sum(irate(istio_request_duration_milliseconds_bucket{reporter="source", connection_security_policy!="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+            - label: "{{ .destination_service }} P99"
+              query: histogram_quantile(0.99, sum(irate(istio_request_duration_milliseconds_bucket{reporter="source", connection_security_policy!="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+        - title: Outgoing Request Size By Destination
+          type: line
+          unit: bytes
+          size: 4
+          queries:
+            - label: "{{ .destination_service }} P50 (🔐 mTLS)"
+              query: histogram_quantile(0.50, sum(irate(istio_request_bytes_bucket{reporter="source", connection_security_policy="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+            - label: "{{ .destination_service }} P90 (🔐 mTLS)"
+              query: histogram_quantile(0.90, sum(irate(istio_request_bytes_bucket{reporter="source", connection_security_policy="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+            - label: "{{ .destination_service }} P95 (🔐 mTLS)"
+              query: histogram_quantile(0.95, sum(irate(istio_request_bytes_bucket{reporter="source", connection_security_policy="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+            - label: "{{ .destination_service }} P99 (🔐 mTLS)"
+              query: histogram_quantile(0.99, sum(irate(istio_request_bytes_bucket{reporter="source", connection_security_policy="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+            - label: "{{ .destination_service }} P50"
+              query: histogram_quantile(0.50, sum(irate(istio_request_bytes_bucket{reporter="source", connection_security_policy!="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+            - label: "{{ .destination_service }} P90"
+              query: histogram_quantile(0.90, sum(irate(istio_request_bytes_bucket{reporter="source", connection_security_policy!="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+            - label: "{{ .destination_service }} P95"
+              query: histogram_quantile(0.95, sum(irate(istio_request_bytes_bucket{reporter="source", connection_security_policy!="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+            - label: "{{ .destination_service }} P99"
+              query: histogram_quantile(0.99, sum(irate(istio_request_bytes_bucket{reporter="source", connection_security_policy!="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+        - title: Response Size By Destination
+          type: line
+          unit: bytes
+          size: 4
+          queries:
+            - label: "{{ .destination_service }} P50 (🔐 mTLS)"
+              query: histogram_quantile(0.50, sum(irate(istio_response_bytes_bucket{reporter="source", connection_security_policy="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+            - label: "{{ .destination_service }} P90 (🔐 mTLS)"
+              query: histogram_quantile(0.90, sum(irate(istio_response_bytes_bucket{reporter="source", connection_security_policy="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+            - label: "{{ .destination_service }} P95 (🔐 mTLS)"
+              query: histogram_quantile(0.95, sum(irate(istio_response_bytes_bucket{reporter="source", connection_security_policy="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+            - label: "{{ .destination_service }}  P99 (🔐 mTLS)"
+              query: histogram_quantile(0.99, sum(irate(istio_response_bytes_bucket{reporter="source", connection_security_policy="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+            - label: "{{ .destination_service }} P50"
+              query: histogram_quantile(0.50, sum(irate(istio_response_bytes_bucket{reporter="source", connection_security_policy!="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+            - label: "{{ .destination_service }} P90"
+              query: histogram_quantile(0.90, sum(irate(istio_response_bytes_bucket{reporter="source", connection_security_policy!="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+            - label: "{{ .destination_service }} P95"
+              query: histogram_quantile(0.95, sum(irate(istio_response_bytes_bucket{reporter="source", connection_security_policy!="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))
+            - label: "{{ .destination_service }} P99"
+              query: histogram_quantile(0.99, sum(irate(istio_response_bytes_bucket{reporter="source", connection_security_policy!="mutual_tls", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service, le))

--- a/deploy/templates/prometheus-istio-workload-tcp.yaml
+++ b/deploy/templates/prometheus-istio-workload-tcp.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: kobs.io/v1alpha1
+kind: Template
+metadata:
+  name: prometheus-istio-workload-tcp
+spec:
+  description: Istio Workload Dashboard for TCP traffic, similar to the one provided for Grafana https://grafana.com/grafana/dashboards/7630.
+  variables:
+    - name: namespace
+      description: The workload namespace.
+    - name: workload
+      description: The workload name.
+  plugin:
+    name: Prometheus
+    prometheus:
+      variables:
+        - name: Reporter
+          label: reporter
+          query: istio_tcp_sent_bytes_total{destination_workload="<< workload >>", destination_workload_namespace=~"<< namespace >>"}
+          allowAll: false
+        - name: Source Workload Namespace
+          label: source_workload_namespace
+          query: istio_tcp_sent_bytes_total{reporter="{{ .Reporter }}", destination_workload="<< workload >>", destination_workload_namespace=~"<< namespace >>"}
+          allowAll: true
+        - name: Source Workload
+          label: source_workload
+          query: istio_tcp_sent_bytes_total{reporter="{{ .Reporter }}", destination_workload="<< workload >>", destination_workload_namespace=~"<< namespace >>", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}
+          allowAll: true
+        - name: Destination Service
+          label: destination_service
+          query: istio_tcp_sent_bytes_total{reporter="source", source_workload=~"<< workload >>", source_workload_namespace=~"<< namespace >>"}
+          allowAll: true
+      charts:
+        - title: TCP Server Traffic
+          type: sparkline
+          unit: bytes
+          size: 6
+          queries:
+            - label: TCP Server Traffic
+              query: sum(irate(istio_tcp_sent_bytes_total{reporter="{{ .Reporter }}", destination_workload_namespace=~"<< namespace >>", destination_workload=~"<< workload >>"}[1m])) + sum(irate(istio_tcp_received_bytes_total{reporter="{{ .Reporter }}", destination_workload_namespace=~"<< namespace >>", destination_workload=~"<< workload >>"}[1m]))
+        - title: TCP Client Traffic
+          type: sparkline
+          unit: bytes
+          size: 6
+          queries:
+            - label: TCP Client Traffic
+              query: sum(irate(istio_tcp_sent_bytes_total{reporter="{{ .Reporter }}", source_workload_namespace=~"<< namespace >>", source_workload=~"<< workload >>"}[1m])) + sum(irate(istio_tcp_received_bytes_total{reporter="{{ .Reporter }}", source_workload_namespace=~"<< namespace >>", source_workload=~"<< workload >>"}[1m]))
+
+        - title: Inbound Workloads
+          type: divider
+        - title: Bytes Received from Incoming TCP Connection
+          type: line
+          unit: bytes
+          size: 6
+          queries:
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} (🔐 mTLS)"
+              query: round(sum(irate(istio_tcp_received_bytes_total{reporter="{{ .Reporter }}", connection_security_policy="mutual_tls", destination_workload_namespace=~"<< namespace >>", destination_workload=~"<< workload >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace), 0.001)
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }}"
+              query: round(sum(irate(istio_tcp_received_bytes_total{reporter="{{ .Reporter }}", connection_security_policy!="mutual_tls", destination_workload_namespace=~"<< namespace >>", destination_workload=~"<< workload >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace), 0.001)
+        - title: Bytes Sent to Incoming TCP Connection
+          type: line
+          unit: bytes
+          size: 6
+          queries:
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }} (🔐 mTLS)"
+              query: round(sum(irate(istio_tcp_sent_bytes_total{connection_security_policy="mutual_tls", reporter="{{ .Reporter }}", destination_workload_namespace=~"<< namespace >>", destination_workload=~"<< workload >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace), 0.001)
+            - label: "{{ .source_workload }}.{{ .source_workload_namespace }}"
+              query: round(sum(irate(istio_tcp_sent_bytes_total{connection_security_policy!="mutual_tls", reporter="{{ .Reporter }}", destination_workload_namespace=~"<< namespace >>", destination_workload=~"<< workload >>", source_workload=~"{{ index . "Source Workload" }}", source_workload_namespace=~"{{ index . "Source Workload Namespace" }}"}[1m])) by (source_workload, source_workload_namespace), 0.001)
+
+        - title: Outbound Workloads
+          type: divider
+        - title: Bytes Sent on Outgoing TCP Connection
+          type: line
+          unit: bytes
+          size: 6
+          queries:
+            - label: "{{ .destination_service }} (🔐 mTLS)"
+              query: round(sum(irate(istio_tcp_sent_bytes_total{connection_security_policy="mutual_tls", reporter="source", source_workload_namespace=~"<< namespace >>", source_workload=~"<< workload >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service), 0.001)
+            - label: "{{ .destination_service }}"
+              query: round(sum(irate(istio_tcp_sent_bytes_total{connection_security_policy!="mutual_tls", reporter="source", source_workload_namespace=~"<< namespace >>", source_workload=~"<< workload >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service), 0.001)
+        - title: Bytes Received from Outgoing TCP Connection
+          type: line
+          unit: bytes
+          size: 6
+          queries:
+            - label: "{{ .destination_service }} (🔐 mTLS)"
+              query: round(sum(irate(istio_tcp_received_bytes_total{reporter="source", connection_security_policy="mutual_tls", source_workload_namespace=~"<< namespace >>", source_workload=~"<< workload >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service), 0.001)
+            - label: "{{ .destination_service }}"
+              query: round(sum(irate(istio_tcp_received_bytes_total{reporter="source", connection_security_policy!="mutual_tls", source_workload_namespace=~"<< namespace >>", source_workload=~"<< workload >>", destination_service=~"{{ index . "Destination Service" }}"}[1m])) by (destination_service), 0.001)
+

--- a/deploy/templates/prometheus-kubernetes-resources-pod.yaml
+++ b/deploy/templates/prometheus-kubernetes-resources-pod.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: kobs.io/v1alpha1
+kind: Template
+metadata:
+  name: prometheus-kubernetes-resources-pod
+spec:
+  description: CPU, Memory and Network useage of a Pod via Prometheus.
+  variables:
+    - name: namespace
+      description: "The Pod namespace. Can be set with the following JSONPath: '<< $.metadata.namespace >>'"
+    - name: name
+      description: "The Pod name. Can be set with the following JSONPath: '<< $.metadata.namespace >>'"
+  plugin:
+    name: Prometheus
+    prometheus:
+      variables:
+        - name: Container
+          label: container
+          query: container_cpu_usage_seconds_total{namespace="<< namespace >>", image!="", pod="<< name >>", container!="POD", container!=""}
+          allowAll: true
+      charts:
+        - title: CPU Usage
+          type: area
+          unit: Cores
+          size: 12
+          queries:
+          - label: Current
+            query: sum(max(rate(container_cpu_usage_seconds_total{namespace="<< namespace >>", image!="", pod="<< name >>", container=~"{{ .Container }}", container!="POD", container!=""}[2m])) by (container))
+          - label: Requested
+            query: sum(kube_pod_container_resource_requests{namespace="<< namespace >>", resource="cpu", pod="<< name >>", container=~"{{ .Container }}"})
+          - label: Limit
+            query: sum(kube_pod_container_resource_limits{namespace="<< namespace >>", resource="cpu", pod="<< name >>", container=~"{{ .Container }}"})
+        - title: Memory Usage
+          type: area
+          unit: MiB
+          size: 12
+          queries:
+          - label: Current
+            query: sum(max(container_memory_working_set_bytes{namespace="<< namespace >>", pod="<< name >>", container=~"{{ .Container }}", container!="POD", container!=""}) by (container)) / 1024 / 1024
+          - label: Requested
+            query: sum(kube_pod_container_resource_requests{namespace="<< namespace >>", resource="memory", pod="<< name >>", container=~"{{ .Container }}"}) / 1024 / 1024
+          - label: Limit
+            query: sum(kube_pod_container_resource_limits{namespace="<< namespace >>", resource="memory", pod="<< name >>", container=~"{{ .Container }}"}) / 1024 / 1024
+
+        - name: Network
+          type: divider
+        - title: Bandwidth
+          type: area
+          unit: bytes/s
+          size: 12
+          queries:
+          - label: Received
+            query: sum(irate(container_network_receive_bytes_total{namespace="<< namespace >>", pod="<< name >>"}[2m])) by (pod)
+          - label: Transmitted
+            query: -sum(irate(container_network_transmit_bytes_total{namespace="<< namespace >>", pod="<< name >>"}[2m])) by (pod)
+        - title: Rate of Packets
+          type: area
+          unit: bytes/s
+          size: 12
+          queries:
+          - label: Received
+            query: sum(irate(container_network_receive_packets_total{namespace=~"<< namespace >>", pod=~"<< name >>"}[2m])) by (pod)
+          - label: Transmitted
+            query: -sum(irate(container_network_transmit_packets_total{namespace=~"<< namespace >>", pod=~"<< name >>"}[2m])) by (pod)
+        - title: Rate of Packets Dropped
+          type: area
+          unit: bytes/s
+          size: 12
+          queries:
+          - label: Received
+            query: sum(irate(container_network_receive_packets_dropped_total{namespace=~"<< namespace >>", pod=~"<< name >>"}[2m])) by (pod)
+          - label: Transmitted
+            query: -sum(irate(container_network_transmit_packets_dropped_total{namespace=~"<< namespace >>", pod=~"<< name >>"}[2m])) by (pod)
+
+        - name: Restarts
+          type: divider
+        - title: Restarts
+          type: area
+          size: 12
+          queries:
+          - label: Restarts
+            query: max(kube_pod_container_status_restarts_total{namespace="<< namespace >>", pod="<< name >>", container=~"{{ .Container }}"})


### PR DESCRIPTION
Add example templates, which shows the usage of the Prometheus and
Elasticsearch plugin for the Kubernetes resource metrics and Istio.

We also slightly improved the Prometheus variable view, by showing the
variable name within the select box.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
