### PR TITLE
Improve reliability of kobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#141](https://github.com/kobsio/kobs/pull/141): Add `node_modules` to `.dockerignore`.
 - [#144](https://github.com/kobsio/kobs/pull/144): Avoid timeouts for long running requests in the ClickHouse plugin.
 - [#147](https://github.com/kobsio/kobs/pull/147): Improve query performance for ClickHouse plugin and allow custom values for the maximum amount of documents, which should be returned (see [#133](https://github.com/kobsio/kobs/pull/133)).
+- [#148](https://github.com/kobsio/kobs/pull/148): Improve reliability of kobs, by do not checking the database connection for a configured ClickHouse instance.
 
 ## [v0.5.0](https://github.com/kobsio/kobs/releases/tag/v0.5.0) (2021-08-03)
 

--- a/plugins/clickhouse/clickhouse.go
+++ b/plugins/clickhouse/clickhouse.go
@@ -161,13 +161,15 @@ func (router *Router) getLogs(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
+	defer func() {
+		done <- true
+	}()
+
 	documents, fields, count, took, buckets, newOffset, newTimeStart, err := i.GetLogs(r.Context(), query, order, orderBy, parsedMaxDocuments, parsedLimit, parsedOffset, parsedTimeStart, parsedTimeEnd)
 	if err != nil {
 		errresponse.Render(w, r, err, http.StatusBadRequest, "Could not get logs")
 		return
 	}
-
-	done <- true
 
 	data := struct {
 		Documents []map[string]interface{} `json:"documents"`

--- a/plugins/clickhouse/pkg/instance/instance.go
+++ b/plugins/clickhouse/pkg/instance/instance.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go"
+	_ "github.com/ClickHouse/clickhouse-go"
 	"github.com/sirupsen/logrus"
 )
 
@@ -241,15 +241,17 @@ func New(config Config) (*Instance, error) {
 		return nil, err
 	}
 
-	if err := client.Ping(); err != nil {
-		if exception, ok := err.(*clickhouse.Exception); ok {
-			log.WithError(err).WithFields(logrus.Fields{"code": exception.Code, "message": exception.Message, "stacktrace": exception.StackTrace}).Errorf("could not ping database")
-		} else {
-			log.WithError(err).Errorf("could not ping database")
-		}
+	// We do not execute the Ping command anymore to increase the reliability of kobs. So that kobs also starts when
+	// the ClickHouse instance isn't available during the start of kobs.
+	// if err := client.Ping(); err != nil {
+	// 	if exception, ok := err.(*clickhouse.Exception); ok {
+	// 		log.WithError(err).WithFields(logrus.Fields{"code": exception.Code, "message": exception.Message, "stacktrace": exception.StackTrace}).Errorf("could not ping database")
+	// 	} else {
+	// 		log.WithError(err).Errorf("could not ping database")
+	// 	}
 
-		return nil, err
-	}
+	// 	return nil, err
+	// }
 
 	return &Instance{
 		Name:     config.Name,


### PR DESCRIPTION
This commit improves the reliability of kobs, be not checking the
database connection in the ClickHouse instance after a new instance was
created. In this way kobs can also start, when the configured ClickHouse
instance is temporarly unavailable.

We also fixed a small bug, where we forgot to stop the goroutine which
writes a new line for long running queries, when an error occured.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
