### PR TITLE
Fix time in log buckets of the ClickHouse plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#123](https://github.com/kobsio/kobs/pull/123): Fix fields handling in ClickHouse and Elasticsearch plugin.
 - [#125](https://github.com/kobsio/kobs/pull/125): Fix missing `return` statement in ClickHouse panel.
 - [#129](https://github.com/kobsio/kobs/pull/129): Fix handling of traces in the Jaeger plugin by using some function from the [jaegertracing/jaeger-ui](https://github.com/jaegertracing/jaeger-ui).
+- [#134](https://github.com/kobsio/kobs/pull/134): Fix time in log buckets of the ClickHouse plugin.
 
 ### Changed
 

--- a/plugins/clickhouse/pkg/instance/structs.go
+++ b/plugins/clickhouse/pkg/instance/structs.go
@@ -33,7 +33,7 @@ type Row struct {
 // Bucket is the struct which is used to represent the distribution of the returned rows for a logs query for the given
 // time range.
 type Bucket struct {
-	Interval          time.Time `json:"-"`
-	IntervalFormatted string    `json:"interval"`
-	Count             int64     `json:"count"`
+	Interval          int64  `json:"interval"`
+	IntervalFormatted string `json:"intervalFormatted"`
+	Count             int64  `json:"count"`
 }

--- a/plugins/clickhouse/src/components/panel/LogsChart.tsx
+++ b/plugins/clickhouse/src/components/panel/LogsChart.tsx
@@ -14,12 +14,24 @@ const LogsChart: React.FunctionComponent<ILogsChartProps> = ({ buckets }: ILogsC
     return <div style={{ height: '250px' }}></div>;
   }
 
+  const data: IBucket[] = buckets.map((bucket) => {
+    const d = new Date(bucket.interval * 1000);
+
+    return {
+      count: bucket.count,
+      interval: bucket.interval,
+      intervalFormatted: `${('0' + (d.getMonth() + 1)).slice(-2)}-${('0' + d.getDate()).slice(-2)} ${(
+        '0' + d.getHours()
+      ).slice(-2)}:${('0' + d.getMinutes()).slice(-2)}:${('0' + d.getSeconds()).slice(-2)}`,
+    };
+  });
+
   return (
     <div style={{ height: '250px' }}>
       <ResponsiveBarCanvas
         axisBottom={{
           legend: '',
-          tickValues: buckets.filter((bucket, index) => index % 2 === 0).map((bucket) => bucket.interval),
+          tickValues: data.filter((bucket, index) => index % 2 === 0).map((bucket) => bucket.intervalFormatted),
         }}
         axisLeft={{
           format: '>-.0s',
@@ -32,12 +44,12 @@ const LogsChart: React.FunctionComponent<ILogsChartProps> = ({ buckets }: ILogsC
         borderWidth={0}
         colorBy="id"
         colors={['#0066cc']}
-        data={buckets}
+        data={data}
         enableLabel={false}
         enableGridX={false}
         enableGridY={true}
         groupMode="stacked"
-        indexBy="interval"
+        indexBy="intervalFormatted"
         indexScale={{ round: true, type: 'band' }}
         isInteractive={true}
         keys={['count']}
@@ -54,7 +66,7 @@ const LogsChart: React.FunctionComponent<ILogsChartProps> = ({ buckets }: ILogsC
         }}
         // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
         tooltip={(tooltip) => {
-          const isFirstHalf = tooltip.index < buckets.length / 2;
+          const isFirstHalf = tooltip.index < data.length / 2;
 
           return (
             <TooltipWrapper anchor={isFirstHalf ? 'right' : 'left'} position={[0, 20]}>
@@ -68,7 +80,7 @@ const LogsChart: React.FunctionComponent<ILogsChartProps> = ({ buckets }: ILogsC
                 }}
               >
                 <div>
-                  <b>{tooltip.data.interval}</b>
+                  <b>{tooltip.data.intervalFormatted}</b>
                 </div>
                 <div>
                   <SquareIcon color="#0066cc" /> Documents: {tooltip.data.count}

--- a/plugins/clickhouse/src/utils/interfaces.ts
+++ b/plugins/clickhouse/src/utils/interfaces.ts
@@ -39,7 +39,8 @@ export interface IDocument {
 }
 
 export interface IBucket extends BarDatum {
-  interval: string;
+  interval: number;
+  intervalFormatted: string;
   count: number;
 }
 


### PR DESCRIPTION
The time of the log buckets in the ClickHouse plugin was wrong. The time
in the bar chart was always shown as UTC and not in the users timezon.
This is fixed now by formating the time in the React UI instead of the
Go API.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
