### PR TITLE
Fix handling of traces in the Jaeger plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,13 +35,14 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#120](https://github.com/kobsio/kobs/pull/120): Fix reconcilation of Flux resources.
 - [#123](https://github.com/kobsio/kobs/pull/123): Fix fields handling in ClickHouse and Elasticsearch plugin.
 - [#125](https://github.com/kobsio/kobs/pull/125): Fix missing `return` statement in ClickHouse panel.
+- [#129](https://github.com/kobsio/kobs/pull/129): Fix handling of traces in the Jaeger plugin by using some function from the [jaegertracing/jaeger-ui](https://github.com/jaegertracing/jaeger-ui).
 
 ### Changed
 
 - [#106](https://github.com/kobsio/kobs/pull/106): :warning: *Breaking change:* :warning: Change Prometheus sparkline chart to allow the usage of labels.
 - [#107](https://github.com/kobsio/kobs/pull/107): Add new option for Prometheus chart legend and change formatting of values.
 - [#108](https://github.com/kobsio/kobs/pull/108): Improve tooltip position in all nivo charts.
-- [#121](https://github.com/kobsio/kobs/pull/121): :warning: *Breaking change:* Allow multiple queries in the panel options for the Elasticsearch plugin.
+- [#121](https://github.com/kobsio/kobs/pull/121): :warning: *Breaking change:* :warning: Allow multiple queries in the panel options for the Elasticsearch plugin.
 
 ## [v0.5.0](https://github.com/kobsio/kobs/releases/tag/v0.5.0) (2021-08-03)
 

--- a/plugins/jaeger/package.json
+++ b/plugins/jaeger/package.json
@@ -23,6 +23,7 @@
     "react-dropzone": "^11.3.4",
     "react-query": "^3.17.2",
     "react-router-dom": "^5.2.0",
+    "react-virtuoso": "^1.11.1",
     "typescript": "^4.3.4"
   }
 }

--- a/plugins/jaeger/src/components/page/Trace.tsx
+++ b/plugins/jaeger/src/components/page/Trace.tsx
@@ -3,7 +3,8 @@ import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 
 import { ITrace } from '../../utils/interfaces';
-import TraceCompare from './TraceCompare';
+import TraceCompareData from './TraceCompareData';
+import TraceCompareID from './TraceCompareID';
 import TraceSelect from './TraceSelect';
 
 interface IJaegerPageCompareParams {
@@ -40,7 +41,7 @@ const JaegerPageCompare: React.FunctionComponent<IJaegerPageCompareProps> = ({ n
 
   // handleUpload handles the upload of a JSON file, which contains a trace. When the file upload is finished we parse
   // the content of the file and set the uploadedTrace state. This state (trace) is then passed to the first
-  // TraceCompare so that the trace can be viewed.
+  // TraceCompareID so that the trace can be viewed.
   const handleUpload = (trace: ITrace): void => {
     setUploadedTrace(trace);
     history.push({
@@ -66,12 +67,16 @@ const JaegerPageCompare: React.FunctionComponent<IJaegerPageCompareProps> = ({ n
   return (
     <Grid>
       <GridItem sm={12} md={12} lg={compareTrace ? 6 : 12} xl={compareTrace ? 6 : 12} xl2={compareTrace ? 6 : 12}>
-        <TraceCompare name={name} traceID={params.traceID} trace={uploadedTrace} />
+        {uploadedTrace ? (
+          <TraceCompareData name={name} traceData={uploadedTrace} />
+        ) : (
+          <TraceCompareID name={name} traceID={params.traceID} />
+        )}
       </GridItem>
 
       {compareTrace ? (
         <GridItem sm={12} md={12} lg={compareTrace ? 6 : 12} xl={compareTrace ? 6 : 12} xl2={compareTrace ? 6 : 12}>
-          <TraceCompare name={name} traceID={compareTrace} />
+          <TraceCompareID name={name} traceID={compareTrace} />
         </GridItem>
       ) : null}
     </Grid>

--- a/plugins/jaeger/src/components/page/TraceCompare.tsx
+++ b/plugins/jaeger/src/components/page/TraceCompare.tsx
@@ -1,19 +1,6 @@
-import {
-  Alert,
-  AlertActionLink,
-  AlertVariant,
-  Grid,
-  GridItem,
-  PageSection,
-  PageSectionVariants,
-  Spinner,
-  Title,
-} from '@patternfly/react-core';
-import { QueryObserverResult, useQuery } from 'react-query';
+import { Grid, GridItem, PageSection, PageSectionVariants, Title } from '@patternfly/react-core';
 import React from 'react';
-import { useHistory } from 'react-router-dom';
 
-import { addColorForProcesses, getRootSpan } from '../../utils/helpers';
 import { ITrace } from '../../utils/interfaces';
 import Spans from '../panel/details/Spans';
 import TraceActions from '../panel/details/TraceActions';
@@ -21,90 +8,21 @@ import TraceHeader from '../panel/details/TraceHeader';
 
 interface ITraceCompareProps {
   name: string;
-  traceID: string;
-  trace?: ITrace;
+  trace: ITrace;
 }
 
-const TraceCompare: React.FunctionComponent<ITraceCompareProps> = ({ name, traceID, trace }: ITraceCompareProps) => {
-  const history = useHistory();
-
-  const { isError, isLoading, error, data, refetch } = useQuery<ITrace, Error>(
-    ['jaeger/trace', name, traceID, trace],
-    async () => {
-      try {
-        if (trace && trace.traceID === traceID) {
-          return addColorForProcesses([trace])[0];
-        }
-
-        const response = await fetch(`/api/plugins/jaeger/trace/${name}?traceID=${traceID}`, {
-          method: 'get',
-        });
-        const json = await response.json();
-
-        if (response.status >= 200 && response.status < 300) {
-          return addColorForProcesses(json.data)[0];
-        } else {
-          if (json.error) {
-            throw new Error(json.error);
-          } else {
-            throw new Error('An unknown error occured');
-          }
-        }
-      } catch (err) {
-        throw err;
-      }
-    },
-  );
-
-  if (isLoading) {
-    return (
-      <div className="pf-u-text-align-center">
-        <Spinner />
-      </div>
-    );
-  }
-
-  if (isError) {
-    return (
-      <PageSection variant={PageSectionVariants.default}>
-        <Alert
-          variant={AlertVariant.danger}
-          title="Could not get trace"
-          actionLinks={
-            <React.Fragment>
-              <AlertActionLink onClick={(): void => history.push('/')}>Home</AlertActionLink>
-              <AlertActionLink onClick={(): Promise<QueryObserverResult<ITrace, Error>> => refetch()}>
-                Retry
-              </AlertActionLink>
-            </React.Fragment>
-          }
-        >
-          <p>{error?.message}</p>
-        </Alert>
-      </PageSection>
-    );
-  }
-
-  if (!data) {
-    return null;
-  }
-
-  const rootSpan = data && data.spans.length > 0 ? getRootSpan(data.spans) : undefined;
-  if (!rootSpan) {
-    return null;
-  }
-
+const TraceCompare: React.FunctionComponent<ITraceCompareProps> = ({ name, trace }: ITraceCompareProps) => {
   return (
     <React.Fragment>
       <Grid>
         <GridItem sm={11} md={11} lg={11} xl={11} xl2={11}>
           <PageSection style={{ height: '100%' }} variant={PageSectionVariants.light}>
             <Title className="pf-u-text-nowrap pf-u-text-truncate" headingLevel="h6" size="xl">
-              {data.processes[rootSpan.processID].serviceName}: {rootSpan.operationName}
-              <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">{data.traceID}</span>
+              {trace.traceName}
+              <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">{trace.traceID}</span>
             </Title>
             <p>
-              <TraceHeader trace={data} rootSpan={rootSpan} />
+              <TraceHeader trace={trace} />
             </p>
           </PageSection>
         </GridItem>
@@ -112,7 +30,7 @@ const TraceCompare: React.FunctionComponent<ITraceCompareProps> = ({ name, trace
         <GridItem sm={1} md={1} lg={1} xl={1} xl2={1}>
           <PageSection style={{ height: '100%' }} variant={PageSectionVariants.light}>
             <div style={{ float: 'right', textAlign: 'right' }}>
-              <TraceActions name={name} trace={data} />
+              <TraceActions name={name} trace={trace} />
             </div>
           </PageSection>
         </GridItem>
@@ -120,7 +38,7 @@ const TraceCompare: React.FunctionComponent<ITraceCompareProps> = ({ name, trace
         <GridItem sm={12} md={12} lg={12} xl={12} xl2={12}>
           <PageSection variant={PageSectionVariants.default}>
             <div style={{ position: 'relative' }}>
-              <Spans name={name} trace={data} />
+              <Spans name={name} trace={trace} />
             </div>
           </PageSection>
         </GridItem>

--- a/plugins/jaeger/src/components/page/TraceCompareData.tsx
+++ b/plugins/jaeger/src/components/page/TraceCompareData.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { ITrace } from '../../utils/interfaces';
+import TraceCompare from './TraceCompare';
+import { addColorForProcesses } from '../../utils/colors';
+import { transformTraceData } from '../../utils/helpers';
+
+interface ITraceCompareDataProps {
+  name: string;
+  traceData: ITrace;
+}
+
+const TraceCompareData: React.FunctionComponent<ITraceCompareDataProps> = ({
+  name,
+  traceData,
+}: ITraceCompareDataProps) => {
+  const trace = transformTraceData(addColorForProcesses([traceData])[0]);
+
+  if (!trace) {
+    return null;
+  }
+
+  return <TraceCompare name={name} trace={trace} />;
+};
+
+export default TraceCompareData;

--- a/plugins/jaeger/src/components/page/TraceCompareID.tsx
+++ b/plugins/jaeger/src/components/page/TraceCompareID.tsx
@@ -1,0 +1,86 @@
+import {
+  Alert,
+  AlertActionLink,
+  AlertVariant,
+  PageSection,
+  PageSectionVariants,
+  Spinner,
+} from '@patternfly/react-core';
+import { QueryObserverResult, useQuery } from 'react-query';
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+
+import { ITrace } from '../../utils/interfaces';
+import TraceCompare from './TraceCompare';
+import { addColorForProcesses } from '../../utils/colors';
+import { transformTraceData } from '../../utils/helpers';
+
+interface ITraceCompareIDProps {
+  name: string;
+  traceID: string;
+}
+
+const TraceCompareID: React.FunctionComponent<ITraceCompareIDProps> = ({ name, traceID }: ITraceCompareIDProps) => {
+  const history = useHistory();
+
+  const { isError, isLoading, error, data, refetch } = useQuery<ITrace | null, Error>(
+    ['jaeger/trace', name, traceID],
+    async () => {
+      try {
+        const response = await fetch(`/api/plugins/jaeger/trace/${name}?traceID=${traceID}`, {
+          method: 'get',
+        });
+        const json = await response.json();
+
+        if (response.status >= 200 && response.status < 300) {
+          return transformTraceData(addColorForProcesses(json.data)[0]);
+        } else {
+          if (json.error) {
+            throw new Error(json.error);
+          } else {
+            throw new Error('An unknown error occured');
+          }
+        }
+      } catch (err) {
+        throw err;
+      }
+    },
+  );
+
+  if (isLoading) {
+    return (
+      <div className="pf-u-text-align-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <PageSection variant={PageSectionVariants.default}>
+        <Alert
+          variant={AlertVariant.danger}
+          title="Could not get trace"
+          actionLinks={
+            <React.Fragment>
+              <AlertActionLink onClick={(): void => history.push('/')}>Home</AlertActionLink>
+              <AlertActionLink onClick={(): Promise<QueryObserverResult<ITrace | null, Error>> => refetch()}>
+                Retry
+              </AlertActionLink>
+            </React.Fragment>
+          }
+        >
+          <p>{error?.message}</p>
+        </Alert>
+      </PageSection>
+    );
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return <TraceCompare name={name} trace={data} />;
+};
+
+export default TraceCompareID;

--- a/plugins/jaeger/src/components/panel/Traces.tsx
+++ b/plugins/jaeger/src/components/panel/Traces.tsx
@@ -3,11 +3,12 @@ import { QueryObserverResult, useQuery } from 'react-query';
 import React from 'react';
 
 import { IOptions, ITrace } from '../../utils/interfaces';
-import { addColorForProcesses, encodeTags } from '../../utils/helpers';
+import { encodeTags, transformTraceData } from '../../utils/helpers';
 import { PluginCard } from '@kobsio/plugin-core';
 import TracesActions from './TracesActions';
 import TracesChart from './TracesChart';
 import TracesList from './TracesList';
+import { addColorForProcesses } from '../../utils/colors';
 
 interface ITracesProps extends IOptions {
   name: string;
@@ -46,7 +47,17 @@ const Traces: React.FunctionComponent<ITracesProps> = ({
         const json = await response.json();
 
         if (response.status >= 200 && response.status < 300) {
-          return addColorForProcesses(json.data);
+          const traceData = addColorForProcesses(json.data);
+          const traces: ITrace[] = [];
+
+          for (const trace of traceData) {
+            const transformedTrace = transformTraceData(trace);
+            if (transformedTrace) {
+              traces.push(transformedTrace);
+            }
+          }
+
+          return traces;
         } else {
           if (json.error) {
             throw new Error(json.error);

--- a/plugins/jaeger/src/components/panel/TracesChart.tsx
+++ b/plugins/jaeger/src/components/panel/TracesChart.tsx
@@ -5,7 +5,6 @@ import { SquareIcon } from '@patternfly/react-icons';
 import { TooltipWrapper } from '@nivo/tooltip';
 import Trace from './details/Trace';
 
-import { getDuration, getRootSpan } from '../../utils/helpers';
 import { ITrace } from '../../utils/interfaces';
 
 interface IDatum extends Datum {
@@ -39,27 +38,13 @@ const TracesChart: React.FunctionComponent<ITracesChartProps> = ({ name, traces,
         maximalSpans = trace.spans.length;
       }
 
-      const rootSpan = getRootSpan(trace.spans);
-      if (!rootSpan) {
-        result.push({
-          label: `${trace.traceID}`,
-          size: trace.spans.length,
-          trace,
-          x: new Date(Math.floor(trace.spans[0].startTime / 1000)),
-          y: getDuration(trace.spans),
-        });
-      } else {
-        const rootSpanProcess = trace.processes[rootSpan.processID];
-        const rootSpanService = rootSpanProcess.serviceName;
-
-        result.push({
-          label: `${rootSpanService}: ${rootSpan.operationName}`,
-          size: trace.spans.length,
-          trace,
-          x: new Date(Math.floor(trace.spans[0].startTime / 1000)),
-          y: getDuration(trace.spans),
-        });
-      }
+      result.push({
+        label: trace.traceName,
+        size: trace.spans.length,
+        trace,
+        x: new Date(Math.floor(trace.spans[0].startTime / 1000)),
+        y: trace.duration / 1000,
+      });
     });
 
     return {
@@ -90,7 +75,7 @@ const TracesChart: React.FunctionComponent<ITracesChartProps> = ({ name, traces,
             enableGridX={false}
             enableGridY={false}
             margin={{ bottom: 25, left: 0, right: 0, top: 0 }}
-            nodeSize={{ key: 'size', sizes: [15, 20], values: [min, max] }}
+            nodeSize={{ key: 'size', sizes: [15, 75], values: [min, max] }}
             theme={{
               background: '#ffffff',
               fontFamily: 'RedHatDisplay, Overpass, overpass, helvetica, arial, sans-serif',

--- a/plugins/jaeger/src/components/panel/TracesListItem.tsx
+++ b/plugins/jaeger/src/components/panel/TracesListItem.tsx
@@ -4,15 +4,10 @@ import React from 'react';
 
 import { LinkWrapper } from '@kobsio/plugin-core';
 
-import {
-  doesTraceContainsError,
-  formatTraceTime,
-  getDuration,
-  getRootSpan,
-  getSpansPerServices,
-} from '../../utils/helpers';
+import { doesTraceContainsError, formatTraceTime } from '../../utils/helpers';
 import { ITrace } from '../../utils/interfaces';
 import Trace from './details/Trace';
+import { getColorForService } from '../../utils/colors';
 
 interface ITracesListItemProps {
   name: string;
@@ -25,15 +20,6 @@ const TracesListItem: React.FunctionComponent<ITracesListItemProps> = ({
   trace,
   showDetails,
 }: ITracesListItemProps) => {
-  const rootSpan = getRootSpan(trace.spans);
-  if (!rootSpan) {
-    return null;
-  }
-
-  const rootSpanProcess = trace.processes[rootSpan.processID];
-  const rootSpanService = rootSpanProcess.serviceName;
-  const services = getSpansPerServices(trace);
-
   const card = (
     <Card
       style={{ cursor: 'pointer' }}
@@ -47,7 +33,7 @@ const TracesListItem: React.FunctionComponent<ITracesListItemProps> = ({
     >
       <CardHeader>
         <CardTitle>
-          {rootSpanService}: {rootSpan.operationName}
+          {trace.traceName}
           <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">
             {trace.traceID}
             {doesTraceContainsError(trace) ? (
@@ -59,7 +45,7 @@ const TracesListItem: React.FunctionComponent<ITracesListItemProps> = ({
           </span>
         </CardTitle>
         <CardActions>
-          <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">{getDuration(trace.spans)}ms</span>
+          <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">{trace.duration / 1000}ms</span>
         </CardActions>
       </CardHeader>
       <CardBody>
@@ -67,13 +53,17 @@ const TracesListItem: React.FunctionComponent<ITracesListItemProps> = ({
           {trace.spans.length} Spans
         </Badge>
 
-        {Object.keys(services).map((name) => (
-          <Badge key={name} className="pf-u-ml-sm" style={{ backgroundColor: services[name].color }}>
-            {services[name].service} ({services[name].spans})
+        {trace.services.map((service, index) => (
+          <Badge
+            key={index}
+            className="pf-u-ml-sm"
+            style={{ backgroundColor: getColorForService(trace.processes, service.name) }}
+          >
+            {service.name} ({service.numberOfSpans})
           </Badge>
         ))}
 
-        <span style={{ float: 'right' }}>{formatTraceTime(rootSpan.startTime)}</span>
+        <span style={{ float: 'right' }}>{formatTraceTime(trace.startTime)}</span>
       </CardBody>
     </Card>
   );

--- a/plugins/jaeger/src/components/panel/details/Span.tsx
+++ b/plugins/jaeger/src/components/panel/details/Span.tsx
@@ -2,7 +2,7 @@ import { AccordionContent, AccordionItem, AccordionToggle } from '@patternfly/re
 import React, { useState } from 'react';
 import { ExclamationIcon } from '@patternfly/react-icons';
 
-import { IProcesses, ISpan } from '../../../utils/interfaces';
+import { IProcess, ISpan } from '../../../utils/interfaces';
 import SpanLogs from './SpanLogs';
 import SpanTag from './SpanTag';
 import { doesSpanContainsError } from '../../../utils/helpers';
@@ -12,12 +12,16 @@ const PADDING = 24;
 export interface ISpanProps {
   name: string;
   span: ISpan;
-  processes: IProcesses;
-  level: number;
+  duration: number;
+  startTime: number;
+  processes: Record<string, IProcess>;
 }
 
-const Span: React.FunctionComponent<ISpanProps> = ({ name, span, processes, level }: ISpanProps) => {
+const Span: React.FunctionComponent<ISpanProps> = ({ name, span, duration, startTime, processes }: ISpanProps) => {
   const [expanded, setExpanded] = useState<boolean>(false);
+
+  const offset = ((span.startTime - startTime) / 1000 / (duration / 1000)) * 100;
+  const fill = (span.duration / 1000 / (duration / 1000)) * 100;
 
   const time = (
     <span
@@ -35,16 +39,16 @@ const Span: React.FunctionComponent<ISpanProps> = ({ name, span, processes, leve
             ? processes[span.processID].color
             : 'var(--pf-global--primary-color--100)',
           height: '5px',
-          left: `${span.offset}%`,
+          left: `${offset}%`,
           position: 'absolute',
-          width: `${span.fill}%`,
+          width: `${fill}%`,
         }}
       ></span>
     </span>
   );
 
   const treeOffset = [];
-  for (let index = 0; index < level; index++) {
+  for (let index = 0; index < span.depth + 1; index++) {
     if (index > 0) {
       treeOffset.push(
         <span
@@ -62,70 +66,74 @@ const Span: React.FunctionComponent<ISpanProps> = ({ name, span, processes, leve
   }
 
   return (
-    <React.Fragment>
-      <AccordionItem>
-        {treeOffset}
-        <AccordionToggle
-          id={`span-${span.spanID}`}
-          className="kobsio-jaeger-accordion-toggle"
-          style={{ paddingLeft: `${level * PADDING}px` }}
-          onClick={(): void => setExpanded(!expanded)}
-          isExpanded={expanded}
-        >
-          <span>
-            {processes[span.processID].serviceName}: {span.operationName}
-          </span>
-          <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">
-            {span.spanID}
-            {doesSpanContainsError(span) ? (
-              <ExclamationIcon
-                className="pf-u-ml-sm pf-u-font-size-sm"
-                style={{ color: 'var(--pf-global--danger-color--100)' }}
-              />
-            ) : null}
-          </span>
-          <span className="pf-u-font-size-sm pf-u-color-400" style={{ float: 'right' }}>
-            {span.duration / 1000}ms
-          </span>
-          {!expanded && span.fill !== undefined && span.offset !== undefined ? time : null}
-        </AccordionToggle>
+    <AccordionItem>
+      {treeOffset}
+      <AccordionToggle
+        id={`span-${span.spanID}`}
+        className="kobsio-jaeger-accordion-toggle"
+        style={{ paddingLeft: `${(span.depth + 1) * PADDING}px` }}
+        onClick={(): void => setExpanded(!expanded)}
+        isExpanded={expanded}
+      >
+        <span>
+          {processes[span.processID].serviceName}: {span.operationName}
+        </span>
+        <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">
+          {span.spanID}
+          {doesSpanContainsError(span) ? (
+            <ExclamationIcon
+              className="pf-u-ml-sm pf-u-font-size-sm"
+              style={{ color: 'var(--pf-global--danger-color--100)' }}
+            />
+          ) : null}
+        </span>
+        <span className="pf-u-font-size-sm pf-u-color-400" style={{ float: 'right' }}>
+          {span.duration / 1000}ms
+        </span>
+        {!expanded && fill !== undefined && offset !== undefined ? time : null}
+      </AccordionToggle>
 
-        <AccordionContent id={`span-${span.spanID}`} isHidden={!expanded} isFixed={false}>
-          <div style={{ paddingLeft: `${level * PADDING - 16}px` }}>
-            {processes[span.processID].tags.length > 0 ? (
-              <div className="pf-u-pb-md">
-                Process:
-                {processes[span.processID].tags.map((tag, index) => (
-                  <SpanTag key={index} tag={tag} />
-                ))}
-              </div>
-            ) : null}
-            {span.tags.length > 0 ? (
-              <div className="pf-u-pb-md">
-                Tags:
-                {span.tags.map((tag, index) => (
-                  <SpanTag key={index} tag={tag} />
-                ))}
-              </div>
-            ) : null}
-            {span.logs.length > 0 ? (
-              <div className="pf-u-pb-md">
-                Logs:
-                <SpanLogs logs={span.logs} />
-              </div>
-            ) : null}
-          </div>
+      <AccordionContent id={`span-${span.spanID}`} isHidden={!expanded} isFixed={false}>
+        <div style={{ paddingLeft: `${(span.depth + 1) * PADDING - 16}px` }}>
+          {processes[span.processID].tags.length > 0 ? (
+            <div className="pf-u-pb-md">
+              Process:
+              {processes[span.processID].tags.map((tag, index) => (
+                <SpanTag key={index} tag={tag} />
+              ))}
+            </div>
+          ) : null}
+          {span.tags.length > 0 ? (
+            <div className="pf-u-pb-md">
+              Tags:
+              {span.tags.map((tag, index) => (
+                <SpanTag key={index} tag={tag} />
+              ))}
+            </div>
+          ) : null}
+          {span.logs.length > 0 ? (
+            <div className="pf-u-pb-md">
+              Logs:
+              <SpanLogs logs={span.logs} />
+            </div>
+          ) : null}
+          {span.warnings.length > 0 ? (
+            <div className="pf-u-pb-md">
+              Warnings:
+              {span.warnings.map((warning, index) => (
+                <div key={index} className="pf-c-chip pf-u-ml-sm pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+                  <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+                    {warning}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </div>
 
-          {expanded && span.fill !== undefined && span.offset !== undefined ? time : null}
-        </AccordionContent>
-      </AccordionItem>
-
-      {span.childs
-        ? span.childs.map((span, index) => (
-            <Span key={index} name={name} span={span} processes={processes} level={level + 1} />
-          ))
-        : null}
-    </React.Fragment>
+        {expanded && fill !== undefined && offset !== undefined ? time : null}
+      </AccordionContent>
+    </AccordionItem>
   );
 };
 

--- a/plugins/jaeger/src/components/panel/details/SpanTag.tsx
+++ b/plugins/jaeger/src/components/panel/details/SpanTag.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import { Tooltip } from '@patternfly/react-core';
 
-import { IKeyValue } from '../../../utils/interfaces';
+import { IKeyValuePair } from '../../../utils/interfaces';
 
 interface ISpanTagProps {
-  tag: IKeyValue;
+  tag: IKeyValuePair;
 }
 
 const SpanTag: React.FunctionComponent<ISpanTagProps> = ({ tag }: ISpanTagProps) => {

--- a/plugins/jaeger/src/components/panel/details/Spans.tsx
+++ b/plugins/jaeger/src/components/panel/details/Spans.tsx
@@ -1,8 +1,8 @@
 import { Accordion, Card, CardBody } from '@patternfly/react-core';
 import React from 'react';
+import { Virtuoso } from 'react-virtuoso';
 
-import { ISpan, ITrace } from '../../../utils/interfaces';
-import { createSpansTree, getDuration, getRootSpan } from '../../../utils/helpers';
+import { ITrace } from '../../../utils/interfaces';
 import Span from './Span';
 import SpansChart from './SpansChart';
 
@@ -12,38 +12,50 @@ export interface ISpansProps {
 }
 
 const Spans: React.FunctionComponent<ISpansProps> = ({ name, trace }: ISpansProps) => {
-  const rootSpan = trace.spans.length > 0 ? getRootSpan(trace.spans) : undefined;
-  if (!rootSpan) {
-    return null;
-  }
-
-  const duration = getDuration(trace.spans);
-  const spans: ISpan[] = createSpansTree(trace.spans, rootSpan.startTime, duration);
-
   return (
     <React.Fragment>
-      <Card>
-        <CardBody>
-          <div style={{ height: `${trace.spans.length > 20 ? 100 : trace.spans.length * 5}px`, position: 'relative' }}>
-            {spans.map((span, index) => (
-              <SpansChart
-                key={index}
-                span={span}
-                processes={trace.processes}
-                height={trace.spans.length > 20 ? 100 / trace.spans.length : 5}
-              />
-            ))}
-          </div>
-        </CardBody>
-      </Card>
+      {trace.spans.length <= 100 && (
+        <div>
+          <Card>
+            <CardBody>
+              <div
+                style={{ height: `${trace.spans.length > 20 ? 100 : trace.spans.length * 5}px`, position: 'relative' }}
+              >
+                {trace.spans.map((span, index) => (
+                  <SpansChart
+                    key={index}
+                    span={span}
+                    duration={trace.duration}
+                    startTime={trace.startTime}
+                    processes={trace.processes}
+                    height={trace.spans.length > 20 ? 100 / trace.spans.length : 5}
+                  />
+                ))}
+              </div>
+            </CardBody>
+          </Card>
 
-      <p>&nbsp;</p>
+          <p>&nbsp;</p>
+        </div>
+      )}
 
       <Card>
         <Accordion asDefinitionList={false}>
-          {spans.map((span, index) => (
-            <Span key={index} name={name} span={span} processes={trace.processes} level={1} />
-          ))}
+          <div style={{ height: 'calc(100vh - 76px - 154px - 84px - 72px)' }}>
+            <Virtuoso
+              useWindowScroll={false}
+              data={trace.spans}
+              itemContent={(index, span): React.ReactNode => (
+                <Span
+                  name={name}
+                  span={span}
+                  duration={trace.duration}
+                  startTime={trace.startTime}
+                  processes={trace.processes}
+                />
+              )}
+            />
+          </div>
         </Accordion>
       </Card>
     </React.Fragment>

--- a/plugins/jaeger/src/components/panel/details/SpansChart.tsx
+++ b/plugins/jaeger/src/components/panel/details/SpansChart.tsx
@@ -1,21 +1,28 @@
 import React from 'react';
 
-import { IProcesses, ISpan } from '../../../utils/interfaces';
+import { IProcess, ISpan } from '../../../utils/interfaces';
 
-export interface IJaegerSpansChartProps {
+export interface ISpansChartProps {
   span: ISpan;
-  processes: IProcesses;
+  duration: number;
+  startTime: number;
+  processes: Record<string, IProcess>;
   height: number;
 }
 
-// JaegerSpansChart is a single line in the chart to visualize the spans over time. The component requires a span, all
+// SpansChart is a single line in the chart to visualize the spans over time. The component requires a span, all
 // processes to set the correct color for the line and a height for the line. The height is calculated by the container
 // height divided by the number of spans.
-const JaegerSpansChart: React.FunctionComponent<IJaegerSpansChartProps> = ({
+const SpansChart: React.FunctionComponent<ISpansChartProps> = ({
   span,
+  duration,
+  startTime,
   processes,
   height,
-}: IJaegerSpansChartProps) => {
+}: ISpansChartProps) => {
+  const offset = ((span.startTime - startTime) / 1000 / (duration / 1000)) * 100;
+  const fill = (span.duration / 1000 / (duration / 1000)) * 100;
+
   return (
     <React.Fragment>
       <div style={{ height: `${height}px`, position: 'relative' }}>
@@ -34,21 +41,15 @@ const JaegerSpansChart: React.FunctionComponent<IJaegerSpansChartProps> = ({
                 ? processes[span.processID].color
                 : 'var(--pf-global--primary-color--100)',
               height: `${height}px`,
-              left: `${span.offset}%`,
+              left: `${offset}%`,
               position: 'absolute',
-              width: `${span.fill}%`,
+              width: `${fill}%`,
             }}
           ></span>
         </span>
       </div>
-
-      {span.childs
-        ? span.childs.map((span, index) => (
-            <JaegerSpansChart key={index} span={span} processes={processes} height={height} />
-          ))
-        : null}
     </React.Fragment>
   );
 };
 
-export default JaegerSpansChart;
+export default SpansChart;

--- a/plugins/jaeger/src/components/panel/details/Trace.tsx
+++ b/plugins/jaeger/src/components/panel/details/Trace.tsx
@@ -12,7 +12,6 @@ import Spans from './Spans';
 import { Title } from '@kobsio/plugin-core';
 import TraceActions from './TraceActions';
 import TraceHeader from './TraceHeader';
-import { getRootSpan } from '../../../utils/helpers';
 
 export interface ITraceProps {
   name: string;
@@ -21,18 +20,10 @@ export interface ITraceProps {
 }
 
 const Trace: React.FunctionComponent<ITraceProps> = ({ name, trace, close }: ITraceProps) => {
-  const rootSpan = getRootSpan(trace.spans);
-  if (!rootSpan) {
-    return null;
-  }
-
-  const rootSpanProcess = trace.processes[rootSpan.processID];
-  const rootSpanService = rootSpanProcess.serviceName;
-
   return (
     <DrawerPanelContent minSize="50%">
       <DrawerHead>
-        <Title title={`${rootSpanService}: ${rootSpan.operationName}`} subtitle={trace.traceID} size="lg" />
+        <Title title={trace.traceName} subtitle={trace.traceID} size="lg" />
         <DrawerActions style={{ padding: 0 }}>
           <TraceActions name={name} trace={trace} />
           <DrawerCloseButton onClose={close} />
@@ -40,7 +31,7 @@ const Trace: React.FunctionComponent<ITraceProps> = ({ name, trace, close }: ITr
       </DrawerHead>
 
       <DrawerPanelBody>
-        <TraceHeader trace={trace} rootSpan={rootSpan} />
+        <TraceHeader trace={trace} />
         <p>&nbsp;</p>
         <Spans name={name} trace={trace} />
         <p>&nbsp;</p>

--- a/plugins/jaeger/src/components/panel/details/TraceHeader.tsx
+++ b/plugins/jaeger/src/components/panel/details/TraceHeader.tsx
@@ -1,29 +1,26 @@
 import React from 'react';
 
-import { ISpan, ITrace } from '../../../utils/interfaces';
-import { formatTraceTime, getDuration, getSpansPerServices } from '../../../utils/helpers';
+import { ITrace } from '../../../utils/interfaces';
+import { formatTraceTime } from '../../../utils/helpers';
 
 export interface ITraceHeaderProps {
   trace: ITrace;
-  rootSpan: ISpan;
 }
 
-const TraceHeader: React.FunctionComponent<ITraceHeaderProps> = ({ trace, rootSpan }: ITraceHeaderProps) => {
-  const services = getSpansPerServices(trace);
-
+const TraceHeader: React.FunctionComponent<ITraceHeaderProps> = ({ trace }: ITraceHeaderProps) => {
   return (
     <React.Fragment>
       <span>
         <span className="pf-u-color-400">Trace Start: </span>
-        <b className="pf-u-pr-md">{formatTraceTime(rootSpan.startTime)}</b>
+        <b className="pf-u-pr-md">{formatTraceTime(trace.startTime)}</b>
       </span>
       <span>
         <span className="pf-u-color-400">Duration: </span>
-        <b className="pf-u-pr-md">{getDuration(trace.spans)}ms</b>
+        <b className="pf-u-pr-md">{trace.duration / 1000}ms</b>
       </span>
       <span>
         <span className="pf-u-color-400">Services: </span>
-        <b className="pf-u-pr-md">{Object.keys(services).length}</b>
+        <b className="pf-u-pr-md">{trace.services.length}</b>
       </span>
       <span>
         <span className="pf-u-color-400">Total Spans: </span>

--- a/plugins/jaeger/src/utils/TreeNode.js
+++ b/plugins/jaeger/src/utils/TreeNode.js
@@ -1,0 +1,120 @@
+// TreeNode is necessary to sort the spans, so children follow parents, and siblings are sorted by start time.
+// See: https://github.com/jaegertracing/jaeger-ui/blob/master/packages/jaeger-ui/src/utils/TreeNode.js
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export default class TreeNode {
+  static iterFunction(fn, depth = 0) {
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    return (node) => fn(node.value, node, depth);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  static searchFunction(search) {
+    if (typeof search === 'function') {
+      return search;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    return (value, node) => (search instanceof TreeNode ? node === search : value === search);
+  }
+
+  constructor(value, children = []) {
+    this.value = value;
+    this.children = children;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  get depth() {
+    return this.children.reduce((depth, child) => Math.max(child.depth + 1, depth), 1);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  get size() {
+    let i = 0;
+    this.walk(() => i++);
+    return i;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  addChild(child) {
+    this.children.push(child instanceof TreeNode ? child : new TreeNode(child));
+    return this;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  find(search) {
+    const searchFn = TreeNode.iterFunction(TreeNode.searchFunction(search));
+    if (searchFn(this)) {
+      return this;
+    }
+    for (let i = 0; i < this.children.length; i++) {
+      const result = this.children[i].find(search);
+      if (result) {
+        return result;
+      }
+    }
+    return null;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  getPath(search) {
+    const searchFn = TreeNode.iterFunction(TreeNode.searchFunction(search));
+
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    const findPath = (currentNode, currentPath) => {
+      // skip if we already found the result
+      const attempt = currentPath.concat([currentNode]);
+      // base case: return the array when there is a match
+      if (searchFn(currentNode)) {
+        return attempt;
+      }
+      for (let i = 0; i < currentNode.children.length; i++) {
+        const child = currentNode.children[i];
+        const match = findPath(child, attempt);
+        if (match) {
+          return match;
+        }
+      }
+      return null;
+    };
+
+    return findPath(this, []);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  walk(fn, depth = 0) {
+    const nodeStack = [];
+    let actualDepth = depth;
+    nodeStack.push({ depth: actualDepth, node: this });
+    while (nodeStack.length) {
+      const { node, depth: nodeDepth } = nodeStack.pop();
+      fn(node.value, node, nodeDepth);
+      actualDepth = nodeDepth + 1;
+      let i = node.children.length - 1;
+      while (i >= 0) {
+        nodeStack.push({ depth: actualDepth, node: node.children[i] });
+        i--;
+      }
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  paths(fn) {
+    const stack = [];
+    stack.push({ childIndex: 0, node: this });
+    const paths = [];
+    while (stack.length) {
+      const { node, childIndex } = stack[stack.length - 1];
+      if (node.children.length >= childIndex + 1) {
+        stack[stack.length - 1].childIndex++;
+        stack.push({ childIndex: 0, node: node.children[childIndex] });
+      } else {
+        if (node.children.length === 0) {
+          const path = stack.map((item) => item.node.value);
+          fn(path);
+        }
+        stack.pop();
+      }
+    }
+    return paths;
+  }
+}

--- a/plugins/jaeger/src/utils/colors.ts
+++ b/plugins/jaeger/src/utils/colors.ts
@@ -24,6 +24,8 @@ import chart_color_orange_300 from '@patternfly/react-tokens/dist/js/chart_color
 import chart_color_orange_400 from '@patternfly/react-tokens/dist/js/chart_color_orange_400';
 import chart_color_orange_500 from '@patternfly/react-tokens/dist/js/chart_color_orange_500';
 
+import { IProcess, IProcessColors, ITrace } from './interfaces';
+
 // We are using the multi color ordered theme from Patternfly for the charts.
 // See: https://github.com/patternfly/patternfly-react/blob/main/packages/react-charts/src/components/ChartTheme/themes/light/multi-color-ordered-theme.ts
 export const COLOR_SCALE = [
@@ -58,4 +60,39 @@ export const COLOR_SCALE = [
 // we can split the legend and chart into separate components.
 export const getColor = (index: number): string => {
   return COLOR_SCALE[index % COLOR_SCALE.length];
+};
+
+// addColorForProcesses add a color to each process in all the given traces. If a former trace already uses a process,
+// with the same service name we reuse the former color.
+export const addColorForProcesses = (traces: ITrace[]): ITrace[] => {
+  const usedColors: IProcessColors = {};
+
+  for (let i = 0; i < traces.length; i++) {
+    const processes = Object.keys(traces[i].processes);
+
+    for (let j = 0; j < processes.length; j++) {
+      const process = processes[j];
+
+      if (usedColors.hasOwnProperty(traces[i].processes[process].serviceName)) {
+        traces[i].processes[process].color = usedColors[traces[i].processes[process].serviceName];
+      } else {
+        const color = getColor(j);
+        usedColors[traces[i].processes[process].serviceName] = color;
+        traces[i].processes[process].color = color;
+      }
+    }
+  }
+
+  return traces;
+};
+
+// getColorForService returns the correct color for a given service from the processes.
+export const getColorForService = (processes: Record<string, IProcess>, serviceName: string): string => {
+  for (const process in processes) {
+    if (processes[process].serviceName === serviceName) {
+      return processes[process].color || chart_color_blue_300.value;
+    }
+  }
+
+  return chart_color_blue_300.value;
 };

--- a/plugins/jaeger/src/utils/interfaces.ts
+++ b/plugins/jaeger/src/utils/interfaces.ts
@@ -29,52 +29,86 @@ export interface IOperation {
   spanKind: string;
 }
 
-// ITrace is the interface for a single trace as it is returned from the API.
-export interface ITrace {
-  traceID: string;
-  spans: ISpan[];
-  processes: IProcesses;
+// The following interfaces are used to represent a trace like it returned from the API.
+// See: https://github.com/jaegertracing/jaeger-ui/blob/master/packages/jaeger-ui/src/types/trace.tsx
+export interface IKeyValuePair {
+  key: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  value: any;
 }
 
-export interface IKeyValue {
-  key: string;
-  type: string;
-  value: string | boolean | number;
+export interface ILink {
+  url: string;
+  text: string;
 }
 
 export interface ILog {
   timestamp: number;
-  fields: IKeyValue[];
+  fields: IKeyValuePair[];
 }
 
 export interface IProcess {
   serviceName: string;
-  tags: IKeyValue[];
+  tags: IKeyValuePair[];
+  // color is a custom field, which we add after the all traces are loaded from the API. It is used to simplify the
+  // coloring and to have a consistent color accross all traces.
   color?: string;
 }
 
-export interface IProcesses {
-  [key: string]: IProcess;
-}
-
-export interface IReference {
-  refType: string;
+export interface ISpanReference {
+  refType: 'CHILD_OF' | 'FOLLOWS_FROM';
+  // eslint-disable-next-line no-use-before-define
+  span: ISpan | null | undefined;
   spanID: string;
   traceID: string;
 }
 
-export interface ISpan {
-  traceID: string;
+export interface ISpanData {
   spanID: string;
-  flags: number;
+  traceID: string;
+  processID: string;
   operationName: string;
-  references: IReference[];
   startTime: number;
   duration: number;
-  tags: IKeyValue[];
   logs: ILog[];
-  processID: string;
-  offset?: number;
-  fill?: number;
-  childs?: ISpan[];
+  tags?: IKeyValuePair[];
+  references?: ISpanReference[];
+  warnings?: string[] | null;
+}
+
+export interface ISpan extends ISpanData {
+  depth: number;
+  hasChildren: boolean;
+  process: IProcess;
+  relativeStartTime: number;
+  tags: NonNullable<ISpanData['tags']>;
+  references: NonNullable<ISpanData['references']>;
+  warnings: NonNullable<ISpanData['warnings']>;
+  subsidiarilyReferencedBy: ISpanReference[];
+}
+
+export interface ITraceData {
+  processes: Record<string, IProcess>;
+  traceID: string;
+}
+
+export interface ITrace extends ITraceData {
+  duration: number;
+  endTime: number;
+  spans: ISpan[];
+  startTime: number;
+  traceName: string;
+  services: { name: string; numberOfSpans: number }[];
+}
+
+// IProcessColors is the interface we use to store a map of process and colors, so that we can reuse the color for
+// processes with the same service name.
+export interface IProcessColors {
+  [key: string]: string;
+}
+
+// IDeduplicateTags is the interface, which is returned by the deduplicateTags function.
+export interface IDeduplicateTags {
+  tags: IKeyValuePair[];
+  warnings: string[];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3272,6 +3272,18 @@
     "@typescript-eslint/types" "4.29.1"
     eslint-visitor-keys "^2.0.0"
 
+"@virtuoso.dev/react-urx@^0.2.5":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@virtuoso.dev/react-urx/-/react-urx-0.2.6.tgz#e1d8bc717723b2fc23d80ea4e07703dbc276448b"
+  integrity sha512-+PLQ2iWmSH/rW7WGPEf+Kkql+xygHFL43Jij5aREde/O9mE0OFFGqeetA2a6lry3LDVWzupPntvvWhdaYw0TyA==
+  dependencies:
+    "@virtuoso.dev/urx" "^0.2.6"
+
+"@virtuoso.dev/urx@^0.2.5", "@virtuoso.dev/urx@^0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@virtuoso.dev/urx/-/urx-0.2.6.tgz#0028c49e52037e673993900d32abea83262fbd53"
+  integrity sha512-EKJ0WvJgWaXIz6zKbh9Q63Bcq//p8OHXHbdz4Fy+ruhjJCyI8ADE8E5gwSqBoUchaiYlgwKrT+sX4L2h/H+hMg==
+
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
@@ -12393,6 +12405,15 @@ react-scripts@4.0.3:
     workbox-webpack-plugin "5.1.4"
   optionalDependencies:
     fsevents "^2.1.3"
+
+react-virtuoso@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-1.11.1.tgz#350dc88866b3f42cb396bf8f40b90efc6daaadde"
+  integrity sha512-NH8eLLmoowdq0x7/AEfXxOY9OY4PDpLuPPmCc8F2IoBQLvIcMait3A2TnR0fT9UT+gl8n7GHoORzeGqF5Ka0MA==
+  dependencies:
+    "@virtuoso.dev/react-urx" "^0.2.5"
+    "@virtuoso.dev/urx" "^0.2.5"
+    resize-observer-polyfill "^1.5.1"
 
 react@^17.0.2:
   version "17.0.2"


### PR DESCRIPTION
We had the problem, that in some cases the UI of the Jaeger plugin was
broken, when the trace wasn't as expected. To handle all these special
cases we decided to use some functions from the jaegertracing/jaeger-ui
repository, because the know what they do. Now all cases which can be
handled by the Jaeger UI should also work within kobs.

We also improved they way how we are rendering the list of spans for a
trace. in former versions of kobs, the UI crashed when a trace contained
to much spans. Now we are using react-virtuoso to render these large
lists of spans, which improves the performance quite a lot. We tested
this with a trace with 13500 spans. The current solution for rendering
the spans isn't perfect, because we had to set a fixed sice for the
container. In the future we want to use "useWindowScroll" property of
the package, but at the moment we are seeing a bug with react-virtuoso
as it is also described in the react-virtualized project (#1671).

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
