### PR TITLE
:zap: Add node_modules to docker ignore list

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ docs
 plugins/*/lib
 plugins/*/lib-esm
 plugins/*/node_modules
+node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#137](https://github.com/kobsio/kobs/pull/137): Change log view for the ClickHouse and Elasticsearch plugin.
 - [#139](https://github.com/kobsio/kobs/pull/139): Update Go and JavaScript dependencies.
 - [#140](https://github.com/kobsio/kobs/pull/140): Fill the chart for the distribution of the log lines with zero value.
+- [#141](https://github.com/kobsio/kobs/pull/141): Add `node_modules` to `.dockerignore`.
 
 ## [v0.5.0](https://github.com/kobsio/kobs/releases/tag/v0.5.0) (2021-08-03)
 


### PR DESCRIPTION
<!--
  Keep PR title verbose enough.
-->


<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

Ignore top level `node_modules` folder during docker build.

Before: 
>$> docker build -t localhost:5000/kobs:dev -f cmd/kobs/Dockerfile .
>Sending build context to Docker daemon  494.2MB
>Step 1/25 : FROM --platform=linux/amd64 node:14 as app


After:
>$> docker build -t localhost:5000/kobs:dev -f cmd/kobs/Dockerfile .
>Sending build context to Docker daemon  18.73MB
>Step 1/25 : FROM --platform=linux/amd64 node:14 as app



<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
