### PR TITLE
Add option to stream (follow) logs via WebSockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#131](https://github.com/kobsio/kobs/pull/131): Add chart which shows the distribution of the logs lines in the selected time range for the ClickHouse plugin.
 - [#132](https://github.com/kobsio/kobs/pull/132): Support the download of log lines in their JSON representation in the ClickHouse and Elasticsearch plugin.
 - [#136](https://github.com/kobsio/kobs/pull/136): Allow custom order for the returned logs and add `!~` and `_exists_` operator for ClickHouse plugin.
+- [#138](https://github.com/kobsio/kobs/pull/138): Add option to stream (follow) logs via WebSockets.
 
 ### Fixed
 

--- a/plugins/resources/src/components/panel/details/actions/Terminal.tsx
+++ b/plugins/resources/src/components/panel/details/actions/Terminal.tsx
@@ -114,7 +114,7 @@ const Terminal: React.FunctionComponent<ITerminalProps> = ({ request, resource, 
       };
 
       terminalsContext.addTerminal({
-        name: `${resource.namespace.title}: ${container} (${shell})`,
+        name: `${resource.name.title}: ${container} (${shell})`,
         terminal: term,
         webSocket: ws,
       });
@@ -122,7 +122,7 @@ const Terminal: React.FunctionComponent<ITerminalProps> = ({ request, resource, 
       if (err.message) {
         term.write(`${err.message}\n\r`);
         terminalsContext.addTerminal({
-          name: `${resource.namespace.title}: ${container} (${shell})`,
+          name: `${resource.name.title}: ${container} (${shell})`,
           terminal: term,
         });
       }


### PR DESCRIPTION
A new option follow was added for the logs of a container. By selecting
the "follow" option in the logs modal, we will establish a WebSocket
connection. Via this connection we will then stream all incoming logs of
the selected container and show them in the terminal. This is like the
"-f" option for kubectl.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
