### PR TITLE
Preparation to build a own kobs version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#87](https://github.com/kobsio/kobs/pull/87): Rework Kiali plugin to show the topology chart from Kiali for a list of namespaces.
 - [#89](https://github.com/kobsio/kobs/pull/89): Rework Opsgenie plugin to show alerts and incidents from Opsgenie.
 - [#91](https://github.com/kobsio/kobs/pull/91): Add force delete option for Kubernetes resources.
+- [#92](https://github.com/kobsio/kobs/pull/92): Preparation to build a own version of kobs using the [kobsio/app](https://github.com/kobsio/app) template.
 
 ### Fixed
 

--- a/app/package.json
+++ b/app/package.json
@@ -11,6 +11,7 @@
     "@kobsio/plugin-jaeger": "*",
     "@kobsio/plugin-kiali": "*",
     "@kobsio/plugin-markdown": "*",
+    "@kobsio/plugin-opsgenie": "*",
     "@kobsio/plugin-prometheus": "*",
     "@kobsio/plugin-resources": "*",
     "@kobsio/plugin-teams": "*",

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1,0 +1,9 @@
+/* Fix missing border for the Select component in a production build
+ * This fixes an issue mentioned in https://github.com/patternfly/patternfly-react/issues/5650 where the borders of the
+ * Select component are missing after running yarn build. */
+ .pf-c-select__toggle:before {
+  border-top: var(--pf-c-select__toggle--before--BorderTopWidth) solid var(--pf-c-select__toggle--before--BorderTopColor);
+  border-right: var(--pf-c-select__toggle--before--BorderRightWidth) solid var(--pf-c-select__toggle--before--BorderRightColor);
+  border-bottom: var(--pf-c-select__toggle--before--BorderBottomWidth) solid var(--pf-c-select__toggle--before--BorderBottomColor);
+  border-left: var(--pf-c-select__toggle--before--BorderLeftWidth) solid var(--pf-c-select__toggle--before--BorderLeftColor);
+}

--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import './index.css';
+
 // Import plugins. Here we import all plugins, which we want to add to the current kobs app. By default this are all
 // first party plugins from the /plugins folder.
 import { App } from '@kobsio/plugin-core';

--- a/cmd/kobs/config/config.go
+++ b/cmd/kobs/config/config.go
@@ -4,8 +4,8 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/kobsio/kobs/cmd/kobs/plugins"
 	"github.com/kobsio/kobs/pkg/api/clusters"
-	"github.com/kobsio/kobs/pkg/api/plugins"
 
 	"gopkg.in/yaml.v2"
 )

--- a/cmd/kobs/plugins/plugins.go
+++ b/cmd/kobs/plugins/plugins.go
@@ -1,0 +1,74 @@
+package plugins
+
+import (
+	"net/http"
+
+	"github.com/kobsio/kobs/pkg/api/clusters"
+	"github.com/kobsio/kobs/pkg/api/plugins/plugin"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+
+	// Import all plugins, which should be used with the kobs instance. By default this are all first party plugins from
+	// the plugins folder.
+	"github.com/kobsio/kobs/plugins/applications"
+	"github.com/kobsio/kobs/plugins/dashboards"
+	"github.com/kobsio/kobs/plugins/elasticsearch"
+	"github.com/kobsio/kobs/plugins/jaeger"
+	"github.com/kobsio/kobs/plugins/kiali"
+	"github.com/kobsio/kobs/plugins/markdown"
+	"github.com/kobsio/kobs/plugins/opsgenie"
+	"github.com/kobsio/kobs/plugins/prometheus"
+	"github.com/kobsio/kobs/plugins/resources"
+	"github.com/kobsio/kobs/plugins/teams"
+)
+
+// Config holds the configuration for all plugins. We have to add the configuration for all the imported plugins.
+type Config struct {
+	Applications  applications.Config  `yaml:"applications"`
+	Resources     resources.Config     `yaml:"resources"`
+	Teams         teams.Config         `yaml:"teams"`
+	Dashboards    dashboards.Config    `yaml:"dashboards"`
+	Prometheus    prometheus.Config    `yaml:"prometheus"`
+	Elasticsearch elasticsearch.Config `yaml:"elasticsearch"`
+	Jaeger        jaeger.Config        `yaml:"jaeger"`
+	Markdown      markdown.Config      `yaml:"markdown"`
+	Kiali         kiali.Config         `yaml:"kiali"`
+	Opsgenie      opsgenie.Config      `yaml:"opsgenie"`
+}
+
+// Router implements the router for the plugins package. This only registeres one route which is used to return all the
+// configured plugins.
+type Router struct {
+	*chi.Mux
+	plugins *plugin.Plugins
+}
+
+// getPlugins returns all registered plugin instances.
+func (router *Router) getPlugins(w http.ResponseWriter, r *http.Request) {
+	render.JSON(w, r, router.plugins)
+}
+
+// Register is used to register all api routes for plugins.
+func Register(clusters *clusters.Clusters, config Config) chi.Router {
+	router := Router{
+		chi.NewRouter(),
+		&plugin.Plugins{},
+	}
+
+	router.Get("/", router.getPlugins)
+
+	// Register all plugins
+	router.Mount(applications.Route, applications.Register(clusters, router.plugins, config.Applications))
+	router.Mount(resources.Route, resources.Register(clusters, router.plugins, config.Resources))
+	router.Mount(teams.Route, teams.Register(clusters, router.plugins, config.Teams))
+	router.Mount(dashboards.Route, dashboards.Register(clusters, router.plugins, config.Dashboards))
+	router.Mount(prometheus.Route, prometheus.Register(clusters, router.plugins, config.Prometheus))
+	router.Mount(elasticsearch.Route, elasticsearch.Register(clusters, router.plugins, config.Elasticsearch))
+	router.Mount(jaeger.Route, jaeger.Register(clusters, router.plugins, config.Jaeger))
+	router.Mount(markdown.Route, markdown.Register(clusters, router.plugins, config.Markdown))
+	router.Mount(kiali.Route, kiali.Register(clusters, router.plugins, config.Kiali))
+	router.Mount(opsgenie.Route, opsgenie.Register(clusters, router.plugins, config.Opsgenie))
+
+	return router
+}

--- a/docs/contributing/using-the-kobsio-app.md
+++ b/docs/contributing/using-the-kobsio-app.md
@@ -1,0 +1,127 @@
+# Using the kobsio/app
+
+The [kobsio/app](https://github.com/kobsio/app) can be used to build your own version of kobs. This is required if you want to use one of the [community plugins](../plugins/getting-started.md#community-plugins) or if you want to build your own private plugins for kobs.
+
+To use the kobsio/app repository you can use the **Use this template** button from the repository to create your own version of kobs.
+
+## Add a new Plugin
+
+To add a new plugin you have to adjust two files: The `app/src/index.tsx` file for the React UI of the plugin and the `cmd/kobs/plugins/plugins.go` file to register the API routes for your plugin.
+
+To add the React UI for the plugin you have to import `IPluginComponents` object from the Node module:
+
+```diff
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import './index.css';
+
+import { App } from '@kobsio/plugin-core';
+import resourcesPlugin from '@kobsio/plugin-resources';
+import helloWorldPlugin from './plugins/helloworld';
++import myNewPlugin  from  'my-new-plugin';
+
+ReactDOM.render(
+  <React.StrictMode>
+    <App plugins={{
+      ...resourcesPlugin,
++      ...myNewPlugin,
+    }} />
+  </React.StrictMode>,
+  document.getElementById('root')
+);
+```
+
+To register the API routes for the plugin you have to add the `Config` for the plugin to the plugins configuration and you have to `Register` the chi router for the plugin:
+
+```diff
+package plugins
+
+import (
+        "net/http"
+
+        "github.com/kobsio/kobs/pkg/api/clusters"
+        "github.com/kobsio/kobs/pkg/api/plugins/plugin"
+
+        "github.com/go-chi/chi/v5"
+        "github.com/go-chi/render"
+
+        // Import all plugins, which should be used with the kobs instance. By default this are all first party plugins from
+        // the plugins folder.
+        "github.com/kobsio/app/pkg/plugins/helloworld"
++        "github.com/my-new-plugin/my-new-plugin"
+        "github.com/kobsio/kobs/plugins/resources"
+)
+
+// Config holds the configuration for all plugins. We have to add the configuration for all the imported plugins.
+type Config struct {
+        Resources     resources.Config     `yaml:"resources"`
+        HelloWorld    helloworld.Config    `yaml:"helloworld"`
++        MyNewPlugin      mynewplugin.Config      `yaml:"myNewPlugin"`
+}
+
+// Router implements the router for the plugins package. This only registeres one route which is used to return all the
+// configured plugins.
+type Router struct {
+        *chi.Mux
+        plugins *plugin.Plugins
+}
+
+// getPlugins returns all registered plugin instances.
+func (router *Router) getPlugins(w http.ResponseWriter, r *http.Request) {
+        render.JSON(w, r, router.plugins)
+}
+
+// Register is used to register all api routes for plugins.
+func Register(clusters *clusters.Clusters, config Config) chi.Router {
+        router := Router{
+                chi.NewRouter(),
+                &plugin.Plugins{},
+        }
+
+        router.Get("/", router.getPlugins)
+
+        // Register all plugins
+        router.Mount(resources.Route, resources.Register(clusters, router.plugins, config.Resources))
+        router.Mount(helloworld.Route, helloworld.Register(clusters, router.plugins, config.HelloWorld))
++        router.Mount(mynewplugin.Route, mynewplugin.Register(clusters, router.plugins, config.MyNewPlugin))
+
+        return router
+}
+```
+
+## Build
+
+To build your own version of kobs you have to build the React you first. For that switch into the `app` folder and run `yarn build`:
+
+```sh
+cd app
+yarn build
+```
+
+Then you can go back to the root folder of the repository and build the Go application:
+
+```sh
+make build
+```
+
+The above command puts the binary into a folder called `bin`. To start kobs you can use the following command:
+
+```sh
+./bin/kobs --config=config.yaml --development
+```
+
+To build the Docker image for kobs you can use the Dockerfile from the `cmd/kobs` folder:
+
+```sh
+docker build -f ./cmd/kobs/Dockerfile -t kobsio/kobs:dev .
+docker run -it --rm --name kobs -p 15219:15219 -p 15220:15220 -p 15221:15221 -v $(pwd)/config.yaml:/kobs/config.yaml -v $HOME/.kube/config:/.kube/config kobsio/kobs:dev --development
+```
+
+## Develop a private Plugin
+
+If you want to develop your own private plugins within your version of the [kobsio/app](https://github.com/kobsio/app) repository, we recommend that you create a new folder for each plugin. The frontend code for your plugin should go into the `app/src/plugins` folder and the backend code into the `pkg/plugins` folder.
+
+To get a better idea for the structure of your plugin you can take a look at the `helloworld` plugin in the `app/src/plugins/helloworld` and `pkg/plugins/helloworld` folders.
+
+More information on the development of a plugin can be found in the documentation: [Add a Plugin](./add-a-plugin.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
       - Getting Started: contributing/getting-started.md
       - Add a Plugin: contributing/add-a-plugin.md
       - Development using the Demo: contributing/development-using-the-demo.md
+      - Using the kobsio/app: contributing/using-the-kobsio-app.md
 
 plugins:
   - search

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/kobsio/kobs/pkg/api/clusters"
 	"github.com/kobsio/kobs/pkg/api/middleware/httplog"
-	"github.com/kobsio/kobs/pkg/api/plugins"
-	"github.com/kobsio/kobs/pkg/config"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -68,12 +66,7 @@ func (s *Server) Stop() {
 
 // New return a new api server. It creates the underlying http server, with the defined address from the api.address
 // flag.
-func New(cfg *config.Config, isDevelopment bool) (*Server, error) {
-	loadedClusters, err := clusters.Load(cfg.Clusters)
-	if err != nil {
-		return nil, err
-	}
-
+func New(loadedClusters *clusters.Clusters, pluginsRouter chi.Router, isDevelopment bool) (*Server, error) {
 	router := chi.NewRouter()
 	router.Use(middleware.RequestID)
 	router.Use(middleware.Recoverer)
@@ -94,7 +87,7 @@ func New(cfg *config.Config, isDevelopment bool) (*Server, error) {
 			render.JSON(w, r, nil)
 		})
 		r.Mount("/clusters", clusters.NewRouter(loadedClusters))
-		r.Mount("/plugins", plugins.Register(loadedClusters, cfg.Plugins))
+		r.Mount("/plugins", pluginsRouter)
 	})
 
 	return &Server{

--- a/plugins/core/src/assets/app.css
+++ b/plugins/core/src/assets/app.css
@@ -4,13 +4,3 @@
  #root {
   height: 100%;
 }
-
-/* Fix missing border for the Select component in a production build
- * This fixes an issue mentioned in https://github.com/patternfly/patternfly-react/issues/5650 where the borders of the
- * Select component are missing after running yarn build. */
-.pf-c-select__toggle:before {
-  border-top: var(--pf-c-select__toggle--before--BorderTopWidth) solid var(--pf-c-select__toggle--before--BorderTopColor);
-  border-right: var(--pf-c-select__toggle--before--BorderRightWidth) solid var(--pf-c-select__toggle--before--BorderRightColor);
-  border-bottom: var(--pf-c-select__toggle--before--BorderBottomWidth) solid var(--pf-c-select__toggle--before--BorderBottomColor);
-  border-left: var(--pf-c-select__toggle--before--BorderLeftWidth) solid var(--pf-c-select__toggle--before--BorderLeftColor);
-}

--- a/plugins/kiali/src/components/panel/GraphWrapper.tsx
+++ b/plugins/kiali/src/components/panel/GraphWrapper.tsx
@@ -51,7 +51,6 @@ const GraphWrapper: React.FunctionComponent<IGraphWrapperProps> = ({
         throw err;
       }
     },
-    { keepPreviousData: true },
   );
 
   if (isLoading) {


### PR DESCRIPTION
This is the preparation for the kobsio/app respository, which allows
users to build their own version of kobs. This is useful, so that users
can decide which plugins they want to use within kobs and that users can
build their own private plugins.

To support this function we moved the config and plugins package of kobs
from the pkg folder to the cmd folder. The cmd folder is then reused in
the kobsio/app repository and allows a user to add his own plugins to
the plugins.go file. To add the frontend code of a plugin the user can
modify the index.tsx file from the app folder, where we just added a new
css file with a fix for the Patternfly Design System.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
