### PR TITLE
Allow custom order for returned logs in ClickHouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#128](https://github.com/kobsio/kobs/pull/128): Allow users to specify dashboards within a Team or Application via the new `inline` property.
 - [#131](https://github.com/kobsio/kobs/pull/131): Add chart which shows the distribution of the logs lines in the selected time range for the ClickHouse plugin.
 - [#132](https://github.com/kobsio/kobs/pull/132): Support the download of log lines in their JSON representation in the ClickHouse and Elasticsearch plugin.
+- [#136](https://github.com/kobsio/kobs/pull/136): Allow custom order for the returned logs and add `!~` and `_exists_` operator for ClickHouse plugin.
 
 ### Fixed
 

--- a/docs/plugins/clickhouse.md
+++ b/docs/plugins/clickhouse.md
@@ -26,6 +26,8 @@ The following options can be used for a panel with the ClickHouse plugin:
 | name | string | A name for the ClickHouse query, which is displayed in the select box. | Yes |
 | query | string | The query which should be run against ClickHouse. See [Query Syntax](#query-syntax) for more information on the syntax, when ClickHouse is used in the `logs` mode. | Yes |
 | fields | []string | A list of fields to display in the results table. If this field is omitted, the whole document is displayed in the results table. This field is only available for the `logs`. | No |
+| order | string | Order for the returned logs. Must be `ascending` or `descending`. The default value for this field is `descending`. | No |
+| orderBy | string | The name of the field, by which the results should be orderd. The default value for this field is `timestamp`. | No |
 
 ```yaml
 ---
@@ -74,6 +76,7 @@ kobs supports multiple operators which can be used in a query to retrieve logs f
 | `_not_` | Exclude the term from the query. | `cluster='kobs-demo' _and_ _not_ namespace='bookinfo'` |
 | `_and_` | Both terms must be included in the results. | `namespace='bookinfo' _and_ app='bookinfo'` |
 | `_or_` | The result can contain one of the given terms. | `namespace='bookinfo' _or_ namespace='istio-system'` |
+| `_exists_` | The field can not be `null` | `container_name='istio-proxy' _and_ _exists_ content.request_id` |
 | `=` | The field must have this value. | `namespace='bookinfo'` |
 | `!=` | The field should not have this value. | `namespace!='bookinfo'` |
 | `>` | The value of the field must be greater than the specified value. | `content.response_code>499` |
@@ -81,6 +84,7 @@ kobs supports multiple operators which can be used in a query to retrieve logs f
 | `<` | The value of the field must be lower than the specified value. | `content.response_code<500` |
 | `<=` | The value of the field must be lower than or equal to the specified value. | `content.response_code<=499` |
 | `=~` | The value of the field is compared using `ILIKE`. | `content.upstream_cluster=~'inbound%'` |
+| `!~` | The value of the field is compared using `NOT ILIKE`. | `content.upstream_cluster!~'inbound%'` |
 | `~` | The value of the field must match the regular expression. The syntax of the `re2` regular expressions can be found [here](https://github.com/google/re2/wiki/Syntax). | `content.upstream_cluster~'inbound.*'` |
 
 ### Default Fields

--- a/plugins/clickhouse/clickhouse.go
+++ b/plugins/clickhouse/clickhouse.go
@@ -84,12 +84,14 @@ func (router *Router) getSQL(w http.ResponseWriter, r *http.Request) {
 func (router *Router) getLogs(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	query := r.URL.Query().Get("query")
+	order := r.URL.Query().Get("order")
+	orderBy := r.URL.Query().Get("orderBy")
 	limit := r.URL.Query().Get("limit")
 	offset := r.URL.Query().Get("offset")
 	timeStart := r.URL.Query().Get("timeStart")
 	timeEnd := r.URL.Query().Get("timeEnd")
 
-	log.WithFields(logrus.Fields{"name": name, "query": query, "limit": limit, "offset": offset, "timeStart": timeStart, "timeEnd": timeEnd}).Tracef("getLogs")
+	log.WithFields(logrus.Fields{"name": name, "query": query, "order": order, "orderBy": orderBy, "limit": limit, "offset": offset, "timeStart": timeStart, "timeEnd": timeEnd}).Tracef("getLogs")
 
 	i := router.getInstance(name)
 	if i == nil {
@@ -124,7 +126,7 @@ func (router *Router) getLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	documents, fields, count, took, buckets, newOffset, newTimeStart, err := i.GetLogs(r.Context(), query, parsedLimit, parsedOffset, parsedTimeStart, parsedTimeEnd)
+	documents, fields, count, took, buckets, newOffset, newTimeStart, err := i.GetLogs(r.Context(), query, order, orderBy, parsedLimit, parsedOffset, parsedTimeStart, parsedTimeEnd)
 	if err != nil {
 		errresponse.Render(w, r, err, http.StatusBadRequest, "Could not get logs")
 		return

--- a/plugins/clickhouse/src/components/page/Logs.tsx
+++ b/plugins/clickhouse/src/components/page/Logs.tsx
@@ -27,6 +27,8 @@ import LogsFields from './LogsFields';
 interface IPageLogsProps {
   name: string;
   fields?: string[];
+  order: string;
+  orderBy: string;
   query: string;
   selectField: (field: string) => void;
   times: IPluginTimes;
@@ -36,6 +38,8 @@ interface IPageLogsProps {
 const PageLogs: React.FunctionComponent<IPageLogsProps> = ({
   name,
   fields,
+  order,
+  orderBy,
   query,
   selectField,
   times,
@@ -44,12 +48,13 @@ const PageLogs: React.FunctionComponent<IPageLogsProps> = ({
   const history = useHistory();
 
   const { isError, isFetching, isLoading, data, error, fetchNextPage, refetch } = useInfiniteQuery<ILogsData, Error>(
-    ['clickhouse/logs', query, times],
+    ['clickhouse/logs', query, order, orderBy, times],
     async ({ pageParam }) => {
       try {
-        console.log(pageParam);
         const response = await fetch(
-          `/api/plugins/clickhouse/logs/${name}?query=${encodeURIComponent(query)}&timeStart=${
+          `/api/plugins/clickhouse/logs/${name}?query=${encodeURIComponent(
+            query,
+          )}&order=${order}&orderBy=${encodeURIComponent(orderBy)}&timeStart=${
             pageParam && pageParam.timeStart ? pageParam.timeStart : times.timeStart
           }&timeEnd=${times.timeEnd}&limit=100&offset=${pageParam && pageParam.offset ? pageParam.offset : ''}`,
           {

--- a/plugins/clickhouse/src/components/page/LogsPage.tsx
+++ b/plugins/clickhouse/src/components/page/LogsPage.tsx
@@ -28,9 +28,9 @@ const LogsPage: React.FunctionComponent<IPluginPageProps> = ({ name, displayName
 
     history.push({
       pathname: location.pathname,
-      search: `?query=${opts.query}&time=${opts.times.time}&timeEnd=${opts.times.timeEnd}&timeStart=${
-        opts.times.timeStart
-      }${fields.length > 0 ? fields.join('') : ''}`,
+      search: `?query=${opts.query}&order=${opts.order}&orderBy=${opts.orderBy}&time=${opts.times.time}&timeEnd=${
+        opts.times.timeEnd
+      }&timeStart=${opts.times.timeStart}${fields.length > 0 ? fields.join('') : ''}`,
     });
   };
 
@@ -64,7 +64,14 @@ const LogsPage: React.FunctionComponent<IPluginPageProps> = ({ name, displayName
           {displayName}
         </Title>
         <p>{description}</p>
-        <LogsToolbar query={options.query} fields={options.fields} times={options.times} setOptions={changeOptions} />
+        <LogsToolbar
+          query={options.query}
+          order={options.order}
+          orderBy={options.orderBy}
+          fields={options.fields}
+          times={options.times}
+          setOptions={changeOptions}
+        />
       </PageSection>
 
       <Drawer isExpanded={selectedDocument !== undefined}>
@@ -76,6 +83,8 @@ const LogsPage: React.FunctionComponent<IPluginPageProps> = ({ name, displayName
                   name={name}
                   fields={options.fields}
                   query={options.query}
+                  order={options.order}
+                  orderBy={options.orderBy}
                   selectField={selectField}
                   times={options.times}
                   showDetails={setSelectedDocument}

--- a/plugins/clickhouse/src/components/page/LogsToolbar.tsx
+++ b/plugins/clickhouse/src/components/page/LogsToolbar.tsx
@@ -20,11 +20,15 @@ interface ILogsToolbarProps extends IOptions {
 
 const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({
   query,
+  order,
+  orderBy,
   fields,
   times,
   setOptions,
 }: ILogsToolbarProps) => {
   const [data, setData] = useState<IOptions>({
+    order: order,
+    orderBy: orderBy,
     query: query,
     times: times,
   });
@@ -53,20 +57,26 @@ const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({
     timeEnd: number,
     timeStart: number,
   ): void => {
-    const tmpData = { ...data };
+    if (additionalFields && additionalFields.length === 2) {
+      const tmpData = { ...data };
 
-    if (refresh) {
-      setOptions({
+      if (refresh) {
+        setOptions({
+          ...tmpData,
+          fields: fields,
+          order: additionalFields[1].value,
+          orderBy: additionalFields[0].value,
+          times: { time: time, timeEnd: timeEnd, timeStart: timeStart },
+        });
+      }
+
+      setData({
         ...tmpData,
-        fields: fields,
+        order: additionalFields[1].value,
+        orderBy: additionalFields[0].value,
         times: { time: time, timeEnd: timeEnd, timeStart: timeStart },
       });
     }
-
-    setData({
-      ...tmpData,
-      times: { time: time, timeEnd: timeEnd, timeStart: timeStart },
-    });
   };
 
   return (
@@ -79,6 +89,22 @@ const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({
             </ToolbarItem>
             <ToolbarItem>
               <Options
+                additionalFields={[
+                  {
+                    label: 'Order By',
+                    name: 'orderBy',
+                    placeholder: '',
+                    value: data.orderBy,
+                  },
+                  {
+                    label: 'Order',
+                    name: 'order',
+                    placeholder: '',
+                    type: 'select',
+                    value: data.order,
+                    values: ['ascending', 'descending'],
+                  },
+                ]}
                 time={data.times.time}
                 timeEnd={data.times.timeEnd}
                 timeStart={data.times.timeStart}

--- a/plugins/clickhouse/src/components/panel/Logs.tsx
+++ b/plugins/clickhouse/src/components/panel/Logs.tsx
@@ -50,9 +50,11 @@ const Logs: React.FunctionComponent<ILogsProps> = ({
         }
 
         const response = await fetch(
-          `/api/plugins/clickhouse/logs/${name}?query=${encodeURIComponent(selectedQuery.query)}&timeStart=${
-            times.timeStart
-          }&timeEnd=${times.timeEnd}&limit=100&offset=${pageParam || ''}`,
+          `/api/plugins/clickhouse/logs/${name}?query=${encodeURIComponent(selectedQuery.query)}&order=${
+            selectedQuery.order || ''
+          }&orderBy=${encodeURIComponent(selectedQuery.orderBy || '')}&timeStart=${times.timeStart}&timeEnd=${
+            times.timeEnd
+          }&limit=100&offset=${pageParam || ''}`,
           {
             method: 'get',
           },

--- a/plugins/clickhouse/src/components/panel/LogsDocument.tsx
+++ b/plugins/clickhouse/src/components/panel/LogsDocument.tsx
@@ -1,4 +1,5 @@
 import { TableText, Td, Tr } from '@patternfly/react-table';
+import { DropdownPosition } from '@patternfly/react-core';
 import React from 'react';
 
 import Details from './details/Details';
@@ -16,16 +17,25 @@ const LogsDocument: React.FunctionComponent<ILogsDocumentProps> = ({
   fields,
   showDetails,
 }: ILogsDocumentProps) => {
-  return (
-    <Tr
-      onClick={(): void =>
+  const defaultActions = [
+    {
+      onClick: (): void =>
         showDetails
           ? showDetails(<Details document={document} close={(): void => showDetails(undefined)} />)
-          : undefined
-      }
-    >
+          : undefined,
+      title: 'Details',
+    },
+  ];
+
+  return (
+    <Tr>
+      <Td
+        noPadding={true}
+        style={{ padding: 0 }}
+        actions={{ dropdownPosition: DropdownPosition.left, items: defaultActions }}
+      />
       <Td dataLabel="Time">
-        <TableText wrapModifier="nowrap"> {formatTimeWrapper(document['timestamp'])}</TableText>
+        <TableText wrapModifier="nowrap">{formatTimeWrapper(document['timestamp'])}</TableText>
       </Td>
       {fields && fields.length > 0 ? (
         fields.map((field, index) => (

--- a/plugins/clickhouse/src/components/panel/LogsDocuments.tsx
+++ b/plugins/clickhouse/src/components/panel/LogsDocuments.tsx
@@ -19,6 +19,7 @@ const LogsDocuments: React.FunctionComponent<ILogsDocumentsProps> = ({
     <TableComposable aria-label="Logs" variant={TableVariant.compact} borders={false}>
       <Thead>
         <Tr>
+          <Th />
           <Th>Time</Th>
           {fields && fields.length > 0 ? (
             fields.map((selectedField, index) => <Th key={index}>{selectedField}</Th>)

--- a/plugins/clickhouse/src/utils/helpers.ts
+++ b/plugins/clickhouse/src/utils/helpers.ts
@@ -5,6 +5,8 @@ import { IOptions } from './interfaces';
 export const getOptionsFromSearch = (search: string): IOptions => {
   const params = new URLSearchParams(search);
   const fields = params.getAll('field');
+  const order = params.get('order');
+  const orderBy = params.get('orderBy');
   const query = params.get('query');
   const time = params.get('time');
   const timeEnd = params.get('timeEnd');
@@ -12,6 +14,8 @@ export const getOptionsFromSearch = (search: string): IOptions => {
 
   return {
     fields: fields.length > 0 ? fields : undefined,
+    order: order ? order : 'ascending',
+    orderBy: orderBy ? orderBy : '',
     query: query ? query : '',
     times: {
       time: time && TTimeOptions.includes(time) ? (time as TTime) : 'last15Minutes',

--- a/plugins/clickhouse/src/utils/interfaces.ts
+++ b/plugins/clickhouse/src/utils/interfaces.ts
@@ -5,6 +5,8 @@ import { IPluginTimes } from '@kobsio/plugin-core';
 // IOptions is the interface for all options, which can be set for an ClickHouse query.
 export interface IOptions {
   fields?: string[];
+  order: string;
+  orderBy: string;
   query: string;
   times: IPluginTimes;
 }
@@ -20,6 +22,8 @@ export interface IQuery {
   name?: string;
   query?: string;
   fields?: string[];
+  order?: string;
+  orderBy?: string;
 }
 
 // ILogsData is the interface of the data returned from our Go API for the logs view of the ClickHouse plugin.

--- a/plugins/core/src/components/misc/Options.tsx
+++ b/plugins/core/src/components/misc/Options.tsx
@@ -3,6 +3,8 @@ import {
   ButtonVariant,
   Form,
   FormGroup,
+  FormSelect,
+  FormSelectOption,
   Level,
   LevelItem,
   Modal,
@@ -16,6 +18,8 @@ import { RedoIcon } from '@patternfly/react-icons';
 
 import { formatTime } from '../../utils/time';
 
+export type TOptionsAdditionalFields = 'text' | 'select';
+
 // IOptionsAdditionalFields is the interface for an additional field which should be shown in the options modal. This
 // allows the usage of the component within a plugin (e.g. the Prometheus plugin can use the Options component to allow
 // a user to select the time range and additional he can also select the resolution). Each field must define a label,
@@ -25,6 +29,8 @@ export interface IOptionsAdditionalFields {
   name: string;
   placeholder: string;
   value: string;
+  values?: string[];
+  type?: TOptionsAdditionalFields;
 }
 
 // TTime is the type with all possible values for the time property. A value of "custom" identifies that a user
@@ -326,18 +332,34 @@ export const Options: React.FunctionComponent<IOptionsProps> = ({
           {internalAdditionalFields && internalAdditionalFields.length > 0 ? (
             <LevelItem style={{ paddingBottom: '16px' }}>
               <Form>
-                {internalAdditionalFields.map((field, index) => (
-                  <FormGroup key={index} label={field.label} isRequired={false} fieldId={field.name}>
-                    <TextInput
-                      type="text"
-                      id={field.name}
-                      name={field.name}
-                      placeholder={field.placeholder}
-                      value={field.value}
-                      onChange={(value): void => changeAdditionalField(index, value)}
-                    />
-                  </FormGroup>
-                ))}
+                {internalAdditionalFields.map((field, index) =>
+                  field.type === 'select' ? (
+                    <FormGroup key={index} label={field.label} isRequired={false} fieldId={field.name}>
+                      <FormSelect
+                        value={field.value}
+                        onChange={(value): void => changeAdditionalField(index, value)}
+                        id={field.name}
+                        name={field.name}
+                        aria-label={field.name}
+                      >
+                        {field.values
+                          ? field.values.map((value) => <FormSelectOption key={value} value={value} label={value} />)
+                          : null}
+                      </FormSelect>
+                    </FormGroup>
+                  ) : (
+                    <FormGroup key={index} label={field.label} isRequired={false} fieldId={field.name}>
+                      <TextInput
+                        type="text"
+                        id={field.name}
+                        name={field.name}
+                        placeholder={field.placeholder}
+                        value={field.value}
+                        onChange={(value): void => changeAdditionalField(index, value)}
+                      />
+                    </FormGroup>
+                  ),
+                )}
               </Form>
             </LevelItem>
           ) : null}


### PR DESCRIPTION
It is now possible to set a custom order for the retunred logs from the
user defined query. For that two new options "order" and "orderBy" were
added which allows a user to specify if the logs should be sorted
ascending or descending and to set the fields by which the logs should
be ordered.

We also added two new operators. The "!~" operator can be used for "NOT
ILIKE" queries and the "\_exists\_" operator can be used to filter out
NULL values.

We also improved the UI, so that the details view for a log line isn't
opened by clicking on the row. Instead we added a action dropdown which
can be used to open the details view for a log line.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
