### PR TITLE
Improve query performance for ClickHouse plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#140](https://github.com/kobsio/kobs/pull/140): Fill the chart for the distribution of the log lines with zero value.
 - [#141](https://github.com/kobsio/kobs/pull/141): Add `node_modules` to `.dockerignore`.
 - [#144](https://github.com/kobsio/kobs/pull/144): Avoid timeouts for long running requests in the ClickHouse plugin.
+- [#147](https://github.com/kobsio/kobs/pull/147): Improve query performance for ClickHouse plugin and allow custom values for the maximum amount of documents, which should be returned (see [#133](https://github.com/kobsio/kobs/pull/133)).
 
 ## [v0.5.0](https://github.com/kobsio/kobs/releases/tag/v0.5.0) (2021-08-03)
 

--- a/docs/plugins/clickhouse.md
+++ b/docs/plugins/clickhouse.md
@@ -28,6 +28,7 @@ The following options can be used for a panel with the ClickHouse plugin:
 | fields | []string | A list of fields to display in the results table. If this field is omitted, the whole document is displayed in the results table. This field is only available for the `logs`. | No |
 | order | string | Order for the returned logs. Must be `ascending` or `descending`. The default value for this field is `descending`. | No |
 | orderBy | string | The name of the field, by which the results should be orderd. The default value for this field is `timestamp`. | No |
+| maxDocuments | string | The maximum amount of documents, which should be returned. The default value for this field is `1000`. | No |
 
 ```yaml
 ---

--- a/plugins/clickhouse/src/components/page/Logs.tsx
+++ b/plugins/clickhouse/src/components/page/Logs.tsx
@@ -27,6 +27,7 @@ import LogsFields from './LogsFields';
 interface IPageLogsProps {
   name: string;
   fields?: string[];
+  maxDocuments: string;
   order: string;
   orderBy: string;
   query: string;
@@ -37,6 +38,7 @@ interface IPageLogsProps {
 const PageLogs: React.FunctionComponent<IPageLogsProps> = ({
   name,
   fields,
+  maxDocuments,
   order,
   orderBy,
   query,
@@ -46,13 +48,13 @@ const PageLogs: React.FunctionComponent<IPageLogsProps> = ({
   const history = useHistory();
 
   const { isError, isFetching, isLoading, data, error, fetchNextPage, refetch } = useInfiniteQuery<ILogsData, Error>(
-    ['clickhouse/logs', query, order, orderBy, times],
+    ['clickhouse/logs', query, order, orderBy, maxDocuments, times],
     async ({ pageParam }) => {
       try {
         const response = await fetch(
           `/api/plugins/clickhouse/logs/${name}?query=${encodeURIComponent(
             query,
-          )}&order=${order}&orderBy=${encodeURIComponent(orderBy)}&timeStart=${
+          )}&order=${order}&orderBy=${encodeURIComponent(orderBy)}&maxDocuments=${maxDocuments}&timeStart=${
             pageParam && pageParam.timeStart ? pageParam.timeStart : times.timeStart
           }&timeEnd=${times.timeEnd}&limit=100&offset=${pageParam && pageParam.offset ? pageParam.offset : ''}`,
           {

--- a/plugins/clickhouse/src/components/page/LogsPage.tsx
+++ b/plugins/clickhouse/src/components/page/LogsPage.tsx
@@ -20,9 +20,11 @@ const LogsPage: React.FunctionComponent<IPluginPageProps> = ({ name, displayName
 
     history.push({
       pathname: location.pathname,
-      search: `?query=${opts.query}&order=${opts.order}&orderBy=${opts.orderBy}&time=${opts.times.time}&timeEnd=${
-        opts.times.timeEnd
-      }&timeStart=${opts.times.timeStart}${fields.length > 0 ? fields.join('') : ''}`,
+      search: `?query=${opts.query}&order=${opts.order}&orderBy=${opts.orderBy}&maxDocuments=${
+        opts.maxDocuments
+      }&time=${opts.times.time}&timeEnd=${opts.times.timeEnd}&timeStart=${opts.times.timeStart}${
+        fields.length > 0 ? fields.join('') : ''
+      }`,
     });
   };
 
@@ -65,6 +67,7 @@ const LogsPage: React.FunctionComponent<IPluginPageProps> = ({ name, displayName
           query={options.query}
           order={options.order}
           orderBy={options.orderBy}
+          maxDocuments={options.maxDocuments}
           fields={options.fields}
           times={options.times}
           setOptions={changeOptions}
@@ -79,6 +82,7 @@ const LogsPage: React.FunctionComponent<IPluginPageProps> = ({ name, displayName
             query={options.query}
             order={options.order}
             orderBy={options.orderBy}
+            maxDocuments={options.maxDocuments}
             selectField={selectField}
             times={options.times}
           />

--- a/plugins/clickhouse/src/components/page/LogsToolbar.tsx
+++ b/plugins/clickhouse/src/components/page/LogsToolbar.tsx
@@ -22,11 +22,13 @@ const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({
   query,
   order,
   orderBy,
+  maxDocuments,
   fields,
   times,
   setOptions,
 }: ILogsToolbarProps) => {
   const [data, setData] = useState<IOptions>({
+    maxDocuments: maxDocuments,
     order: order,
     orderBy: orderBy,
     query: query,
@@ -57,13 +59,14 @@ const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({
     timeEnd: number,
     timeStart: number,
   ): void => {
-    if (additionalFields && additionalFields.length === 2) {
+    if (additionalFields && additionalFields.length === 3) {
       const tmpData = { ...data };
 
       if (refresh) {
         setOptions({
           ...tmpData,
           fields: fields,
+          maxDocuments: additionalFields[2].value,
           order: additionalFields[1].value,
           orderBy: additionalFields[0].value,
           times: { time: time, timeEnd: timeEnd, timeStart: timeStart },
@@ -72,6 +75,7 @@ const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({
 
       setData({
         ...tmpData,
+        maxDocuments: additionalFields[2].value,
         order: additionalFields[1].value,
         orderBy: additionalFields[0].value,
         times: { time: time, timeEnd: timeEnd, timeStart: timeStart },
@@ -93,7 +97,7 @@ const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({
                   {
                     label: 'Order By',
                     name: 'orderBy',
-                    placeholder: '',
+                    placeholder: 'timestamp',
                     value: data.orderBy,
                   },
                   {
@@ -103,6 +107,12 @@ const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({
                     type: 'select',
                     value: data.order,
                     values: ['ascending', 'descending'],
+                  },
+                  {
+                    label: 'Max Documents',
+                    name: 'maxDocuments',
+                    placeholder: '1000',
+                    value: data.maxDocuments,
                   },
                 ]}
                 time={data.times.time}

--- a/plugins/clickhouse/src/components/panel/Logs.tsx
+++ b/plugins/clickhouse/src/components/panel/Logs.tsx
@@ -50,9 +50,9 @@ const Logs: React.FunctionComponent<ILogsProps> = ({
         const response = await fetch(
           `/api/plugins/clickhouse/logs/${name}?query=${encodeURIComponent(selectedQuery.query)}&order=${
             selectedQuery.order || ''
-          }&orderBy=${encodeURIComponent(selectedQuery.orderBy || '')}&timeStart=${times.timeStart}&timeEnd=${
-            times.timeEnd
-          }&limit=100&offset=${pageParam || ''}`,
+          }&orderBy=${encodeURIComponent(selectedQuery.orderBy || '')}&maxDocuments=${
+            selectedQuery.maxDocuments || ''
+          }&timeStart=${times.timeStart}&timeEnd=${times.timeEnd}&limit=100&offset=${pageParam || ''}`,
           {
             method: 'get',
           },

--- a/plugins/clickhouse/src/utils/helpers.ts
+++ b/plugins/clickhouse/src/utils/helpers.ts
@@ -5,6 +5,7 @@ import { IOptions } from './interfaces';
 export const getOptionsFromSearch = (search: string): IOptions => {
   const params = new URLSearchParams(search);
   const fields = params.getAll('field');
+  const maxDocuments = params.get('maxDocuments');
   const order = params.get('order');
   const orderBy = params.get('orderBy');
   const query = params.get('query');
@@ -14,6 +15,7 @@ export const getOptionsFromSearch = (search: string): IOptions => {
 
   return {
     fields: fields.length > 0 ? fields : undefined,
+    maxDocuments: maxDocuments ? maxDocuments : '',
     order: order ? order : 'ascending',
     orderBy: orderBy ? orderBy : '',
     query: query ? query : '',

--- a/plugins/clickhouse/src/utils/interfaces.ts
+++ b/plugins/clickhouse/src/utils/interfaces.ts
@@ -7,6 +7,7 @@ export interface IOptions {
   fields?: string[];
   order: string;
   orderBy: string;
+  maxDocuments: string;
   query: string;
   times: IPluginTimes;
 }
@@ -24,6 +25,7 @@ export interface IQuery {
   fields?: string[];
   order?: string;
   orderBy?: string;
+  maxDocuments?: string;
 }
 
 // ILogsData is the interface of the data returned from our Go API for the logs view of the ClickHouse plugin.

--- a/plugins/elasticsearch/src/components/panel/LogsChart.tsx
+++ b/plugins/elasticsearch/src/components/panel/LogsChart.tsx
@@ -14,8 +14,6 @@ const LogsChart: React.FunctionComponent<ILogsChartProps> = ({ buckets }: ILogsC
     return <div style={{ height: '250px' }}></div>;
   }
 
-  console.log(buckets);
-
   return (
     <div style={{ height: '250px' }}>
       <ResponsiveBarCanvas


### PR DESCRIPTION
Instead of running the counts and buckets query before getting the logs
from ClickHouse we are now just running the buckets query. The count
query was removed, because we can also determine the count by building
the sum of the count in each bucket. This should improve the query
performance for some queries by up to 50%.

In #133 we introduced an setting, where we limit the amount of
documents, which are returned by the API. There we set a limit of 10000
documents. This setting can now be set by the user via the additional
options. If the user doesn't provide this option we set a default limit
of 1000.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
