### PR TITLE
Fix read and write i/o timeouts for web terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#125](https://github.com/kobsio/kobs/pull/125): Fix missing `return` statement in ClickHouse panel.
 - [#129](https://github.com/kobsio/kobs/pull/129): Fix handling of traces in the Jaeger plugin by using some function from the [jaegertracing/jaeger-ui](https://github.com/jaegertracing/jaeger-ui).
 - [#134](https://github.com/kobsio/kobs/pull/134): Fix time in log buckets of the ClickHouse plugin.
+- [#135](https://github.com/kobsio/kobs/pull/135): Fix read and write i/o timeouts for web terminal.
 
 ### Changed
 

--- a/plugins/resources/resources.go
+++ b/plugins/resources/resources.go
@@ -24,14 +24,8 @@ import (
 const Route = "/resources"
 
 var (
-	log = logrus.WithFields(logrus.Fields{"package": "resources"})
-
-	// Time allowed to write a message to the peer.
-	writeWait = 10 * time.Second
-	// Time allowed to read the next pong message from the peer.
-	pongWait = 30 * time.Second
-	// Send pings to peer with this period. Must be less than pongWait.
-	pingPeriod = (pongWait * 9) / 10
+	log        = logrus.WithFields(logrus.Fields{"package": "resources"})
+	pingPeriod = 30 * time.Second
 )
 
 // Resources is the structure for the getResources api call. It contains the cluster, namespace and the json
@@ -349,8 +343,7 @@ func (router *Router) getTerminal(w http.ResponseWriter, r *http.Request) {
 	}
 	defer c.Close()
 
-	c.SetReadDeadline(time.Now().Add(pongWait))
-	c.SetPongHandler(func(string) error { c.SetReadDeadline(time.Now().Add(pongWait)); return nil })
+	c.SetPongHandler(func(string) error { return nil })
 
 	go func() {
 		ticker := time.NewTicker(pingPeriod)
@@ -359,7 +352,6 @@ func (router *Router) getTerminal(w http.ResponseWriter, r *http.Request) {
 		for {
 			select {
 			case <-ticker.C:
-				c.SetWriteDeadline(time.Now().Add(writeWait))
 				if err := c.WriteMessage(websocket.PingMessage, nil); err != nil {
 					return
 				}


### PR DESCRIPTION
This commit fixes the read and write i/o timeouts for the web terminal.
The timeouts occured because of the introduced ping/pong mechanism. We
keep the ping/pong but we are removeing the timeouts which are set
there.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
