### PR TITLE
Allow mapping values in Prometheus table panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#103](https://github.com/kobsio/kobs/pull/103): Add option to get user information from a request.
 - [#104](https://github.com/kobsio/kobs/pull/104): Add actions for Opsgenie plugin to acknowledge, snooze and close alerts.
 - [#105](https://github.com/kobsio/kobs/pull/105): Add Prometheus metrics for API requests.
+- [#112](https://github.com/kobsio/kobs/pull/112): Allow mapping values in Prometheus table panel.
 
 ### Fixed
 

--- a/docs/plugins/prometheus.md
+++ b/docs/plugins/prometheus.md
@@ -37,6 +37,7 @@ The following options can be used for a panel with the Prometheus plugin:
 | name | string | The name of a column must be a returned label from the specified queries. To get the result of a query the special column `value-N`, where `N` is the index of the query. | Yes |
 | header | string | An optional value for the header of the column. When this is not specified the name will be used as header for the column. | No |
 | unit | string | An optional unit for the column values. | No |
+| mappings | map<string, string> | Specify value mappings for the column. **Note:** The value must be provided as string (e.g. `"1": "Green"`). | No |
 
 ## Example
 

--- a/plugins/dashboards/src/components/dashboards/Dashboard.tsx
+++ b/plugins/dashboards/src/components/dashboards/Dashboard.tsx
@@ -1,14 +1,4 @@
-import {
-  Alert,
-  AlertActionLink,
-  AlertVariant,
-  Grid,
-  GridItem,
-  PageSection,
-  PageSectionVariants,
-  Spinner,
-  Title,
-} from '@patternfly/react-core';
+import { Alert, AlertActionLink, AlertVariant, Grid, GridItem, Spinner, Title } from '@patternfly/react-core';
 import { QueryObserverResult, useQuery } from 'react-query';
 import React, { memo, useContext, useState } from 'react';
 
@@ -79,7 +69,7 @@ const Dashboard: React.FunctionComponent<IDashboardProps> = ({
   // parameter in the options. When the user changes the variables, we keep the old variable values, so that we not have
   // to rerender all the panels in the dashboard.
   const { isError, error, data, refetch } = useQuery<IVariableValues[] | null, Error>(
-    ['dashboard/variables', dashboard.title, variables, times, activeKey],
+    ['dashboard/variables', dashboard, variables, times, activeKey],
     async () => {
       if (activeKey !== eventKey) {
         return null;
@@ -163,36 +153,32 @@ const Dashboard: React.FunctionComponent<IDashboardProps> = ({
 
   if (isError) {
     return (
-      <PageSection variant={PageSectionVariants.default} isFilled={true}>
-        <Alert
-          variant={AlertVariant.danger}
-          title="Variables were not fetched"
-          actionLinks={
-            <React.Fragment>
-              <AlertActionLink onClick={(): Promise<QueryObserverResult<IVariableValues[] | null, Error>> => refetch()}>
-                Retry
-              </AlertActionLink>
-            </React.Fragment>
-          }
-        >
-          <p>{error?.message}</p>
-        </Alert>
-      </PageSection>
+      <Alert
+        variant={AlertVariant.danger}
+        title="Variables were not fetched"
+        actionLinks={
+          <React.Fragment>
+            <AlertActionLink onClick={(): Promise<QueryObserverResult<IVariableValues[] | null, Error>> => refetch()}>
+              Retry
+            </AlertActionLink>
+          </React.Fragment>
+        }
+      >
+        <p>{error?.message}</p>
+      </Alert>
     );
   }
 
   if (!data) {
     return (
-      <PageSection variant={PageSectionVariants.default} isFilled={true}>
-        <div className="pf-u-text-align-center">
-          <Spinner />
-        </div>
-      </PageSection>
+      <div className="pf-u-text-align-center">
+        <Spinner />
+      </div>
     );
   }
 
   return (
-    <PageSection variant={PageSectionVariants.default} isFilled={true}>
+    <React.Fragment>
       <DashboardToolbar variables={data} setVariables={setVariables} times={times} setTimes={setTimes} />
 
       <p>&nbsp;</p>
@@ -233,7 +219,7 @@ const Dashboard: React.FunctionComponent<IDashboardProps> = ({
           </React.Fragment>
         ))}
       </Grid>
-    </PageSection>
+    </React.Fragment>
   );
 };
 

--- a/plugins/dashboards/src/components/dashboards/DashboardToolbarVariable.tsx
+++ b/plugins/dashboards/src/components/dashboards/DashboardToolbarVariable.tsx
@@ -27,6 +27,32 @@ const DashboardToolbarVariable: React.FunctionComponent<IDashboardToolbarVariabl
     setShow(false);
   };
 
+  const filter = (
+    e: React.ChangeEvent<HTMLInputElement> | null,
+    value: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): React.ReactElement<any, string | React.JSXElementConstructor<any>>[] => {
+    if (value) {
+      return [
+        <SelectGroup label={variable.label || variable.name} key="variable">
+          {variable.values
+            .filter((item) => item.includes(value))
+            .map((item, index) => (
+              <SelectOption key={index} value={item} />
+            ))}
+        </SelectGroup>,
+      ];
+    } else {
+      return [
+        <SelectGroup label={variable.label || variable.name} key="variable">
+          {variable.values.map((item, index) => (
+            <SelectOption key={index} value={item} />
+          ))}
+        </SelectGroup>,
+      ];
+    }
+  };
+
   // group is the select group for the select box. We can not render this in the return function, because the Select
   // component requires an array of SelectGroup components.
   const group = [
@@ -39,13 +65,15 @@ const DashboardToolbarVariable: React.FunctionComponent<IDashboardToolbarVariabl
 
   return (
     <Select
-      variant={SelectVariant.single}
+      variant={SelectVariant.typeahead}
       typeAheadAriaLabel={`Select ${variable.label || variable.name}`}
       placeholderText={`Select ${variable.label || variable.name}`}
       onToggle={(): void => setShow(!show)}
+      onFilter={filter}
       onSelect={onSelect}
       selections={variable.value}
       isOpen={show}
+      isGrouped={true}
       width={250}
     >
       {group}

--- a/plugins/dashboards/src/components/dashboards/Dashboards.tsx
+++ b/plugins/dashboards/src/components/dashboards/Dashboards.tsx
@@ -146,14 +146,16 @@ const Dashboards: React.FunctionComponent<IDashboardsProps> = ({
     >
       {data.map((dashboard) => (
         <Tab key={dashboard.title} eventKey={dashboard.title} title={<TabTitleText>{dashboard.title}</TabTitleText>}>
-          <Dashboard
-            activeKey={options.dashboard}
-            eventKey={dashboard.title}
-            defaults={defaults}
-            dashboard={dashboard}
-            forceDefaultSpan={forceDefaultSpan}
-            showDetails={useDrawer ? setDetails : undefined}
-          />
+          <PageSection variant={PageSectionVariants.default} isFilled={true}>
+            <Dashboard
+              activeKey={options.dashboard}
+              eventKey={dashboard.title}
+              defaults={defaults}
+              dashboard={dashboard}
+              forceDefaultSpan={forceDefaultSpan}
+              showDetails={useDrawer ? setDetails : undefined}
+            />
+          </PageSection>
         </Tab>
       ))}
     </Tabs>

--- a/plugins/prometheus/src/components/page/PageChart.tsx
+++ b/plugins/prometheus/src/components/page/PageChart.tsx
@@ -113,7 +113,7 @@ const PageChart: React.FunctionComponent<IPageChartProps> = ({ queries, times, m
             }}
             xScale={{ max: new Date(times.timeEnd * 1000), min: new Date(times.timeStart * 1000), type: 'time' }}
             yScale={{ stacked: stacked, type: 'linear' }}
-            yFormat=" >-.2f"
+            yFormat=" >-.4f"
           />
         </div>
         <p>&nbsp;</p>

--- a/plugins/prometheus/src/components/panel/Chart.tsx
+++ b/plugins/prometheus/src/components/panel/Chart.tsx
@@ -74,7 +74,7 @@ export const Chart: React.FunctionComponent<IChartProps> = ({ times, options, la
       }}
       xScale={{ max: new Date(times.timeEnd * 1000), min: new Date(times.timeStart * 1000), type: 'time' }}
       yScale={{ max: 'auto', min: 'auto', stacked: options.stacked, type: 'linear' }}
-      yFormat=" >-.2f"
+      yFormat=" >-.4f"
     />
   );
 };

--- a/plugins/prometheus/src/components/panel/ChartLegend.tsx
+++ b/plugins/prometheus/src/components/panel/ChartLegend.tsx
@@ -66,9 +66,8 @@ const ChartLegend: React.FunctionComponent<IChartLegendProps> = ({
             </Td>
             <Td style={{ fontSize: '12px', padding: 0 }} dataLabel="Current">
               {metric.data[metric.data.length - 1].y
-                ? roundNumber(metric.data[metric.data.length - 1].y as number)
-                : metric.data[metric.data.length - 1].y}{' '}
-              {unit}
+                ? `${roundNumber(metric.data[metric.data.length - 1].y as number)} ${unit}`
+                : ''}
             </Td>
           </Tr>
         ))}

--- a/plugins/prometheus/src/components/panel/Table.tsx
+++ b/plugins/prometheus/src/components/panel/Table.tsx
@@ -3,10 +3,10 @@ import { QueryObserverResult, useQuery } from 'react-query';
 import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import React from 'react';
 
-import { IPanelOptions, IRows } from '../../utils/interfaces';
+import { IColumn, IPanelOptions, IRows } from '../../utils/interfaces';
 import { IPluginTimes, PluginCard } from '@kobsio/plugin-core';
+import { getMappingValue, roundNumber } from '../../utils/helpers';
 import Actions from './Actions';
-import { roundNumber } from '../../utils/helpers';
 
 interface ITableProps {
   name: string;
@@ -15,6 +15,22 @@ interface ITableProps {
   times: IPluginTimes;
   options: IPanelOptions;
 }
+
+const formatColumValue = (key: string, column: IColumn, data: IRows): string | number => {
+  if (!column.name) {
+    return '';
+  }
+
+  if (column.mappings) {
+    return getMappingValue(data[key][column.name], column.mappings);
+  }
+
+  if (column.name.startsWith('value')) {
+    return roundNumber(parseFloat(data[key][column.name]));
+  }
+
+  return data[key][column.name];
+};
 
 // The Table component can be used to show the result of multiple Prometheus queries in a table. To get the data for the
 // table we have to use the table endpoint of the Prometheus plugin API. This will return a list of columns, where the
@@ -101,7 +117,8 @@ export const Table: React.FunctionComponent<ITableProps> = ({
                 {options.columns
                   ? options.columns.map((column, index) => (
                       <Td key={index} dataLabel={column.title ? column.title : column.name}>
-                        {column.name ? roundNumber(parseFloat(data[key][column.name])) : ''} {column.unit}
+                        {formatColumValue(key, column, data)}
+                        {column.unit ? ` ${column.unit}` : ''}
                       </Td>
                     ))
                   : null}

--- a/plugins/prometheus/src/utils/interfaces.ts
+++ b/plugins/prometheus/src/utils/interfaces.ts
@@ -78,4 +78,5 @@ export interface IColumn {
   name?: string;
   title?: string;
   unit?: string;
+  mappings?: IMappings;
 }


### PR DESCRIPTION
It is now possible to use the value mapping from the sparkline panel in
the table panel for the Prometheus plugin. To use this feature we added
a new option for the specified columns named "mapping". If a user
specifies such mappings the corresponding value will be shown in the
table instead of the returned value from the PromQL query.

We also using the "dashboard" as query key instead of the
"dashboard.title".

Last but not least it is now possible to filter the variable values in a
dashboard.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
