### PR TITLE
Improve topology graph style

### DIFF
--- a/app/src/components/applications/ApplicationsTopologyGraph.tsx
+++ b/app/src/components/applications/ApplicationsTopologyGraph.tsx
@@ -1,6 +1,13 @@
 import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
 import CytoscapeComponent from 'react-cytoscapejs';
 import cytoscape from 'cytoscape';
+import nodeHtmlLabel from 'cytoscape-node-html-label';
+
+import { Node } from 'proto/clusters_grpc_web_pb';
+
+import 'components/applications/applications.css';
+
+nodeHtmlLabel(cytoscape);
 
 // layout is the layout for the topology graph.
 // See: https://js.cytoscape.org/#layouts
@@ -28,7 +35,9 @@ const styleSheet: cytoscape.Stylesheet[] = [
       label: 'data(label)',
       shape: 'roundrectangle',
       'text-halign': 'center',
+      'text-opacity': 0,
       'text-valign': 'bottom',
+      'text-wrap': 'wrap',
     },
   },
   {
@@ -46,7 +55,7 @@ const styleSheet: cytoscape.Stylesheet[] = [
   {
     selector: "node[type='application']",
     style: {
-      'background-color': '#0066cc',
+      'background-color': '#ffffff',
     },
   },
   {
@@ -60,6 +69,25 @@ const styleSheet: cytoscape.Stylesheet[] = [
     },
   },
 ];
+
+const nodeLabel = (node: Node.AsObject): string => {
+  if (node.type === 'cluster' || node.type === 'namespace') {
+    return `<div class="kobsio-application-topology-label boxed">
+      <div class="kobsio-application-topology-label-text boxed">
+        <span class="pf-c-badge pf-m-unread kobsio-application-topology-label-badge">
+          ${node.type === 'cluster' ? 'C' : 'N'}
+        </span>
+        ${node.label}
+      </div>
+    </div>`;
+  }
+
+  return `<div class="kobsio-application-topology-label">
+    <div class="kobsio-application-topology-label-text">
+      ${node.label}
+    </div>
+  </div>`;
+};
 
 interface IApplicationsTopologyGraphProps {
   edges: cytoscape.ElementDefinition[];
@@ -103,6 +131,17 @@ const ApplicationsTopologyGraph: React.FunctionComponent<IApplicationsTopologyGr
       if (graphRef.current) return;
       graphRef.current = cy;
       cy.on('tap', onTap);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (cy as any).nodeHtmlLabel([
+        {
+          halign: 'center',
+          halignBox: 'center',
+          query: 'node:visible',
+          tpl: nodeLabel,
+          valign: 'bottom',
+          valignBox: 'bottom',
+        },
+      ]);
     },
     [onTap],
   );

--- a/app/src/components/applications/applications.css
+++ b/app/src/components/applications/applications.css
@@ -1,0 +1,39 @@
+.kobsio-application-topology-label {
+  border-radius: 3px;
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2), 0 2px 8px 0 rgba(0, 0, 0, 0.19);
+  display: flex;
+  font-family: Verdana,Arial,Helvetica,sans-serif,pficon;
+  font-size: 8px;
+  font-weight: normal;
+  line-height: 11px;
+  margin-top: 4px;
+  text-align: center;
+}
+
+.kobsio-application-topology-label.boxed {
+  margin-top: 13px;
+}
+
+.kobsio-application-topology-label-text {
+  align-items: center;
+  background-color: var(--pf-global--palette--white);
+  border-radius: 3px;
+  border-width: 1px;
+  color: var(--pf-global--palette--black-1000);
+  display: flex;
+  font-size: 8px;
+  padding: 3px 5px;
+}
+
+.kobsio-application-topology-label-text.boxed {
+  background-color: var(--pf-global--palette--black-700);
+  color: var(--pf-global--palette--white);
+}
+
+.kobsio-application-topology-label-badge {
+  background-color: var(--pf-global--palette--blue-200);
+  margin-right: 5px;
+  min-width: 24px;
+  padding-left: 0px;
+  padding-right: 0px;
+}

--- a/app/src/plugins/kiali/KialiGraph.tsx
+++ b/app/src/plugins/kiali/KialiGraph.tsx
@@ -3,14 +3,12 @@ import CytoscapeComponent from 'react-cytoscapejs';
 import cytoscape from 'cytoscape';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 import dagre from 'cytoscape-dagre';
-import nodeHtmlLabel from 'cytoscape-node-html-label';
 
 import { Node } from 'proto/kiali_grpc_web_pb';
 
 import 'plugins/kiali/kiali.css';
 
 cytoscape.use(dagre);
-nodeHtmlLabel(cytoscape);
 
 // layout is the layout for the topology graph.
 // See: https://js.cytoscape.org/#layouts
@@ -91,6 +89,7 @@ const styleSheet: cytoscape.Stylesheet[] = [
       'line-color': '#6a6e73',
       'target-arrow-color': '#6a6e73',
       'target-arrow-shape': 'triangle',
+      'text-wrap': 'wrap',
       width: 3,
     },
   },

--- a/pkg/api/plugins/kiali/kiali.go
+++ b/pkg/api/plugins/kiali/kiali.go
@@ -174,7 +174,7 @@ func (k *Kiali) GetGraph(ctx context.Context, getGraphRequest *kialiProto.GetGra
 						if edgeLabel == "" {
 							edgeLabel = httpPercent
 						} else {
-							edgeLabel = edgeLabel + " - " + httpPercent + "%"
+							edgeLabel = edgeLabel + "\n" + httpPercent + "%"
 						}
 
 						if instance.traffic.Enabled {


### PR DESCRIPTION
We are now using a similar style for the application topology chart as
it is used in the Kiali plugin. For that we are moving the registration
of the nodeHtmlLabel component to the topology graph component.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [ ] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
