### PR TITLE
Add terminal support for Kubernetes Pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#92](https://github.com/kobsio/kobs/pull/92): Preparation to build a own version of kobs using the [kobsio/app](https://github.com/kobsio/app) template.
 - [#93](https://github.com/kobsio/kobs/pull/93): Show status of Kubernetes resource in the table of the resources plugin.
 - [#97](https://github.com/kobsio/kobs/pull/97): Add support for Kiali metrics.
+- [#98](https://github.com/kobsio/kobs/pull/98): Add terminal support for Kubernetes Pods.
 
 ### Fixed
 

--- a/docs/configuration/plugins.md
+++ b/docs/configuration/plugins.md
@@ -158,8 +158,13 @@ plugins:
   resources:
     forbidden:
       - secrets
+    webSocket:
+      address: ws://localhost:15220
+      allowAllOrigins: true
 ```
 
 | Field | Type | Description | Required |
 | ----- | ---- | ----------- | -------- |
 | forbidden | []string | A list of resources, which can not be retrieved via the kobs API. | No |
+| webSocket.address | string | The address, which should be used for the WebSocket connection. By default this will be the current host, but it can be overwritten for development purposes. | No |
+| webSocket.allowAllOrigins | boolean | When this is `true`, WebSocket connections are allowed for all origins. This should only be used for development. | No |

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-chi/chi/v5 v5.0.3
 	github.com/go-chi/cors v1.2.0
 	github.com/go-chi/render v1.0.1
+	github.com/gorilla/websocket v1.4.2
 	github.com/kiali/kiali v1.38.0
 	github.com/mmcdole/gofeed v1.1.3
 	github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.8

--- a/go.sum
+++ b/go.sum
@@ -254,6 +254,7 @@ github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=

--- a/pkg/api/clusters/cluster/terminal/terminal.go
+++ b/pkg/api/clusters/cluster/terminal/terminal.go
@@ -1,0 +1,134 @@
+// Package terminal implements the functions for all terminal interactions in the frontend. These includes to get a
+// shell into a Pod, SSH sessions for a Node and the streaming of log files.
+// The implementation is very similar to the implementation in the "Kubernetes Dashboard", you can find the file
+// here: https://github.com/kubernetes/dashboard/blob/master/src/app/backend/handler/terminal.go
+package terminal
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+
+	"github.com/gorilla/websocket"
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+var (
+	log = logrus.WithFields(logrus.Fields{"package": "clusters"})
+)
+
+const END_OF_TRANSMISSION = "\u0004"
+
+// PtyHandler is what remotecommand expects from a pty.
+type PtyHandler interface {
+	io.Reader
+	io.Writer
+	remotecommand.TerminalSizeQueue
+}
+
+// Message is the messaging protocol between the shell and terminal session.
+//
+// OP      DIRECTION  FIELD(S) USED  DESCRIPTION
+// ---------------------------------------------------------------------
+// stdin   fe->be     Data           Keystrokes/paste buffer
+// resize  fe->be     Rows, Cols     New terminal size
+// stdout  be->fe     Data           Output from the process
+type Message struct {
+	Op, Data   string
+	Rows, Cols uint16
+}
+
+// Session implements PtyHandler (using a WebSocket connection).
+type Session struct {
+	WebSocket *websocket.Conn
+	SizeChan  chan remotecommand.TerminalSize
+	DoneChan  chan struct{}
+}
+
+// Next is called in a loop from remotecommand as long as the process is running.
+// TerminalSize handles pty->process resize events.
+func (t Session) Next() *remotecommand.TerminalSize {
+	select {
+	case size := <-t.SizeChan:
+		return &size
+	case <-t.DoneChan:
+		return nil
+	}
+}
+
+// Read handles pty->process messages (stdin, resize).
+// Called in a loop from remotecommand as long as the process is running.
+func (t Session) Read(p []byte) (int, error) {
+	_, m, err := t.WebSocket.ReadMessage()
+	if err != nil {
+		// Send terminated signal to process to avoid resource leak.
+		return copy(p, END_OF_TRANSMISSION), err
+	}
+
+	var msg Message
+	if err := json.Unmarshal([]byte(m), &msg); err != nil {
+		return copy(p, END_OF_TRANSMISSION), err
+	}
+
+	switch msg.Op {
+	case "stdin":
+		return copy(p, msg.Data), nil
+	case "resize":
+		t.SizeChan <- remotecommand.TerminalSize{Width: msg.Cols, Height: msg.Rows}
+		return 0, nil
+	default:
+		return copy(p, END_OF_TRANSMISSION), fmt.Errorf("unknown message type '%s'", msg.Op)
+	}
+}
+
+// Write handles process->pty stdout.
+// Called from remotecommand whenever there is any output.
+func (t Session) Write(p []byte) (int, error) {
+	msg, err := json.Marshal(Message{
+		Op:   "stdout",
+		Data: string(p),
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	if err = t.WebSocket.WriteMessage(websocket.TextMessage, msg); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+// StartProcess executes the given command (cmd) in the container specified in the request and connects it up with the
+// ptyHandler (a session).
+func StartProcess(config *rest.Config, reqURL *url.URL, cmd []string, ptyHandler PtyHandler) error {
+	exec, err := remotecommand.NewSPDYExecutor(config, "POST", reqURL)
+	if err != nil {
+		return err
+	}
+
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:             ptyHandler,
+		Stdout:            ptyHandler,
+		Stderr:            ptyHandler,
+		TerminalSizeQueue: ptyHandler,
+		Tty:               true,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// IsValidShell checks if the user provided shell is an allowed one.
+func IsValidShell(shell string) bool {
+	for _, validShell := range []string{"bash", "sh", "powershell", "cmd"} {
+		if validShell == shell {
+			return true
+		}
+	}
+	return false
+}

--- a/plugins/core/package.json
+++ b/plugins/core/package.json
@@ -24,6 +24,8 @@
     "react-dom": "^17.0.2",
     "react-query": "^3.17.2",
     "react-router-dom": "^5.2.0",
-    "typescript": "^4.3.4"
+    "typescript": "^4.3.4",
+    "xterm": "^4.13.0",
+    "xterm-addon-fit": "^0.5.0"
   }
 }

--- a/plugins/core/src/assets/app.css
+++ b/plugins/core/src/assets/app.css
@@ -4,3 +4,10 @@
  #root {
   height: 100%;
 }
+
+/* kobsio-filled-tabs
+ * The kobsio-filled-tabs CSS class is used to force a full height for tabs. */
+.kobsio-filled-tabs .pf-c-tab-content {
+  height: calc(100% - 24px);
+  overflow: hidden;
+}

--- a/plugins/core/src/components/app/App.tsx
+++ b/plugins/core/src/components/app/App.tsx
@@ -11,6 +11,7 @@ import { IPluginComponents, PluginsContextProvider } from '../../context/Plugins
 import { ClustersContextProvider } from '../../context/ClustersContext';
 import HomePage from './HomePage';
 import { PluginPage } from '../plugin/PluginPage';
+import { TerminalsContextProvider } from '../../context/TerminalsContext';
 
 import logo from '../../assets/logo.png';
 
@@ -42,14 +43,16 @@ export const App: React.FunctionComponent<IAppProps> = ({ plugins }: IAppProps) 
     <QueryClientProvider client={queryClient}>
       <ClustersContextProvider>
         <PluginsContextProvider components={plugins}>
-          <Router>
-            <Page header={Header}>
-              <Switch>
-                <Route exact={true} path="/" component={HomePage} />
-                <Route exact={false} path="/:name" component={PluginPage} />
-              </Switch>
-            </Page>
-          </Router>
+          <TerminalsContextProvider>
+            <Router>
+              <Page header={Header}>
+                <Switch>
+                  <Route exact={true} path="/" component={HomePage} />
+                  <Route exact={false} path="/:name" component={PluginPage} />
+                </Switch>
+              </Page>
+            </Router>
+          </TerminalsContextProvider>
         </PluginsContextProvider>
       </ClustersContextProvider>
     </QueryClientProvider>

--- a/plugins/core/src/components/terminal/Terminal.tsx
+++ b/plugins/core/src/components/terminal/Terminal.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Terminal as xTerm } from 'xterm';
+import { FitAddon as xTermFitAddon } from 'xterm-addon-fit';
+
+import { ITerminal } from '../../context/TerminalsContext';
+
+interface ITerminalProps {
+  terminal: ITerminal;
+  size: number;
+}
+
+const Terminal: React.FunctionComponent<ITerminalProps> = ({ terminal, size }: ITerminalProps) => {
+  const termRef = useRef<HTMLDivElement>(null);
+  const [term, setTerm] = useState<xTerm>();
+
+  const fitAddon = new xTermFitAddon();
+
+  useEffect(() => {
+    setTerm(terminal.terminal);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    return (): void => {
+      window.removeEventListener('resize', updateTerminalSize);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (termRef.current && term) {
+      term.loadAddon(fitAddon);
+      updateTerminalSize();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [size]);
+
+  useEffect(() => {
+    const handleTerminalInit = async (): Promise<void> => {
+      setTimeout(() => {
+        if (termRef.current && term) {
+          term.loadAddon(fitAddon);
+          term.open(termRef.current);
+          updateTerminalSize();
+
+          if (terminal.webSocket) {
+            term.focus();
+          }
+
+          window.addEventListener('resize', updateTerminalSize);
+        }
+      }, 1000);
+    };
+
+    handleTerminalInit();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [termRef, term]);
+
+  const updateTerminalSize = (): void => {
+    setTimeout(() => {
+      fitAddon.fit();
+    }, 100);
+  };
+
+  return <div ref={termRef} style={{ height: '100%', minHeight: '100px' }}></div>;
+};
+
+export default Terminal;

--- a/plugins/core/src/components/terminal/Terminals.tsx
+++ b/plugins/core/src/components/terminal/Terminals.tsx
@@ -1,0 +1,66 @@
+import { DrawerPanelBody, DrawerPanelContent, Tab, TabTitleIcon, TabTitleText, Tabs } from '@patternfly/react-core';
+import React, { useState } from 'react';
+import { CloseIcon } from '@patternfly/react-icons';
+
+import { ITerminal } from '../../context/TerminalsContext';
+import Terminal from './Terminal';
+
+interface ITerminalsProps {
+  terminals: ITerminal[];
+  activeTerminal: number;
+  setActiveTerminal: (index: number) => void;
+  removeTerminal: (index: number) => void;
+}
+
+const Terminals: React.FunctionComponent<ITerminalsProps> = ({
+  terminals,
+  activeTerminal,
+  setActiveTerminal,
+  removeTerminal,
+}: ITerminalsProps) => {
+  const [size, setSize] = useState<number>(0);
+
+  const resize = (width: number): void => {
+    setSize(width);
+  };
+
+  const handleClose = (e: React.MouseEvent<HTMLSpanElement, MouseEvent>, index: number): void => {
+    e.stopPropagation();
+    e.preventDefault();
+    removeTerminal(index);
+  };
+
+  return (
+    <DrawerPanelContent isResizable={true} onResize={resize}>
+      <DrawerPanelBody className="kobsio-filled-tabs">
+        <Tabs
+          activeKey={activeTerminal}
+          onSelect={(event, tabIndex): void => setActiveTerminal(tabIndex as number)}
+          isFilled={false}
+          mountOnEnter={true}
+        >
+          {terminals.map((terminal, index) => (
+            <Tab
+              key={index}
+              eventKey={index}
+              title={
+                <React.Fragment>
+                  <TabTitleText>{terminal.name}</TabTitleText>
+                  <TabTitleIcon onClick={(e): void => handleClose(e, index)}>
+                    <CloseIcon />
+                  </TabTitleIcon>
+                </React.Fragment>
+              }
+            >
+              <div style={{ height: '100%', paddingTop: '12px' }}>
+                <Terminal terminal={terminal} size={size} />
+              </div>
+            </Tab>
+          ))}
+        </Tabs>
+      </DrawerPanelBody>
+    </DrawerPanelContent>
+  );
+};
+
+export default Terminals;

--- a/plugins/core/src/context/TerminalsContext.tsx
+++ b/plugins/core/src/context/TerminalsContext.tsx
@@ -1,0 +1,119 @@
+import { Drawer, DrawerContent, DrawerContentBody } from '@patternfly/react-core';
+import { ITerminalOptions, Terminal as xTerm } from 'xterm';
+import React, { useState } from 'react';
+
+import Terminals from '../components/terminal/Terminals';
+
+export interface ITerminal {
+  name: string;
+  terminal?: xTerm;
+  webSocket?: WebSocket;
+}
+
+// ITerminalContext is the terminal context, it contains all terminals.
+export interface ITerminalContext {
+  terminals: ITerminal[];
+  addTerminal: (terminal: ITerminal) => Promise<void>;
+}
+
+// TERMINAL_OPTIONS are the options for a xterm.js terminal, which should be used by all packages which are using the
+// terminal context.
+export const TERMINAL_OPTIONS: ITerminalOptions = {
+  bellStyle: 'sound',
+  cursorBlink: true,
+  fontSize: 12,
+  scrollback: 10000,
+  theme: {
+    background: '#2e3440',
+    black: '#3b4251',
+    blue: '#81a1c1',
+    brightBlack: '#4c556a',
+    brightBlue: '#81a1c1',
+    brightCyan: '#8fbcbb',
+    brightGreen: '#a3be8b',
+    brightMagenta: '#b48dac',
+    brightRed: '#bf6069',
+    brightWhite: '#eceef4',
+    brightYellow: '#eacb8a',
+    cursor: '#d8dee9',
+    cyan: '#88c0d0',
+    foreground: '#d8dee9',
+    green: '#a3be8b',
+    magenta: '#b48dac',
+    red: '#bf6069',
+    selection: '#434c5ecc',
+    white: '#e5e9f0',
+    yellow: '#eacb8a',
+  },
+};
+
+// TerminalsContext is the cluster context object.
+export const TerminalsContext = React.createContext<ITerminalContext>({
+  addTerminal: (terminal: ITerminal): Promise<void> => {
+    return new Promise(() => {
+      return;
+    });
+  },
+  terminals: [],
+});
+
+// TerminalsContextConsumer is a React component that subscribes to context changes. This lets you subscribe to a
+// context within a function component.
+export const TerminalsContextConsumer = TerminalsContext.Consumer;
+
+// ITerminalsContextProviderProps is the interface for the TerminalsContextProvider component. The only valid properties
+// are child components of the type ReactElement.
+interface ITerminalsContextProviderProps {
+  children: React.ReactElement;
+}
+
+// TerminalsContextProvider is a Provider React component that allows consuming components to subscribe to context
+// changes.
+export const TerminalsContextProvider: React.FunctionComponent<ITerminalsContextProviderProps> = ({
+  children,
+}: ITerminalsContextProviderProps) => {
+  const [terminals, setTerminals] = useState<ITerminal[]>([]);
+  const [activeTerminal, setActiveTerminal] = useState<number>(0);
+
+  const addTerminal = async (terminal: ITerminal): Promise<void> => {
+    const tmpTerminals = [...terminals];
+    tmpTerminals.push(terminal);
+    setTerminals(tmpTerminals);
+    setActiveTerminal(tmpTerminals.length - 1);
+  };
+
+  const removeTerminal = (index: number): void => {
+    if (terminals[index].webSocket) {
+      terminals[index].webSocket?.close();
+    }
+
+    const tmpTerminals = [...terminals];
+    tmpTerminals.splice(index, 1);
+    setTerminals(tmpTerminals);
+    setActiveTerminal(0);
+  };
+
+  return (
+    <TerminalsContext.Provider
+      value={{
+        addTerminal: addTerminal,
+        terminals: terminals,
+      }}
+    >
+      <Drawer isExpanded={terminals.length > 0} position="bottom">
+        <DrawerContent
+          panelContent={
+            <Terminals
+              terminals={terminals}
+              activeTerminal={activeTerminal}
+              setActiveTerminal={setActiveTerminal}
+              removeTerminal={removeTerminal}
+            />
+          }
+        >
+          <DrawerContentBody>{children}</DrawerContentBody>
+        </DrawerContent>
+      </Drawer>
+    </TerminalsContext.Provider>
+  );
+};

--- a/plugins/core/src/index.ts
+++ b/plugins/core/src/index.ts
@@ -1,3 +1,5 @@
+import 'xterm/css/xterm.css';
+
 export * from './components/app/App';
 
 export * from './components/misc/DrawerLink';
@@ -14,6 +16,7 @@ export * from './components/plugin/PluginPreview';
 
 export * from './context/ClustersContext';
 export * from './context/PluginsContext';
+export * from './context/TerminalsContext';
 
 export * from './utils/manifests';
 export * from './utils/resources';

--- a/plugins/resources/package.json
+++ b/plugins/resources/package.json
@@ -27,6 +27,7 @@
     "react-dom": "^17.0.2",
     "react-query": "^3.17.2",
     "react-router-dom": "^5.2.0",
-    "typescript": "^4.3.4"
+    "typescript": "^4.3.4",
+    "xterm": "^4.13.0"
   }
 }

--- a/plugins/resources/src/components/panel/details/Actions.tsx
+++ b/plugins/resources/src/components/panel/details/Actions.tsx
@@ -9,6 +9,7 @@ import { IAlert } from '../../../utils/interfaces';
 import { IResource } from '@kobsio/plugin-core';
 import Restart from './actions/Restart';
 import Scale from './actions/Scale';
+import Terminal from './actions/Terminal';
 
 interface IActionProps {
   request: IResource;
@@ -22,6 +23,7 @@ const Actions: React.FunctionComponent<IActionProps> = ({ request, resource, ref
   const [showScale, setShowScale] = useState<boolean>(false);
   const [showRestart, setShowRestart] = useState<boolean>(false);
   const [showCreateJob, setShowCreateJob] = useState<boolean>(false);
+  const [showTerminal, setShowTerminal] = useState<boolean>(false);
   const [showEdit, setShowEdit] = useState<boolean>(false);
   const [showDelete, setShowDelete] = useState<boolean>(false);
 
@@ -74,6 +76,20 @@ const Actions: React.FunctionComponent<IActionProps> = ({ request, resource, ref
         }}
       >
         Create Job
+      </DropdownItem>,
+    );
+  }
+
+  if (request.resource === 'pods') {
+    dropdownItems.push(
+      <DropdownItem
+        key="terminal"
+        onClick={(): void => {
+          setShowDropdown(false);
+          setShowTerminal(true);
+        }}
+      >
+        Terminal
       </DropdownItem>,
     );
   }
@@ -151,6 +167,8 @@ const Actions: React.FunctionComponent<IActionProps> = ({ request, resource, ref
         setAlert={(alert: IAlert): void => setAlerts([...alerts, alert])}
         refetch={refetch}
       />
+
+      <Terminal request={request} resource={resource} show={showTerminal} setShow={setShowTerminal} />
 
       <Edit
         request={request}

--- a/plugins/resources/src/components/panel/details/actions/Terminal.tsx
+++ b/plugins/resources/src/components/panel/details/actions/Terminal.tsx
@@ -1,0 +1,176 @@
+import {
+  Button,
+  ButtonVariant,
+  Form,
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+  Modal,
+  ModalVariant,
+} from '@patternfly/react-core';
+import React, { useContext, useState } from 'react';
+import { IRow } from '@patternfly/react-table';
+import { V1Pod } from '@kubernetes/client-node';
+import { Terminal as xTerm } from 'xterm';
+
+import {
+  IPluginsContext,
+  IResource,
+  ITerminalContext,
+  PluginsContext,
+  TERMINAL_OPTIONS,
+  TerminalsContext,
+} from '@kobsio/plugin-core';
+
+// getContainers returns a list with all container names for the given Pod. It contains all specified init containers
+// and the "normal" containers.
+const getContainers = (pod: V1Pod): string[] => {
+  const containers: string[] = [];
+
+  if (pod.spec?.initContainers) {
+    for (const container of pod.spec?.initContainers) {
+      containers.push(container.name);
+    }
+  }
+
+  if (pod.spec?.containers) {
+    for (const container of pod.spec?.containers) {
+      containers.push(container.name);
+    }
+  }
+
+  return containers;
+};
+
+interface ITerminalProps {
+  request: IResource;
+  resource: IRow;
+  show: boolean;
+  setShow: (value: boolean) => void;
+}
+
+const Terminal: React.FunctionComponent<ITerminalProps> = ({ request, resource, show, setShow }: ITerminalProps) => {
+  const containers = getContainers(resource.props);
+  const shells = ['bash', 'sh', 'powershell', 'cmd'];
+
+  const pluginsContext = useContext<IPluginsContext>(PluginsContext);
+  const terminalsContext = useContext<ITerminalContext>(TerminalsContext);
+  const [container, setContainer] = useState<string>(containers[0]);
+  const [shell, setShell] = useState<string>(shells[1]);
+
+  const createTerminal = async (): Promise<void> => {
+    setShow(false);
+
+    const term = new xTerm(TERMINAL_OPTIONS);
+
+    try {
+      const pluginDetails = pluginsContext.getPluginDetails('resources');
+      const configuredWebSocketAddress =
+        pluginDetails && pluginDetails.options && pluginDetails.options && pluginDetails.options.webSocketAddress
+          ? pluginDetails.options.webSocketAddress
+          : undefined;
+      const host = configuredWebSocketAddress || `wss://${window.location.host}`;
+
+      console.log(host);
+
+      const ws = new WebSocket(
+        `${host}/api/plugins/resources/terminal?cluster=${resource.cluster.title}${
+          resource.namespace ? `&namespace=${resource.namespace.title}` : ''
+        }&name=${resource.name.title}&container=${container}&shell=${shell}`,
+      );
+
+      term.reset();
+
+      term.onData((str) => {
+        ws.send(
+          JSON.stringify({
+            Cols: term.cols,
+            Data: str,
+            Op: 'stdin',
+            Rows: term.rows,
+          }),
+        );
+      });
+
+      term.onResize(() => {
+        ws.send(
+          JSON.stringify({
+            Cols: term.cols,
+            Op: 'resize',
+            Rows: term.rows,
+          }),
+        );
+      });
+
+      ws.onmessage = (event): void => {
+        const msg = JSON.parse(event.data);
+        if (msg.Op === 'stdout') {
+          term.write(msg.Data);
+        }
+      };
+
+      terminalsContext.addTerminal({
+        name: `${resource.namespace.title}: ${container} (${shell})`,
+        terminal: term,
+        webSocket: ws,
+      });
+    } catch (err) {
+      if (err.message) {
+        term.write(`${err.message}\n\r`);
+        terminalsContext.addTerminal({
+          name: `${resource.namespace.title}: ${container} (${shell})`,
+          terminal: term,
+        });
+      }
+    }
+  };
+
+  return (
+    <Modal
+      variant={ModalVariant.small}
+      title="Terminal"
+      isOpen={show}
+      onClose={(): void => setShow(false)}
+      actions={[
+        <Button key="createJob" variant={ButtonVariant.primary} onClick={createTerminal}>
+          Create Terminal
+        </Button>,
+        <Button key="cancel" variant={ButtonVariant.link} onClick={(): void => setShow(false)}>
+          Cancel
+        </Button>,
+      ]}
+    >
+      <Form isHorizontal={true}>
+        <FormGroup label="Container" fieldId="terminal-form-container">
+          <FormSelect
+            value={container}
+            onChange={(value): void => setContainer(value)}
+            id="terminal-form-container"
+            name="terminal-form-container"
+            aria-label="Container"
+          >
+            {containers.map((container, index) => (
+              <FormSelectOption key={index} value={container} label={container} />
+            ))}
+          </FormSelect>
+        </FormGroup>
+
+        <FormGroup label="Shell" fieldId="terminal-form-shell">
+          <FormSelect
+            value={shell}
+            onChange={(value): void => setShell(value)}
+            id="terminal-form-shell"
+            name="terminal-form-shell"
+            aria-label="Shell"
+          >
+            {shells.map((shell, index) => (
+              <FormSelectOption key={index} value={shell} label={shell} />
+            ))}
+          </FormSelect>
+        </FormGroup>
+      </Form>
+    </Modal>
+  );
+};
+
+export default Terminal;

--- a/yarn.lock
+++ b/yarn.lock
@@ -15249,6 +15249,16 @@ xtend@^4.0.0, xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
+xterm-addon-fit@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.5.0.tgz#2d51b983b786a97dcd6cde805e700c7f913bc596"
+  integrity sha512-DsS9fqhXHacEmsPxBJZvfj2la30Iz9xk+UKjhQgnYNkrUIN5CYLbw7WEfz117c7+S86S/tpHPfvNxJsF5/G8wQ==
+
+xterm@^4.13.0:
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.13.0.tgz#7998de1e2ad92c4796fe45807be4f31061f3d9d1"
+  integrity sha512-HVW1gdoLOTnkMaqQCr2r3mQy4fX9iSa5gWxKZ2UTYdLa4iqavv7QxJ8n1Ypse32shPVkhTYPLS6vHEFZp5ghzw==
+
 y18n@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"


### PR DESCRIPTION
It is now possible to create a terminal for a Kubernetes Pods. The
terminal can be created via the actions in the Pod details drawer. We
are using xterm.js for the terminal, all the input / output is send over
a WebSocket connection.

By default we are using the current domain for the WebSocket connection.
This can be overwritten in the configuration of the resources plugin for
kobs.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
