### PR TITLE
[Jaeger] Open detail view when clicking a chart node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#105](https://github.com/kobsio/kobs/pull/105): Add Prometheus metrics for API requests.
 - [#112](https://github.com/kobsio/kobs/pull/112): Allow mapping values in Prometheus table panel.
 - [#113](https://github.com/kobsio/kobs/pull/113): Allow and improve customization of axis scaling.
+- [#116](https://github.com/kobsio/kobs/pull/116): Open details when clicking on Jaeger chart nodes.
 
 ### Fixed
 

--- a/plugins/jaeger/src/components/panel/Traces.tsx
+++ b/plugins/jaeger/src/components/panel/Traces.tsx
@@ -100,7 +100,7 @@ const Traces: React.FunctionComponent<ITracesProps> = ({
         <React.Fragment>
           {showChart ? (
             <React.Fragment>
-              <TracesChart traces={data} />
+              <TracesChart name={name} traces={data} showDetails={showDetails} />
               <p>&nbsp;</p>
               <p>&nbsp;</p>
               <p>&nbsp;</p>


### PR DESCRIPTION
<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

Jaeger Plugin: Open detail view when clicking a chart node

Also contains https://github.com/kobsio/kobs/pull/115 ; so merge it first :smile: 

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).


### How to test:

Run "demo" setup https://kobs.io/installation/demo/

Build local image and push to "local" registry
```bash
docker build -t localhost:5000/kobs:dev -f cmd/kobs/Dockerfile .
docker push localhost:5000/kobs:dev
```

Change to "dev" mode: `kustomize build deploy/demo/kobs/dev | kubectl apply -f -`

- Open the Jaeger plugin
- Click any trace in the chart 
- Should open the detail view 