### PR TITLE
Fix usage of memo and resource table for CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#102](https://github.com/kobsio/kobs/pull/102): Fix GitHub Action for creating a new Helm release.
 - [#109](https://github.com/kobsio/kobs/pull/109): Fix tooltip position in Prometheus charts.
 - [#110](https://github.com/kobsio/kobs/pull/110): Fix Dashboard tabs showing wrong variables.
+- [#111](https://github.com/kobsio/kobs/pull/111): Fix usage of `memo` in Dashboards and fix resources table for CRDs when a value is undefined.
 
 ### Changed
 

--- a/plugins/core/src/utils/resources.tsx
+++ b/plugins/core/src/utils/resources.tsx
@@ -1415,6 +1415,7 @@ export const customResourceDefinition = (crds: ICRD[]): IResources => {
               crd.columns && crd.columns.length > 0
                 ? crd.columns.map((column) => {
                     const value = JSONPath({ json: cr, path: `$.${column.jsonPath}` })[0];
+                    if (!value) return '';
                     if (column.type === 'date') return timeDifference(new Date().getTime(), new Date(value).getTime());
                     return value;
                   })

--- a/plugins/dashboards/src/components/dashboards/Dashboard.tsx
+++ b/plugins/dashboards/src/components/dashboards/Dashboard.tsx
@@ -239,8 +239,10 @@ const Dashboard: React.FunctionComponent<IDashboardProps> = ({
 
 export default memo(Dashboard, (prevProps, nextProps) => {
   if (
+    prevProps.activeKey === nextProps.activeKey &&
+    JSON.stringify(prevProps.defaults) === JSON.stringify(nextProps.defaults) &&
     JSON.stringify(prevProps.dashboard) === JSON.stringify(nextProps.dashboard) &&
-    prevProps.activeKey === nextProps.activeKey
+    prevProps.forceDefaultSpan === nextProps.forceDefaultSpan
   ) {
     return true;
   }


### PR DESCRIPTION
This commit fixes the usage of "memo" in the Dashboard component, where
we forgot some important properties.

This also fixes a problem with CRDs in the resources table. When the
JSONPath for a shown column returned undefined and the column was of
type date it showed NaN in the table. Now we are returning an empty
string when the returned value from the JSONPath is undefined.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
