### PR TITLE
Adjust Pod and Service labels for Helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#61](https://github.com/kobsio/kobs/pull/61): Improve caching logic, by generating the teams and topology graph only when it is requested and not via an additional goroutine.
 - [#62](https://github.com/kobsio/kobs/pull/62): Show the name of a variable within the select box in the Prometheus dashboards.
 - [#64](https://github.com/kobsio/kobs/pull/64): Recreate Pods when ConfigMap in Helm chart is changed.
+- [#67](https://github.com/kobsio/kobs/pull/67): :warning: *Breaking change:* :warning: Adjust Pod and Service labels, which can now be set via the `pod.labels`, `pod.annotations`, `service.labels` and `service.annotations` values.
 
 ## [v0.2.0](https://github.com/kobsio/kobs/releases/tag/v0.2.0) (2021-04-23)
 

--- a/deploy/helm/kobs/Chart.yaml
+++ b/deploy/helm/kobs/Chart.yaml
@@ -4,5 +4,5 @@ description: Kubernetes Observability Platform
 type: application
 home: https://kobs.io
 icon: https://kobs.io/assets/images/logo.svg
-version: 0.4.1
+version: 0.4.2
 appVersion: v0.2.0

--- a/deploy/helm/kobs/templates/_helpers.tpl
+++ b/deploy/helm/kobs/templates/_helpers.tpl
@@ -77,8 +77,8 @@ Create the name of the cluster role and cluster role binding to use
 Additional annotations for Pods
 */}}
 {{- define "kobs.podAnnotations" -}}
-{{- if .Values.podAnnotations }}
-{{- toYaml .Values.podAnnotations }}
+{{- if .Values.pod.annotations }}
+{{- toYaml .Values.pod.annotations }}
 {{- end }}
 {{- end }}
 
@@ -86,7 +86,25 @@ Additional annotations for Pods
 Additional labels for Pods
 */}}
 {{- define "kobs.podLabels" -}}
-{{- if .Values.podLabels }}
-{{- toYaml .Values.podLabels }}
+{{- if .Values.pod.labels }}
+{{- toYaml .Values.pod.labels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Additional annotations for the Service
+*/}}
+{{- define "kobs.serviceAnnotations" -}}
+{{- if .Values.service.annotations }}
+{{- toYaml .Values.service.annotations }}
+{{- end }}
+{{- end }}
+
+{{/*
+Additional labels for the Service
+*/}}
+{{- define "kobs.serviceLabels" -}}
+{{- if .Values.service.labels }}
+{{- toYaml .Values.service.labels }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/kobs/templates/service.yaml
+++ b/deploy/helm/kobs/templates/service.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "kobs.fullname" . }}
   labels:
     {{- include "kobs.labels" . | nindent 4 }}
+    {{- include "kobs.serviceLabels" . | nindent 4 }}
+  annotations:
+    {{- include "kobs.serviceAnnotations" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/deploy/helm/kobs/values.yaml
+++ b/deploy/helm/kobs/values.yaml
@@ -36,13 +36,11 @@ tolerations: []
 ##
 affinity: {}
 
-## Specify additional annotations for the created Pods.
+## Specify additional labels and annotations for the created Pods.
 ##
-podAnnotations: {}
-
-## Specify additional labels for the created Pods.
-##
-podLabels: {}
+pod:
+  annotations: {}
+  labels: {}
 
 kobs:
   image:
@@ -190,6 +188,9 @@ crd:
 ##
 service:
   type: ClusterIP
+
+  annotations: {}
+  labels: {}
 
 ## Create an Ingress to expose kobs.
 ## See: https://kubernetes.io/docs/concepts/services-networking/ingress/

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -59,8 +59,8 @@ helm upgrade kobs kobs/kobs
 | `nodeSelector` | Specify a map of key-value pairs, to assign the Pods to a specific set of nodes. | `{}` |
 | `tolerations` | Specify the tolerations for the kobs Pods. | `[]` |
 | `affinity` | Specify a node affinity or inter-pod affinity / anti-affinity for an advanced scheduling of the kobs Pods. | `{}` |
-| `podAnnotations` | Specify additional annotations for the created Pods. | `{}` |
-| `podLabels` | Specify additional labels for the created Pods. | `{}` |
+| `pod.annotations` | Specify additional annotations for the created Pods. | `{}` |
+| `pod.labels` | Specify additional labels for the created Pods. | `{}` |
 | `kobs.image.repository` | The repository for the Docker image. | `kobsio/kobs` |
 | `kobs.image.tag` | The tag of the Docker image which should be used. | `v0.2.0` |
 | `kobs.image.pullPolicy` | The image pull policy for the Docker image. | `IfNotPresent` |
@@ -87,7 +87,9 @@ helm upgrade kobs kobs/kobs
 | `rbac.create` | Specifies whether a cluster role and cluster role binding should be created. | `true` |
 | `rbac.name` | The name of the cluster role and cluster role binding to use. If not set and create is true, a name is generated using the fullname template. | `""` |
 | `crd.create` | Specifies whether the custom resource definitions for kobs should be created. | `true` |
-| `service.type` | Set the type for the created service: `ClusterIP`, `NodePort`, `LoadBalancer`. | `ClusterIP` |
+| `service.type` | Set the type for the created Service: `ClusterIP`, `NodePort`, `LoadBalancer`. | `ClusterIP` |
+| `service.annotations` | Specify additional annotations for the created Service. | `{}` |
+| `service.labels` | Specify additional labels for the created Service. | `{}` |
 | `ingress.enabled` | Create an Ingress to expose kobs. | `false` |
 | `ingress.annotations` | Annotations to add to the ingress. | `{}` |
 | `ingress.hosts` | Hosts to use for the ingress. | `[]` |


### PR DESCRIPTION
The Pod and Service labels can now be set via the "pod.labels",
"pod.annotations", "service.labels" and "service.annotations" values in
the Helm chart.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [x] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
