### PR TITLE
Fix field handling in ClickHouse and Elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#115](https://github.com/kobsio/kobs/pull/115): Fix maximum node size of the Jaeger chart and utilize `useMemo` to cache computation for it.
 - [#118](https://github.com/kobsio/kobs/pull/118): Fix `null is not an object (evaluating 'e[Symbol.iterator]')` error for Prometheus charts.
 - [#120](https://github.com/kobsio/kobs/pull/120): Fix reconcilation of Flux resources.
+- [#123](https://github.com/kobsio/kobs/pull/123): Fix fields handling in ClickHouse and Elasticsearch plugin.
 
 ### Changed
 

--- a/plugins/clickhouse/pkg/instance/instance.go
+++ b/plugins/clickhouse/pkg/instance/instance.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go"
@@ -58,6 +59,7 @@ func (i *Instance) GetLogs(ctx context.Context, query string, limit, offset, tim
 	// timestamp of a row is within the selected query range and the parsed query. We also order all the results by the
 	// timestamp field and limiting the results / using a offset for pagination.
 	sqlQuery := fmt.Sprintf("SELECT %s FROM %s.logs WHERE timestamp >= ? AND timestamp <= ? %s ORDER BY timestamp DESC LIMIT %d OFFSET %d", defaultColumns, i.database, conditions, limit, offset)
+	log.WithFields(logrus.Fields{"query": sqlQuery}).Tracef("sql query")
 	rows, err := i.client.QueryContext(ctx, sqlQuery, time.Unix(timeStart, 0), time.Unix(timeEnd, 0))
 	if err != nil {
 		return nil, nil, offset, err
@@ -110,6 +112,7 @@ func (i *Instance) GetLogs(ctx context.Context, query string, limit, offset, tim
 		return nil, nil, offset, err
 	}
 
+	sort.Strings(fields)
 	return documents, fields, offset + limit, nil
 }
 

--- a/plugins/clickhouse/pkg/instance/logs.go
+++ b/plugins/clickhouse/pkg/instance/logs.go
@@ -55,14 +55,9 @@ func parseLogsQuery(query string) (string, error) {
 // that we pass the key (first item), value (second item) and the operator to the handleConditionParts to build the
 // where condition.
 func splitOperator(condition string) (string, error) {
-	equal := strings.Split(condition, "=")
-	if len(equal) == 2 {
-		return handleConditionParts(equal[0], equal[1], "=")
-	}
-
-	notEqual := strings.Split(condition, "!=")
-	if len(notEqual) == 2 {
-		return handleConditionParts(notEqual[0], notEqual[1], "!=")
+	greaterThanOrEqual := strings.Split(condition, ">=")
+	if len(greaterThanOrEqual) == 2 {
+		return handleConditionParts(greaterThanOrEqual[0], greaterThanOrEqual[1], ">=")
 	}
 
 	greaterThan := strings.Split(condition, ">")
@@ -70,9 +65,9 @@ func splitOperator(condition string) (string, error) {
 		return handleConditionParts(greaterThan[0], greaterThan[1], ">")
 	}
 
-	greaterThanOrEqual := strings.Split(condition, ">=")
-	if len(greaterThanOrEqual) == 2 {
-		return handleConditionParts(greaterThanOrEqual[0], greaterThanOrEqual[1], ">=")
+	lessThanOrEqual := strings.Split(condition, "<=")
+	if len(lessThanOrEqual) == 2 {
+		return handleConditionParts(lessThanOrEqual[0], lessThanOrEqual[1], "<=")
 	}
 
 	lessThan := strings.Split(condition, "<")
@@ -80,9 +75,14 @@ func splitOperator(condition string) (string, error) {
 		return handleConditionParts(lessThan[0], lessThan[1], "<")
 	}
 
-	lessThanOrEqual := strings.Split(condition, "<=")
-	if len(lessThanOrEqual) == 2 {
-		return handleConditionParts(lessThanOrEqual[0], lessThanOrEqual[1], "<=")
+	notEqual := strings.Split(condition, "!=")
+	if len(notEqual) == 2 {
+		return handleConditionParts(notEqual[0], notEqual[1], "!=")
+	}
+
+	equal := strings.Split(condition, "=")
+	if len(equal) == 2 {
+		return handleConditionParts(equal[0], equal[1], "=")
 	}
 
 	regex := strings.Split(condition, "~")
@@ -125,5 +125,5 @@ func handleConditionParts(key, value, operator string) (string, error) {
 		return fmt.Sprintf("fields_string.value[indexOf(fields_string.key, '%s')] %s %s", key, operator, value), nil
 	}
 
-	return fmt.Sprintf("fields_number.value[indexOf(fields_number.key, '%s')] %s '%s'", key, operator, value), nil
+	return fmt.Sprintf("fields_number.value[indexOf(fields_number.key, '%s')] %s %s", key, operator, value), nil
 }

--- a/plugins/clickhouse/src/components/page/LogsPage.tsx
+++ b/plugins/clickhouse/src/components/page/LogsPage.tsx
@@ -64,7 +64,7 @@ const LogsPage: React.FunctionComponent<IPluginPageProps> = ({ name, displayName
           {displayName}
         </Title>
         <p>{description}</p>
-        <LogsToolbar query={options.query} times={options.times} setOptions={changeOptions} />
+        <LogsToolbar query={options.query} fields={options.fields} times={options.times} setOptions={changeOptions} />
       </PageSection>
 
       <Drawer isExpanded={selectedDocument !== undefined}>

--- a/plugins/clickhouse/src/components/page/LogsToolbar.tsx
+++ b/plugins/clickhouse/src/components/page/LogsToolbar.tsx
@@ -18,7 +18,12 @@ interface ILogsToolbarProps extends IOptions {
   setOptions: (data: IOptions) => void;
 }
 
-const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({ query, times, setOptions }: ILogsToolbarProps) => {
+const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({
+  query,
+  fields,
+  times,
+  setOptions,
+}: ILogsToolbarProps) => {
   const [data, setData] = useState<IOptions>({
     query: query,
     times: times,
@@ -34,7 +39,7 @@ const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({ query, times,
   // use "SHIFT" + "ENTER".
   const onEnter = (e: React.KeyboardEvent<HTMLInputElement> | undefined): void => {
     if (e?.key === 'Enter' && !e.shiftKey) {
-      setOptions(data);
+      setOptions({ ...data, fields: fields });
     }
   };
 
@@ -53,6 +58,7 @@ const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({ query, times,
     if (refresh) {
       setOptions({
         ...tmpData,
+        fields: fields,
         times: { time: time, timeEnd: timeEnd, timeStart: timeStart },
       });
     }
@@ -80,7 +86,11 @@ const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({ query, times,
               />
             </ToolbarItem>
             <ToolbarItem>
-              <Button variant={ButtonVariant.primary} icon={<SearchIcon />} onClick={(): void => setOptions(data)}>
+              <Button
+                variant={ButtonVariant.primary}
+                icon={<SearchIcon />}
+                onClick={(): void => setOptions({ ...data, fields: fields })}
+              >
                 Search
               </Button>
             </ToolbarItem>

--- a/plugins/elasticsearch/src/components/page/Page.tsx
+++ b/plugins/elasticsearch/src/components/page/Page.tsx
@@ -64,7 +64,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
           {displayName}
         </Title>
         <p>{description}</p>
-        <PageToolbar query={options.query} times={options.times} setOptions={changeOptions} />
+        <PageToolbar query={options.query} fields={options.fields} times={options.times} setOptions={changeOptions} />
       </PageSection>
 
       <Drawer isExpanded={selectedDocument !== undefined}>

--- a/plugins/elasticsearch/src/components/page/PageToolbar.tsx
+++ b/plugins/elasticsearch/src/components/page/PageToolbar.tsx
@@ -20,7 +20,12 @@ interface IPageToolbarProps extends IOptions {
 
 // PageToolbar is the toolbar for the Elasticsearch plugin page. It allows a user to specify query and to select a start
 // time and end time for the query.
-const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({ query, times, setOptions }: IPageToolbarProps) => {
+const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({
+  query,
+  fields,
+  times,
+  setOptions,
+}: IPageToolbarProps) => {
   const [data, setData] = useState<IOptions>({
     query: query,
     times: times,
@@ -36,7 +41,7 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({ query, times,
   // use "SHIFT" + "ENTER".
   const onEnter = (e: React.KeyboardEvent<HTMLInputElement> | undefined): void => {
     if (e?.key === 'Enter' && !e.shiftKey) {
-      setOptions(data);
+      setOptions({ ...data, fields: fields });
     }
   };
 
@@ -55,6 +60,7 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({ query, times,
     if (refresh) {
       setOptions({
         ...tmpData,
+        fields: fields,
         times: { time: time, timeEnd: timeEnd, timeStart: timeStart },
       });
     }
@@ -82,7 +88,11 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({ query, times,
               />
             </ToolbarItem>
             <ToolbarItem>
-              <Button variant={ButtonVariant.primary} icon={<SearchIcon />} onClick={(): void => setOptions(data)}>
+              <Button
+                variant={ButtonVariant.primary}
+                icon={<SearchIcon />}
+                onClick={(): void => setOptions({ ...data, fields: fields })}
+              >
                 Search
               </Button>
             </ToolbarItem>


### PR DESCRIPTION
This commit fixes the field handling in the ClickHouse and Elasticsearch
plugin. The issue was that the fields where not reused after a user
adjusted the search term or time range. Instead a user was forced to
reselect all fields. Now all fields are preserved after the time range
was adjusted or the search term was changed.

We also sort the fields for the ClickHouse plugin alphabetical before
they are shown to the user.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
