### PR TITLE
Fix tooltip position in Prometheus charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 ### Fixed
 
 - [#102](https://github.com/kobsio/kobs/pull/102): Fix GitHub Action for creating a new Helm release.
+- [#109](https://github.com/kobsio/kobs/pull/109): Fix tooltip position in Prometheus charts.
 
 ### Changed
 

--- a/plugins/prometheus/pkg/instance/instance.go
+++ b/plugins/prometheus/pkg/instance/instance.go
@@ -102,11 +102,12 @@ func (i *Instance) GetMetrics(ctx context.Context, queries []Query, resolution s
 
 			var data []Datum
 			for index, value := range stream.Values {
+				timestamp := value.Timestamp.Unix() * 1000
 				val := float64(value.Value)
 
 				if math.IsNaN(val) {
 					data = append(data, Datum{
-						X: value.Timestamp.Unix() * 1000,
+						X: timestamp,
 					})
 				} else {
 					avg = avg + val
@@ -124,7 +125,7 @@ func (i *Instance) GetMetrics(ctx context.Context, queries []Query, resolution s
 					}
 
 					data = append(data, Datum{
-						X: value.Timestamp.Unix() * 1000,
+						X: timestamp,
 						Y: &val,
 					})
 				}

--- a/plugins/prometheus/src/components/page/PageChart.tsx
+++ b/plugins/prometheus/src/components/page/PageChart.tsx
@@ -86,8 +86,8 @@ const PageChart: React.FunctionComponent<IPageChartProps> = ({ queries, times, m
             }}
             // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
             tooltip={(tooltip) => {
-              const serie = selectedSeries.filter((serie) => serie.id === tooltip.point.serieId);
-              const isFirstHalf = tooltip.point.index % serie[0].data.length < serie[0].data.length / 2;
+              const isFirstHalf =
+                Math.floor(new Date(tooltip.point.data.x).getTime() / 1000) < (times.timeEnd + times.timeStart) / 2;
 
               return (
                 <TooltipWrapper anchor={isFirstHalf ? 'right' : 'left'} position={[0, 20]}>
@@ -111,7 +111,7 @@ const PageChart: React.FunctionComponent<IPageChartProps> = ({ queries, times, m
                 </TooltipWrapper>
               );
             }}
-            xScale={{ type: 'time' }}
+            xScale={{ max: new Date(times.timeEnd * 1000), min: new Date(times.timeStart * 1000), type: 'time' }}
             yScale={{ stacked: stacked, type: 'linear' }}
             yFormat=" >-.2f"
           />

--- a/plugins/prometheus/src/components/page/PageChartLegend.tsx
+++ b/plugins/prometheus/src/components/page/PageChartLegend.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { Serie } from '@nivo/line';
 
 import { getColor } from '../../utils/colors';
+import { roundNumber } from '../../utils/helpers';
 
 interface IPageChartLegendProps {
   queries: string[];
@@ -54,10 +55,10 @@ const PageChartLegend: React.FunctionComponent<IPageChartLegendProps> = ({
                 {metric.label === '{}' && series.length === queries.length ? queries[index] : metric.label}
               </Button>
             </Td>
-            <Td dataLabel="Min">{metric.min}</Td>
-            <Td dataLabel="Max">{metric.max}</Td>
-            <Td dataLabel="Avg">{metric.avg}</Td>
-            <Td dataLabel="Current">{metric.data[metric.data.length - 1].y}</Td>
+            <Td dataLabel="Min">{roundNumber(metric.min)}</Td>
+            <Td dataLabel="Max">{roundNumber(metric.max)}</Td>
+            <Td dataLabel="Avg">{roundNumber(metric.avg)}</Td>
+            <Td dataLabel="Current">{roundNumber(metric.data[metric.data.length - 1].y as number)}</Td>
           </Tr>
         ))}
       </Tbody>

--- a/plugins/prometheus/src/components/panel/Chart.tsx
+++ b/plugins/prometheus/src/components/panel/Chart.tsx
@@ -47,8 +47,8 @@ export const Chart: React.FunctionComponent<IChartProps> = ({ times, options, la
       }}
       // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
       tooltip={(tooltip) => {
-        const serie = series.filter((serie) => serie.id === tooltip.point.serieId);
-        const isFirstHalf = tooltip.point.index % serie[0].data.length < serie[0].data.length / 2;
+        const isFirstHalf =
+          Math.floor(new Date(tooltip.point.data.x).getTime() / 1000) < (times.timeEnd + times.timeStart) / 2;
 
         return (
           <TooltipWrapper anchor={isFirstHalf ? 'right' : 'left'} position={[0, 20]}>
@@ -72,7 +72,7 @@ export const Chart: React.FunctionComponent<IChartProps> = ({ times, options, la
           </TooltipWrapper>
         );
       }}
-      xScale={{ type: 'time' }}
+      xScale={{ max: new Date(times.timeEnd * 1000), min: new Date(times.timeStart * 1000), type: 'time' }}
       yScale={{ max: 'auto', min: 'auto', stacked: options.stacked, type: 'linear' }}
       yFormat=" >-.2f"
     />


### PR DESCRIPTION
The tooltip position wasN't correct in charts where a metric contained
gabs. This is now fixed by setting the min and max value for the x axis
to the selected time range and by using this time range to determin if a
point is in the first or seconde half of the chart.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
