### PR TITLE
Add support for Ephemeral Containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#93](https://github.com/kobsio/kobs/pull/93): Show status of Kubernetes resource in the table of the resources plugin.
 - [#97](https://github.com/kobsio/kobs/pull/97): Add support for Kiali metrics.
 - [#98](https://github.com/kobsio/kobs/pull/98): Add terminal support for Kubernetes Pods.
+- [#100](https://github.com/kobsio/kobs/pull/100): Add support for Ephemeral Containers.
 
 ### Fixed
 

--- a/cmd/kobs/config/config.go
+++ b/cmd/kobs/config/config.go
@@ -7,13 +7,13 @@ import (
 	"github.com/kobsio/kobs/cmd/kobs/plugins"
 	"github.com/kobsio/kobs/pkg/api/clusters"
 
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 // Config is the complete configuration for kobs.
 type Config struct {
-	Clusters clusters.Config `yaml:"clusters"`
-	Plugins  plugins.Config  `yaml:"plugins"`
+	Clusters clusters.Config `json:"clusters"`
+	Plugins  plugins.Config  `json:"plugins"`
 }
 
 // Load the configuration for kobs. Most of the configuration options are available as command-line flag, but we also

--- a/cmd/kobs/plugins/plugins.go
+++ b/cmd/kobs/plugins/plugins.go
@@ -26,17 +26,17 @@ import (
 
 // Config holds the configuration for all plugins. We have to add the configuration for all the imported plugins.
 type Config struct {
-	Applications  applications.Config  `yaml:"applications"`
-	Resources     resources.Config     `yaml:"resources"`
-	Teams         teams.Config         `yaml:"teams"`
-	Dashboards    dashboards.Config    `yaml:"dashboards"`
-	Prometheus    prometheus.Config    `yaml:"prometheus"`
-	Elasticsearch elasticsearch.Config `yaml:"elasticsearch"`
-	Jaeger        jaeger.Config        `yaml:"jaeger"`
-	Markdown      markdown.Config      `yaml:"markdown"`
-	Kiali         kiali.Config         `yaml:"kiali"`
-	Opsgenie      opsgenie.Config      `yaml:"opsgenie"`
-	RSS           rss.Config           `yaml:"rss"`
+	Applications  applications.Config  `json:"applications"`
+	Resources     resources.Config     `json:"resources"`
+	Teams         teams.Config         `json:"teams"`
+	Dashboards    dashboards.Config    `json:"dashboards"`
+	Prometheus    prometheus.Config    `json:"prometheus"`
+	Elasticsearch elasticsearch.Config `json:"elasticsearch"`
+	Jaeger        jaeger.Config        `json:"jaeger"`
+	Markdown      markdown.Config      `json:"markdown"`
+	Kiali         kiali.Config         `json:"kiali"`
+	Opsgenie      opsgenie.Config      `json:"opsgenie"`
+	RSS           rss.Config           `json:"rss"`
 }
 
 // Router implements the router for the plugins package. This only registeres one route which is used to return all the

--- a/deploy/demo/kind-with-registry.sh
+++ b/deploy/demo/kind-with-registry.sh
@@ -16,6 +16,8 @@ cat <<EOF | kind create cluster --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: kobs-demo
+featureGates:
+  EphemeralContainers: true
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]

--- a/docs/configuration/plugins.md
+++ b/docs/configuration/plugins.md
@@ -168,3 +168,4 @@ plugins:
 | forbidden | []string | A list of resources, which can not be retrieved via the kobs API. | No |
 | webSocket.address | string | The address, which should be used for the WebSocket connection. By default this will be the current host, but it can be overwritten for development purposes. | No |
 | webSocket.allowAllOrigins | boolean | When this is `true`, WebSocket connections are allowed for all origins. This should only be used for development. | No |
+| ephemeralContainers | [[]EphemeralContainer](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#ephemeralcontainer-v1-core) | A list of templates for Ephemeral Containers, which can be used to [debug running pods](https://kubernetes.io/docs/tasks/debug-application-cluster/debug-running-pod/#ephemeral-container). | No |

--- a/docs/contributing/using-the-kobsio-app.md
+++ b/docs/contributing/using-the-kobsio-app.md
@@ -55,9 +55,9 @@ import (
 
 // Config holds the configuration for all plugins. We have to add the configuration for all the imported plugins.
 type Config struct {
-        Resources     resources.Config     `yaml:"resources"`
-        HelloWorld    helloworld.Config    `yaml:"helloworld"`
-+        MyNewPlugin      mynewplugin.Config      `yaml:"myNewPlugin"`
+        Resources     resources.Config     `json:"resources"`
+        HelloWorld    helloworld.Config    `json:"helloworld"`
++        MyNewPlugin      mynewplugin.Config      `json:"myNewPlugin"`
 }
 
 // Router implements the router for the plugins package. This only registeres one route which is used to return all the

--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,9 @@ require (
 	github.com/prometheus/common v0.30.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/pflag v1.0.5
-	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.21.3
 	k8s.io/apiextensions-apiserver v0.21.3
 	k8s.io/apimachinery v0.21.3
 	k8s.io/client-go v0.21.3
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/pkg/api/clusters/cluster/cluster.go
+++ b/pkg/api/clusters/cluster/cluster.go
@@ -173,8 +173,18 @@ func (c *Cluster) PatchResource(ctx context.Context, namespace, name, path, reso
 
 // CreateResource can be used to create the given resource. The resource is identified by the Kubernetes API path and the
 // name of the resource.
-func (c *Cluster) CreateResource(ctx context.Context, namespace, path, resource string, body []byte) error {
-	_, err := c.clientset.RESTClient().Post().AbsPath(path).Namespace(namespace).Resource(resource).Body(body).DoRaw(ctx)
+func (c *Cluster) CreateResource(ctx context.Context, namespace, name, path, resource, subResource string, body []byte) error {
+	if name != "" && subResource != "" {
+		_, err := c.clientset.RESTClient().Put().AbsPath(path).Namespace(namespace).Name(name).Resource(resource).SubResource(subResource).Body(body).DoRaw(ctx)
+		if err != nil {
+			log.WithError(err).WithFields(logrus.Fields{"cluster": c.name, "namespace": namespace, "name": name, "path": path, "resource": resource, "subResource": subResource}).Errorf("CreateResource")
+			return err
+		}
+
+		return nil
+	}
+
+	_, err := c.clientset.RESTClient().Post().AbsPath(path).Namespace(namespace).Resource(resource).SubResource(subResource).Body(body).DoRaw(ctx)
 	if err != nil {
 		log.WithError(err).WithFields(logrus.Fields{"cluster": c.name, "namespace": namespace, "path": path, "resource": resource}).Errorf("CreateResource")
 		return err

--- a/pkg/api/clusters/clusters.go
+++ b/pkg/api/clusters/clusters.go
@@ -33,7 +33,7 @@ func init() {
 // Config is the configuration required to load all clusters. It takes an array of providers, which are defined in the
 // providers package.
 type Config struct {
-	Providers []provider.Config `yaml:"providers"`
+	Providers []provider.Config `json:"providers"`
 }
 
 // TODO

--- a/pkg/api/clusters/provider/incluster/incluster.go
+++ b/pkg/api/clusters/provider/incluster/incluster.go
@@ -13,7 +13,7 @@ var (
 
 // Config is the configuration for the InCluster provider.
 type Config struct {
-	Name string `yaml:"name"`
+	Name string `json:"name"`
 }
 
 // GetCluster returns the cluster, where kobs is running in via the incluster configuration. For the selection of the

--- a/pkg/api/clusters/provider/kubeconfig/kubeconfig.go
+++ b/pkg/api/clusters/provider/kubeconfig/kubeconfig.go
@@ -14,7 +14,7 @@ var (
 
 // Config is the configuration for the Kubeconfig provider.
 type Config struct {
-	Path string `yaml:"path"`
+	Path string `json:"path"`
 }
 
 // GetClusters returns all clusters from a given Kubeconfig file. For that the user have to provide the path to the

--- a/pkg/api/clusters/provider/provider.go
+++ b/pkg/api/clusters/provider/provider.go
@@ -28,9 +28,9 @@ const (
 // Config is the provider configuration to get Kubernetes clusters from. The provider configuration only contains the
 // provider type and a provider specific configuration.
 type Config struct {
-	Provider   Type              `yaml:"provider"`
-	InCluster  incluster.Config  `yaml:"incluster"`
-	Kubeconfig kubeconfig.Config `yaml:"kubeconfig"`
+	Provider   Type              `json:"provider"`
+	InCluster  incluster.Config  `json:"incluster"`
+	Kubeconfig kubeconfig.Config `json:"kubeconfig"`
 }
 
 // GetClusters returns all clusters for the given provider. When the provider field doesn't match our custom Type, we

--- a/plugins/applications/applications.go
+++ b/plugins/applications/applications.go
@@ -26,8 +26,8 @@ var (
 
 // Config is the structure of the configuration for the applications plugin.
 type Config struct {
-	TopologyCacheDuration time.Duration `yaml:"topologyCacheDuration"`
-	TeamsCacheDuration    time.Duration `yaml:"teamsCacheDuration"`
+	TopologyCacheDuration string `json:"topologyCacheDuration"`
+	TeamsCacheDuration    string `json:"teamsCacheDuration"`
 }
 
 // Router implements the router for the resources plugin, which can be registered in the router for our rest api.
@@ -209,15 +209,19 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 	})
 
 	var topology topology.Cache
-	topology.CacheDuration = config.TopologyCacheDuration
-	if topology.CacheDuration.Seconds() < 60 {
+	topologyCacheDuration, err := time.ParseDuration(config.TopologyCacheDuration)
+	if err != nil || topologyCacheDuration.Seconds() < 60 {
 		topology.CacheDuration = time.Duration(1 * time.Hour)
+	} else {
+		topology.CacheDuration = topologyCacheDuration
 	}
 
 	var teams teams.Cache
-	teams.CacheDuration = config.TeamsCacheDuration
-	if teams.CacheDuration.Seconds() < 60 {
+	teamsCacheDuration, err := time.ParseDuration(config.TeamsCacheDuration)
+	if err != nil || teamsCacheDuration.Seconds() < 60 {
 		teams.CacheDuration = time.Duration(1 * time.Hour)
+	} else {
+		teams.CacheDuration = teamsCacheDuration
 	}
 
 	router := Router{

--- a/plugins/elasticsearch/pkg/instance/instance.go
+++ b/plugins/elasticsearch/pkg/instance/instance.go
@@ -19,13 +19,13 @@ var (
 
 // Config is the structure of the configuration for a single Elasticsearch instance.
 type Config struct {
-	Name        string `yaml:"name"`
-	DisplayName string `yaml:"displayName"`
-	Description string `yaml:"description"`
-	Address     string `yaml:"address"`
-	Username    string `yaml:"username"`
-	Password    string `yaml:"password"`
-	Token       string `yaml:"token"`
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+	Description string `json:"description"`
+	Address     string `json:"address"`
+	Username    string `json:"username"`
+	Password    string `json:"password"`
+	Token       string `json:"token"`
 }
 
 // Instance represents a single Elasticsearch instance, which can be added via the configuration file.

--- a/plugins/jaeger/pkg/instance/instance.go
+++ b/plugins/jaeger/pkg/instance/instance.go
@@ -17,13 +17,13 @@ var (
 
 // Config is the structure of the configuration for a single Jaeger instance.
 type Config struct {
-	Name        string `yaml:"name"`
-	DisplayName string `yaml:"displayName"`
-	Description string `yaml:"description"`
-	Address     string `yaml:"address"`
-	Username    string `yaml:"username"`
-	Password    string `yaml:"password"`
-	Token       string `yaml:"token"`
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+	Description string `json:"description"`
+	Address     string `json:"address"`
+	Username    string `json:"username"`
+	Password    string `json:"password"`
+	Token       string `json:"token"`
 }
 
 // ResponseError is the structure for a failed Jaeger API request.

--- a/plugins/kiali/pkg/instance/instance.go
+++ b/plugins/kiali/pkg/instance/instance.go
@@ -22,20 +22,20 @@ var (
 
 // Config is the structure of the configuration for a single Kiali instance.
 type Config struct {
-	Name        string  `yaml:"name"`
-	DisplayName string  `yaml:"displayName"`
-	Description string  `yaml:"description"`
-	Address     string  `yaml:"address"`
-	Username    string  `yaml:"username"`
-	Password    string  `yaml:"password"`
-	Token       string  `yaml:"token"`
-	Traffic     Traffic `yaml:"traffic"`
+	Name        string  `json:"name"`
+	DisplayName string  `json:"displayName"`
+	Description string  `json:"description"`
+	Address     string  `json:"address"`
+	Username    string  `json:"username"`
+	Password    string  `json:"password"`
+	Token       string  `json:"token"`
+	Traffic     Traffic `json:"traffic"`
 }
 
 // Traffic is the traffic configuration, to set the value to mark a edge as degraded and failure.
 type Traffic struct {
-	Degraded float64 `yaml:"degraded"`
-	Failure  float64 `yaml:"failure"`
+	Degraded float64 `json:"degraded"`
+	Failure  float64 `json:"failure"`
 }
 
 // Graph is the structure of the returned topology graph from Kiali. We have to implement it by ourselve, because we

--- a/plugins/opsgenie/pkg/instance/instance.go
+++ b/plugins/opsgenie/pkg/instance/instance.go
@@ -17,12 +17,12 @@ var (
 
 // Config is the structure of the configuration for a single Opsgenie instance.
 type Config struct {
-	Name        string `yaml:"name"`
-	DisplayName string `yaml:"displayName"`
-	Description string `yaml:"description"`
-	APIKey      string `yaml:"apiKey"`
-	APIUrl      string `yaml:"apiUrl"`
-	URL         string `yaml:"url"`
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+	Description string `json:"description"`
+	APIKey      string `json:"apiKey"`
+	APIUrl      string `json:"apiUrl"`
+	URL         string `json:"url"`
 }
 
 // Instance represents a single Jaeger instance, which can be added via the configuration file.

--- a/plugins/prometheus/pkg/instance/instance.go
+++ b/plugins/prometheus/pkg/instance/instance.go
@@ -22,13 +22,13 @@ var (
 
 // Config is the structure of the configuration for a single Prometheus instance.
 type Config struct {
-	Name        string `yaml:"name"`
-	DisplayName string `yaml:"displayName"`
-	Description string `yaml:"description"`
-	Address     string `yaml:"address"`
-	Username    string `yaml:"username"`
-	Password    string `yaml:"password"`
-	Token       string `yaml:"token"`
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+	Description string `json:"description"`
+	Address     string `json:"address"`
+	Username    string `json:"username"`
+	Password    string `json:"password"`
+	Token       string `json:"token"`
 }
 
 // Instance represents a single Prometheus instance, which can be added via the configuration file.

--- a/plugins/resources/src/components/panel/details/Actions.tsx
+++ b/plugins/resources/src/components/panel/details/Actions.tsx
@@ -2,6 +2,7 @@ import { Alert, AlertActionCloseButton, AlertGroup, Dropdown, DropdownItem, Keba
 import React, { useState } from 'react';
 import { IRow } from '@patternfly/react-table';
 
+import CreateEphemeralContainer from './actions/CreateEphemeralContainer';
 import CreateJob from './actions/CreateJob';
 import Delete from './actions/Delete';
 import Edit from './actions/Edit';
@@ -24,6 +25,7 @@ const Actions: React.FunctionComponent<IActionProps> = ({ request, resource, ref
   const [showRestart, setShowRestart] = useState<boolean>(false);
   const [showCreateJob, setShowCreateJob] = useState<boolean>(false);
   const [showTerminal, setShowTerminal] = useState<boolean>(false);
+  const [showCreateEphemeralContainer, setShowCreateEphemeralContainer] = useState<boolean>(false);
   const [showEdit, setShowEdit] = useState<boolean>(false);
   const [showDelete, setShowDelete] = useState<boolean>(false);
 
@@ -90,6 +92,20 @@ const Actions: React.FunctionComponent<IActionProps> = ({ request, resource, ref
         }}
       >
         Terminal
+      </DropdownItem>,
+    );
+  }
+
+  if (request.resource === 'pods') {
+    dropdownItems.push(
+      <DropdownItem
+        key="debug"
+        onClick={(): void => {
+          setShowDropdown(false);
+          setShowCreateEphemeralContainer(true);
+        }}
+      >
+        Create Ephemeral Container
       </DropdownItem>,
     );
   }
@@ -169,6 +185,15 @@ const Actions: React.FunctionComponent<IActionProps> = ({ request, resource, ref
       />
 
       <Terminal request={request} resource={resource} show={showTerminal} setShow={setShowTerminal} />
+
+      <CreateEphemeralContainer
+        request={request}
+        resource={resource}
+        show={showCreateEphemeralContainer}
+        setShow={setShowCreateEphemeralContainer}
+        setAlert={(alert: IAlert): void => setAlerts([...alerts, alert])}
+        refetch={refetch}
+      />
 
       <Edit
         request={request}

--- a/plugins/resources/src/components/panel/details/actions/CreateEphemeralContainer.tsx
+++ b/plugins/resources/src/components/panel/details/actions/CreateEphemeralContainer.tsx
@@ -1,0 +1,132 @@
+import {
+  AlertVariant,
+  Button,
+  ButtonVariant,
+  Form,
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+  Modal,
+  ModalVariant,
+} from '@patternfly/react-core';
+import React, { useContext, useState } from 'react';
+import { V1EphemeralContainer, V1EphemeralContainers } from '@kubernetes/client-node';
+import { IRow } from '@patternfly/react-table';
+import yaml from 'js-yaml';
+
+import { Editor, IPluginsContext, IResource, PluginsContext } from '@kobsio/plugin-core';
+import { IAlert } from '../../../../utils/interfaces';
+
+interface ICreateEphemeralContainerProps {
+  request: IResource;
+  resource: IRow;
+  show: boolean;
+  setShow: (value: boolean) => void;
+  setAlert: (alert: IAlert) => void;
+  refetch: () => void;
+}
+
+const CreateEphemeralContainer: React.FunctionComponent<ICreateEphemeralContainerProps> = ({
+  resource,
+  show,
+  setShow,
+  setAlert,
+  refetch,
+}: ICreateEphemeralContainerProps) => {
+  const pluginsContext = useContext<IPluginsContext>(PluginsContext);
+  const pluginDetails = pluginsContext.getPluginDetails('resources');
+  const ephemeralContainers: V1EphemeralContainer[] | undefined =
+    pluginDetails && pluginDetails.options && pluginDetails.options && pluginDetails.options.ephemeralContainers
+      ? pluginDetails.options.ephemeralContainers
+      : undefined;
+
+  const [ephemeralContainer, setEphemeralContainer] = useState<string>(
+    ephemeralContainers && ephemeralContainers.length > 0 ? yaml.dump(ephemeralContainers[0]) : '',
+  );
+
+  const createEphemeralContainer = async (): Promise<void> => {
+    try {
+      const parsedEphemeralContainer: V1EphemeralContainer = yaml.load(ephemeralContainer);
+      const manifest: V1EphemeralContainers = {
+        apiVersion: 'v1',
+        ephemeralContainers: [parsedEphemeralContainer],
+        kind: 'EphemeralContainers',
+        metadata: {
+          name: resource.name.title,
+          namespace: resource.namespace.title,
+        },
+      };
+
+      const response = await fetch(
+        `/api/plugins/resources/resources?cluster=${resource.cluster.title}${
+          resource.namespace ? `&namespace=${resource.namespace.title}` : ''
+        }&name=${resource.name.title}&resource=pods&path=/api/v1&subResource=ephemeralcontainers`,
+        {
+          body: JSON.stringify(manifest),
+          method: 'post',
+        },
+      );
+      const json = await response.json();
+
+      if (response.status >= 200 && response.status < 300) {
+        setShow(false);
+        setAlert({
+          title: `Ephemeral Container ${parsedEphemeralContainer.name} was created`,
+          variant: AlertVariant.success,
+        });
+        refetch();
+      } else {
+        if (json.error) {
+          throw new Error(json.error);
+        } else {
+          throw new Error('An unknown error occured');
+        }
+      }
+    } catch (err) {
+      setShow(false);
+      setAlert({ title: err.message, variant: AlertVariant.danger });
+    }
+  };
+
+  return (
+    <Modal
+      variant={ModalVariant.medium}
+      title="Create Ephemeral Container"
+      isOpen={show}
+      onClose={(): void => setShow(false)}
+      actions={[
+        <Button key="createEphemeralContainer" variant={ButtonVariant.primary} onClick={createEphemeralContainer}>
+          Create Ephemeral Container
+        </Button>,
+        <Button key="cancel" variant={ButtonVariant.link} onClick={(): void => setShow(false)}>
+          Cancel
+        </Button>,
+      ]}
+    >
+      {ephemeralContainers && ephemeralContainers.length > 0 && (
+        <React.Fragment>
+          <Form isHorizontal={true}>
+            <FormGroup label="Template" fieldId="create-ephemeral-container-form-container">
+              <FormSelect
+                value={ephemeralContainer}
+                onChange={(value): void => setEphemeralContainer(value)}
+                id="create-ephemeral-container-form-container"
+                name="create-ephemeral-container-form-container"
+                aria-label="Template"
+              >
+                {ephemeralContainers.map((container, index) => (
+                  <FormSelectOption key={index} value={yaml.dump(container)} label={container.name} />
+                ))}
+              </FormSelect>
+            </FormGroup>
+          </Form>
+          <p>&nbsp;</p>
+        </React.Fragment>
+      )}
+
+      <Editor value={ephemeralContainer} mode="yaml" readOnly={false} onChange={setEphemeralContainer} />
+    </Modal>
+  );
+};
+
+export default CreateEphemeralContainer;

--- a/plugins/resources/src/components/panel/details/actions/Terminal.tsx
+++ b/plugins/resources/src/components/panel/details/actions/Terminal.tsx
@@ -39,6 +39,12 @@ const getContainers = (pod: V1Pod): string[] => {
     }
   }
 
+  if (pod.spec?.ephemeralContainers) {
+    for (const container of pod.spec?.ephemeralContainers) {
+      containers.push(container.name);
+    }
+  }
+
   return containers;
 };
 
@@ -70,8 +76,6 @@ const Terminal: React.FunctionComponent<ITerminalProps> = ({ request, resource, 
           ? pluginDetails.options.webSocketAddress
           : undefined;
       const host = configuredWebSocketAddress || `wss://${window.location.host}`;
-
-      console.log(host);
 
       const ws = new WebSocket(
         `${host}/api/plugins/resources/terminal?cluster=${resource.cluster.title}${
@@ -132,7 +136,7 @@ const Terminal: React.FunctionComponent<ITerminalProps> = ({ request, resource, 
       isOpen={show}
       onClose={(): void => setShow(false)}
       actions={[
-        <Button key="createJob" variant={ButtonVariant.primary} onClick={createTerminal}>
+        <Button key="createTerminal" variant={ButtonVariant.primary} onClick={createTerminal}>
           Create Terminal
         </Button>,
         <Button key="cancel" variant={ButtonVariant.link} onClick={(): void => setShow(false)}>

--- a/plugins/resources/src/components/panel/details/overview/Pod.tsx
+++ b/plugins/resources/src/components/panel/details/overview/Pod.tsx
@@ -161,6 +161,14 @@ const Pod: React.FunctionComponent<IPodProps> = ({ cluster, namespace, name, pod
           containerMetrics={isError ? undefined : data}
         />
       )}
+      {pod.spec?.ephemeralContainers && (
+        <Containers
+          title="Ephemeral Containers"
+          containers={pod.spec?.ephemeralContainers}
+          containerStatuses={pod.status?.ephemeralContainerStatuses}
+          containerMetrics={isError ? undefined : data}
+        />
+      )}
     </React.Fragment>
   );
 };


### PR DESCRIPTION
It is now possible to view Ephemeral Containers in the overview page of
a pod and to create Ephemeral Containers via the debug actions. To make
it easier for users to create such containers it is possible to specify
a list of templates for the Ephemeral Containers in the configuration
file via the 'ephemeralContainers' key in the resources plugin section.

To make use of an created Ephemeral Container we also added them to the
terminal modal. This allows our users to exec into the created
containers.

To support the parsing of these templates in from the configuration
file, we had to switch our used yaml package from gopkg.in/yaml.v2 to
sigs.k8s.io/yaml, which also supports parsing of yaml files via the
specified json tags.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
