### PR TITLE
Add actions for Opsgenie plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 ### Added
 
 - [#103](https://github.com/kobsio/kobs/pull/103): Add option to get user information from a request.
+- [#104](https://github.com/kobsio/kobs/pull/104): Add actions for Opsgenie plugin to acknowledge, snooze and close alerts.
 
 ### Fixed
 

--- a/docs/configuration/plugins.md
+++ b/docs/configuration/plugins.md
@@ -116,6 +116,10 @@ plugins:
       apiUrl: api.eu.opsgenie.com
       apiKey: ${OPSGENIE_API_KEY}
       url: https://<your-organisation>.app.eu.opsgenie.com
+      actions:
+        acknowledge: true
+        snooze: true
+        close: true
 ```
 
 | Field | Type | Description | Required |
@@ -125,7 +129,10 @@ plugins:
 | descriptions | string | Description of the Opsgenie instance. | No |
 | apiKey | string | API Key for the Opsgenie API. More information can be found at [API key management](https://support.atlassian.com/opsgenie/docs/api-key-management/). | Yes |
 | apiUrl | string | API URL for the Opsgenie API. Must be `api.opsgenie.com` or `api.eu.opsgenie.com`. | Yes |
-| url | string | The address for the Opsgenie account of your organisation | No |
+| url | string | The address for the Opsgenie account of your organisation. | No |
+| actions.acknowledge | boolean | Allow users to acknowledge Opsgenie alerts via kobs. | No |
+| actions.snooze | boolean | Allow users to snooze Opsgenie alerts via kobs. | No |
+| actions.close | boolean | Allow users to close Opsgenie alerts via kobs. | No |
 
 ## Prometheus
 

--- a/plugins/opsgenie/src/components/panel/details/alert/Actions.tsx
+++ b/plugins/opsgenie/src/components/panel/details/alert/Actions.tsx
@@ -1,8 +1,11 @@
-import { Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
+import { Alert, AlertActionCloseButton, AlertGroup, Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
 import React, { useContext, useState } from 'react';
 
+import { IAlert, IMessage } from '../../../../utils/interfaces';
 import { IPluginsContext, PluginsContext } from '@kobsio/plugin-core';
-import { IAlert } from '../../../../utils/interfaces';
+import Acknowledge from './actions/Acknowledge';
+import Close from './actions/Close';
+import Snooze from './actions/Snooze';
 
 interface IActionsProps {
   name: string;
@@ -12,30 +15,94 @@ interface IActionsProps {
 const Actions: React.FunctionComponent<IActionsProps> = ({ name, alert }: IActionsProps) => {
   const pluginsContext = useContext<IPluginsContext>(PluginsContext);
   const [showDropdown, setShowDropdown] = useState<boolean>(false);
+  const [messages, setMessages] = useState<IMessage[]>([]);
 
   const pluginDetails = pluginsContext.getPluginDetails(name);
-  const url =
+  const options =
     pluginDetails && pluginDetails.options && pluginDetails.options && pluginDetails.options.url
-      ? pluginDetails.options.url
+      ? pluginDetails.options
       : undefined;
+  const url = options && options.url ? options.url : undefined;
+  // const acknowledge =
+  //   options && options.actions && options.actions.acknowledge ? options.actions.acknowledge : undefined;
+  // const close = options && options.actions && options.actions.close ? options.actions.close : undefined;
 
-  if (!url) {
+  const dropdownItems = [];
+  if (options && options.actions && options.actions.acknowledge) {
+    dropdownItems.push(
+      <Acknowledge
+        key="acknowledge"
+        name={name}
+        alert={alert}
+        hideDropdown={(): void => setShowDropdown(false)}
+        setMessage={(message: IMessage): void => setMessages([...messages, message])}
+      />,
+    );
+  }
+  if (options && options.actions && options.actions.snooze) {
+    dropdownItems.push(
+      <Snooze
+        key="snooze"
+        name={name}
+        alert={alert}
+        hideDropdown={(): void => setShowDropdown(false)}
+        setMessage={(message: IMessage): void => setMessages([...messages, message])}
+      />,
+    );
+  }
+  if (options && options.actions && options.actions.close) {
+    dropdownItems.push(
+      <Close
+        key="close"
+        name={name}
+        alert={alert}
+        hideDropdown={(): void => setShowDropdown(false)}
+        setMessage={(message: IMessage): void => setMessages([...messages, message])}
+      />,
+    );
+  }
+  if (url) {
+    dropdownItems.push(
+      <DropdownItem key="url" href={`${url}/alert/detail/${alert.id}/details`} target="_blank">
+        Open in Opsgenie
+      </DropdownItem>,
+    );
+  }
+
+  if (dropdownItems.length === 0) {
     return null;
   }
 
+  // removeMessage is used to remove a message from the list of messages, when the user clicks the close button.
+  const removeMessage = (index: number): void => {
+    const tmpMessages = [...messages];
+    tmpMessages.splice(index, 1);
+    setMessages(tmpMessages);
+  };
+
   return (
-    <Dropdown
-      className="pf-c-drawer__close"
-      toggle={<KebabToggle onToggle={(): void => setShowDropdown(!showDropdown)} />}
-      isOpen={showDropdown}
-      isPlain={true}
-      position="right"
-      dropdownItems={[
-        <DropdownItem key={0} href={`${url}/alert/detail/${alert.id}/details`} target="_blank">
-          Open in Opsgenie
-        </DropdownItem>,
-      ]}
-    />
+    <React.Fragment>
+      <Dropdown
+        className="pf-c-drawer__close"
+        toggle={<KebabToggle onToggle={(): void => setShowDropdown(!showDropdown)} />}
+        isOpen={showDropdown}
+        isPlain={true}
+        position="right"
+        dropdownItems={dropdownItems}
+      />
+
+      <AlertGroup isToast={true}>
+        {messages.map((message, index) => (
+          <Alert
+            key={index}
+            isLiveRegion={true}
+            variant={message.variant}
+            title={message.title}
+            actionClose={<AlertActionCloseButton onClick={(): void => removeMessage(index)} />}
+          />
+        ))}
+      </AlertGroup>
+    </React.Fragment>
   );
 };
 

--- a/plugins/opsgenie/src/components/panel/details/alert/actions/Acknowledge.tsx
+++ b/plugins/opsgenie/src/components/panel/details/alert/actions/Acknowledge.tsx
@@ -1,0 +1,48 @@
+import { AlertVariant, DropdownItem } from '@patternfly/react-core';
+import React from 'react';
+
+import { IAlert, IMessage } from '../../../../../utils/interfaces';
+
+interface IAcknowledgeProps {
+  name: string;
+  alert: IAlert;
+  hideDropdown: () => void;
+  setMessage: (message: IMessage) => void;
+}
+
+const Acknowledge: React.FunctionComponent<IAcknowledgeProps> = ({
+  name,
+  alert,
+  hideDropdown,
+  setMessage,
+}: IAcknowledgeProps) => {
+  const acknowledge = async (): Promise<void> => {
+    hideDropdown();
+
+    try {
+      const response = await fetch(`/api/plugins/opsgenie/alert/acknowledge/${name}?id=${alert.id}`, {
+        method: 'get',
+      });
+      const json = await response.json();
+
+      if (response.status >= 200 && response.status < 300) {
+        setMessage({
+          title: `Alert ${alert.message} was acknowledge`,
+          variant: AlertVariant.success,
+        });
+      } else {
+        if (json.error) {
+          throw new Error(json.error);
+        } else {
+          throw new Error('An unknown error occured');
+        }
+      }
+    } catch (err) {
+      setMessage({ title: err.message, variant: AlertVariant.danger });
+    }
+  };
+
+  return <DropdownItem onClick={acknowledge}>Acknowledge</DropdownItem>;
+};
+
+export default Acknowledge;

--- a/plugins/opsgenie/src/components/panel/details/alert/actions/Close.tsx
+++ b/plugins/opsgenie/src/components/panel/details/alert/actions/Close.tsx
@@ -1,0 +1,43 @@
+import { AlertVariant, DropdownItem } from '@patternfly/react-core';
+import React from 'react';
+
+import { IAlert, IMessage } from '../../../../../utils/interfaces';
+
+interface ICloseProps {
+  name: string;
+  alert: IAlert;
+  hideDropdown: () => void;
+  setMessage: (message: IMessage) => void;
+}
+
+const Close: React.FunctionComponent<ICloseProps> = ({ name, alert, hideDropdown, setMessage }: ICloseProps) => {
+  const close = async (): Promise<void> => {
+    hideDropdown();
+
+    try {
+      const response = await fetch(`/api/plugins/opsgenie/alert/close/${name}?id=${alert.id}`, {
+        method: 'get',
+      });
+      const json = await response.json();
+
+      if (response.status >= 200 && response.status < 300) {
+        setMessage({
+          title: `Alert ${alert.message} was closed`,
+          variant: AlertVariant.success,
+        });
+      } else {
+        if (json.error) {
+          throw new Error(json.error);
+        } else {
+          throw new Error('An unknown error occured');
+        }
+      }
+    } catch (err) {
+      setMessage({ title: err.message, variant: AlertVariant.danger });
+    }
+  };
+
+  return <DropdownItem onClick={close}>Close</DropdownItem>;
+};
+
+export default Close;

--- a/plugins/opsgenie/src/components/panel/details/alert/actions/Snooze.tsx
+++ b/plugins/opsgenie/src/components/panel/details/alert/actions/Snooze.tsx
@@ -1,0 +1,101 @@
+import {
+  AlertVariant,
+  Button,
+  ButtonVariant,
+  DropdownItem,
+  Form,
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+  Modal,
+  ModalVariant,
+} from '@patternfly/react-core';
+import React, { useState } from 'react';
+
+import { IAlert, IMessage } from '../../../../../utils/interfaces';
+
+interface ISnoozeProps {
+  name: string;
+  alert: IAlert;
+  hideDropdown: () => void;
+  setMessage: (message: IMessage) => void;
+}
+
+const Snooze: React.FunctionComponent<ISnoozeProps> = ({ name, alert, hideDropdown, setMessage }: ISnoozeProps) => {
+  const [showModal, setShowModal] = useState<boolean>(false);
+  const [duration, setDuration] = useState<string>('1h');
+
+  const snooze = async (): Promise<void> => {
+    hideDropdown();
+
+    try {
+      const response = await fetch(`/api/plugins/opsgenie/alert/snooze/${name}?id=${alert.id}&snooze=${duration}`, {
+        method: 'get',
+      });
+      const json = await response.json();
+
+      if (response.status >= 200 && response.status < 300) {
+        setShowModal(false);
+        setMessage({
+          title: `Alert ${alert.message} was snoozed for ${duration}`,
+          variant: AlertVariant.success,
+        });
+      } else {
+        if (json.error) {
+          throw new Error(json.error);
+        } else {
+          throw new Error('An unknown error occured');
+        }
+      }
+    } catch (err) {
+      setShowModal(false);
+      setMessage({ title: err.message, variant: AlertVariant.danger });
+    }
+  };
+
+  return (
+    <React.Fragment>
+      <DropdownItem onClick={(): void => setShowModal(true)}>Snooze</DropdownItem>
+
+      <Modal
+        variant={ModalVariant.medium}
+        title="Snooze Alert"
+        isOpen={showModal}
+        onClose={(): void => setShowModal(false)}
+        actions={[
+          <Button key="snooze" variant={ButtonVariant.primary} onClick={snooze}>
+            Snooze
+          </Button>,
+          <Button key="cancel" variant={ButtonVariant.link} onClick={(): void => setShowModal(false)}>
+            Cancel
+          </Button>,
+        ]}
+      >
+        <Form isHorizontal={true}>
+          <FormGroup label="Duration" fieldId="opsgenie-snooze-duration">
+            <FormSelect
+              value={duration}
+              onChange={(value): void => setDuration(value)}
+              id="opsgenie-snooze-duration"
+              name="opsgenie-snooze-duration"
+              aria-label="Duration"
+            >
+              <FormSelectOption key={0} value="15m" label="15m" />
+              <FormSelectOption key={1} value="30m" label="30m" />
+              <FormSelectOption key={2} value="1h" label="1h" />
+              <FormSelectOption key={3} value="3h" label="3h" />
+              <FormSelectOption key={4} value="6h" label="6h" />
+              <FormSelectOption key={5} value="12h" label="12h" />
+              <FormSelectOption key={6} value="24h" label="24h" />
+              <FormSelectOption key={7} value="48h" label="48h" />
+              <FormSelectOption key={8} value="72h" label="72h" />
+              <FormSelectOption key={9} value="168h" label="168h" />
+            </FormSelect>
+          </FormGroup>
+        </Form>
+      </Modal>
+    </React.Fragment>
+  );
+};
+
+export default Snooze;

--- a/plugins/opsgenie/src/utils/interfaces.ts
+++ b/plugins/opsgenie/src/utils/interfaces.ts
@@ -1,3 +1,5 @@
+import { AlertVariant } from '@patternfly/react-core';
+
 import { IPluginTimes } from '@kobsio/plugin-core';
 
 // IOptions is the interface for the options on the Opsgenie page.
@@ -131,4 +133,11 @@ export interface IDescription {
 export interface ILastEdit {
   editTime?: string;
   actor?: IActor;
+}
+
+// IMessage is the interface for an message. A message shuld identicate if a triggered action was succesful or if the
+// action failed.
+export interface IMessage {
+  title: string;
+  variant: AlertVariant;
 }


### PR DESCRIPTION
With the new authentication logic, which was introduced in #103 it is
now possible to acknowledge, snooze and close Opsgenie alerts via kobs.
These action must be enabled via the configuration file for kobs. When
they are enabled they will be added as additional actions in the React
UI. If kobs is used with a setup like it was introduced in #103 we will
use the correct user for these action. If no user is set we use the
default user named "kobs.io".

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
