### PR TITLE
Fill ClickHouse chart with zero values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#133](https://github.com/kobsio/kobs/pull/133): Improve querie performance to get logs from ClickHouse.
 - [#137](https://github.com/kobsio/kobs/pull/137): Change log view for the ClickHouse and Elasticsearch plugin.
 - [#139](https://github.com/kobsio/kobs/pull/139): Update Go and JavaScript dependencies.
+- [#140](https://github.com/kobsio/kobs/pull/140): Fill the chart for the distribution of the log lines with zero value.
 
 ## [v0.5.0](https://github.com/kobsio/kobs/releases/tag/v0.5.0) (2021-08-03)
 

--- a/plugins/clickhouse/src/components/panel/LogsChart.tsx
+++ b/plugins/clickhouse/src/components/panel/LogsChart.tsx
@@ -83,7 +83,7 @@ const LogsChart: React.FunctionComponent<ILogsChartProps> = ({ buckets }: ILogsC
                   <b>{tooltip.data.intervalFormatted}</b>
                 </div>
                 <div>
-                  <SquareIcon color="#0066cc" /> Documents: {tooltip.data.count}
+                  <SquareIcon color="#0066cc" /> Documents: {tooltip.data.count || 0}
                 </div>
               </div>
             </TooltipWrapper>


### PR DESCRIPTION
We are now filling up the chart for the distribution of log lines in the
ClickHouse plugin with zero values. So that we always returning 30
buckets also when there are no logs in the interval for a bucket.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
