### PR TITLE
Improve overview page for Pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 ### Changed
 
 - [#82](https://github.com/kobsio/kobs/pull/82): Improve error handling for our API.
+- [#85](https://github.com/kobsio/kobs/pull/85): Improve overview page for Pods, by displaying all Containers in an expandable table and by including the current resource usage of all Containers.
 
 ## [v0.4.0](https://github.com/kobsio/kobs/releases/tag/v0.4.0) (2021-07-14)
 

--- a/plugins/resources/resources.go
+++ b/plugins/resources/resources.go
@@ -61,12 +61,13 @@ func (router *Router) isForbidden(resource string) bool {
 func (router *Router) getResources(w http.ResponseWriter, r *http.Request) {
 	clusterNames := r.URL.Query()["cluster"]
 	namespaces := r.URL.Query()["namespace"]
+	name := r.URL.Query().Get("name")
 	resource := r.URL.Query().Get("resource")
 	path := r.URL.Query().Get("path")
 	paramName := r.URL.Query().Get("paramName")
 	param := r.URL.Query().Get("param")
 
-	log.WithFields(logrus.Fields{"clusters": clusterNames, "namespaces": namespaces, "resource": resource, "path": path, "paramName": paramName, "param": param}).Tracef("getResources")
+	log.WithFields(logrus.Fields{"clusters": clusterNames, "namespaces": namespaces, "name": name, "resource": resource, "path": path, "paramName": paramName, "param": param}).Tracef("getResources")
 
 	var resources []Resources
 
@@ -88,7 +89,7 @@ func (router *Router) getResources(w http.ResponseWriter, r *http.Request) {
 		// provided we loop through all the namespaces and return the resources for these namespaces. All results are
 		// added to the resources slice, which is then returned by the api.
 		if namespaces == nil {
-			list, err := cluster.GetResources(r.Context(), "", path, resource, paramName, param)
+			list, err := cluster.GetResources(r.Context(), "", name, path, resource, paramName, param)
 			if err != nil {
 				errresponse.Render(w, r, err, http.StatusBadRequest, "Could not get resources")
 				return
@@ -108,7 +109,7 @@ func (router *Router) getResources(w http.ResponseWriter, r *http.Request) {
 			})
 		} else {
 			for _, namespace := range namespaces {
-				list, err := cluster.GetResources(r.Context(), namespace, path, resource, paramName, param)
+				list, err := cluster.GetResources(r.Context(), namespace, name, path, resource, paramName, param)
 				if err != nil {
 					errresponse.Render(w, r, err, http.StatusBadRequest, "Could not get resources")
 					return

--- a/plugins/resources/src/components/panel/details/Overview.tsx
+++ b/plugins/resources/src/components/panel/details/Overview.tsx
@@ -36,7 +36,14 @@ const Overview: React.FunctionComponent<IOverviewProps> = ({ resource }: IOvervi
   // Overwrite the additions for several resources.
   if (resource.props && resource.props.apiVersion && resource.props.kind) {
     if (resource.props.apiVersion === 'v1' && resource.props.kind === 'Pod') {
-      additions = <Pod pod={resource.props} />;
+      additions = (
+        <Pod
+          cluster={resource.cluster?.title}
+          namespace={resource.namespace?.title}
+          name={resource.name?.title}
+          pod={resource.props}
+        />
+      );
     } else if (resource.props.apiVersion === 'apps/v1' && resource.props.kind === 'Deployment') {
       additions = (
         <Deployment

--- a/plugins/resources/src/components/panel/details/overview/Containers.tsx
+++ b/plugins/resources/src/components/panel/details/overview/Containers.tsx
@@ -1,0 +1,85 @@
+import { TableComposable, TableVariant, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
+import { V1Container, V1ContainerStatus } from '@kubernetes/client-node';
+import React from 'react';
+import { Title } from '@patternfly/react-core';
+
+import Container from './Container';
+import { IMetricContainer } from '../../../../utils/interfaces';
+
+const getContainerStatus = (name: string, status?: V1ContainerStatus[]): V1ContainerStatus | undefined => {
+  if (!status) {
+    return undefined;
+  }
+
+  for (const s of status) {
+    if (s.name === name) {
+      return s;
+    }
+  }
+
+  return undefined;
+};
+
+const getContainerMetric = (name: string, metrics?: IMetricContainer[]): IMetricContainer | undefined => {
+  if (!metrics) {
+    return undefined;
+  }
+
+  for (const metric of metrics) {
+    if (metric.name === name) {
+      return metric;
+    }
+  }
+
+  return undefined;
+};
+
+interface IPodProps {
+  title: string;
+  containers: V1Container[];
+  containerStatuses?: V1ContainerStatus[];
+  containerMetrics?: IMetricContainer[];
+}
+
+const Containers: React.FunctionComponent<IPodProps> = ({
+  title,
+  containers,
+  containerStatuses,
+  containerMetrics,
+}: IPodProps) => {
+  return (
+    <React.Fragment>
+      <Title headingLevel="h4" size="lg">
+        {title}
+      </Title>
+      <TableComposable aria-label={title} variant={TableVariant.compact} borders={false}>
+        <Thead>
+          <Tr>
+            <Th>Name</Th>
+            <Th>Ready</Th>
+            <Th>Restarts</Th>
+            <Th>Status</Th>
+            <Th>CPU Usage</Th>
+            <Th>CPU Requests</Th>
+            <Th>CPU Limits</Th>
+            <Th>Memory Usage</Th>
+            <Th>Memory Requests</Th>
+            <Th>Memory Limits</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {containers.map((container) => (
+            <Container
+              key={container.name}
+              container={container}
+              containerStatus={getContainerStatus(container.name, containerStatuses)}
+              containerMetric={getContainerMetric(container.name, containerMetrics)}
+            />
+          ))}
+        </Tbody>
+      </TableComposable>
+    </React.Fragment>
+  );
+};
+
+export default Containers;

--- a/plugins/resources/src/utils/helpers.ts
+++ b/plugins/resources/src/utils/helpers.ts
@@ -1,0 +1,52 @@
+// formatResourceValue converts the given value for CPU, memory or ephemeral storage to another unit.
+export const formatResourceValue = (type: string, value: string): string => {
+  if (value === '' || value === undefined) {
+    return '';
+  }
+
+  if (type === 'cpu') {
+    if (value.slice(-1) === 'm') {
+      return value;
+    }
+
+    if (value.slice(-1) === 'n') {
+      return Math.round(parseInt(value.slice(0, -1)) / 1000000) + 'm';
+    }
+
+    return parseInt(value) * 1000 + 'm';
+  }
+
+  if (type === 'memory') {
+    if (value.slice(-2) === 'Ki') {
+      return Math.round(parseInt(value.slice(0, -2)) / 1024) + 'Mi';
+    }
+
+    if (value.slice(-2) === 'Mi') {
+      return value;
+    }
+
+    if (value.slice(-2) === 'Gi') {
+      return Math.round(parseInt(value.slice(0, -2)) * 1024) + 'Mi';
+    }
+
+    return value;
+  }
+
+  if (type === 'ephemeral-storage') {
+    if (value.slice(-2) === 'Ki') {
+      return Math.round(parseInt(value.slice(0, -2)) / 1024 / 1024) + 'Gi';
+    }
+
+    if (value.slice(-2) === 'Mi') {
+      return Math.round(parseInt(value.slice(0, -2)) / 1024) + 'Gi';
+    }
+
+    if (value.slice(-2) === 'Gi') {
+      return value;
+    }
+
+    return Math.round(parseInt(value) / 1024 / 1024 / 1024) + 'Gi';
+  }
+
+  return value;
+};

--- a/plugins/resources/src/utils/interfaces.ts
+++ b/plugins/resources/src/utils/interfaces.ts
@@ -7,3 +7,28 @@ export interface IPanelOptions {
   resources?: string[];
   selector?: string;
 }
+
+// IMetric is the interface for the response for a metrics request.
+export interface IMetric {
+  cluster?: string;
+  namespace?: string;
+  resources?: IMetricResources;
+}
+
+export interface IMetricResources {
+  apiVersion?: string;
+  containers?: IMetricContainer[];
+  kind?: string;
+  timestamp?: Date;
+  window?: string;
+}
+
+export interface IMetricContainer {
+  name?: string;
+  usage?: IMetricUsage;
+}
+
+export interface IMetricUsage {
+  cpu?: string;
+  memory?: string;
+}


### PR DESCRIPTION
The overview page for Pods now, displays all Containers in an expandable
table. When a container is selected all the details for the selected
container are displayed below this table row in a description list like
the Pod details.

We also try to get the CPU and memory usage for all containers. If the
API call returns the resources, we display them in the containers table.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
