### PR TITLE
Change Prometheus sparkline chart to allow labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,15 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 - [#103](https://github.com/kobsio/kobs/pull/103): Add option to get user information from a request.
 - [#104](https://github.com/kobsio/kobs/pull/104): Add actions for Opsgenie plugin to acknowledge, snooze and close alerts.
+- [#105](https://github.com/kobsio/kobs/pull/105): Add Prometheus metrics for API requests.
 
 ### Fixed
 
 - [#102](https://github.com/kobsio/kobs/pull/102): Fix GitHub Action for creating a new Helm release.
 
 ### Changed
+
+- [#106](https://github.com/kobsio/kobs/pull/106): :warning: *Breaking change:* :warning: Change Prometheus sparkline chart to allow the usage of labels.
 
 ## [v0.5.0](https://github.com/kobsio/kobs/releases/tag/v0.5.0) (2021-08-03)
 

--- a/deploy/demo/bookinfo/details-application.yaml
+++ b/deploy/demo/bookinfo/details-application.yaml
@@ -23,8 +23,7 @@ spec:
       options:
         unit: "%"
         queries:
-          - label: Incoming Success Rate
-            query: sum(irate(istio_requests_total{reporter="destination",destination_workload_namespace=~"bookinfo",destination_workload=~"details-v1",response_code!~"5.*"}[5m])) / sum(irate(istio_requests_total{reporter="destination",destination_workload_namespace=~"bookinfo",destination_workload=~"details-v1"}[5m])) * 100
+          - query: sum(irate(istio_requests_total{reporter="destination",destination_workload_namespace=~"bookinfo",destination_workload=~"details-v1",response_code!~"5.*"}[5m])) / sum(irate(istio_requests_total{reporter="destination",destination_workload_namespace=~"bookinfo",destination_workload=~"details-v1"}[5m])) * 100
   dashboards:
     - name: resources
       namespace: kobs

--- a/deploy/demo/bookinfo/productpage-application.yaml
+++ b/deploy/demo/bookinfo/productpage-application.yaml
@@ -32,8 +32,7 @@ spec:
       options:
         unit: "%"
         queries:
-          - label: Incoming Success Rate
-            query: sum(irate(istio_requests_total{reporter="destination",destination_workload_namespace=~"bookinfo",destination_workload=~"productpage-v1",response_code!~"5.*"}[5m])) / sum(irate(istio_requests_total{reporter="destination",destination_workload_namespace=~"bookinfo",destination_workload=~"productpage-v1"}[5m])) * 100
+          - query: sum(irate(istio_requests_total{reporter="destination",destination_workload_namespace=~"bookinfo",destination_workload=~"productpage-v1",response_code!~"5.*"}[5m])) / sum(irate(istio_requests_total{reporter="destination",destination_workload_namespace=~"bookinfo",destination_workload=~"productpage-v1"}[5m])) * 100
   dashboards:
     - name: resources
       namespace: kobs

--- a/deploy/demo/bookinfo/ratings-application.yaml
+++ b/deploy/demo/bookinfo/ratings-application.yaml
@@ -23,8 +23,7 @@ spec:
       options:
         unit: "%"
         queries:
-          - label: Incoming Success Rate
-            query: sum(irate(istio_requests_total{reporter="destination",destination_workload_namespace=~"bookinfo",destination_workload=~"ratings-v1",response_code!~"5.*"}[5m])) / sum(irate(istio_requests_total{reporter="destination",destination_workload_namespace=~"bookinfo",destination_workload=~"ratings-v1"}[5m])) * 100
+          - query: sum(irate(istio_requests_total{reporter="destination",destination_workload_namespace=~"bookinfo",destination_workload=~"ratings-v1",response_code!~"5.*"}[5m])) / sum(irate(istio_requests_total{reporter="destination",destination_workload_namespace=~"bookinfo",destination_workload=~"ratings-v1"}[5m])) * 100
   dashboards:
     - name: resources
       namespace: kobs

--- a/deploy/demo/bookinfo/reviews-application.yaml
+++ b/deploy/demo/bookinfo/reviews-application.yaml
@@ -26,8 +26,7 @@ spec:
       options:
         unit: "%"
         queries:
-          - label: Incoming Success Rate
-            query: sum(irate(istio_requests_total{reporter="destination",destination_workload_namespace=~"bookinfo",destination_workload=~"reviews-.*",response_code!~"5.*"}[5m])) / sum(irate(istio_requests_total{reporter="destination",destination_workload_namespace=~"bookinfo",destination_workload=~"reviews-.*"}[5m])) * 100
+          - query: sum(irate(istio_requests_total{reporter="destination",destination_workload_namespace=~"bookinfo",destination_workload=~"reviews-.*",response_code!~"5.*"}[5m])) / sum(irate(istio_requests_total{reporter="destination",destination_workload_namespace=~"bookinfo",destination_workload=~"reviews-.*"}[5m])) * 100
   dashboards:
     - name: resources
       namespace: kobs

--- a/deploy/demo/kobs/base/dashboards/istio-http.yaml
+++ b/deploy/demo/kobs/base/dashboards/istio-http.yaml
@@ -58,8 +58,7 @@ spec:
               unit: req/s
               type: sparkline
               queries:
-                - label: Incoming Request Volume
-                  query: round(sum(irate(istio_requests_total{reporter="{% .var_reporter %}",destination_workload_namespace=~"{{ .namespace }}",destination_workload=~"{% .var_workload %}"}[5m])), 0.001)
+                - query: round(sum(irate(istio_requests_total{reporter="{% .var_reporter %}",destination_workload_namespace=~"{{ .namespace }}",destination_workload=~"{% .var_workload %}"}[5m])), 0.001)
         - title: Incoming Success Rate
           colSpan: 6
           plugin:
@@ -68,8 +67,7 @@ spec:
               unit: "%"
               type: sparkline
               queries:
-                - label: Incoming Success Rate
-                  query: sum(irate(istio_requests_total{reporter="{% .var_reporter %}",destination_workload_namespace=~"{{ .namespace }}",destination_workload=~"{% .var_workload %}",response_code!~"5.*"}[5m])) / sum(irate(istio_requests_total{reporter="{% .var_reporter %}",destination_workload_namespace=~"{{ .namespace }}",destination_workload=~"{% .var_workload %}"}[5m])) * 100
+                - query: sum(irate(istio_requests_total{reporter="{% .var_reporter %}",destination_workload_namespace=~"{{ .namespace }}",destination_workload=~"{% .var_workload %}",response_code!~"5.*"}[5m])) / sum(irate(istio_requests_total{reporter="{% .var_reporter %}",destination_workload_namespace=~"{{ .namespace }}",destination_workload=~"{% .var_workload %}"}[5m])) * 100
     - size: 2
       panels:
         - title: Request Duration

--- a/deploy/demo/kobs/base/dashboards/resource-usage.yaml
+++ b/deploy/demo/kobs/base/dashboards/resource-usage.yaml
@@ -32,8 +32,7 @@ spec:
               type: sparkline
               unit: Cores
               queries:
-                - label: CPU Usage
-                  query: sum(rate(container_cpu_usage_seconds_total{namespace="{{ .namespace }}", image!="", pod=~"{% .var_pod %}", container!="POD", container!=""}[2m]))
+                - query: sum(rate(container_cpu_usage_seconds_total{namespace="{{ .namespace }}", image!="", pod=~"{% .var_pod %}", container!="POD", container!=""}[2m]))
         - title: Memory Usage
           colSpan: 4
           plugin:
@@ -42,8 +41,7 @@ spec:
               type: sparkline
               unit: MiB
               queries:
-                - label: Memory Usage
-                  query: sum(container_memory_working_set_bytes{namespace="{{ .namespace }}", pod=~"{% .var_pod %}", container!="POD", container!=""}) / 1024 / 1024
+                - query: sum(container_memory_working_set_bytes{namespace="{{ .namespace }}", pod=~"{% .var_pod %}", container!="POD", container!=""}) / 1024 / 1024
         - title: Restarts
           colSpan: 4
           plugin:
@@ -51,8 +49,7 @@ spec:
             options:
               type: sparkline
               queries:
-                - label: Restarts
-                  query: kube_pod_container_status_restarts_total{namespace="{{ .namespace }}", pod=~"{% .var_pod %}"}
+                - query: kube_pod_container_status_restarts_total{namespace="{{ .namespace }}", pod=~"{% .var_pod %}"}
     - size: 3
       panels:
         - title: CPU Usage

--- a/docs/plugins/prometheus.md
+++ b/docs/plugins/prometheus.md
@@ -25,7 +25,10 @@ The following options can be used for a panel with the Prometheus plugin:
 | Field | Type | Description | Required |
 | ----- | ---- | ----------- | -------- |
 | query | string | The PromQL query. | Yes |
-| label | string | The label the results. The label can use the value of a variable or a label of the returned time series, e.g. `{% .<prometheus-label> %}`. If you want to use a Prometheus label make sure that the label name doesn't conflict with a variable name | Yes |
+| label | string | The label the results. The label can use the value of a variable or a label of the returned time series, e.g. `{% .<prometheus-label> %}`. If you want to use a Prometheus label make sure that the label name doesn't conflict with a variable name. | Yes |
+
+!!! note
+    In `sparkline` charts the label must not be provided. If the label is provided in a `sparkline` chart the label will be displayed instead of the current value.
 
 ### Column
 
@@ -73,8 +76,7 @@ spec:
               type: sparkline
               unit: Cores
               queries:
-                - label: CPU Usage
-                  query: sum(rate(container_cpu_usage_seconds_total{namespace="{{ .namespace }}", image!="", pod=~"{% .var_pod %}", container!="POD", container!=""}[2m]))
+                - query: sum(rate(container_cpu_usage_seconds_total{namespace="{{ .namespace }}", image!="", pod=~"{% .var_pod %}", container!="POD", container!=""}[2m]))
         - title: Memory Usage
           colSpan: 4
           plugin:
@@ -83,8 +85,7 @@ spec:
               type: sparkline
               unit: MiB
               queries:
-                - label: Memory Usage
-                  query: sum(container_memory_working_set_bytes{namespace="{{ .namespace }}", pod=~"{% .var_pod %}", container!="POD", container!=""}) / 1024 / 1024
+                - query: sum(container_memory_working_set_bytes{namespace="{{ .namespace }}", pod=~"{% .var_pod %}", container!="POD", container!=""}) / 1024 / 1024
         - title: Restarts
           colSpan: 4
           plugin:
@@ -92,8 +93,7 @@ spec:
             options:
               type: sparkline
               queries:
-                - label: Restarts
-                  query: kube_pod_container_status_restarts_total{namespace="{{ .namespace }}", pod=~"{% .var_pod %}"}
+                - query: kube_pod_container_status_restarts_total{namespace="{{ .namespace }}", pod=~"{% .var_pod %}"}
     - size: 3
       panels:
         - title: CPU Usage

--- a/docs/resources/applications.md
+++ b/docs/resources/applications.md
@@ -111,8 +111,7 @@ spec:
       options:
         unit: "%"
         queries:
-          - label: Incoming Success Rate
-            query: sum(irate(istio_requests_total{reporter="destination",destination_workload_namespace=~"bookinfo",destination_workload=~"reviews-.*",response_code!~"5.*"}[5m])) / sum(irate(istio_requests_total{reporter="destination",destination_workload_namespace=~"bookinfo",destination_workload=~"reviews-.*"}[5m])) * 100
+          - query: sum(irate(istio_requests_total{reporter="destination",destination_workload_namespace=~"bookinfo",destination_workload=~"reviews-.*",response_code!~"5.*"}[5m])) / sum(irate(istio_requests_total{reporter="destination",destination_workload_namespace=~"bookinfo",destination_workload=~"reviews-.*"}[5m])) * 100
   dashboards:
     - name: resources
       namespace: kobs

--- a/docs/resources/dashboards.md
+++ b/docs/resources/dashboards.md
@@ -166,8 +166,7 @@ spec:
               type: sparkline
               unit: Cores
               queries:
-                - label: CPU Usage
-                  query: sum(rate(container_cpu_usage_seconds_total{namespace="{{ .namespace }}", image!="", pod=~"{% .var_pod %}", container!="POD", container!=""}[2m]))
+                - query: sum(rate(container_cpu_usage_seconds_total{namespace="{{ .namespace }}", image!="", pod=~"{% .var_pod %}", container!="POD", container!=""}[2m]))
         - title: Memory Usage
           colSpan: 4
           plugin:
@@ -176,8 +175,7 @@ spec:
               type: sparkline
               unit: MiB
               queries:
-                - label: Memory Usage
-                  query: sum(container_memory_working_set_bytes{namespace="{{ .namespace }}", pod=~"{% .var_pod %}", container!="POD", container!=""}) / 1024 / 1024
+                - query: sum(container_memory_working_set_bytes{namespace="{{ .namespace }}", pod=~"{% .var_pod %}", container!="POD", container!=""}) / 1024 / 1024
         - title: Restarts
           colSpan: 4
           plugin:
@@ -185,8 +183,7 @@ spec:
             options:
               type: sparkline
               queries:
-                - label: Restarts
-                  query: kube_pod_container_status_restarts_total{namespace="{{ .namespace }}", pod=~"{% .var_pod %}"}
+                - query: kube_pod_container_status_restarts_total{namespace="{{ .namespace }}", pod=~"{% .var_pod %}"}
     - size: 3
       panels:
         - title: CPU Usage

--- a/plugins/prometheus/pkg/instance/instance.go
+++ b/plugins/prometheus/pkg/instance/instance.go
@@ -98,6 +98,7 @@ func (i *Instance) GetMetrics(ctx context.Context, queries []Query, resolution s
 			var min float64
 			var max float64
 			var avg float64
+			var count float64
 
 			var data []Datum
 			for index, value := range stream.Values {
@@ -109,6 +110,7 @@ func (i *Instance) GetMetrics(ctx context.Context, queries []Query, resolution s
 					})
 				} else {
 					avg = avg + val
+					count = count + 1
 
 					if index == 0 {
 						min = val
@@ -128,8 +130,8 @@ func (i *Instance) GetMetrics(ctx context.Context, queries []Query, resolution s
 				}
 			}
 
-			if avg != 0 {
-				avg = avg / float64(len(stream.Values))
+			if avg != 0 && count != 0 {
+				avg = avg / count
 			}
 
 			var labels map[string]string


### PR DESCRIPTION
It is now possible to use the labels of a Prometheus metric as value in
the sparkline chart. This means when the user provides a label in a
sparkline chart the label will be shown instead of the current value of
the returned metric.

We also improved the calculation of the average value of a metric by
excluding all the null values.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
