### PR TITLE
Enable dark mode and set to user's system preference

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,17 @@ theme:
   logo: assets/images/logo.png
   include_search_page: false
   search_index_only: true
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/toggle-switch-off-outline
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/toggle-switch
+        name: Switch to light mode
 
 nav:
   - Introduction: index.md


### PR DESCRIPTION
Would be great to have dark-mode support on kobs documentation. See [Material for MkDocs documentation](https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/?#system-preference).