### PR TITLE
Add force delete option for Kubernetes resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#84](https://github.com/kobsio/kobs/pull/84): Add actions for resource, so that they can be modified or deleted within kobs.
 - [#87](https://github.com/kobsio/kobs/pull/87): Rework Kiali plugin to show the topology chart from Kiali for a list of namespaces.
 - [#89](https://github.com/kobsio/kobs/pull/89): Rework Opsgenie plugin to show alerts and incidents from Opsgenie.
+- [#91](https://github.com/kobsio/kobs/pull/91): Add force delete option for Kubernetes resources.
 
 ### Fixed
 

--- a/pkg/api/clusters/cluster/cluster.go
+++ b/pkg/api/clusters/cluster/cluster.go
@@ -144,8 +144,8 @@ func (c *Cluster) GetResources(ctx context.Context, namespace, name, path, resou
 
 // DeleteResource can be used to delete the given resource. The resource is identified by the Kubernetes API path and
 // the name of the resource.
-func (c *Cluster) DeleteResource(ctx context.Context, namespace, name, path, resource string) error {
-	_, err := c.clientset.RESTClient().Delete().AbsPath(path).Namespace(namespace).Resource(resource).Name(name).DoRaw(ctx)
+func (c *Cluster) DeleteResource(ctx context.Context, namespace, name, path, resource string, body []byte) error {
+	_, err := c.clientset.RESTClient().Delete().AbsPath(path).Namespace(namespace).Resource(resource).Name(name).Body(body).DoRaw(ctx)
 	if err != nil {
 		log.WithError(err).WithFields(logrus.Fields{"cluster": c.name, "namespace": namespace, "path": path, "resource": resource}).Errorf("DeleteResource")
 		return err

--- a/plugins/opsgenie/src/utils/helpers.ts
+++ b/plugins/opsgenie/src/utils/helpers.ts
@@ -11,7 +11,7 @@ export const getOptionsFromSearch = (search: string): IOptions => {
   const timeStart = params.get('timeStart');
 
   return {
-    query: query ? query : 'status: open',
+    query: query === null ? 'status: open' : query,
     times: {
       time: time && TTimeOptions.includes(time) ? (time as TTime) : 'last15Minutes',
       timeEnd:

--- a/plugins/resources/src/components/panel/details/actions/CreateJob.tsx
+++ b/plugins/resources/src/components/panel/details/actions/CreateJob.tsx
@@ -86,7 +86,7 @@ const CreateJob: React.FunctionComponent<ICreateJobProps> = ({
 
       if (response.status >= 200 && response.status < 300) {
         setShow(false);
-        setAlert({ title: `Job ${jobName} was created`, variant: AlertVariant.danger });
+        setAlert({ title: `Job ${jobName} was created`, variant: AlertVariant.success });
         refetch();
       } else {
         if (json.error) {

--- a/plugins/resources/src/components/panel/details/actions/Delete.tsx
+++ b/plugins/resources/src/components/panel/details/actions/Delete.tsx
@@ -1,6 +1,6 @@
-import { AlertVariant, Button, ButtonVariant, Modal, ModalVariant } from '@patternfly/react-core';
+import { AlertVariant, Button, ButtonVariant, Checkbox, Modal, ModalVariant } from '@patternfly/react-core';
+import React, { useState } from 'react';
 import { IRow } from '@patternfly/react-table';
-import React from 'react';
 
 import { IAlert } from '../../../../utils/interfaces';
 import { IResource } from '@kobsio/plugin-core';
@@ -22,19 +22,21 @@ const Delete: React.FunctionComponent<IDeleteProps> = ({
   setAlert,
   refetch,
 }: IDeleteProps) => {
+  const [force, setForce] = useState<boolean>(false);
+
   const handleDelete = async (): Promise<void> => {
     try {
       const response = await fetch(
         `/api/plugins/resources/resources?cluster=${resource.cluster.title}${
           resource.namespace ? `&namespace=${resource.namespace.title}` : ''
-        }&name=${resource.name.title}&resource=${request.resource}&path=${request.path}`,
+        }&name=${resource.name.title}&resource=${request.resource}&path=${request.path}&force=${force}`,
         { method: 'delete' },
       );
       const json = await response.json();
 
       if (response.status >= 200 && response.status < 300) {
         setShow(false);
-        setAlert({ title: `${resource.name.title} was deleted`, variant: AlertVariant.danger });
+        setAlert({ title: `${resource.name.title} was deleted`, variant: AlertVariant.success });
         refetch();
       } else {
         if (json.error) {
@@ -68,6 +70,15 @@ const Delete: React.FunctionComponent<IDeleteProps> = ({
         Do you really want to delete <b>{resource.name.title}</b> (
         {resource.namespace ? `${resource.namespace.title} ${resource.cluster.title}` : resource.cluster.title})?
       </p>
+      <p>&nbsp;</p>
+      <Checkbox
+        label="Force"
+        isChecked={force}
+        onChange={setForce}
+        aria-label="Force"
+        id="force-delete"
+        name="force-delete"
+      />
     </Modal>
   );
 };

--- a/plugins/resources/src/components/panel/details/actions/Edit.tsx
+++ b/plugins/resources/src/components/panel/details/actions/Edit.tsx
@@ -44,7 +44,7 @@ const Edit: React.FunctionComponent<IEditProps> = ({
 
       if (response.status >= 200 && response.status < 300) {
         setShow(false);
-        setAlert({ title: `${resource.name.title} was saved`, variant: AlertVariant.danger });
+        setAlert({ title: `${resource.name.title} was saved`, variant: AlertVariant.success });
         refetch();
       } else {
         if (json.error) {


### PR DESCRIPTION
It is now possible to force delete Kubernetes resources. To use this
options the user has to check the corresponding checkbox in the delete
modal. We then set the force parameter to true and creating the
corresponding request body in the backend to let the Kubernetes API now
that a resource should be force deleted.

This commit also fixes a bug in the Opsgenie plugin, where it was not
possible to query for all alerts/incidents. This is now possible,
because we only add the default "status: open" query, when the query
parameter is null.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
