### PR TITLE
Fix bug where Jaeger results were not refreshed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#129](https://github.com/kobsio/kobs/pull/129): Fix handling of traces in the Jaeger plugin by using some function from the [jaegertracing/jaeger-ui](https://github.com/jaegertracing/jaeger-ui).
 - [#134](https://github.com/kobsio/kobs/pull/134): Fix time in log buckets of the ClickHouse plugin.
 - [#135](https://github.com/kobsio/kobs/pull/135): Fix read and write i/o timeouts for web terminal.
+- [#143](https://github.com/kobsio/kobs/pull/143): Fix a bug in the Jaeger plugin, where results were not refreshed after a user selected another service, operation, etc.
 
 ### Changed
 

--- a/plugins/jaeger/src/components/panel/Traces.tsx
+++ b/plugins/jaeger/src/components/panel/Traces.tsx
@@ -9,7 +9,7 @@ import {
   Spinner,
 } from '@patternfly/react-core';
 import { QueryObserverResult, useQuery } from 'react-query';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { IPluginTimes, PluginCard } from '@kobsio/plugin-core';
 import { IQuery, ITrace } from '../../utils/interfaces';
@@ -81,6 +81,12 @@ const Traces: React.FunctionComponent<ITracesProps> = ({
       }
     },
   );
+
+  useEffect(() => {
+    if (queries.length === 1) {
+      setSelectedQuery(queries[0]);
+    }
+  }, [queries]);
 
   const select = (
     event: React.MouseEvent<Element, MouseEvent> | React.ChangeEvent<Element>,


### PR DESCRIPTION
In #130 we changed the options for the Jaeger plugin to allow multiple
queries. For that we set the initial selected query to the first query
from the "queries" property. This caused a bug, were the results were
not refreshed after a user changed the service, operation, etc. on the
Jaeger page, because we didn't updated the selected query. The selected
query is now always updated when the queries property is changed and
when it only contains one query, which is always the case for the page
implementation of the Jaeger plugin.

Fixes #142.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
