### PR TITLE
Improve handling of actions for resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#82](https://github.com/kobsio/kobs/pull/82): Improve error handling for our API.
 - [#85](https://github.com/kobsio/kobs/pull/85): Improve overview page for Pods, by displaying all Containers in an expandable table and by including the current resource usage of all Containers.
 - [#86](https://github.com/kobsio/kobs/pull/86): Improve overview page for Nodes, by displaying the resource metrics for the CPU, Memory and Pods.
+- [#88](https://github.com/kobsio/kobs/pull/88): Improve handling of actions for Kubernetes resources.
 
 ## [v0.4.0](https://github.com/kobsio/kobs/releases/tag/v0.4.0) (2021-07-14)
 

--- a/plugins/resources/src/components/panel/PanelListItem.tsx
+++ b/plugins/resources/src/components/panel/PanelListItem.tsx
@@ -20,7 +20,7 @@ const PanelListItem: React.FunctionComponent<IPanelListItemProps> = ({
   selector,
   showDetails,
 }: IPanelListItemProps) => {
-  const { isError, isLoading, error, data } = useQuery<IRow[], Error>(
+  const { isError, isLoading, error, data, refetch } = useQuery<IRow[], Error>(
     ['resources/panellistitem', clusters, namespaces, resource.scope, resource.resource, resource.path, selector],
     async () => {
       try {
@@ -52,6 +52,14 @@ const PanelListItem: React.FunctionComponent<IPanelListItemProps> = ({
     },
   );
 
+  // refetchhWithDelay is used to call the refetch function to get the resource, but with a delay of 3 seconde. This is
+  // required, because sometime the Kubenretes isn't that fast after an action (edit, delete, ...) was triggered.
+  const refetchhWithDelay = (): void => {
+    setTimeout(() => {
+      refetch();
+    }, 3000);
+  };
+
   return (
     <Table
       aria-label={resource.title}
@@ -70,7 +78,14 @@ const PanelListItem: React.FunctionComponent<IPanelListItemProps> = ({
         onRowClick={
           showDetails && data && data.length > 0 && data[0].cells?.length === resource.columns.length
             ? (e, row, props, data): void =>
-                showDetails(<Details request={resource} resource={row} close={(): void => showDetails(undefined)} />)
+                showDetails(
+                  <Details
+                    request={resource}
+                    resource={row}
+                    close={(): void => showDetails(undefined)}
+                    refetch={refetchhWithDelay}
+                  />,
+                )
             : undefined
         }
       />

--- a/plugins/resources/src/components/panel/details/Actions.tsx
+++ b/plugins/resources/src/components/panel/details/Actions.tsx
@@ -1,10 +1,11 @@
-import { Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
+import { Alert, AlertActionCloseButton, AlertGroup, Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
 import React, { useState } from 'react';
 import { IRow } from '@patternfly/react-table';
 
 import CreateJob from './actions/CreateJob';
 import Delete from './actions/Delete';
 import Edit from './actions/Edit';
+import { IAlert } from '../../../utils/interfaces';
 import { IResource } from '@kobsio/plugin-core';
 import Restart from './actions/Restart';
 import Scale from './actions/Scale';
@@ -12,15 +13,24 @@ import Scale from './actions/Scale';
 interface IActionProps {
   request: IResource;
   resource: IRow;
+  refetch: () => void;
 }
 
-const Actions: React.FunctionComponent<IActionProps> = ({ request, resource }: IActionProps) => {
+const Actions: React.FunctionComponent<IActionProps> = ({ request, resource, refetch }: IActionProps) => {
   const [showDropdown, setShowDropdown] = useState<boolean>(false);
+  const [alerts, setAlerts] = useState<IAlert[]>([]);
   const [showScale, setShowScale] = useState<boolean>(false);
   const [showRestart, setShowRestart] = useState<boolean>(false);
   const [showCreateJob, setShowCreateJob] = useState<boolean>(false);
   const [showEdit, setShowEdit] = useState<boolean>(false);
   const [showDelete, setShowDelete] = useState<boolean>(false);
+
+  // removeAlert is used to remove an alert from the list of alerts, when the user clicks the close button.
+  const removeAlert = (index: number): void => {
+    const tmpAlerts = [...alerts];
+    tmpAlerts.splice(index, 1);
+    setAlerts(tmpAlerts);
+  };
 
   // We have to add different items to the actions dropdown menu. For that we are checking the resource before it is
   // added to the menu. The only exceptions are the edit and delete actions, which are available for all resources.
@@ -103,11 +113,62 @@ const Actions: React.FunctionComponent<IActionProps> = ({ request, resource }: I
         dropdownItems={dropdownItems}
       />
 
-      <Scale request={request} resource={resource} show={showScale} setShow={setShowScale} />
-      <Restart request={request} resource={resource} show={showRestart} setShow={setShowRestart} />
-      <CreateJob request={request} resource={resource} show={showCreateJob} setShow={setShowCreateJob} />
-      <Edit request={request} resource={resource} show={showEdit} setShow={setShowEdit} />
-      <Delete request={request} resource={resource} show={showDelete} setShow={setShowDelete} />
+      <AlertGroup isToast={true}>
+        {alerts.map((alert, index) => (
+          <Alert
+            key={index}
+            isLiveRegion={true}
+            variant={alert.variant}
+            title={alert.title}
+            actionClose={<AlertActionCloseButton onClick={(): void => removeAlert(index)} />}
+          />
+        ))}
+      </AlertGroup>
+
+      <Scale
+        request={request}
+        resource={resource}
+        show={showScale}
+        setShow={setShowScale}
+        setAlert={(alert: IAlert): void => setAlerts([...alerts, alert])}
+        refetch={refetch}
+      />
+
+      <Restart
+        request={request}
+        resource={resource}
+        show={showRestart}
+        setShow={setShowRestart}
+        setAlert={(alert: IAlert): void => setAlerts([...alerts, alert])}
+        refetch={refetch}
+      />
+
+      <CreateJob
+        request={request}
+        resource={resource}
+        show={showCreateJob}
+        setShow={setShowCreateJob}
+        setAlert={(alert: IAlert): void => setAlerts([...alerts, alert])}
+        refetch={refetch}
+      />
+
+      <Edit
+        request={request}
+        resource={resource}
+        show={showEdit}
+        setShow={setShowEdit}
+        setAlert={(alert: IAlert): void => setAlerts([...alerts, alert])}
+        refetch={refetch}
+      />
+
+      <Delete
+        request={request}
+        resource={resource}
+        show={showDelete}
+        setShow={setShowDelete}
+        setAlert={(alert: IAlert): void => setAlerts([...alerts, alert])}
+        refetch={refetch}
+      />
     </React.Fragment>
   );
 };

--- a/plugins/resources/src/components/panel/details/Details.tsx
+++ b/plugins/resources/src/components/panel/details/Details.tsx
@@ -45,9 +45,10 @@ interface IDetailsProps {
   request: IResource;
   resource: IRow;
   close: () => void;
+  refetch: () => void;
 }
 
-const Details: React.FunctionComponent<IDetailsProps> = ({ request, resource, close }: IDetailsProps) => {
+const Details: React.FunctionComponent<IDetailsProps> = ({ request, resource, close, refetch }: IDetailsProps) => {
   const [activeTab, setActiveTab] = useState<string>('overview');
 
   const podSelector = getSelector(request, resource);
@@ -63,7 +64,7 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ request, resource, cl
           size="lg"
         />
         <DrawerActions style={{ padding: 0 }}>
-          <Actions request={request} resource={resource} />
+          <Actions request={request} resource={resource} refetch={refetch} />
           <DrawerCloseButton onClose={close} />
         </DrawerActions>
       </DrawerHead>

--- a/plugins/resources/src/components/panel/details/actions/CreateJob.tsx
+++ b/plugins/resources/src/components/panel/details/actions/CreateJob.tsx
@@ -1,17 +1,9 @@
-import {
-  Alert,
-  AlertActionCloseButton,
-  AlertGroup,
-  AlertVariant,
-  Button,
-  ButtonVariant,
-  Modal,
-  ModalVariant,
-} from '@patternfly/react-core';
-import React, { useState } from 'react';
+import { AlertVariant, Button, ButtonVariant, Modal, ModalVariant } from '@patternfly/react-core';
 import { IRow } from '@patternfly/react-table';
+import React from 'react';
 import { V1Job } from '@kubernetes/client-node';
 
+import { IAlert } from '../../../../utils/interfaces';
 import { IResource } from '@kobsio/plugin-core';
 
 export const randomString = (length: number): string => {
@@ -31,11 +23,18 @@ interface ICreateJobProps {
   resource: IRow;
   show: boolean;
   setShow: (value: boolean) => void;
+  setAlert: (alert: IAlert) => void;
+  refetch: () => void;
 }
 
-const CreateJob: React.FunctionComponent<ICreateJobProps> = ({ request, resource, show, setShow }: ICreateJobProps) => {
-  const [error, setError] = useState<string>('');
-
+const CreateJob: React.FunctionComponent<ICreateJobProps> = ({
+  request,
+  resource,
+  show,
+  setShow,
+  setAlert,
+  refetch,
+}: ICreateJobProps) => {
   const jobName = `${
     resource.props && resource.props.metadata && resource.props.metadata.name ? resource.props.metadata.name : ''
   }-manual-${randomString(6)}`.toLowerCase();
@@ -87,6 +86,8 @@ const CreateJob: React.FunctionComponent<ICreateJobProps> = ({ request, resource
 
       if (response.status >= 200 && response.status < 300) {
         setShow(false);
+        setAlert({ title: `Job ${jobName} was created`, variant: AlertVariant.danger });
+        refetch();
       } else {
         if (json.error) {
           throw new Error(json.error);
@@ -96,24 +97,9 @@ const CreateJob: React.FunctionComponent<ICreateJobProps> = ({ request, resource
       }
     } catch (err) {
       setShow(false);
-      setError(err.message);
+      setAlert({ title: err.message, variant: AlertVariant.danger });
     }
   };
-
-  if (error) {
-    return (
-      <div style={{ height: '100%', minHeight: '100%' }}>
-        <AlertGroup isToast={true}>
-          <Alert
-            isLiveRegion={true}
-            variant={AlertVariant.danger}
-            title={error}
-            actionClose={<AlertActionCloseButton onClick={(): void => setError('')} />}
-          />
-        </AlertGroup>
-      </div>
-    );
-  }
 
   return (
     <Modal

--- a/plugins/resources/src/components/panel/details/actions/Delete.tsx
+++ b/plugins/resources/src/components/panel/details/actions/Delete.tsx
@@ -1,16 +1,8 @@
-import {
-  Alert,
-  AlertActionCloseButton,
-  AlertGroup,
-  AlertVariant,
-  Button,
-  ButtonVariant,
-  Modal,
-  ModalVariant,
-} from '@patternfly/react-core';
-import React, { useState } from 'react';
+import { AlertVariant, Button, ButtonVariant, Modal, ModalVariant } from '@patternfly/react-core';
 import { IRow } from '@patternfly/react-table';
+import React from 'react';
 
+import { IAlert } from '../../../../utils/interfaces';
 import { IResource } from '@kobsio/plugin-core';
 
 interface IDeleteProps {
@@ -18,11 +10,18 @@ interface IDeleteProps {
   resource: IRow;
   show: boolean;
   setShow: (value: boolean) => void;
+  setAlert: (alert: IAlert) => void;
+  refetch: () => void;
 }
 
-const Delete: React.FunctionComponent<IDeleteProps> = ({ request, resource, show, setShow }: IDeleteProps) => {
-  const [error, setError] = useState<string>('');
-
+const Delete: React.FunctionComponent<IDeleteProps> = ({
+  request,
+  resource,
+  show,
+  setShow,
+  setAlert,
+  refetch,
+}: IDeleteProps) => {
   const handleDelete = async (): Promise<void> => {
     try {
       const response = await fetch(
@@ -35,6 +34,8 @@ const Delete: React.FunctionComponent<IDeleteProps> = ({ request, resource, show
 
       if (response.status >= 200 && response.status < 300) {
         setShow(false);
+        setAlert({ title: `${resource.name.title} was deleted`, variant: AlertVariant.danger });
+        refetch();
       } else {
         if (json.error) {
           throw new Error(json.error);
@@ -44,24 +45,9 @@ const Delete: React.FunctionComponent<IDeleteProps> = ({ request, resource, show
       }
     } catch (err) {
       setShow(false);
-      setError(err.message);
+      setAlert({ title: err.message, variant: AlertVariant.danger });
     }
   };
-
-  if (error) {
-    return (
-      <div style={{ height: '100%', minHeight: '100%' }}>
-        <AlertGroup isToast={true}>
-          <Alert
-            isLiveRegion={true}
-            variant={AlertVariant.danger}
-            title={error}
-            actionClose={<AlertActionCloseButton onClick={(): void => setError('')} />}
-          />
-        </AlertGroup>
-      </div>
-    );
-  }
 
   return (
     <Modal

--- a/plugins/resources/src/components/panel/details/actions/Edit.tsx
+++ b/plugins/resources/src/components/panel/details/actions/Edit.tsx
@@ -1,30 +1,30 @@
-import {
-  Alert,
-  AlertActionCloseButton,
-  AlertGroup,
-  AlertVariant,
-  Button,
-  ButtonVariant,
-  Modal,
-  ModalVariant,
-} from '@patternfly/react-core';
+import { AlertVariant, Button, ButtonVariant, Modal, ModalVariant } from '@patternfly/react-core';
 import React, { useEffect, useState } from 'react';
 import { IRow } from '@patternfly/react-table';
 import { compare } from 'fast-json-patch';
 import yaml from 'js-yaml';
 
 import { Editor, IResource } from '@kobsio/plugin-core';
+import { IAlert } from '../../../../utils/interfaces';
 
 interface IEditProps {
   request: IResource;
   resource: IRow;
   show: boolean;
   setShow: (value: boolean) => void;
+  setAlert: (alert: IAlert) => void;
+  refetch: () => void;
 }
 
-const Edit: React.FunctionComponent<IEditProps> = ({ request, resource, show, setShow }: IEditProps) => {
+const Edit: React.FunctionComponent<IEditProps> = ({
+  request,
+  resource,
+  show,
+  setShow,
+  setAlert,
+  refetch,
+}: IEditProps) => {
   const [value, setValue] = useState<string>(yaml.dump(resource.props));
-  const [error, setError] = useState<string>('');
 
   const handleEdit = async (): Promise<void> => {
     try {
@@ -44,6 +44,8 @@ const Edit: React.FunctionComponent<IEditProps> = ({ request, resource, show, se
 
       if (response.status >= 200 && response.status < 300) {
         setShow(false);
+        setAlert({ title: `${resource.name.title} was saved`, variant: AlertVariant.danger });
+        refetch();
       } else {
         if (json.error) {
           throw new Error(json.error);
@@ -53,28 +55,13 @@ const Edit: React.FunctionComponent<IEditProps> = ({ request, resource, show, se
       }
     } catch (err) {
       setShow(false);
-      setError(err.message);
+      setAlert({ title: err.message, variant: AlertVariant.danger });
     }
   };
 
   useEffect(() => {
     setValue(yaml.dump(resource.props));
   }, [resource.props]);
-
-  if (error) {
-    return (
-      <div style={{ height: '100%', minHeight: '100%' }}>
-        <AlertGroup isToast={true}>
-          <Alert
-            isLiveRegion={true}
-            variant={AlertVariant.danger}
-            title={error}
-            actionClose={<AlertActionCloseButton onClick={(): void => setError('')} />}
-          />
-        </AlertGroup>
-      </div>
-    );
-  }
 
   return (
     <Modal

--- a/plugins/resources/src/components/panel/details/actions/Restart.tsx
+++ b/plugins/resources/src/components/panel/details/actions/Restart.tsx
@@ -1,17 +1,9 @@
-import {
-  Alert,
-  AlertActionCloseButton,
-  AlertGroup,
-  AlertVariant,
-  Button,
-  ButtonVariant,
-  Modal,
-  ModalVariant,
-} from '@patternfly/react-core';
-import React, { useState } from 'react';
+import { AlertVariant, Button, ButtonVariant, Modal, ModalVariant } from '@patternfly/react-core';
 import { IRow } from '@patternfly/react-table';
+import React from 'react';
 import { compare } from 'fast-json-patch';
 
+import { IAlert } from '../../../../utils/interfaces';
 import { IResource } from '@kobsio/plugin-core';
 
 interface IRestartProps {
@@ -19,11 +11,18 @@ interface IRestartProps {
   resource: IRow;
   show: boolean;
   setShow: (value: boolean) => void;
+  setAlert: (alert: IAlert) => void;
+  refetch: () => void;
 }
 
-const Restart: React.FunctionComponent<IRestartProps> = ({ request, resource, show, setShow }: IRestartProps) => {
-  const [error, setError] = useState<string>('');
-
+const Restart: React.FunctionComponent<IRestartProps> = ({
+  request,
+  resource,
+  show,
+  setShow,
+  setAlert,
+  refetch,
+}: IRestartProps) => {
   const handleRestart = async (): Promise<void> => {
     try {
       const now = new Date();
@@ -52,6 +51,8 @@ const Restart: React.FunctionComponent<IRestartProps> = ({ request, resource, sh
 
       if (response.status >= 200 && response.status < 300) {
         setShow(false);
+        setAlert({ title: `${resource.name.title} was restarted`, variant: AlertVariant.success });
+        refetch();
       } else {
         if (json.error) {
           throw new Error(json.error);
@@ -61,24 +62,9 @@ const Restart: React.FunctionComponent<IRestartProps> = ({ request, resource, sh
       }
     } catch (err) {
       setShow(false);
-      setError(err.message);
+      setAlert({ title: err.message, variant: AlertVariant.danger });
     }
   };
-
-  if (error) {
-    return (
-      <div style={{ height: '100%', minHeight: '100%' }}>
-        <AlertGroup isToast={true}>
-          <Alert
-            isLiveRegion={true}
-            variant={AlertVariant.danger}
-            title={error}
-            actionClose={<AlertActionCloseButton onClick={(): void => setError('')} />}
-          />
-        </AlertGroup>
-      </div>
-    );
-  }
 
   return (
     <Modal

--- a/plugins/resources/src/components/panel/details/actions/Scale.tsx
+++ b/plugins/resources/src/components/panel/details/actions/Scale.tsx
@@ -1,17 +1,8 @@
-import {
-  Alert,
-  AlertActionCloseButton,
-  AlertGroup,
-  AlertVariant,
-  Button,
-  ButtonVariant,
-  Modal,
-  ModalVariant,
-  NumberInput,
-} from '@patternfly/react-core';
+import { AlertVariant, Button, ButtonVariant, Modal, ModalVariant, NumberInput } from '@patternfly/react-core';
 import React, { useEffect, useState } from 'react';
 import { IRow } from '@patternfly/react-table';
 
+import { IAlert } from '../../../../utils/interfaces';
 import { IResource } from '@kobsio/plugin-core';
 
 interface IScaleProps {
@@ -19,11 +10,19 @@ interface IScaleProps {
   resource: IRow;
   show: boolean;
   setShow: (value: boolean) => void;
+  setAlert: (alert: IAlert) => void;
+  refetch: () => void;
 }
 
-const Scale: React.FunctionComponent<IScaleProps> = ({ request, resource, show, setShow }: IScaleProps) => {
+const Scale: React.FunctionComponent<IScaleProps> = ({
+  request,
+  resource,
+  show,
+  setShow,
+  setAlert,
+  refetch,
+}: IScaleProps) => {
   const [replicas, setReplicas] = useState<number>(resource.props?.spec?.replicas || 0);
-  const [error, setError] = useState<string>('');
 
   const handleScale = async (): Promise<void> => {
     try {
@@ -40,6 +39,8 @@ const Scale: React.FunctionComponent<IScaleProps> = ({ request, resource, show, 
 
       if (response.status >= 200 && response.status < 300) {
         setShow(false);
+        setAlert({ title: `Scale replicas for ${resource.name.title} to ${replicas}`, variant: AlertVariant.success });
+        refetch();
       } else {
         if (json.error) {
           throw new Error(json.error);
@@ -49,28 +50,13 @@ const Scale: React.FunctionComponent<IScaleProps> = ({ request, resource, show, 
       }
     } catch (err) {
       setShow(false);
-      setError(err.message);
+      setAlert({ title: err.message, variant: AlertVariant.danger });
     }
   };
 
   useEffect(() => {
     setReplicas(resource.props?.spec?.replicas || 0);
   }, [resource.props?.spec?.replicas]);
-
-  if (error) {
-    return (
-      <div style={{ height: '100%', minHeight: '100%' }}>
-        <AlertGroup isToast={true}>
-          <Alert
-            isLiveRegion={true}
-            variant={AlertVariant.danger}
-            title={error}
-            actionClose={<AlertActionCloseButton onClick={(): void => setError('')} />}
-          />
-        </AlertGroup>
-      </div>
-    );
-  }
 
   return (
     <Modal

--- a/plugins/resources/src/utils/interfaces.ts
+++ b/plugins/resources/src/utils/interfaces.ts
@@ -1,3 +1,5 @@
+import { AlertVariant } from '@patternfly/react-core';
+
 // IPanelOptions is the interface for the options property in the plugin panel implementation for the resources plugin.
 // It contains a list of clusters, namespaces, resources and a selector. Since the data is provided by a user and not
 // validated by the Kubernetes API server we have to verify that all required fields are present.
@@ -32,4 +34,11 @@ export interface IMetricContainer {
 export interface IMetricUsage {
   cpu?: string;
   memory?: string;
+}
+
+// IAlert is the interface for an alert. An alert in this component can be an error, when the fetchApplication fails or
+// an information, which explains a dependency.
+export interface IAlert {
+  title: string;
+  variant: AlertVariant;
 }


### PR DESCRIPTION
We are now refreshing the list of resources, when the user triggers an
action for the currently selcted resource. Besides that we also reworked
the shown alerts, so that it is now possible to show multiple alerts at
one time. We also show a success message, so that the user knows that
his action succeeded.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
