### PR TITLE
Fix Prometheus charts, when metrics are null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#110](https://github.com/kobsio/kobs/pull/110): Fix Dashboard tabs showing wrong variables.
 - [#111](https://github.com/kobsio/kobs/pull/111): Fix usage of `memo` in Dashboards and fix resources table for CRDs when a value is undefined.
 - [#114](https://github.com/kobsio/kobs/pull/114): Fix span order and additional fields for Jaeger plugin.
+- [#118](https://github.com/kobsio/kobs/pull/118): Fix `null is not an object (evaluating 'e[Symbol.iterator]')` error for Prometheus charts.
 
 ### Changed
 

--- a/plugins/applications/src/components/panel/details/Details.tsx
+++ b/plugins/applications/src/components/panel/details/Details.tsx
@@ -10,9 +10,9 @@ import {
   ListItem,
   ListVariant,
 } from '@patternfly/react-core';
+import { TopologyIcon, UsersIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
 import React from 'react';
-import { UsersIcon } from '@patternfly/react-icons';
 
 import { ExternalLink, Title } from '@kobsio/plugin-core';
 import { DashboardsWrapper } from '@kobsio/plugin-dashboards';
@@ -42,6 +42,7 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ application, close }:
         <div>
           <p>{application.description}</p>
           {(application.teams && application.teams.length > 0) ||
+          (application.dependencies && application.dependencies.length > 0) ||
           (application.links && application.links.length > 0) ? (
             <List variant={ListVariant.inline}>
               {application.teams && application.teams.length > 0
@@ -55,6 +56,23 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ application, close }:
                       >
                         <Button variant={ButtonVariant.link} isInline={true} icon={<UsersIcon />}>
                           {team.name}
+                        </Button>
+                      </Link>
+                    </ListItem>
+                  ))
+                : null}
+
+              {application.dependencies && application.dependencies.length > 0
+                ? application.dependencies.map((dependency, index) => (
+                    <ListItem key={index}>
+                      <Link
+                        key={index}
+                        to={`/applications/${dependency.cluster ? dependency.cluster : application.cluster}/${
+                          dependency.namespace ? dependency.namespace : application.namespace
+                        }/${dependency.name}`}
+                      >
+                        <Button variant={ButtonVariant.link} isInline={true} icon={<TopologyIcon />}>
+                          {dependency.name}
                         </Button>
                       </Link>
                     </ListItem>

--- a/plugins/prometheus/src/components/page/PageChart.tsx
+++ b/plugins/prometheus/src/components/page/PageChart.tsx
@@ -4,34 +4,30 @@ import { ResponsiveLineCanvas, Serie } from '@nivo/line';
 import { SquareIcon } from '@patternfly/react-icons';
 import { TooltipWrapper } from '@nivo/tooltip';
 
-import { convertMetrics, formatAxisBottom } from '../../utils/helpers';
 import { COLOR_SCALE } from '../../utils/colors';
-import { IMetrics } from '../../utils/interfaces';
+import { ISeries } from '../../utils/interfaces';
 import PageChartLegend from './PageChartLegend';
+import { formatAxisBottom } from '../../utils/helpers';
 
 interface IPageChartProps {
   queries: string[];
-  metrics: IMetrics;
+  series: ISeries;
 }
 
 // The PageChart component is used to render the chart for the given metrics. Above the chart we display two toggle
 // groups so that the user can adjust the basic style of the chart. The user can switch between a line and area chart
 // and between a stacked and unstacked visualization. At the bottom of the page we are including the PageChartLegend
 // component to render the legend for the metrics.
-const PageChart: React.FunctionComponent<IPageChartProps> = ({ queries, metrics }: IPageChartProps) => {
-  // series is an array for the converted metrics, which can be used by nivo. We convert the metrics to a series, so
-  // that we have to do this onyl once and not everytime the selected metrics are changed.
-  const seriesData = convertMetrics(metrics.metrics, metrics.startTime, metrics.endTime, metrics.min, metrics.max);
-
+const PageChart: React.FunctionComponent<IPageChartProps> = ({ queries, series }: IPageChartProps) => {
   const [type, setType] = useState<string>('line');
   const [stacked, setStacked] = useState<boolean>(false);
-  const [selectedSeries, setSelectedSeries] = useState<Serie[]>(seriesData.series);
+  const [selectedSeries, setSelectedSeries] = useState<Serie[]>(series.series);
 
   // select is used to select a single metric, which should be shown in the rendered chart. If the currently selected
   // metric is clicked again, the filter will be removed and all metrics will be shown in the chart.
   const select = (color: string, metric: Serie): void => {
     if (selectedSeries.length === 1 && selectedSeries[0].label === metric.label) {
-      setSelectedSeries(seriesData.series);
+      setSelectedSeries(series.series);
     } else {
       setSelectedSeries([{ ...metric, color: color }]);
     }
@@ -58,7 +54,7 @@ const PageChart: React.FunctionComponent<IPageChartProps> = ({ queries, metrics 
         <div style={{ height: '350px' }}>
           <ResponsiveLineCanvas
             axisBottom={{
-              format: formatAxisBottom(metrics.startTime, metrics.endTime),
+              format: formatAxisBottom(series.startTime, series.endTime),
             }}
             axisLeft={{
               format: '>-.2f',
@@ -84,7 +80,7 @@ const PageChart: React.FunctionComponent<IPageChartProps> = ({ queries, metrics 
             }}
             // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
             tooltip={(tooltip) => {
-              const isFirstHalf = new Date(tooltip.point.data.x).getTime() < (metrics.endTime + metrics.startTime) / 2;
+              const isFirstHalf = new Date(tooltip.point.data.x).getTime() < (series.endTime + series.startTime) / 2;
 
               return (
                 <TooltipWrapper anchor={isFirstHalf ? 'right' : 'left'} position={[0, 20]}>
@@ -101,20 +97,20 @@ const PageChart: React.FunctionComponent<IPageChartProps> = ({ queries, metrics 
                       <b>{tooltip.point.data.xFormatted}</b>
                     </div>
                     <div>
-                      <SquareIcon color={tooltip.point.color} /> {seriesData.labels[tooltip.point.id.split('.')[0]]}:{' '}
+                      <SquareIcon color={tooltip.point.color} /> {series.labels[tooltip.point.id.split('.')[0]]}:{' '}
                       {tooltip.point.data.yFormatted}
                     </div>
                   </div>
                 </TooltipWrapper>
               );
             }}
-            xScale={{ max: new Date(metrics.endTime), min: new Date(metrics.startTime), type: 'time' }}
+            xScale={{ max: new Date(series.endTime), min: new Date(series.startTime), type: 'time' }}
             yScale={{ stacked: stacked, type: 'linear' }}
             yFormat=" >-.4f"
           />
         </div>
         <p>&nbsp;</p>
-        <PageChartLegend queries={queries} series={seriesData.series} selected={selectedSeries} select={select} />
+        <PageChartLegend queries={queries} series={series.series} selected={selectedSeries} select={select} />
       </CardBody>
     </Card>
   );

--- a/plugins/prometheus/src/components/panel/ChartWrapper.tsx
+++ b/plugins/prometheus/src/components/panel/ChartWrapper.tsx
@@ -55,7 +55,11 @@ export const ChartWrapper: React.FunctionComponent<IChartWrapperProps> = ({
         const json = await response.json();
 
         if (response.status >= 200 && response.status < 300) {
-          return convertMetrics(json.metrics, json.startTime, json.endTime, json.min, json.max);
+          if (json && json.metrics) {
+            return convertMetrics(json.metrics, json.startTime, json.endTime, json.min, json.max);
+          } else {
+            return { endTime: times.timeEnd, labels: {}, max: 0, min: 0, series: [], startTime: times.timeStart };
+          }
         } else {
           if (json.error) {
             throw new Error(json.error);


### PR DESCRIPTION
When the API call to get the metrics for a Prometheus chart returned
null an error "null is not an object (evaluating 'e[Symbol.iterator]')"
was thrown. This is now fixed, by checking if the metrics object is null
and if this is the case we are returning an empty array instead of null
in the data. This was already handled for the sparkline charts.

We also showing all the dependencies of an application in the link list
in the application details.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
