### PR TITLE
Get Kubernetes resources for all namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#85](https://github.com/kobsio/kobs/pull/85): Improve overview page for Pods, by displaying all Containers in an expandable table and by including the current resource usage of all Containers.
 - [#86](https://github.com/kobsio/kobs/pull/86): Improve overview page for Nodes, by displaying the resource metrics for the CPU, Memory and Pods.
 - [#88](https://github.com/kobsio/kobs/pull/88): Improve handling of actions for Kubernetes resources.
+- [#95](https://github.com/kobsio/kobs/pull/95): It is now possible to get Kubernetes resources for all namespaces by not selecting a namespace from the select box on the resources page.
 
 ## [v0.4.0](https://github.com/kobsio/kobs/releases/tag/v0.4.0) (2021-07-14)
 

--- a/plugins/core/src/utils/resources.tsx
+++ b/plugins/core/src/utils/resources.tsx
@@ -130,7 +130,16 @@ export const resources: IResources = {
               : '-';
 
           rows.push({
-            cells: [cronJob.metadata?.name, item.namespace, item.cluster, schedule, suspend, active, lastSchedule, age],
+            cells: [
+              cronJob.metadata?.name,
+              item.namespace || cronJob.metadata?.namespace,
+              item.cluster,
+              schedule,
+              suspend,
+              active,
+              lastSchedule,
+              age,
+            ],
             props: cronJob,
           });
         }
@@ -195,7 +204,7 @@ export const resources: IResources = {
           rows.push({
             cells: [
               daemonSet.metadata?.name,
-              item.namespace,
+              item.namespace || daemonSet.metadata?.namespace,
               item.cluster,
               desired,
               current,
@@ -252,7 +261,7 @@ export const resources: IResources = {
           rows.push({
             cells: [
               deployment.metadata?.name,
-              item.namespace,
+              item.namespace || deployment.metadata?.namespace,
               item.cluster,
               `${ready}/${shouldReady}`,
               upToDate,
@@ -307,7 +316,7 @@ export const resources: IResources = {
           rows.push({
             cells: [
               job.metadata?.name,
-              item.namespace,
+              item.namespace || job.metadata?.namespace,
               item.cluster,
               `${completions}/${completionsShould}`,
               duration,
@@ -372,7 +381,7 @@ export const resources: IResources = {
           rows.push({
             cells: [
               pod.metadata?.name,
-              item.namespace,
+              item.namespace || pod.metadata?.namespace,
               item.cluster,
               `${isReady}/${shouldReady}`,
               reason ? reason : phase,
@@ -431,7 +440,7 @@ export const resources: IResources = {
           rows.push({
             cells: [
               replicaSet.metadata?.name,
-              item.namespace,
+              item.namespace || replicaSet.metadata?.namespace,
               item.cluster,
               desired,
               current,
@@ -484,7 +493,7 @@ export const resources: IResources = {
           rows.push({
             cells: [
               statefulSet.metadata?.name,
-              item.namespace,
+              item.namespace || statefulSet.metadata?.namespace,
               item.cluster,
               `${ready}/${shouldReady}`,
               upToDate,
@@ -531,7 +540,13 @@ export const resources: IResources = {
           }
 
           rows.push({
-            cells: [endpoint.metadata?.name, item.namespace, item.cluster, ep.join(', '), age],
+            cells: [
+              endpoint.metadata?.name,
+              item.namespace || endpoint.metadata?.namespace,
+              item.cluster,
+              ep.join(', '),
+              age,
+            ],
             props: endpoint,
           });
         }
@@ -570,7 +585,16 @@ export const resources: IResources = {
               : '-';
 
           rows.push({
-            cells: [hpa.metadata?.name, item.namespace, item.cluster, reference, minPods, maxPods, replicas, age],
+            cells: [
+              hpa.metadata?.name,
+              item.namespace || hpa.metadata?.namespace,
+              item.cluster,
+              reference,
+              minPods,
+              maxPods,
+              replicas,
+              age,
+            ],
             props: hpa,
           });
         }
@@ -608,7 +632,14 @@ export const resources: IResources = {
               : '-';
 
           rows.push({
-            cells: [ingress.metadata?.name, item.namespace, item.cluster, hosts ? hosts.join(', ') : '', address, age],
+            cells: [
+              ingress.metadata?.name,
+              item.namespace || ingress.metadata?.namespace,
+              item.cluster,
+              hosts ? hosts.join(', ') : '',
+              address,
+              age,
+            ],
             props: ingress,
           });
         }
@@ -641,7 +672,13 @@ export const resources: IResources = {
               : '-';
 
           rows.push({
-            cells: [networkPolicy.metadata?.name, item.namespace, item.cluster, podSelector, age],
+            cells: [
+              networkPolicy.metadata?.name,
+              item.namespace || networkPolicy.metadata?.namespace,
+              item.cluster,
+              podSelector,
+              age,
+            ],
             props: networkPolicy,
           });
         }
@@ -687,7 +724,16 @@ export const resources: IResources = {
               : '-';
 
           rows.push({
-            cells: [service.metadata?.name, item.namespace, item.cluster, type, clusterIP, externalIPs, ports, age],
+            cells: [
+              service.metadata?.name,
+              item.namespace || service.metadata?.namespace,
+              item.cluster,
+              type,
+              clusterIP,
+              externalIPs,
+              ports,
+              age,
+            ],
             props: service,
           });
         }
@@ -722,7 +768,7 @@ export const resources: IResources = {
           rows.push({
             cells: [
               configMap.metadata?.name,
-              item.namespace,
+              item.namespace || configMap.metadata?.namespace,
               item.cluster,
               configMap.data ? Object.keys(configMap.data).length : 0,
               age,
@@ -763,7 +809,7 @@ export const resources: IResources = {
           rows.push({
             cells: [
               pvc.metadata?.name,
-              item.namespace,
+              item.namespace || pvc.metadata?.namespace,
               item.cluster,
               status,
               volume,
@@ -890,7 +936,7 @@ export const resources: IResources = {
           rows.push({
             cells: [
               pdb.metadata?.name,
-              item.namespace,
+              item.namespace || pdb.metadata?.namespace,
               item.cluster,
               minAvailable,
               maxUnavailable,
@@ -930,7 +976,7 @@ export const resources: IResources = {
               : '-';
 
           rows.push({
-            cells: [secret.metadata?.name, item.namespace, item.cluster, type, data, age],
+            cells: [secret.metadata?.name, item.namespace || secret.metadata?.namespace, item.cluster, type, data, age],
             props: secret,
           });
         }
@@ -963,7 +1009,13 @@ export const resources: IResources = {
               : '-';
 
           rows.push({
-            cells: [serviceAccount.metadata?.name, item.namespace, item.cluster, secrets, age],
+            cells: [
+              serviceAccount.metadata?.name,
+              item.namespace || serviceAccount.metadata?.namespace,
+              item.cluster,
+              secrets,
+              age,
+            ],
             props: serviceAccount,
           });
         }
@@ -1112,7 +1164,7 @@ export const resources: IResources = {
               : '-';
 
           rows.push({
-            cells: [roleBinding.metadata?.name, item.namespace, item.cluster, age],
+            cells: [roleBinding.metadata?.name, item.namespace || roleBinding.metadata?.namespace, item.cluster, age],
             props: roleBinding,
           });
         }
@@ -1141,7 +1193,7 @@ export const resources: IResources = {
               : '-';
 
           rows.push({
-            cells: [role.metadata?.name, item.namespace, item.cluster, age],
+            cells: [role.metadata?.name, item.namespace || role.metadata?.namespace, item.cluster, age],
             props: role,
           });
         }
@@ -1168,7 +1220,7 @@ export const resources: IResources = {
           rows.push({
             cells: [
               event.metadata?.name,
-              item.namespace,
+              item.namespace || event.metadata.namespace,
               item.cluster,
               event.lastTimestamp
                 ? timeDifference(new Date().getTime(), new Date(event.lastTimestamp.toString()).getTime())
@@ -1306,7 +1358,7 @@ export const resources: IResources = {
           rows.push({
             cells: [
               psp.metadata?.name,
-              item.cluster,
+              item.cluster || psp.metadata?.namespace,
               privileged,
               capabilities,
               seLinux,
@@ -1357,7 +1409,7 @@ export const customResourceDefinition = (crds: ICRD[]): IResources => {
             // retrieved via JSON paths.
             const defaultCells =
               crd.scope === 'Namespaced'
-                ? [cr.metadata?.name, item.namespace, item.cluster]
+                ? [cr.metadata?.name, item.namespace || cr.metadata?.namespace, item.cluster]
                 : [cr.metadata?.name, item.cluster];
             const crdCells =
               crd.columns && crd.columns.length > 0

--- a/plugins/jaeger/src/components/panel/TracesChart.tsx
+++ b/plugins/jaeger/src/components/panel/TracesChart.tsx
@@ -78,7 +78,7 @@ const TracesChart: React.FunctionComponent<ITracesChartProps> = ({ traces }: ITr
             enableGridX={false}
             enableGridY={false}
             margin={{ bottom: 25, left: 0, right: 0, top: 0 }}
-            nodeSize={{ key: 'size', sizes: [15, 50], values: [min, max] }}
+            nodeSize={{ key: 'size', sizes: [15, 20], values: [min, max] }}
             theme={{
               background: '#ffffff',
               fontFamily: 'RedHatDisplay, Overpass, overpass, helvetica, arial, sans-serif',

--- a/plugins/jaeger/src/components/panel/details/SpanTag.tsx
+++ b/plugins/jaeger/src/components/panel/details/SpanTag.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Tooltip } from '@patternfly/react-core';
 
 import { IKeyValue } from '../../../utils/interfaces';
 
@@ -7,12 +8,28 @@ interface ISpanTagProps {
 }
 
 const SpanTag: React.FunctionComponent<ISpanTagProps> = ({ tag }: ISpanTagProps) => {
+  const [visible, setVisible] = useState<boolean>(false);
+
+  const copy = (): void => {
+    if (navigator.clipboard) {
+      setVisible(true);
+
+      navigator.clipboard.writeText(`${tag.key}=${tag.value}`);
+
+      setTimeout(() => {
+        setVisible(false);
+      }, 1500);
+    }
+  };
+
   return (
-    <div className="pf-c-chip pf-u-ml-sm pf-u-mb-sm" style={{ maxWidth: '100%' }}>
-      <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
-        {tag.key}: {tag.value}
-      </span>
-    </div>
+    <Tooltip content={<div>copied</div>} isVisible={visible} trigger="manual">
+      <div className="pf-c-chip pf-u-ml-sm pf-u-mb-sm" style={{ cursor: 'pointer', maxWidth: '100%' }} onClick={copy}>
+        <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+          {tag.key}: {tag.value}
+        </span>
+      </div>
+    </Tooltip>
   );
 };
 

--- a/plugins/resources/src/components/page/Page.tsx
+++ b/plugins/resources/src/components/page/Page.tsx
@@ -8,46 +8,13 @@ import {
   PageSectionVariants,
   Title,
 } from '@patternfly/react-core';
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
-import { ClustersContext, IClusterContext, IPluginPageProps, IResources } from '@kobsio/plugin-core';
 import { IPanelOptions } from '../../utils/interfaces';
+import { IPluginPageProps } from '@kobsio/plugin-core';
 import PageToolbar from './PageToolbar';
 import Panel from '../panel/Panel';
-
-// checkRequiredData checks if the given resources object contains all data, so that we can passed it to the
-// ResourcesPanel component and show the list of resources. We can only pass the object to the component, when it
-// contains a cluster and a resource. Further we also need a namespace, when the list of resource contains a namespaced
-// resource. When the list only contains cluster scoped resources the user must not enter a namespace.
-const checkRequiredData = (resources: IPanelOptions, clustersContextResources: IResources | undefined): boolean => {
-  if (
-    !resources ||
-    !resources.clusters ||
-    resources.clusters.length === 0 ||
-    !resources.resources ||
-    resources.resources.length === 0 ||
-    !clustersContextResources
-  ) {
-    return false;
-  }
-
-  let namespacedOnly = true;
-  for (let i = 0; i < resources.resources.length; i++) {
-    if (
-      clustersContextResources.hasOwnProperty(resources.resources[i]) &&
-      clustersContextResources[resources.resources[i]].scope === 'Namespaced'
-    ) {
-      namespacedOnly = false;
-    }
-  }
-
-  if (!namespacedOnly && resources.namespaces && resources.namespaces.length === 0) {
-    return false;
-  }
-
-  return true;
-};
 
 // getResourcesFromSearch returns the clusters, namespaces, resources and selector for the resources state from a given
 // search location.
@@ -69,7 +36,6 @@ export const getResourcesFromSearch = (search: string): IPanelOptions => {
 const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, description }: IPluginPageProps) => {
   const history = useHistory();
   const location = useLocation();
-  const clustersContext = useContext<IClusterContext>(ClustersContext);
   const [resources, setResources] = useState<IPanelOptions>(getResourcesFromSearch(location.search));
   const [selectedResource, setSelectedResource] = useState<React.ReactNode>(undefined);
 
@@ -107,7 +73,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
         <DrawerContent panelContent={selectedResource}>
           <DrawerContentBody>
             <PageSection style={{ minHeight: '100%' }} variant={PageSectionVariants.default}>
-              {!resources || !checkRequiredData(resources, clustersContext.resources) ? (
+              {!resources ? (
                 <Alert variant={AlertVariant.info} title="Select clusters, resources and namespaces">
                   <p>Select a list of clusters, resources and namespaces from the toolbar.</p>
                 </Alert>

--- a/plugins/resources/src/components/panel/PanelListItem.tsx
+++ b/plugins/resources/src/components/panel/PanelListItem.tsx
@@ -26,13 +26,12 @@ const PanelListItem: React.FunctionComponent<IPanelListItemProps> = ({
       try {
         const clusterParams = clusters.map((cluster) => `cluster=${cluster}`).join('&');
         const namespaceParams = namespaces.map((namespace) => `namespace=${namespace}`).join('&');
+        const path = resource.isCRD ? `/apis/${resource.path}` : resource.path;
 
         const response = await fetch(
           `/api/plugins/resources/resources?${clusterParams}${
             resource.scope === 'Namespaced' ? `&${namespaceParams}` : ''
-          }&resource=${resource.resource}&path=${resource.path}${
-            selector ? `&paramName=labelSelector&param=${selector}` : ''
-          }`,
+          }&resource=${resource.resource}&path=${path}${selector ? `&paramName=labelSelector&param=${selector}` : ''}`,
           { method: 'get' },
         );
         const json = await response.json();


### PR DESCRIPTION
It is now possible to get Kubernetes resources for all namespaces, by
not selecting a namespaces from the select box on the resources page.

We also fixed a bug, where it was not possible to get custom resources
for a CRD, because the request path for all CRDs was wrong.

In the Jaeger plugin it is now possible to copy the value of a tag by
clicking on it.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
