### PR TITLE
Improve overview page for Nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 - [#82](https://github.com/kobsio/kobs/pull/82): Improve error handling for our API.
 - [#85](https://github.com/kobsio/kobs/pull/85): Improve overview page for Pods, by displaying all Containers in an expandable table and by including the current resource usage of all Containers.
+- [#86](https://github.com/kobsio/kobs/pull/86): Improve overview page for Nodes, by displaying the resource metrics for the CPU, Memory and Pods.
 
 ## [v0.4.0](https://github.com/kobsio/kobs/releases/tag/v0.4.0) (2021-07-14)
 

--- a/pkg/api/clusters/cluster/cluster.go
+++ b/pkg/api/clusters/cluster/cluster.go
@@ -114,14 +114,26 @@ func (c *Cluster) GetNamespaces(ctx context.Context, cacheDuration time.Duration
 // list of resources.
 func (c *Cluster) GetResources(ctx context.Context, namespace, name, path, resource, paramName, param string) ([]byte, error) {
 	if name != "" {
-		res, err := c.clientset.RESTClient().Get().AbsPath(path).Namespace(namespace).Resource(resource).Name(name).DoRaw(ctx)
+		if namespace != "" {
+			res, err := c.clientset.RESTClient().Get().AbsPath(path).Namespace(namespace).Resource(resource).Name(name).DoRaw(ctx)
+			if err != nil {
+				log.WithError(err).WithFields(logrus.Fields{"cluster": c.name, "namespace": namespace, "name": name, "path": path, "resource": resource}).Errorf("GetResources")
+				return nil, err
+			}
+
+			return res, nil
+		}
+
+		res, err := c.clientset.RESTClient().Get().AbsPath(path).Resource(resource).Name(name).DoRaw(ctx)
 		if err != nil {
-			log.WithError(err).WithFields(logrus.Fields{"cluster": c.name, "namespace": namespace, "name": name, "path": path, "resource": resource}).Errorf("GetResources")
+			log.WithError(err).WithFields(logrus.Fields{"cluster": c.name, "name": name, "path": path, "resource": resource}).Errorf("GetResources")
 			return nil, err
 		}
 
 		return res, nil
 	}
+
+	fmt.Printf("\n\n\n\n paramName: %s param: %s\n\n\n\n", paramName, param)
 
 	res, err := c.clientset.RESTClient().Get().AbsPath(path).Namespace(namespace).Resource(resource).Param(paramName, param).DoRaw(ctx)
 	if err != nil {

--- a/plugins/core/src/utils/resources.tsx
+++ b/plugins/core/src/utils/resources.tsx
@@ -127,7 +127,7 @@ export const resources: IResources = {
 
           rows.push({
             cells: [cronJob.metadata?.name, item.namespace, item.cluster, schedule, suspend, active, lastSchedule, age],
-            props: { apiVersion: 'batch/v1beta1', kind: 'CronJob', ...cronJob },
+            props: cronJob,
           });
         }
       }
@@ -191,7 +191,7 @@ export const resources: IResources = {
               nodeSelector.join(', '),
               age,
             ],
-            props: { apiVersion: 'apps/v1', kind: 'DaemonSet', ...daemonSet },
+            props: daemonSet,
           });
         }
       }
@@ -235,7 +235,7 @@ export const resources: IResources = {
               available,
               age,
             ],
-            props: { apiVersion: 'apps/v1', kind: 'Deployment', ...deployment },
+            props: deployment,
           });
         }
       }
@@ -281,7 +281,7 @@ export const resources: IResources = {
               duration,
               age,
             ],
-            props: { apiVersion: 'batch/v1', kind: 'Job', ...job },
+            props: job,
           });
         }
       }
@@ -344,7 +344,7 @@ export const resources: IResources = {
               restarts,
               age,
             ],
-            props: { apiVersion: 'v1', kind: 'Pod', ...pod },
+            props: pod,
           });
         }
       }
@@ -414,7 +414,7 @@ export const resources: IResources = {
 
           rows.push({
             cells: [statefulSet.metadata?.name, item.namespace, item.cluster, `${ready}/${shouldReady}`, upToDate, age],
-            props: { apiVersion: 'apps/v1', kind: 'StatefulSet', ...statefulSet },
+            props: statefulSet,
           });
         }
       }

--- a/plugins/resources/package.json
+++ b/plugins/resources/package.json
@@ -13,6 +13,7 @@
     "@kobsio/plugin-core": "*",
     "@kobsio/plugin-dashboards": "*",
     "@kubernetes/client-node": "^0.15.0",
+    "@nivo/bar": "^0.73.1",
     "@patternfly/react-core": "^4.128.2",
     "@patternfly/react-icons": "^4.10.11",
     "@patternfly/react-log-viewer": "^4.1.19",

--- a/plugins/resources/src/components/panel/details/Overview.tsx
+++ b/plugins/resources/src/components/panel/details/Overview.tsx
@@ -14,18 +14,21 @@ import Conditions from './overview/Conditions';
 import CronJob from './overview/CronJob';
 import DaemonSet from './overview/DaemonSet';
 import Deployment from './overview/Deployment';
+import { IResource } from '@kobsio/plugin-core';
 import Job from './overview/Job';
+import Node from './overview/Node';
 import Pod from './overview/Pod';
 import StatefulSet from './overview/StatefulSet';
 import { timeDifference } from '@kobsio/plugin-core';
 
 interface IOverviewProps {
+  request: IResource;
   resource: IRow;
 }
 
 // Overview is the overview tab for a resource. It shows the metadata of a resource in a clear way. We can also
 // add some additional fields on a per resource basis.
-const Overview: React.FunctionComponent<IOverviewProps> = ({ resource }: IOverviewProps) => {
+const Overview: React.FunctionComponent<IOverviewProps> = ({ request, resource }: IOverviewProps) => {
   // additions contains a React component with additional details for a resource. The default component just renders the
   // conditions of a resource.
   let additions =
@@ -34,41 +37,44 @@ const Overview: React.FunctionComponent<IOverviewProps> = ({ resource }: IOvervi
     ) : null;
 
   // Overwrite the additions for several resources.
-  if (resource.props && resource.props.apiVersion && resource.props.kind) {
-    if (resource.props.apiVersion === 'v1' && resource.props.kind === 'Pod') {
-      additions = (
-        <Pod
-          cluster={resource.cluster?.title}
-          namespace={resource.namespace?.title}
-          name={resource.name?.title}
-          pod={resource.props}
-        />
-      );
-    } else if (resource.props.apiVersion === 'apps/v1' && resource.props.kind === 'Deployment') {
-      additions = (
-        <Deployment
-          cluster={resource.cluster?.title}
-          namespace={resource.namespace?.title}
-          deployment={resource.props}
-        />
-      );
-    } else if (resource.props.apiVersion === 'apps/v1' && resource.props.kind === 'DaemonSet') {
-      additions = (
-        <DaemonSet cluster={resource.cluster?.title} namespace={resource.namespace?.title} daemonSet={resource.props} />
-      );
-    } else if (resource.props.apiVersion === 'apps/v1' && resource.props.kind === 'StatefulSet') {
-      additions = (
-        <StatefulSet
-          cluster={resource.cluster?.title}
-          namespace={resource.namespace?.title}
-          statefulSet={resource.props}
-        />
-      );
-    } else if (resource.props.apiVersion === 'batch/v1beta1' && resource.props.kind === 'CronJob') {
-      additions = <CronJob cronJob={resource.props} />;
-    } else if (resource.props.apiVersion === 'batch/v1' && resource.props.kind === 'Job') {
-      additions = <Job cluster={resource.cluster?.title} namespace={resource.namespace?.title} job={resource.props} />;
-    }
+  if (request.resource === 'Pod') {
+    additions = (
+      <Pod
+        cluster={resource.cluster?.title}
+        namespace={resource.namespace?.title}
+        name={resource.name?.title}
+        pod={resource.props}
+      />
+    );
+  } else if (request.resource === 'deployments') {
+    additions = (
+      <Deployment cluster={resource.cluster?.title} namespace={resource.namespace?.title} deployment={resource.props} />
+    );
+  } else if (request.resource === 'daemonsets') {
+    additions = (
+      <DaemonSet cluster={resource.cluster?.title} namespace={resource.namespace?.title} daemonSet={resource.props} />
+    );
+  } else if (request.resource === 'statefulsets') {
+    additions = (
+      <StatefulSet
+        cluster={resource.cluster?.title}
+        namespace={resource.namespace?.title}
+        statefulSet={resource.props}
+      />
+    );
+  } else if (request.resource === 'cronjobs') {
+    additions = <CronJob cronJob={resource.props} />;
+  } else if (request.resource === 'jobs') {
+    additions = <Job cluster={resource.cluster?.title} namespace={resource.namespace?.title} job={resource.props} />;
+  } else if (request.resource === 'nodes') {
+    additions = (
+      <Node
+        cluster={resource.cluster?.title}
+        namespace={resource.namespace?.title}
+        name={resource.name?.title}
+        node={resource.props}
+      />
+    );
   }
 
   return (

--- a/plugins/resources/src/components/panel/details/Pods.tsx
+++ b/plugins/resources/src/components/panel/details/Pods.tsx
@@ -8,20 +8,21 @@ import { ClustersContext, IClusterContext, emptyState } from '@kobsio/plugin-cor
 interface IPodsProps {
   cluster: string;
   namespace: string;
-  selector: string;
+  paramName: string;
+  param: string;
 }
 
 // Pods is the pods tab for various resources. It can be used to show the pods for a deployment, statefulset,
 // etc. within the tabs.
-const Pods: React.FunctionComponent<IPodsProps> = ({ cluster, namespace, selector }: IPodsProps) => {
+const Pods: React.FunctionComponent<IPodsProps> = ({ cluster, namespace, paramName, param }: IPodsProps) => {
   const clustersContext = useContext<IClusterContext>(ClustersContext);
 
   const { isError, isLoading, error, data } = useQuery<IRow[], Error>(
-    ['resources/pods', cluster, namespace, selector],
+    ['resources/pods', cluster, namespace, paramName, param],
     async () => {
       try {
         const response = await fetch(
-          `/api/plugins/resources/resources?cluster=${cluster}&namespace${namespace}&resource=pods&path=/api/v1&paramName=labelSelector&param=${selector}`,
+          `/api/plugins/resources/resources?cluster=${cluster}&namespace${namespace}&resource=pods&path=/api/v1&paramName=${paramName}&param=${param}`,
           { method: 'get' },
         );
         const json = await response.json();

--- a/plugins/resources/src/components/panel/details/overview/Node.tsx
+++ b/plugins/resources/src/components/panel/details/overview/Node.tsx
@@ -1,0 +1,182 @@
+import { V1Container, V1Node, V1Pod } from '@kubernetes/client-node';
+import { BarDatum } from '@nivo/bar';
+import React from 'react';
+import { Title } from '@patternfly/react-core';
+import { useQuery } from 'react-query';
+
+import { IMetric, IMetricUsage } from '../../../../utils/interfaces';
+import NodeChart from './NodeChart';
+import { formatResourceValue } from '../../../../utils/helpers';
+
+interface INodeMetrics {
+  [key: string]: BarDatum[];
+}
+
+const podResources = (containers: V1Container[]): number[] => {
+  let cpuRequests = 0;
+  let cpuLimits = 0;
+  let memoryRequests = 0;
+  let memoryLimits = 0;
+
+  for (const container of containers) {
+    if (container.resources && container.resources.requests && container.resources.requests.hasOwnProperty('cpu')) {
+      cpuRequests = cpuRequests + parseInt(formatResourceValue('cpu', container.resources.requests['cpu']));
+    }
+
+    if (container.resources && container.resources.limits && container.resources.limits.hasOwnProperty('cpu')) {
+      cpuLimits = cpuLimits + parseInt(formatResourceValue('cpu', container.resources.limits['cpu']));
+    }
+
+    if (container.resources && container.resources.requests && container.resources.requests.hasOwnProperty('memory')) {
+      memoryRequests = memoryRequests + parseInt(formatResourceValue('memory', container.resources.requests['memory']));
+    }
+
+    if (container.resources && container.resources.limits && container.resources.limits.hasOwnProperty('memory')) {
+      memoryLimits = memoryLimits + parseInt(formatResourceValue('memory', container.resources.limits['memory']));
+    }
+  }
+
+  return [cpuRequests, cpuLimits, memoryRequests, memoryLimits];
+};
+
+const nodeMetrics = (node: V1Node, nodeUsage: IMetricUsage, pods: V1Pod[]): INodeMetrics => {
+  const cpuUsage = parseInt(formatResourceValue('cpu', nodeUsage.cpu ? nodeUsage.cpu : '0'));
+  const cpuCapacity = parseInt(
+    formatResourceValue(
+      'cpu',
+      node.status && node.status.capacity && node.status.capacity['cpu'] ? node.status.capacity['cpu'] : '0',
+    ),
+  );
+
+  const memoryUsage = parseInt(formatResourceValue('memory', nodeUsage.memory ? nodeUsage.memory : '0'));
+  const memoryCapacity = parseInt(
+    formatResourceValue(
+      'memory',
+      node.status && node.status.capacity && node.status.capacity['memory'] ? node.status.capacity['memory'] : '0',
+    ),
+  );
+
+  const podsUsage = pods.length;
+  const podsCapacity = parseInt(
+    formatResourceValue(
+      'memory',
+      node.status && node.status.capacity && node.status.capacity['pods'] ? node.status.capacity['pods'] : '0',
+    ),
+  );
+
+  let cpuRequest = 0;
+  let cpuLimit = 0;
+  let memoryRequest = 0;
+  let memoryLimit = 0;
+  for (const pod of pods) {
+    if (pod.spec) {
+      const resources = podResources(pod.spec.containers);
+      cpuRequest = cpuRequest + resources[0];
+      cpuLimit = cpuLimit + resources[1];
+      memoryRequest = memoryRequest + resources[2];
+      memoryLimit = memoryLimit + resources[3];
+    }
+  }
+
+  return {
+    cpu: [
+      { name: 'Capacity', value: cpuCapacity },
+      { name: 'Usage', value: cpuUsage },
+      { name: 'Request', value: cpuRequest },
+      { name: 'Limit', value: cpuLimit },
+    ],
+    memory: [
+      { name: 'Capacity', value: memoryCapacity },
+      { name: 'Usage', value: memoryUsage },
+      { name: 'Request', value: memoryRequest },
+      { name: 'Limit', value: memoryLimit },
+    ],
+    pods: [
+      { name: 'Capacity', value: podsCapacity },
+      { name: 'Usage', value: podsUsage },
+    ],
+  };
+};
+
+interface INodeProps {
+  cluster: string;
+  namespace: string;
+  name: string;
+  node: V1Node;
+}
+
+const Node: React.FunctionComponent<INodeProps> = ({ cluster, namespace, name, node }: INodeProps) => {
+  const { isError, data } = useQuery<INodeMetrics, Error>(
+    ['resources/node/metrics', cluster, namespace, name],
+    async () => {
+      try {
+        const responseNodeMetrics = await fetch(
+          `/api/plugins/resources/resources?cluster=${cluster}&name=${name}&resource=nodes&path=/apis/metrics.k8s.io/v1beta1`,
+          { method: 'get' },
+        );
+        const jsonNodeMetrics = await responseNodeMetrics.json();
+
+        if (responseNodeMetrics.status >= 200 && responseNodeMetrics.status < 300) {
+          const metric = jsonNodeMetrics as IMetric[];
+
+          if (metric && metric.length === 1 && metric[0].resources && metric[0].resources.usage) {
+            const responsePods = await fetch(
+              `/api/plugins/resources/resources?cluster=${cluster}&resource=pods&path=/api/v1&paramName=fieldSelector&param=spec.nodeName=${name}`,
+              { method: 'get' },
+            );
+            const jsonPods = await responsePods.json();
+
+            if (responsePods.status >= 200 && responsePods.status < 300) {
+              if (jsonPods && jsonPods.length === 1 && jsonPods[0].resources && jsonPods[0].resources.items) {
+                return nodeMetrics(node, metric[0].resources.usage, jsonPods[0].resources.items);
+              }
+
+              throw new Error('Could not get Pods');
+            }
+
+            if (jsonPods.error) {
+              throw new Error(jsonPods.error);
+            } else {
+              throw new Error('An unknown error occured');
+            }
+          }
+
+          throw new Error('Could not get Node metrics');
+        }
+
+        if (jsonNodeMetrics.error) {
+          throw new Error(jsonNodeMetrics.error);
+        } else {
+          throw new Error('An unknown error occured');
+        }
+      } catch (err) {
+        throw err;
+      }
+    },
+  );
+
+  if (isError || !data) {
+    return null;
+  }
+
+  return (
+    <React.Fragment>
+      <Title headingLevel="h4" size="lg">
+        CPU
+      </Title>
+      <NodeChart data={data.cpu} legend="m" />
+
+      <Title headingLevel="h4" size="lg">
+        Memory
+      </Title>
+      <NodeChart data={data.memory} legend="Mi" />
+
+      <Title headingLevel="h4" size="lg">
+        Pods
+      </Title>
+      <NodeChart data={data.pods} legend="Pods" />
+    </React.Fragment>
+  );
+};
+
+export default Node;

--- a/plugins/resources/src/components/panel/details/overview/NodeChart.tsx
+++ b/plugins/resources/src/components/panel/details/overview/NodeChart.tsx
@@ -1,0 +1,53 @@
+import { BarDatum, ResponsiveBarCanvas } from '@nivo/bar';
+import React from 'react';
+
+interface INodeChartProps {
+  data: BarDatum[];
+  legend: string;
+}
+
+const NodeChart: React.FunctionComponent<INodeChartProps> = ({ data, legend }: INodeChartProps) => {
+  return (
+    <div style={{ height: `${50 * data.length}px` }}>
+      <ResponsiveBarCanvas
+        axisBottom={{
+          legend: legend,
+          legendOffset: 30,
+          legendPosition: 'middle',
+        }}
+        axisLeft={{
+          legend: '',
+        }}
+        borderColor={{ from: 'color', modifiers: [['darker', 1.6]] }}
+        borderRadius={0}
+        borderWidth={0}
+        colorBy="id"
+        colors={['#0066cc']}
+        data={data}
+        enableLabel={false}
+        enableGridX={false}
+        enableGridY={true}
+        groupMode="stacked"
+        indexBy="name"
+        indexScale={{ round: true, type: 'band' }}
+        isInteractive={false}
+        keys={['value']}
+        layout="horizontal"
+        margin={{ bottom: 40, left: 50, right: 0, top: 0 }}
+        maxValue="auto"
+        minValue="auto"
+        reverse={false}
+        theme={{
+          background: '#ffffff',
+          fontFamily: 'RedHatDisplay, Overpass, overpass, helvetica, arial, sans-serif',
+          fontSize: 10,
+          textColor: '#000000',
+        }}
+        valueFormat=""
+        valueScale={{ type: 'linear' }}
+      />
+    </div>
+  );
+};
+
+export default NodeChart;

--- a/plugins/resources/src/components/panel/details/overview/Pod.tsx
+++ b/plugins/resources/src/components/panel/details/overview/Pod.tsx
@@ -60,7 +60,7 @@ const Pod: React.FunctionComponent<IPodProps> = ({ cluster, namespace, name, pod
             return metric[0].resources.containers;
           }
 
-          throw new Error('Could not find Pod metrics');
+          throw new Error('Could not get Pod metrics');
         }
 
         if (json.error) {

--- a/plugins/resources/src/utils/interfaces.ts
+++ b/plugins/resources/src/utils/interfaces.ts
@@ -20,6 +20,7 @@ export interface IMetricResources {
   containers?: IMetricContainer[];
   kind?: string;
   timestamp?: Date;
+  usage?: IMetricUsage;
   window?: string;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2180,6 +2180,15 @@
     "@react-spring/web" "9.2.0"
     lodash "^4.17.21"
 
+"@nivo/annotations@0.73.0":
+  version "0.73.0"
+  resolved "https://registry.yarnpkg.com/@nivo/annotations/-/annotations-0.73.0.tgz#6b88b3c1b58a3c8a3b5dcc114b1026c34c083a6f"
+  integrity sha512-1rLAX5tcQh1Zo8ToENIO2WI1va72UhKc9K3219rtGRhXsy3f2hbmRZiw/iOJCLqzGtmT8RIKA++hOExWSyh4dQ==
+  dependencies:
+    "@nivo/colors" "0.73.0"
+    "@react-spring/web" "9.2.4"
+    lodash "^4.17.21"
+
 "@nivo/axes@0.72.0":
   version "0.72.0"
   resolved "https://registry.yarnpkg.com/@nivo/axes/-/axes-0.72.0.tgz#d65344cf4a21da0dd8802f053e1809136308a18a"
@@ -2187,6 +2196,17 @@
   dependencies:
     "@nivo/scales" "0.72.0"
     "@react-spring/web" "9.2.0"
+    d3-format "^1.4.4"
+    d3-time "^1.0.11"
+    d3-time-format "^3.0.0"
+
+"@nivo/axes@0.73.0":
+  version "0.73.0"
+  resolved "https://registry.yarnpkg.com/@nivo/axes/-/axes-0.73.0.tgz#d4982bda3c21d318507e4c61b9cce31549f8c894"
+  integrity sha512-tyB+PqQTW117q9E5vz1jVTywDG6mjqD/RvtVGeqAwHziHAQxpSVb+r0UUtTFOgyaddEbLDaOXPqjD3l6Npo89g==
+  dependencies:
+    "@nivo/scales" "0.73.0"
+    "@react-spring/web" "9.2.4"
     d3-format "^1.4.4"
     d3-time "^1.0.11"
     d3-time-format "^3.0.0"
@@ -2208,10 +2228,38 @@
     d3-shape "^1.2.2"
     lodash "^4.17.21"
 
+"@nivo/bar@^0.73.1":
+  version "0.73.1"
+  resolved "https://registry.yarnpkg.com/@nivo/bar/-/bar-0.73.1.tgz#86e59e25af151ead0c09298ec9caf133f38e957e"
+  integrity sha512-sBltCxCEgFV7kErW4K14OSUjsU1cmYAWWvKoelVI1NTJ0MWhH/Z4UVip6+Zk7/TOzdZntT0x3SE6cAc9Ov7rxg==
+  dependencies:
+    "@nivo/annotations" "0.73.0"
+    "@nivo/axes" "0.73.0"
+    "@nivo/colors" "0.73.0"
+    "@nivo/legends" "0.73.0"
+    "@nivo/recompose" "0.73.0"
+    "@nivo/scales" "0.73.0"
+    "@nivo/tooltip" "0.73.0"
+    "@react-spring/web" "9.2.4"
+    d3-scale "^3.2.3"
+    d3-shape "^1.2.2"
+    lodash "^4.17.21"
+
 "@nivo/colors@0.72.0":
   version "0.72.0"
   resolved "https://registry.yarnpkg.com/@nivo/colors/-/colors-0.72.0.tgz#257dd15ae9231332718ea16c2a00457703bb1351"
   integrity sha512-E1HAXmk/6uwgfHkzWeEMgsu5G8d+cAXqs3qcRawZ2vBI7/lPWqYf0KiDvGpjl508Pry2DZyyAgy/inKCWC2dKw==
+  dependencies:
+    d3-color "^2.0.0"
+    d3-scale "^3.2.3"
+    d3-scale-chromatic "^2.0.0"
+    lodash "^4.17.21"
+    react-motion "^0.5.2"
+
+"@nivo/colors@0.73.0":
+  version "0.73.0"
+  resolved "https://registry.yarnpkg.com/@nivo/colors/-/colors-0.73.0.tgz#fb22ec0d000b1b471cfa4a7156a787190be45bbe"
+  integrity sha512-6T1FBR+sv7cCfAZCkjeY71//W4RqDNGkXJqsnyJA/6EsjLEbOBc1l2v66cRmZs2bioOkYcS+f4hQxB9d1WAgwA==
   dependencies:
     d3-color "^2.0.0"
     d3-scale "^3.2.3"
@@ -2242,6 +2290,11 @@
   resolved "https://registry.yarnpkg.com/@nivo/legends/-/legends-0.72.0.tgz#d9f05b2fb8e775e0d26a4d333b502a025e92b3fc"
   integrity sha512-QJsTyURfpxe1mk6vM8oxGWdbvH/Pf4HgxtQ3D5/VJ2KeXEcRtTJ2ptavqUOxOfOTCBXo5wbtTDI4ni2ff4RRpg==
 
+"@nivo/legends@0.73.0":
+  version "0.73.0"
+  resolved "https://registry.yarnpkg.com/@nivo/legends/-/legends-0.73.0.tgz#ef344038c4ff03249ffffebaf14412d012004fda"
+  integrity sha512-OWyu3U6PJL2VGlAfoz6nTU4opXHlR0yp0h+0Q0rf/hMKQLiew6NmecKcR1Nx2Qw4dJHgOnZRXqQ6vQrhcNV3WQ==
+
 "@nivo/line@^0.72.0":
   version "0.72.0"
   resolved "https://registry.yarnpkg.com/@nivo/line/-/line-0.72.0.tgz#0070477d35ab8ca61cf785453e750cc8c07fcc1e"
@@ -2264,10 +2317,27 @@
   dependencies:
     react-lifecycles-compat "^3.0.4"
 
+"@nivo/recompose@0.73.0":
+  version "0.73.0"
+  resolved "https://registry.yarnpkg.com/@nivo/recompose/-/recompose-0.73.0.tgz#f228fdc633df5453c67640f59b74368071559e73"
+  integrity sha512-WzFJMkyfX1jGPxjcGjvMKxzodgARv9x+alWbr4o39wJ+0eqpZlq6K7oaJ0RnVazcKrKxIe7mKK2piZ0usRt+Zg==
+  dependencies:
+    react-lifecycles-compat "^3.0.4"
+
 "@nivo/scales@0.72.0":
   version "0.72.0"
   resolved "https://registry.yarnpkg.com/@nivo/scales/-/scales-0.72.0.tgz#d9ef7ee5c4fbeafd6087935a2a590d1e4003321d"
   integrity sha512-R190g+tAvBSDS3PWwvRc8Av3tcKf7OZVC4rb0skz0XuT0OyDxoF+ilaoZYekjuUD2o6aDH6MaqzWkQFx96iJqw==
+  dependencies:
+    d3-scale "^3.2.3"
+    d3-time "^1.0.11"
+    d3-time-format "^3.0.0"
+    lodash "^4.17.21"
+
+"@nivo/scales@0.73.0":
+  version "0.73.0"
+  resolved "https://registry.yarnpkg.com/@nivo/scales/-/scales-0.73.0.tgz#ec1b660b3792fdc509326fd87e88e8f46a532f63"
+  integrity sha512-xnvCEXz6KkT7/SG4ubJ/hBtbMcTraZnJSKKSVkttBkvfIhkSpQChHkNX8g0Wd4hpwBv2QlltLbjoD6pJ0b/mRA==
   dependencies:
     d3-scale "^3.2.3"
     d3-time "^1.0.11"
@@ -2297,6 +2367,13 @@
   integrity sha512-hVfCg8e1KNaDNY3WbPiZq2MYIJoq8mneKLUwMWvhv5JsBGnuEnTsMqNDHltWU7Mr2mfB3fBVGpUMiu4ta4pvtw==
   dependencies:
     "@react-spring/web" "9.2.0"
+
+"@nivo/tooltip@0.73.0":
+  version "0.73.0"
+  resolved "https://registry.yarnpkg.com/@nivo/tooltip/-/tooltip-0.73.0.tgz#c76d69ad90c1fb90b65b221ea74ad07b9e69ec59"
+  integrity sha512-6tRRV5mzn1siArAlChXqBC/ISD0AV0tvGRbuyZokVXcM2xbvtfi6OAPaZ10UYbVejBo1rRI3gnhhyNkP0UG2ug==
+  dependencies:
+    "@react-spring/web" "9.2.4"
 
 "@nivo/voronoi@0.72.0":
   version "0.72.0"
@@ -2602,6 +2679,16 @@
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.2.0.tgz#667f5e4e2226d1515e01b100c143093efab5943b"
   integrity sha512-YWNPRCmC1MiCH+3MZQUTfhf4OzKR1w+0BVxpw7HkHgCz8lJNlvlDeiBdQzYhh+YmmbaF4y1swhCYmI0y4VCZXQ==
+  dependencies:
+    "@react-spring/animated" "~9.2.0"
+    "@react-spring/core" "~9.2.0"
+    "@react-spring/shared" "~9.2.0"
+    "@react-spring/types" "~9.2.0"
+
+"@react-spring/web@9.2.4":
+  version "9.2.4"
+  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.2.4.tgz#c6d5464a954bfd0d7bc90117050f796a95ebfa08"
+  integrity sha512-vtPvOalLFvuju/MDBtoSnCyt0xXSL6Amyv82fljOuWPl1yGd4M1WteijnYL9Zlriljl0a3oXcPunAVYTD9dbDQ==
   dependencies:
     "@react-spring/animated" "~9.2.0"
     "@react-spring/core" "~9.2.0"


### PR DESCRIPTION
This commit adds a separate overview page for nodes, where we show the
requests, limits, usage and capacity for the cpu and memory of the node.
We also show the capacity and usage for pods. This data is shwon in
three bar charts, where each bar indicates one value.

For node we are also showing the Pods tab in the details, which contains
all the Pods running on this node.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
