### PR TITLE
Change teams, topology and metrics handling

### DIFF
--- a/app/src/components/applications/ApplicationsTopologyGraph.tsx
+++ b/app/src/components/applications/ApplicationsTopologyGraph.tsx
@@ -2,23 +2,23 @@ import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
 import CytoscapeComponent from 'react-cytoscapejs';
 import cytoscape from 'cytoscape';
 import nodeHtmlLabel from 'cytoscape-node-html-label';
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import dagre from 'cytoscape-dagre';
 
 import { Node } from 'proto/clusters_grpc_web_pb';
 
 import 'components/applications/applications.css';
 
+cytoscape.use(dagre);
 nodeHtmlLabel(cytoscape);
 
 // layout is the layout for the topology graph.
 // See: https://js.cytoscape.org/#layouts
 const layout = {
-  animate: false,
-  avoidOverlap: true,
-  directed: true,
   fit: true,
-  name: 'breadthfirst',
-  nodeDimensionsIncludeLabels: false,
-  padding: 50,
+  name: 'dagre',
+  nodeDimensionsIncludeLabels: true,
+  rankDir: 'LR',
 };
 
 // styleSheet changes the style of the nodes and edges in the topology graph.

--- a/app/src/plugins/prometheus/PrometheusPreviewChart.tsx
+++ b/app/src/plugins/prometheus/PrometheusPreviewChart.tsx
@@ -11,6 +11,7 @@ import {
   Query,
 } from 'proto/prometheus_grpc_web_pb';
 import { apiURL } from 'utils/constants';
+import { transformData } from 'plugins/prometheus/helpers';
 
 // prometheusService is the gRPC service to get the metrics for the defined query in a chart.
 const prometheusService = new PrometheusPromiseClient(apiURL, null, null);
@@ -85,7 +86,12 @@ const PrometheusPreviewChart: React.FunctionComponent<IPrometheusPreviewChartPro
       <div style={{ height: '75px', position: 'relative', width: '100%' }} ref={refChart}>
         <ChartGroup height={height} padding={0} width={width}>
           {data.metrics.map((metric, index) => (
-            <ChartArea key={index} data={metric.dataList} interpolation="monotoneX" name={`index${index}`} />
+            <ChartArea
+              key={index}
+              data={transformData(metric.dataList)}
+              interpolation="monotoneX"
+              name={`index${index}`}
+            />
           ))}
         </ChartGroup>
       </div>

--- a/pkg/api/plugins/prometheus/prometheus.go
+++ b/pkg/api/plugins/prometheus/prometheus.go
@@ -3,6 +3,7 @@ package prometheus
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -89,6 +90,7 @@ func (p *Prometheus) GetVariables(ctx context.Context, getVariablesRequest *prom
 			}
 		}
 
+		sort.Strings(values)
 		getVariablesRequest.Variables[i].Values = values
 
 		if getVariablesRequest.Variables[i].AllowAll {


### PR DESCRIPTION
This commit changes how teams, the topology graph and the metrics are
handled in the API server:
- When kobs was configured with multiple clusters, the association of
  teams and application didn't work. This is fixed now. We have to
  handle the teams and applications in two separate loops. In the first
  one we create the slice of teams for all clusters. In the seconde one
  we add all applications from all clusters to the corresponding teams.
- When we create the topology chart, we also add applications, which are
  outside of the selected namespace/cluster. For that we also have to
  add the namespaces/clusters for these nodes.
- The values for all variables are now sorted alphabetically, so that it
  is easier for a user to find the wanted value of a variable.
- In the preview charts for an application, we now also replace all NaN
  values with null, so that the chart is also rendered, when it contains
  NaN values.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [ ] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
