### PR TITLE
Add sql mode for ClickHouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#116](https://github.com/kobsio/kobs/pull/116): Open details when clicking on Jaeger chart nodes.
 - [#119](https://github.com/kobsio/kobs/pull/119): Add Flux plugin to view and reconcile [Flux](https://fluxcd.io) resources.
 - [#122](https://github.com/kobsio/kobs/pull/122): Add ClickHouse plugin, to query show logs ingested by the [kobsio/fluent-bit-clickhouse](https://github.com/kobsio/fluent-bit-clickhouse) Fluent Bit plugin.
+- [#124](https://github.com/kobsio/kobs/pull/124): Add `sql` mode for ClickHouse to execute raw SQL queries.
 
 ### Fixed
 

--- a/docs/configuration/plugins.md
+++ b/docs/configuration/plugins.md
@@ -53,7 +53,7 @@ plugins:
 | address | string | Address of the ClickHouse instance. | Yes |
 | username | string | Username to access a ClickHouse instance. | No |
 | password | string | Password to access a ClickHouse instance. | No |
-| type | string | The type which should be used for the ClickHouse instance. Currently the only supported value is `logs`. The `logs` mode should be used together with the [kobsio/fluent-bit-clickhouse](https://github.com/kobsio/fluent-bit-clickhouse) plugin to collect logs via Fluent Bit and save them in ClickHouse. |
+| type | string | The type which should be used for the ClickHouse instance. This must be `sql` or `logs`. While the `sql` mode allows you to use raw SQL queries, the `logs` mode should be used together with the [kobsio/fluent-bit-clickhouse](https://github.com/kobsio/fluent-bit-clickhouse) plugin to collect logs via Fluent Bit and save them in ClickHouse. |
 
 ## Elasticsearch
 

--- a/docs/plugins/clickhouse.md
+++ b/docs/plugins/clickhouse.md
@@ -15,7 +15,7 @@ The following options can be used for a panel with the ClickHouse plugin:
 
 | Field | Type | Description | Required |
 | ----- | ---- | ----------- | -------- |
-| type | string | Set the type for which you want to use the ClickHouse instance. Currently the only supported value is `logs`. | Yes |
+| type | string | Set the type for which you want to use the ClickHouse instance. This must be `sql` or `logs` | Yes |
 | queries | [[]Query](#query) | A list of queries, which can be selected by the user. | Yes |
 
 ### Query
@@ -24,7 +24,7 @@ The following options can be used for a panel with the ClickHouse plugin:
 | ----- | ---- | ----------- | -------- |
 | name | string | A name for the ClickHouse query, which is displayed in the select box. | Yes |
 | query | string | The query which should be run against ClickHouse. See [Query Syntax](#query-syntax) for more information on the syntax, when ClickHouse is used in the `logs` mode. | Yes |
-| fields | []string | A list of fields to display in the results table. If this field is omitted, the whole document is displayed in the results table. | No |
+| fields | []string | A list of fields to display in the results table. If this field is omitted, the whole document is displayed in the results table. This field is only available for the `logs`. | No |
 
 ```yaml
 ---
@@ -81,7 +81,9 @@ kobs supports multiple operators which can be used in a query to retrieve logs f
 | `<=` | The value of the field must be lower than or equal to the specified value. | `content.response_code<=499` |
 | `~` | The value of the field must match the regular expression. | `content.upstream_cluster~'inbound.*'` |
 
-### Standard Fields
+### Default Fields
+
+In the following you can find a list of fields which are available for each log line. Consider to filter you logs by these fields, to keep your queries fast:
 
 - `timestamp`: The timestamp for when the log line was written.
 - `cluster`: The name of the cluster as it is set by Fluent Bit.

--- a/plugins/clickhouse/pkg/instance/instance.go
+++ b/plugins/clickhouse/pkg/instance/instance.go
@@ -36,6 +36,41 @@ type Instance struct {
 	client   *sql.DB
 }
 
+// GetSQL returns all rows for the user provided SQL query.
+func (i *Instance) GetSQL(ctx context.Context, query string) ([][]interface{}, []string, error) {
+	rows, err := i.client.QueryContext(ctx, query)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+
+	var columns []string
+	columns, err = rows.Columns()
+	if err != nil {
+		return nil, nil, err
+	}
+	columnsLen := len(columns)
+
+	var result [][]interface{}
+
+	for rows.Next() {
+		var r []interface{}
+		r = make([]interface{}, columnsLen)
+
+		for i := 0; i < columnsLen; i++ {
+			r[i] = new(interface{})
+		}
+
+		if err := rows.Scan(r...); err != nil {
+			return nil, nil, err
+		}
+
+		result = append(result, r)
+	}
+
+	return result, columns, nil
+}
+
 // GetLogs parses the given query into the sql syntax, which is then run against the ClickHouse instance. The returned
 // rows are converted into a document schema which can be used by our UI.
 func (i *Instance) GetLogs(ctx context.Context, query string, limit, offset, timeStart, timeEnd int64) ([]map[string]interface{}, []string, int64, error) {

--- a/plugins/clickhouse/src/components/page/LogsToolbar.tsx
+++ b/plugins/clickhouse/src/components/page/LogsToolbar.tsx
@@ -70,7 +70,7 @@ const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({
   };
 
   return (
-    <Toolbar id="elasticsearch-toolbar" style={{ paddingBottom: '0px', zIndex: 300 }}>
+    <Toolbar id="clickhouse-logs-toolbar" style={{ paddingBottom: '0px', zIndex: 300 }}>
       <ToolbarContent style={{ padding: '0px' }}>
         <ToolbarToggleGroup style={{ width: '100%' }} toggleIcon={<FilterIcon />} breakpoint="lg">
           <ToolbarGroup style={{ alignItems: 'flex-start', width: '100%' }}>

--- a/plugins/clickhouse/src/components/page/Page.tsx
+++ b/plugins/clickhouse/src/components/page/Page.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { IPluginPageProps } from '@kobsio/plugin-core';
 import LogsPage from './LogsPage';
+import SQLPage from './SQLPage';
 
 const Page: React.FunctionComponent<IPluginPageProps> = ({
   name,
@@ -11,6 +12,8 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({
 }: IPluginPageProps) => {
   if (options && options.type && options.type === 'logs') {
     return <LogsPage name={name} displayName={displayName} description={description} />;
+  } else if (options && options.type && options.type === 'sql') {
+    return <SQLPage name={name} displayName={displayName} description={description} />;
   }
 
   return null;

--- a/plugins/clickhouse/src/components/page/SQL.tsx
+++ b/plugins/clickhouse/src/components/page/SQL.tsx
@@ -1,0 +1,79 @@
+import { Alert, AlertActionLink, AlertVariant, Card, Spinner } from '@patternfly/react-core';
+import { QueryObserverResult, useQuery } from 'react-query';
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+
+import { ISQLData } from '../../utils/interfaces';
+import SQLTable from '../panel/SQLTable';
+
+interface ISQLProps {
+  name: string;
+  query: string;
+}
+
+const SQL: React.FunctionComponent<ISQLProps> = ({ name, query }: ISQLProps) => {
+  const history = useHistory();
+
+  const { isError, isFetching, error, data, refetch } = useQuery<ISQLData, Error>(
+    ['clickhouse/sql', query],
+    async () => {
+      try {
+        const response = await fetch(`/api/plugins/clickhouse/sql/${name}?query=${query}`, {
+          method: 'get',
+        });
+        const json = await response.json();
+
+        if (response.status >= 200 && response.status < 300) {
+          return json;
+        } else {
+          if (json.error) {
+            throw new Error(json.error);
+          } else {
+            throw new Error('An unknown error occured');
+          }
+        }
+      } catch (err) {
+        throw err;
+      }
+    },
+  );
+
+  if (isFetching) {
+    return (
+      <div className="pf-u-text-align-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Alert
+        variant={AlertVariant.danger}
+        title="Could not get result for SQL query"
+        actionLinks={
+          <React.Fragment>
+            <AlertActionLink onClick={(): void => history.push('/')}>Home</AlertActionLink>
+            <AlertActionLink onClick={(): Promise<QueryObserverResult<ISQLData, Error>> => refetch()}>
+              Retry
+            </AlertActionLink>
+          </React.Fragment>
+        }
+      >
+        <p>{error?.message}</p>
+      </Alert>
+    );
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return (
+    <Card isCompact={true} style={{ maxWidth: '100%', overflowX: 'scroll' }}>
+      <SQLTable columns={data.columns} rows={data.rows} />
+    </Card>
+  );
+};
+
+export default SQL;

--- a/plugins/clickhouse/src/components/page/SQLPage.tsx
+++ b/plugins/clickhouse/src/components/page/SQLPage.tsx
@@ -1,0 +1,47 @@
+import { PageSection, PageSectionVariants, Title } from '@patternfly/react-core';
+import React, { useEffect, useState } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+
+import { IPluginPageProps } from '@kobsio/plugin-core';
+import SQL from './SQL';
+import SQLToolbar from './SQLToolbar';
+import { getQueryFromSearch } from '../../utils/helpers';
+
+const SQLPage: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, description }: IPluginPageProps) => {
+  const location = useLocation();
+  const history = useHistory();
+  const [query, setQuery] = useState<string>(getQueryFromSearch(location.search));
+
+  // changeOptions is used to change the options for an ClickHouse query. Instead of directly modifying the options
+  // state we change the URL parameters.
+  const changeOptions = (q: string): void => {
+    history.push({
+      pathname: location.pathname,
+      search: `?query=${q}`,
+    });
+  };
+
+  // useEffect is used to set the options every time the search location for the current URL changes. The URL is changed
+  // via the changeOptions function. When the search location is changed we modify the options state.
+  useEffect(() => {
+    setQuery(getQueryFromSearch(location.search));
+  }, [location.search]);
+
+  return (
+    <React.Fragment>
+      <PageSection variant={PageSectionVariants.light}>
+        <Title headingLevel="h6" size="xl">
+          {displayName}
+        </Title>
+        <p>{description}</p>
+        <SQLToolbar query={query} setQuery={changeOptions} />
+      </PageSection>
+
+      <PageSection style={{ minHeight: '100%' }} variant={PageSectionVariants.default}>
+        {query.length > 0 && <SQL name={name} query={query} />}
+      </PageSection>
+    </React.Fragment>
+  );
+};
+
+export default SQLPage;

--- a/plugins/clickhouse/src/components/page/SQLToolbar.tsx
+++ b/plugins/clickhouse/src/components/page/SQLToolbar.tsx
@@ -1,0 +1,65 @@
+import {
+  Button,
+  ButtonVariant,
+  TextArea,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+  ToolbarToggleGroup,
+} from '@patternfly/react-core';
+import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
+import React, { useState } from 'react';
+
+interface ISQLToolbarProps {
+  query: string;
+  setQuery: (data: string) => void;
+}
+
+const SQLToolbar: React.FunctionComponent<ISQLToolbarProps> = ({ query, setQuery }: ISQLToolbarProps) => {
+  const [data, setData] = useState<string>(query);
+
+  // changeQuery changes the value of a query.
+  const changeQuery = (value: string): void => {
+    setData(value);
+  };
+
+  // onEnter is used to detect if the user pressed the "ENTER" key. If this is the case we are calling the setOptions
+  // function to trigger the search.
+  // use "SHIFT" + "ENTER".
+  const onEnter = (e: React.KeyboardEvent<HTMLTextAreaElement> | undefined): void => {
+    if (e?.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      setQuery(data);
+    }
+  };
+
+  return (
+    <Toolbar id="clickhouse-sql-toolbar" style={{ paddingBottom: '0px', zIndex: 300 }}>
+      <ToolbarContent style={{ padding: '0px' }}>
+        <ToolbarToggleGroup style={{ width: '100%' }} toggleIcon={<FilterIcon />} breakpoint="lg">
+          <ToolbarGroup style={{ alignItems: 'flex-start', width: '100%' }}>
+            <ToolbarItem style={{ width: '100%' }}>
+              <TextArea
+                aria-label="Query"
+                resizeOrientation="vertical"
+                rows={1}
+                type="text"
+                value={data}
+                onChange={changeQuery}
+                onKeyDown={onEnter}
+              />
+            </ToolbarItem>
+            <ToolbarItem>
+              <Button variant={ButtonVariant.primary} icon={<SearchIcon />} onClick={(): void => setQuery(data)}>
+                Search
+              </Button>
+            </ToolbarItem>
+          </ToolbarGroup>
+        </ToolbarToggleGroup>
+      </ToolbarContent>
+    </Toolbar>
+  );
+};
+
+export default SQLToolbar;

--- a/plugins/clickhouse/src/components/panel/Panel.tsx
+++ b/plugins/clickhouse/src/components/panel/Panel.tsx
@@ -3,6 +3,7 @@ import React, { memo } from 'react';
 import { IPluginPanelProps, PluginOptionsMissing } from '@kobsio/plugin-core';
 import { IPanelOptions } from '../../utils/interfaces';
 import Logs from './Logs';
+import SQL from './SQL';
 
 interface IPanelProps extends IPluginPanelProps {
   options?: IPanelOptions;
@@ -19,7 +20,9 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
   if (
     !options ||
     !times ||
-    (options.type === 'logs' && (!options.queries || !Array.isArray(options.queries) || options.queries.length === 0))
+    (options.type === 'logs' &&
+      (!options.queries || !Array.isArray(options.queries) || options.queries.length === 0)) ||
+    (options.type === 'sql' && (!options.queries || !Array.isArray(options.queries) || options.queries.length === 0))
   ) {
     return (
       <PluginOptionsMissing
@@ -40,6 +43,10 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
       times={times}
       showDetails={showDetails}
     />;
+  }
+
+  if (options.type === 'sql' && options.queries) {
+    <SQL name={name} title={title} description={description} queries={options.queries} />;
   }
 
   return null;

--- a/plugins/clickhouse/src/components/panel/SQL.tsx
+++ b/plugins/clickhouse/src/components/panel/SQL.tsx
@@ -1,0 +1,114 @@
+import {
+  Alert,
+  AlertActionLink,
+  AlertVariant,
+  Select,
+  SelectOption,
+  SelectOptionObject,
+  SelectVariant,
+  Spinner,
+} from '@patternfly/react-core';
+import { QueryObserverResult, useQuery } from 'react-query';
+import React, { useState } from 'react';
+
+import { IQuery, ISQLData } from '../../utils/interfaces';
+import { PluginCard } from '@kobsio/plugin-core';
+import SQLActions from './SQLActions';
+import SQLTable from './SQLTable';
+
+interface ISQLProps {
+  name: string;
+  title: string;
+  description?: string;
+  queries: IQuery[];
+}
+
+const SQL: React.FunctionComponent<ISQLProps> = ({ name, title, description, queries }: ISQLProps) => {
+  const [showSelect, setShowSelect] = useState<boolean>(false);
+  const [selectedQuery, setSelectedQuery] = useState<IQuery>(queries[0]);
+
+  const { isError, isFetching, error, data, refetch } = useQuery<ISQLData, Error>(
+    ['clickhouse/sql', selectedQuery],
+    async ({ pageParam }) => {
+      try {
+        const response = await fetch(`/api/plugins/clickhouse/sql/${name}?query=${selectedQuery.query}`, {
+          method: 'get',
+        });
+        const json = await response.json();
+
+        if (response.status >= 200 && response.status < 300) {
+          return json;
+        } else {
+          if (json.error) {
+            throw new Error(json.error);
+          } else {
+            throw new Error('An unknown error occured');
+          }
+        }
+      } catch (err) {
+        throw err;
+      }
+    },
+  );
+
+  const select = (
+    event: React.MouseEvent<Element, MouseEvent> | React.ChangeEvent<Element>,
+    value: string | SelectOptionObject,
+  ): void => {
+    const query = queries.filter((query) => query.name === value);
+    if (query.length === 1) {
+      setSelectedQuery(query[0]);
+    }
+    setShowSelect(false);
+  };
+
+  return (
+    <PluginCard title={title} description={description} actions={<SQLActions name={name} queries={queries} />}>
+      <div>
+        {queries.length > 1 ? (
+          <div>
+            <Select
+              variant={SelectVariant.single}
+              typeAheadAriaLabel="Select query"
+              placeholderText="Select query"
+              onToggle={(): void => setShowSelect(!showSelect)}
+              onSelect={select}
+              selections={selectedQuery.name}
+              isOpen={showSelect}
+            >
+              {queries.map((query, index) => (
+                <SelectOption key={index} value={query.name} description={query.query} />
+              ))}
+            </Select>
+            <p>&nbsp;</p>
+          </div>
+        ) : null}
+
+        {isFetching ? (
+          <div className="pf-u-text-align-center">
+            <Spinner />
+          </div>
+        ) : isError ? (
+          <Alert
+            variant={AlertVariant.danger}
+            isInline={true}
+            title="Could not get logs"
+            actionLinks={
+              <React.Fragment>
+                <AlertActionLink onClick={(): Promise<QueryObserverResult<ISQLData, Error>> => refetch()}>
+                  Retry
+                </AlertActionLink>
+              </React.Fragment>
+            }
+          >
+            <p>{error?.message}</p>
+          </Alert>
+        ) : data ? (
+          <SQLTable columns={data.columns} rows={data.rows} />
+        ) : null}
+      </div>
+    </PluginCard>
+  );
+};
+
+export default SQL;

--- a/plugins/clickhouse/src/components/panel/SQLActions.tsx
+++ b/plugins/clickhouse/src/components/panel/SQLActions.tsx
@@ -1,0 +1,30 @@
+import { CardActions, Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import { IQuery } from '../../utils/interfaces';
+
+interface IActionsProps {
+  name: string;
+  queries: IQuery[];
+}
+
+export const Actions: React.FunctionComponent<IActionsProps> = ({ name, queries }: IActionsProps) => {
+  const [show, setShow] = useState<boolean>(false);
+
+  return (
+    <CardActions>
+      <Dropdown
+        toggle={<KebabToggle onToggle={(): void => setShow(!show)} />}
+        isOpen={show}
+        isPlain={true}
+        position="right"
+        dropdownItems={queries.map((query) => [
+          <DropdownItem key={0} component={<Link to={`/${name}?query=${query.query}`}>{query.name}</Link>} />,
+        ])}
+      />
+    </CardActions>
+  );
+};
+
+export default Actions;

--- a/plugins/clickhouse/src/components/panel/SQLTable.tsx
+++ b/plugins/clickhouse/src/components/panel/SQLTable.tsx
@@ -1,0 +1,37 @@
+import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import React from 'react';
+
+import { ISQLData } from '../../utils/interfaces';
+
+type ISQLTableProps = ISQLData;
+
+const SQLTable: React.FunctionComponent<ISQLTableProps> = ({ rows, columns }: ISQLTableProps) => {
+  if (!columns || columns.length === 0) {
+    return null;
+  }
+
+  return (
+    <TableComposable aria-label="SQL Query Result" variant={TableVariant.compact} borders={false}>
+      <Thead>
+        <Tr>
+          {columns.map((column, index) => (
+            <Th key={index}>{column}</Th>
+          ))}
+        </Tr>
+      </Thead>
+      <Tbody>
+        {rows
+          ? rows.map((row, rowIndex) => (
+              <Tr key={rowIndex}>
+                {row.map((column, columnIndex) => (
+                  <Td key={`${rowIndex}_${columnIndex}`}>{column}</Td>
+                ))}
+              </Tr>
+            ))
+          : null}
+      </Tbody>
+    </TableComposable>
+  );
+};
+
+export default SQLTable;

--- a/plugins/clickhouse/src/utils/helpers.ts
+++ b/plugins/clickhouse/src/utils/helpers.ts
@@ -1,7 +1,7 @@
 import { TTime, TTimeOptions, formatTime } from '@kobsio/plugin-core';
 import { IOptions } from './interfaces';
 
-// getOptionsFromSearch is used to get the Elasticsearch options from a given search location.
+// getOptionsFromSearch is used to get the ClickHouse options from a given search location.
 export const getOptionsFromSearch = (search: string): IOptions => {
   const params = new URLSearchParams(search);
   const fields = params.getAll('field');
@@ -23,6 +23,13 @@ export const getOptionsFromSearch = (search: string): IOptions => {
           : Math.floor(Date.now() / 1000) - 900,
     },
   };
+};
+
+// getQueryFromSearch is used to get the sql query from a given search location.
+export const getQueryFromSearch = (search: string): string => {
+  const params = new URLSearchParams(search);
+  const query = params.get('query');
+  return query ? query : '';
 };
 
 // formatTimeWrapper is a wrapper for our shared formatTime function. It is needed to convert a given time string to the

--- a/plugins/clickhouse/src/utils/interfaces.ts
+++ b/plugins/clickhouse/src/utils/interfaces.ts
@@ -30,3 +30,9 @@ export interface IDocument {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
+
+// ISQLData is the interface of the data returned from our Go API for the sql view of the ClickHouse plugin.
+export interface ISQLData {
+  columns?: string[];
+  rows?: string[][];
+}


### PR DESCRIPTION
This adds a new mode called "sql" for the ClickHouse plugin, which
allows a user to execute raw SQL queries against the configured
ClickHouse instance. The result of the queries will be shown in a table.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
