### PR TITLE
Fix dashboard tabs showing wrong variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 - [#102](https://github.com/kobsio/kobs/pull/102): Fix GitHub Action for creating a new Helm release.
 - [#109](https://github.com/kobsio/kobs/pull/109): Fix tooltip position in Prometheus charts.
+- [#110](https://github.com/kobsio/kobs/pull/110): Fix Dashboard tabs showing wrong variables.
 
 ### Changed
 

--- a/plugins/dashboards/src/components/dashboards/DashboardWrapper.tsx
+++ b/plugins/dashboards/src/components/dashboards/DashboardWrapper.tsx
@@ -21,6 +21,8 @@ const DashboardWrapper: React.FunctionComponent<IDashboardWrapperProps> = ({
   return (
     <div ref={refWrapper}>
       <Dashboard
+        activeKey=""
+        eventKey=""
         defaults={defaults}
         dashboard={dashboard}
         forceDefaultSpan={tabsSize.width < 1200}

--- a/plugins/dashboards/src/components/dashboards/Dashboards.tsx
+++ b/plugins/dashboards/src/components/dashboards/Dashboards.tsx
@@ -143,18 +143,17 @@ const Dashboards: React.FunctionComponent<IDashboardsProps> = ({
       }
       className="pf-u-mt-md kobsio-dashboards-tabs-without-margin-top"
       isFilled={true}
-      mountOnEnter={true}
     >
       {data.map((dashboard) => (
         <Tab key={dashboard.title} eventKey={dashboard.title} title={<TabTitleText>{dashboard.title}</TabTitleText>}>
-          <PageSection variant={PageSectionVariants.default} isFilled={true}>
-            <Dashboard
-              defaults={defaults}
-              dashboard={dashboard}
-              forceDefaultSpan={forceDefaultSpan}
-              showDetails={useDrawer ? setDetails : undefined}
-            />
-          </PageSection>
+          <Dashboard
+            activeKey={options.dashboard}
+            eventKey={dashboard.title}
+            defaults={defaults}
+            dashboard={dashboard}
+            forceDefaultSpan={forceDefaultSpan}
+            showDetails={useDrawer ? setDetails : undefined}
+          />
         </Tab>
       ))}
     </Tabs>

--- a/plugins/jaeger/src/components/panel/TracesChart.tsx
+++ b/plugins/jaeger/src/components/panel/TracesChart.tsx
@@ -89,7 +89,6 @@ const TracesChart: React.FunctionComponent<ITracesChartProps> = ({ traces }: ITr
             // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
             tooltip={(tooltip) => {
               const isFirstHalf = tooltip.node.index < series[0].data.length / 2;
-              console.log(tooltip.node);
 
               return (
                 <TooltipWrapper anchor={isFirstHalf ? 'right' : 'left'} position={[0, 20]}>


### PR DESCRIPTION
Until now it was possible that a dashboard shows the wrong variables /
the variables from another dashboard. This could happen when the user
selected a dashboard with a larger index before another dashboard and
then switched to a dashboard with a lower index.

To fix this issue we do not use the mountOnEnter property from the Tabs
component anymore. Instead we render all dashboards when the Dashboards
component is rendered. To not load all the data for all dashboards we
are passing the activeKey and eventKey from the Tabs component to the
Dashboard component and only load the variables, when the activeKey is
equal the eventKey.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
