### PR TITLE
Show request details for ClickHouse logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#119](https://github.com/kobsio/kobs/pull/119): Add Flux plugin to view and reconcile [Flux](https://fluxcd.io) resources.
 - [#122](https://github.com/kobsio/kobs/pull/122): Add ClickHouse plugin, to query show logs ingested by the [kobsio/fluent-bit-clickhouse](https://github.com/kobsio/fluent-bit-clickhouse) Fluent Bit plugin.
 - [#124](https://github.com/kobsio/kobs/pull/124): Add `sql` mode for ClickHouse to execute raw SQL queries.
+- [#126](https://github.com/kobsio/kobs/pull/126): Show request details when gettings logs from ClickHouse.
 
 ### Fixed
 

--- a/plugins/clickhouse/pkg/instance/logs.go
+++ b/plugins/clickhouse/pkg/instance/logs.go
@@ -20,7 +20,7 @@ func parseLogsQuery(query string) (string, error) {
 	openBrackets := strings.Split(query, "(")
 	for _, openBracket := range openBrackets {
 		var newCloseBrackets []string
-		closeBrackets := strings.Split(openBracket, "(")
+		closeBrackets := strings.Split(openBracket, ")")
 		for _, closeBracket := range closeBrackets {
 			var newNots []string
 			nots := strings.Split(closeBracket, "_not_")

--- a/plugins/clickhouse/src/components/page/Logs.tsx
+++ b/plugins/clickhouse/src/components/page/Logs.tsx
@@ -18,6 +18,7 @@ import { ILogsData } from '../../utils/interfaces';
 import { IPluginTimes } from '@kobsio/plugin-core';
 import LogsDocuments from '../panel/LogsDocuments';
 import LogsFields from './LogsFields';
+import LogsHeader from './LogsHeader';
 
 interface IPageLogsProps {
   name: string;
@@ -43,7 +44,7 @@ const PageLogs: React.FunctionComponent<IPageLogsProps> = ({
     async ({ pageParam }) => {
       try {
         const response = await fetch(
-          `/api/plugins/clickhouse/logs/${name}?query=${query}&timeStart=${times.timeStart}&timeEnd=${
+          `/api/plugins/clickhouse/logs/documents/${name}?query=${query}&timeStart=${times.timeStart}&timeEnd=${
             times.timeEnd
           }&limit=100&offset=${pageParam || ''}`,
           {
@@ -111,6 +112,13 @@ const PageLogs: React.FunctionComponent<IPageLogsProps> = ({
       </GridItem>
       <GridItem sm={12} md={12} lg={9} xl={10} xl2={10}>
         <Card isCompact={true} style={{ maxWidth: '100%', overflowX: 'scroll' }}>
+          <LogsHeader
+            name={name}
+            query={query}
+            times={times}
+            took={data.pages[0].took || 0}
+            isFetchingDocuments={isFetching}
+          />
           <CardBody>
             <LogsDocuments pages={data.pages} fields={fields} showDetails={showDetails} />
           </CardBody>

--- a/plugins/clickhouse/src/components/page/LogsHeader.tsx
+++ b/plugins/clickhouse/src/components/page/LogsHeader.tsx
@@ -1,0 +1,59 @@
+import { CardActions, CardHeader, CardHeaderMain, CardTitle, Spinner } from '@patternfly/react-core';
+import React from 'react';
+import { useQuery } from 'react-query';
+
+import { ILogsCountData } from '../../utils/interfaces';
+import { IPluginTimes } from '@kobsio/plugin-core';
+
+interface ILogsHeaderProps {
+  name: string;
+  query: string;
+  times: IPluginTimes;
+  took: number;
+  isFetchingDocuments: boolean;
+}
+
+const LogsHeader: React.FunctionComponent<ILogsHeaderProps> = ({
+  name,
+  query,
+  times,
+  took,
+  isFetchingDocuments,
+}: ILogsHeaderProps) => {
+  const { data } = useQuery<ILogsCountData, Error>(['clickhouse/logscount', query, times], async () => {
+    try {
+      const response = await fetch(
+        `/api/plugins/clickhouse/logs/count/${name}?query=${query}&timeStart=${times.timeStart}&timeEnd=${times.timeEnd}`,
+        {
+          method: 'get',
+        },
+      );
+      const json = await response.json();
+
+      if (response.status >= 200 && response.status < 300) {
+        return json;
+      } else {
+        if (json.error) {
+          throw new Error(json.error);
+        } else {
+          throw new Error('An unknown error occured');
+        }
+      }
+    } catch (err) {
+      throw err;
+    }
+  });
+
+  return (
+    <CardHeader>
+      <CardHeaderMain>
+        <CardTitle>
+          {data && data.count ? data.count : 0} Documents in {took} Milliseconds
+        </CardTitle>
+      </CardHeaderMain>
+      <CardActions>{isFetchingDocuments && <Spinner size="md" />}</CardActions>
+    </CardHeader>
+  );
+};
+
+export default LogsHeader;

--- a/plugins/clickhouse/src/components/panel/Logs.tsx
+++ b/plugins/clickhouse/src/components/panel/Logs.tsx
@@ -43,9 +43,9 @@ const Logs: React.FunctionComponent<ILogsProps> = ({
     async ({ pageParam }) => {
       try {
         const response = await fetch(
-          `/api/plugins/clickhouse/logs/${name}?query=${selectedQuery.query}&timeStart=${times.timeStart}&timeEnd=${
-            times.timeEnd
-          }&limit=100&offset=${pageParam || ''}`,
+          `/api/plugins/clickhouse/logs/documents/${name}?query=${selectedQuery.query}&timeStart=${
+            times.timeStart
+          }&timeEnd=${times.timeEnd}&limit=100&offset=${pageParam || ''}`,
           {
             method: 'get',
           },

--- a/plugins/clickhouse/src/utils/interfaces.ts
+++ b/plugins/clickhouse/src/utils/interfaces.ts
@@ -22,6 +22,7 @@ export interface IQuery {
 // ILogsData is the interface of the data returned from our Go API for the logs view of the ClickHouse plugin.
 export interface ILogsData {
   offset: number;
+  took?: number;
   fields?: string[];
   documents?: IDocument[];
 }
@@ -29,6 +30,10 @@ export interface ILogsData {
 export interface IDocument {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
+}
+
+export interface ILogsCountData {
+  count?: number;
 }
 
 // ISQLData is the interface of the data returned from our Go API for the sql view of the ClickHouse plugin.

--- a/plugins/core/src/components/app/App.tsx
+++ b/plugins/core/src/components/app/App.tsx
@@ -24,6 +24,7 @@ const queryClient = new QueryClient({
       refetchInterval: false,
       refetchIntervalInBackground: false,
       refetchOnWindowFocus: false,
+      retry: false,
       staleTime: Infinity,
     },
   },

--- a/plugins/elasticsearch/src/components/page/PageLogs.tsx
+++ b/plugins/elasticsearch/src/components/page/PageLogs.tsx
@@ -5,7 +5,10 @@ import {
   Button,
   ButtonVariant,
   Card,
+  CardActions,
   CardBody,
+  CardHeader,
+  CardHeaderMain,
   CardTitle,
   Grid,
   GridItem,
@@ -118,9 +121,15 @@ const PageLogs: React.FunctionComponent<IPageLogsProps> = ({
       </GridItem>
       <GridItem sm={12} md={12} lg={9} xl={10} xl2={10}>
         <Card isCompact={true}>
-          <CardTitle className="pf-u-text-align-center">
-            {data.pages[0].hits} Documents in {data.pages[0].took} Milliseconds
-          </CardTitle>
+          <CardHeader>
+            <CardHeaderMain>
+              <CardTitle>
+                {data.pages[0].hits} Documents in {data.pages[0].took} Milliseconds
+              </CardTitle>
+            </CardHeaderMain>
+            <CardActions>{isFetching && <Spinner size="md" />}</CardActions>
+          </CardHeader>
+
           <CardBody>
             <LogsChart buckets={data.pages[0].buckets} />
           </CardBody>


### PR DESCRIPTION
We are now showing the details for log requests in the ClickHouse
plugin. We added a card header to provide information like the number of
all documents for the query and the time it took to get the entries from
ClickHouse.

This commit also fixes a small typo in the query language parsing, where
closing brackets were not recognized. This is now fixed and queries with
brackets should work as expected.

Last but not least, we are showing a small spinner in the header of the
card for logs retrieved in the ClickHouse or Elasticsearch plugin. So
that a user see that his query is still executed after a change to the
time range or query.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
