### PR TITLE
Fix WebSocket connection for Kubernetes terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 ### Fixed
 
 - [#94](https://github.com/kobsio/kobs/pull/94): Fix variable handling for dashboards.
+- [#99](https://github.com/kobsio/kobs/pull/99): Fix WebSocket connections for the Kubernetes terminal in environments with an idle timeout for all connections.
 
 ### Changed
 


### PR DESCRIPTION
This commit fixes the WebSocket connection for the Kubernetes terminal
in environments where a idle timeout for the connections is defined. To
avoid that the connection is closed when the WebSocket connection is
longer open then the specified idle timeout, we added a ping / pong
implementation. These should avoid that the connection is closed.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
