### PR TITLE
Allow ILIKE queries for ClickHouse logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#122](https://github.com/kobsio/kobs/pull/122): Add ClickHouse plugin, to query show logs ingested by the [kobsio/fluent-bit-clickhouse](https://github.com/kobsio/fluent-bit-clickhouse) Fluent Bit plugin.
 - [#124](https://github.com/kobsio/kobs/pull/124): Add `sql` mode for ClickHouse to execute raw SQL queries.
 - [#126](https://github.com/kobsio/kobs/pull/126): Show request details when gettings logs from ClickHouse.
+- [#127](https://github.com/kobsio/kobs/pull/127): Allow `ILIKE` queries for ClickHouse logs, using the new `=~` operator.
 
 ### Fixed
 

--- a/docs/plugins/clickhouse.md
+++ b/docs/plugins/clickhouse.md
@@ -79,7 +79,8 @@ kobs supports multiple operators which can be used in a query to retrieve logs f
 | `>=` | The value of the field must be greater than or equal to the specified value. | `content.response_code>=500` |
 | `<` | The value of the field must be lower than the specified value. | `content.response_code<500` |
 | `<=` | The value of the field must be lower than or equal to the specified value. | `content.response_code<=499` |
-| `~` | The value of the field must match the regular expression. | `content.upstream_cluster~'inbound.*'` |
+| `=~` | The value of the field is compared using `ILIKE`. | `content.upstream_cluster=~'inbound%'` |
+| `~` | The value of the field must match the regular expression. The syntax of the `re2` regular expressions can be found [here](https://github.com/google/re2/wiki/Syntax). | `content.upstream_cluster~'inbound.*'` |
 
 ### Default Fields
 

--- a/plugins/clickhouse/pkg/instance/instance.go
+++ b/plugins/clickhouse/pkg/instance/instance.go
@@ -167,6 +167,7 @@ func (i *Instance) GetLogsCount(ctx context.Context, query string, timeStart, ti
 	}
 
 	sqlQueryCount := fmt.Sprintf("SELECT count(*) FROM %s.logs WHERE timestamp >= ? AND timestamp <= ? %s", i.database, conditions)
+	log.WithFields(logrus.Fields{"query": sqlQueryCount}).Tracef("sql count query")
 	rowsCount, err := i.client.QueryContext(ctx, sqlQueryCount, time.Unix(timeStart, 0), time.Unix(timeEnd, 0))
 	if err != nil {
 		return 0, err

--- a/plugins/clickhouse/pkg/instance/logs_test.go
+++ b/plugins/clickhouse/pkg/instance/logs_test.go
@@ -15,6 +15,8 @@ func TestParseLogsQuery(t *testing.T) {
 		{query: "cluster = 'foo' _and_ namespace = 'bar'", where: "cluster='foo' AND namespace='bar'", isInvalid: false},
 		{query: "cluster = 'foo' _and_ (namespace='hello' _or_ namespace='world')", where: "cluster='foo' AND (namespace='hello' OR namespace='world')", isInvalid: false},
 		{query: "kubernetes.label_foo = 'bar'", where: "fields_string.value[indexOf(fields_string.key, 'kubernetes.label_foo')] = 'bar'", isInvalid: false},
+		{query: "kubernetes.label_foo_bar =~ '\\%hellow\\%world\\%'", where: "fields_string.value[indexOf(fields_string.key, 'kubernetes.label_foo_bar')] ILIKE '\\%hellow\\%world\\%'", isInvalid: false},
+		{query: "kubernetes.label_foo_bar ~ 'hello.*'", where: "match(fields_string.value[indexOf(fields_string.key, 'kubernetes.label_foo_bar')], 'hello.*')", isInvalid: false},
 	} {
 		t.Run(tc.query, func(t *testing.T) {
 			parsedWhere, err := parseLogsQuery(tc.query)

--- a/plugins/clickhouse/src/components/page/Logs.tsx
+++ b/plugins/clickhouse/src/components/page/Logs.tsx
@@ -44,9 +44,9 @@ const PageLogs: React.FunctionComponent<IPageLogsProps> = ({
     async ({ pageParam }) => {
       try {
         const response = await fetch(
-          `/api/plugins/clickhouse/logs/documents/${name}?query=${query}&timeStart=${times.timeStart}&timeEnd=${
-            times.timeEnd
-          }&limit=100&offset=${pageParam || ''}`,
+          `/api/plugins/clickhouse/logs/documents/${name}?query=${encodeURIComponent(query)}&timeStart=${
+            times.timeStart
+          }&timeEnd=${times.timeEnd}&limit=100&offset=${pageParam || ''}`,
           {
             method: 'get',
           },

--- a/plugins/clickhouse/src/components/page/LogsHeader.tsx
+++ b/plugins/clickhouse/src/components/page/LogsHeader.tsx
@@ -23,7 +23,9 @@ const LogsHeader: React.FunctionComponent<ILogsHeaderProps> = ({
   const { data } = useQuery<ILogsCountData, Error>(['clickhouse/logscount', query, times], async () => {
     try {
       const response = await fetch(
-        `/api/plugins/clickhouse/logs/count/${name}?query=${query}&timeStart=${times.timeStart}&timeEnd=${times.timeEnd}`,
+        `/api/plugins/clickhouse/logs/count/${name}?query=${encodeURIComponent(query)}&timeStart=${
+          times.timeStart
+        }&timeEnd=${times.timeEnd}`,
         {
           method: 'get',
         },

--- a/plugins/clickhouse/src/components/page/SQL.tsx
+++ b/plugins/clickhouse/src/components/page/SQL.tsx
@@ -18,7 +18,7 @@ const SQL: React.FunctionComponent<ISQLProps> = ({ name, query }: ISQLProps) => 
     ['clickhouse/sql', query],
     async () => {
       try {
-        const response = await fetch(`/api/plugins/clickhouse/sql/${name}?query=${query}`, {
+        const response = await fetch(`/api/plugins/clickhouse/sql/${name}?query=${encodeURIComponent(query)}`, {
           method: 'get',
         });
         const json = await response.json();

--- a/plugins/clickhouse/src/components/panel/Logs.tsx
+++ b/plugins/clickhouse/src/components/panel/Logs.tsx
@@ -42,8 +42,12 @@ const Logs: React.FunctionComponent<ILogsProps> = ({
     ['clickhouse/logs', selectedQuery, times],
     async ({ pageParam }) => {
       try {
+        if (!selectedQuery.query) {
+          throw new Error('Query is missing');
+        }
+
         const response = await fetch(
-          `/api/plugins/clickhouse/logs/documents/${name}?query=${selectedQuery.query}&timeStart=${
+          `/api/plugins/clickhouse/logs/documents/${name}?query=${encodeURIComponent(selectedQuery.query)}&timeStart=${
             times.timeStart
           }&timeEnd=${times.timeEnd}&limit=100&offset=${pageParam || ''}`,
           {

--- a/plugins/clickhouse/src/components/panel/SQL.tsx
+++ b/plugins/clickhouse/src/components/panel/SQL.tsx
@@ -31,9 +31,16 @@ const SQL: React.FunctionComponent<ISQLProps> = ({ name, title, description, que
     ['clickhouse/sql', selectedQuery],
     async ({ pageParam }) => {
       try {
-        const response = await fetch(`/api/plugins/clickhouse/sql/${name}?query=${selectedQuery.query}`, {
-          method: 'get',
-        });
+        if (!selectedQuery.query) {
+          throw new Error('Query is missing');
+        }
+
+        const response = await fetch(
+          `/api/plugins/clickhouse/sql/${name}?query=${encodeURIComponent(selectedQuery.query)}`,
+          {
+            method: 'get',
+          },
+        );
         const json = await response.json();
 
         if (response.status >= 200 && response.status < 300) {


### PR DESCRIPTION
It is now possible to use "ILIKE" queries to get logs from ClickHouse,
using the new "=~" operator. With this option we are providing an easier
option next to the regular expressions to filter the logs.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
