### PR TITLE
Allow multiple queries for Elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#106](https://github.com/kobsio/kobs/pull/106): :warning: *Breaking change:* :warning: Change Prometheus sparkline chart to allow the usage of labels.
 - [#107](https://github.com/kobsio/kobs/pull/107): Add new option for Prometheus chart legend and change formatting of values.
 - [#108](https://github.com/kobsio/kobs/pull/108): Improve tooltip position in all nivo charts.
+- [#121](https://github.com/kobsio/kobs/pull/121): :warning: *Breaking change:* Allow multiple queries in the panel options for the Elasticsearch plugin.
 
 ## [v0.5.0](https://github.com/kobsio/kobs/releases/tag/v0.5.0) (2021-08-03)
 

--- a/deploy/demo/kobs/base/dashboards/istio-logs.yaml
+++ b/deploy/demo/kobs/base/dashboards/istio-logs.yaml
@@ -19,16 +19,18 @@ spec:
           plugin:
             name: elasticsearch
             options:
-              query: "kubernetes.namespace: {{ .namespace }} AND kubernetes.labels.app: {{ .app }} AND kubernetes.container.name: istio-proxy AND _exists_: content.method"
-              fields:
-                - "kubernetes.pod.name"
-                - "content.authority"
-                - "content.route_name"
-                - "content.protocol"
-                - "content.method"
-                - "content.path"
-                - "content.response_code"
-                - "content.upstream_service_time"
-                - "content.bytes_received"
-                - "content.bytes_sent"
               showChart: true
+              queries:
+                - name: Istio Logs
+                  query: "kubernetes.namespace: {{ .namespace }} AND kubernetes.labels.app: {{ .app }} AND kubernetes.container.name: istio-proxy AND _exists_: content.method"
+                  fields:
+                    - "kubernetes.pod.name"
+                    - "content.authority"
+                    - "content.route_name"
+                    - "content.protocol"
+                    - "content.method"
+                    - "content.path"
+                    - "content.response_code"
+                    - "content.upstream_service_time"
+                    - "content.bytes_received"
+                    - "content.bytes_sent"

--- a/deploy/demo/kobs/base/dashboards/pod-logs.yaml
+++ b/deploy/demo/kobs/base/dashboards/pod-logs.yaml
@@ -19,8 +19,10 @@ spec:
           plugin:
             name: elasticsearch
             options:
-              query: "kubernetes.namespace: {{ .namespace }} AND kubernetes.pod.name: {{ .name }}"
-              fields:
-                - "kubernetes.container.name"
-                - "message"
               showChart: true
+              queries:
+                - name: Pod Logs
+                  query: "kubernetes.namespace: {{ .namespace }} AND kubernetes.pod.name: {{ .name }}"
+                  fields:
+                    - "kubernetes.container.name"
+                    - "message"

--- a/docs/plugins/elasticsearch.md
+++ b/docs/plugins/elasticsearch.md
@@ -14,9 +14,16 @@ The following options can be used for a panel with the Elasticsearch plugin:
 
 | Field | Type | Description | Required |
 | ----- | ---- | ----------- | -------- |
+| showChart | boolean | If this is `true` the chart with the distribution of the Documents over the selected time range will be shown | No |
+| queries | [[]Query](#query) | A list of Elasticsearch queries, which can be selected by the user. | Yes |
+
+### Query
+
+| Field | Type | Description | Required |
+| ----- | ---- | ----------- | -------- |
+| name | string | A name for the Elasticsearch query, which is displayed in the select box. | Yes |
 | query | string | The Elasticsearch query. We are using the [Query String Syntax](#query-string-syntax) for Elasticsearch. | Yes |
 | fields | []string | A list of fields to display in the results table. If this field is omitted, the whole document is displayed in the results table. | No |
-| showChart | boolean | If this is `true` the chart with the distribution of the Documents over the selected time range will be shown | No |
 
 ```yaml
 ---
@@ -36,19 +43,21 @@ spec:
           plugin:
             name: elasticsearch
             options:
-              query: "kubernetes.namespace: {{ .namespace }} AND kubernetes.labels.app: {{ .app }} AND kubernetes.container.name: istio-proxy AND _exists_: content.method"
-              fields:
-                - "kubernetes.pod.name"
-                - "content.authority"
-                - "content.route_name"
-                - "content.protocol"
-                - "content.method"
-                - "content.path"
-                - "content.response_code"
-                - "content.upstream_service_time"
-                - "content.bytes_received"
-                - "content.bytes_sent"
               showChart: true
+              queries:
+                - name: Istio Logs
+                  query: "kubernetes.namespace: {{ .namespace }} AND kubernetes.labels.app: {{ .app }} AND kubernetes.container.name: istio-proxy AND _exists_: content.method"
+                  fields:
+                    - "kubernetes.pod.name"
+                    - "content.authority"
+                    - "content.route_name"
+                    - "content.protocol"
+                    - "content.method"
+                    - "content.path"
+                    - "content.response_code"
+                    - "content.upstream_service_time"
+                    - "content.bytes_received"
+                    - "content.bytes_sent"
 ```
 
 ## Query String Syntax

--- a/plugins/elasticsearch/src/components/page/PageLogs.tsx
+++ b/plugins/elasticsearch/src/components/page/PageLogs.tsx
@@ -126,11 +126,13 @@ const PageLogs: React.FunctionComponent<IPageLogsProps> = ({
           </CardBody>
         </Card>
         <p>&nbsp;</p>
-        <Card isCompact={true} style={{ maxWidth: '100%', overflowX: 'scroll' }}>
-          <CardBody>
-            <LogsDocuments pages={data.pages} fields={fields} showDetails={showDetails} />
-          </CardBody>
-        </Card>
+        {data.pages[0].documents.length > 0 ? (
+          <Card isCompact={true} style={{ maxWidth: '100%', overflowX: 'scroll' }}>
+            <CardBody>
+              <LogsDocuments pages={data.pages} fields={fields} showDetails={showDetails} />
+            </CardBody>
+          </Card>
+        ) : null}
         <p>&nbsp;</p>
         {data.pages[0].documents.length > 0 ? (
           <Card isCompact={true}>

--- a/plugins/elasticsearch/src/components/page/PageLogsFields.tsx
+++ b/plugins/elasticsearch/src/components/page/PageLogsFields.tsx
@@ -15,7 +15,7 @@ const PageLogsFields: React.FunctionComponent<IPageLogsFieldsProps> = ({
   selectedFields,
   selectField,
 }: IPageLogsFieldsProps) => {
-  if (selectedFields && selectedFields.length === 0 && fields.length === 0) {
+  if ((!selectedFields || selectedFields.length === 0) && fields.length === 0) {
     return null;
   }
 

--- a/plugins/elasticsearch/src/components/panel/Logs.tsx
+++ b/plugins/elasticsearch/src/components/panel/Logs.tsx
@@ -1,9 +1,20 @@
-import { Alert, AlertActionLink, AlertVariant, Button, ButtonVariant, Spinner } from '@patternfly/react-core';
+import {
+  Alert,
+  AlertActionLink,
+  AlertVariant,
+  Button,
+  ButtonVariant,
+  Select,
+  SelectOption,
+  SelectOptionObject,
+  SelectVariant,
+  Spinner,
+} from '@patternfly/react-core';
 import { InfiniteData, InfiniteQueryObserverResult, QueryObserverResult, useInfiniteQuery } from 'react-query';
-import React from 'react';
+import React, { useState } from 'react';
 
+import { ILogsData, IQuery } from '../../utils/interfaces';
 import { IPluginTimes, PluginCard } from '@kobsio/plugin-core';
-import { ILogsData } from '../../utils/interfaces';
 import LogsActions from './LogsActions';
 import LogsChart from '../panel/LogsChart';
 import LogsDocuments from '../panel/LogsDocuments';
@@ -12,8 +23,7 @@ interface ILogsProps {
   name: string;
   title: string;
   description?: string;
-  fields?: string[];
-  query: string;
+  queries: IQuery[];
   showChart: boolean;
   times: IPluginTimes;
   showDetails?: (details: React.ReactNode) => void;
@@ -23,18 +33,20 @@ const Logs: React.FunctionComponent<ILogsProps> = ({
   name,
   title,
   description,
-  fields,
-  query,
+  queries,
   showChart,
   times,
   showDetails,
 }: ILogsProps) => {
+  const [showSelect, setShowSelect] = useState<boolean>(false);
+  const [selectedQuery, setSelectedQuery] = useState<IQuery>(queries[0]);
+
   const { isError, isFetching, isLoading, data, error, fetchNextPage, refetch } = useInfiniteQuery<ILogsData, Error>(
-    ['elasticsearch/logs', query, times],
+    ['elasticsearch/logs', selectedQuery, times],
     async ({ pageParam }) => {
       try {
         const response = await fetch(
-          `/api/plugins/elasticsearch/logs/${name}?query=${query}&timeStart=${times.timeStart}&timeEnd=${
+          `/api/plugins/elasticsearch/logs/${name}?query=${selectedQuery.query}&timeStart=${times.timeStart}&timeEnd=${
             times.timeEnd
           }&scrollID=${pageParam || ''}`,
           {
@@ -62,56 +74,90 @@ const Logs: React.FunctionComponent<ILogsProps> = ({
     },
   );
 
+  const select = (
+    event: React.MouseEvent<Element, MouseEvent> | React.ChangeEvent<Element>,
+    value: string | SelectOptionObject,
+  ): void => {
+    const query = queries.filter((query) => query.name === value);
+    if (query.length === 1) {
+      setSelectedQuery(query[0]);
+    }
+    setShowSelect(false);
+  };
+
   return (
     <PluginCard
       title={title}
       description={description}
-      actions={<LogsActions name={name} query={query} fields={fields} times={times} />}
+      actions={<LogsActions name={name} queries={queries} times={times} />}
     >
-      {isLoading ? (
-        <div className="pf-u-text-align-center">
-          <Spinner />
-        </div>
-      ) : isError ? (
-        <Alert
-          variant={AlertVariant.danger}
-          isInline={true}
-          title="Could not get logs"
-          actionLinks={
-            <React.Fragment>
-              <AlertActionLink onClick={(): Promise<QueryObserverResult<InfiniteData<ILogsData>, Error>> => refetch()}>
-                Retry
-              </AlertActionLink>
-            </React.Fragment>
-          }
-        >
-          <p>{error?.message}</p>
-        </Alert>
-      ) : data && data.pages.length > 0 ? (
-        <div>
-          {showChart ? (
-            <div>
-              <LogsChart buckets={data.pages[0].buckets} />
-              <p>&nbsp;</p>
-            </div>
-          ) : null}
-
-          <LogsDocuments pages={data.pages} fields={fields} showDetails={showDetails} />
-          <p>&nbsp;</p>
-
-          {data.pages[0].documents.length > 0 ? (
-            <Button
-              variant={ButtonVariant.primary}
-              isBlock={true}
-              isDisabled={isFetching}
-              isLoading={isFetching}
-              onClick={(): Promise<InfiniteQueryObserverResult<ILogsData, Error>> => fetchNextPage()}
+      <div>
+        {queries.length > 1 ? (
+          <div>
+            <Select
+              variant={SelectVariant.single}
+              typeAheadAriaLabel="Select query"
+              placeholderText="Select query"
+              onToggle={(): void => setShowSelect(!showSelect)}
+              onSelect={select}
+              selections={selectedQuery.name}
+              isOpen={showSelect}
             >
-              Load more
-            </Button>
-          ) : null}
-        </div>
-      ) : null}
+              {queries.map((query, index) => (
+                <SelectOption key={index} value={query.name} description={query.query} />
+              ))}
+            </Select>
+            <p>&nbsp;</p>
+          </div>
+        ) : null}
+
+        {isLoading ? (
+          <div className="pf-u-text-align-center">
+            <Spinner />
+          </div>
+        ) : isError ? (
+          <Alert
+            variant={AlertVariant.danger}
+            isInline={true}
+            title="Could not get logs"
+            actionLinks={
+              <React.Fragment>
+                <AlertActionLink
+                  onClick={(): Promise<QueryObserverResult<InfiniteData<ILogsData>, Error>> => refetch()}
+                >
+                  Retry
+                </AlertActionLink>
+              </React.Fragment>
+            }
+          >
+            <p>{error?.message}</p>
+          </Alert>
+        ) : data && data.pages.length > 0 ? (
+          <div>
+            {showChart ? (
+              <div>
+                <LogsChart buckets={data.pages[0].buckets} />
+                <p>&nbsp;</p>
+              </div>
+            ) : null}
+
+            <LogsDocuments pages={data.pages} fields={selectedQuery.fields} showDetails={showDetails} />
+            <p>&nbsp;</p>
+
+            {data.pages[0].documents.length > 0 ? (
+              <Button
+                variant={ButtonVariant.primary}
+                isBlock={true}
+                isDisabled={isFetching}
+                isLoading={isFetching}
+                onClick={(): Promise<InfiniteQueryObserverResult<ILogsData, Error>> => fetchNextPage()}
+              >
+                Load more
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
     </PluginCard>
   );
 };

--- a/plugins/elasticsearch/src/components/panel/LogsActions.tsx
+++ b/plugins/elasticsearch/src/components/panel/LogsActions.tsx
@@ -3,17 +3,16 @@ import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { IPluginTimes } from '@kobsio/plugin-core';
+import { IQuery } from '../../utils/interfaces';
 
 interface IActionsProps {
   name: string;
-  query: string;
-  fields?: string[];
+  queries: IQuery[];
   times: IPluginTimes;
 }
 
-export const Actions: React.FunctionComponent<IActionsProps> = ({ name, query, fields, times }: IActionsProps) => {
+export const Actions: React.FunctionComponent<IActionsProps> = ({ name, queries, times }: IActionsProps) => {
   const [show, setShow] = useState<boolean>(false);
-  const fieldParams = fields ? fields.map((field) => `&field=${field}`) : undefined;
 
   return (
     <CardActions>
@@ -22,20 +21,20 @@ export const Actions: React.FunctionComponent<IActionsProps> = ({ name, query, f
         isOpen={show}
         isPlain={true}
         position="right"
-        dropdownItems={[
+        dropdownItems={queries.map((query) => [
           <DropdownItem
             key={0}
             component={
               <Link
-                to={`/${name}?time=${times.time}&timeEnd=${times.timeEnd}&timeStart=${times.timeStart}&query=${query}${
-                  fieldParams && fieldParams.length > 0 ? fieldParams.join('') : ''
-                }`}
+                to={`/${name}?time=${times.time}&timeEnd=${times.timeEnd}&timeStart=${times.timeStart}&query=${
+                  query.query
+                }${query.fields ? query.fields.map((field) => `&field=${field}`).join('') : ''}`}
               >
-                Explore
+                {query.name}
               </Link>
             }
           />,
-        ]}
+        ])}
       />
     </CardActions>
   );

--- a/plugins/elasticsearch/src/components/panel/Panel.tsx
+++ b/plugins/elasticsearch/src/components/panel/Panel.tsx
@@ -16,7 +16,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
   options,
   showDetails,
 }: IPanelProps) => {
-  if (!options || !options.query || !times) {
+  if (!options || !options.queries || !Array.isArray(options.queries) || options.queries.length === 0 || !times) {
     return (
       <PluginOptionsMissing
         title={title}
@@ -32,8 +32,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
       name={name}
       title={title}
       description={description}
-      fields={options.fields}
-      query={options.query}
+      queries={options.queries}
       showChart={options.showChart || false}
       times={times}
       showDetails={showDetails}

--- a/plugins/elasticsearch/src/components/preview/Chart.tsx
+++ b/plugins/elasticsearch/src/components/preview/Chart.tsx
@@ -18,12 +18,18 @@ export const Chart: React.FunctionComponent<IChartProps> = ({ name, times, title
     ['elasticsearch/logs', name, options, times],
     async ({ pageParam }) => {
       try {
-        if (!options.query) {
+        if (
+          !options ||
+          !options.queries ||
+          !Array.isArray(options.queries) ||
+          options.queries.length === 0 ||
+          !options.queries[0].query
+        ) {
           throw new Error('Query is missing');
         }
 
         const response = await fetch(
-          `/api/plugins/elasticsearch/logs/${name}?query=${options.query}&timeStart=${times.timeStart}&timeEnd=${times.timeEnd}&scrollID=`,
+          `/api/plugins/elasticsearch/logs/${name}?query=${options.queries[0].query}&timeStart=${times.timeStart}&timeEnd=${times.timeEnd}&scrollID=`,
           {
             method: 'get',
           },

--- a/plugins/elasticsearch/src/utils/interfaces.ts
+++ b/plugins/elasticsearch/src/utils/interfaces.ts
@@ -11,9 +11,14 @@ export interface IOptions {
 
 // IPanelOptions are the options for the panel component of the Elasticsearch plugin.
 export interface IPanelOptions {
-  fields?: string[];
-  query?: string;
+  queries?: IQuery[];
   showChart?: boolean;
+}
+
+export interface IQuery {
+  name?: string;
+  query?: string;
+  fields?: string[];
 }
 
 // ILogsData is the interface of the data returned from our Go API for the Elasticsearch plugin. The interface must


### PR DESCRIPTION
It is now possible to specify multiple queries in the panel options for
the Elasticsearch plugin. For that a new field queries was added to the
options, which can be used to set a name, the Elasticsearch query and a
list of fields. If the user sets more then one query he can select the
query for which the results should be shown via a select box in the
frontend.

This is a breaking change for the Elasticsearch plugin. This means that
the old fields query and fields are not working anymore with the
Elasticsearch plugin.

We also fixed a bug, which causes the Elasticsearch page to crash, when
no documents where returned for a query.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
