### PR TITLE
Improve query performance for ClickHouse plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#150](https://github.com/kobsio/kobs/pull/150): :warning: _Breaking change:_ :warning: The ClickHouse plugin can now only be used together with the [kobsio/fluent-bit-clickhouse](https://github.com/kobsio/fluent-bit-clickhouse) output plugin for [Fluent Bit](https://fluentbit.io). For raw SQL queries against a ClickHouse instance the SQL plugin added in [#149](https://github.com/kobsio/kobs/pull/149) can be used.
 - [#152](https://github.com/kobsio/kobs/pull/152): Improve performance for large dashboards and open Application page in gallery view.
 - [#155](https://github.com/kobsio/kobs/pull/155): Allow users to get all Applications from all namespaces, by allowing an empty namespace list.
+- [#157](https://github.com/kobsio/kobs/pull/157): Imporve query performance for ClickHouse plugin.
 
 ## [v0.5.0](https://github.com/kobsio/kobs/releases/tag/v0.5.0) (2021-08-03)
 

--- a/docs/plugins/clickhouse.md
+++ b/docs/plugins/clickhouse.md
@@ -25,7 +25,6 @@ The following options can be used for a panel with the ClickHouse plugin:
 | fields | []string | A list of fields to display in the results table. If this field is omitted, the whole document is displayed in the results table. This field is only available for the `logs`. | No |
 | order | string | Order for the returned logs. Must be `ascending` or `descending`. The default value for this field is `descending`. | No |
 | orderBy | string | The name of the field, by which the results should be orderd. The default value for this field is `timestamp`. | No |
-| maxDocuments | string | The maximum amount of documents, which should be returned. The default value for this field is `1000`. | No |
 
 ```yaml
 ---

--- a/plugins/clickhouse/pkg/instance/helpers.go
+++ b/plugins/clickhouse/pkg/instance/helpers.go
@@ -1,5 +1,9 @@
 package instance
 
+import (
+	"sync"
+)
+
 // appendIfMissing appends a value to a slice, when this values doesn't exist in the slice already.
 func appendIfMissing(items []string, item string) []string {
 	for _, ele := range items {
@@ -21,4 +25,19 @@ func contains(items []string, item string) bool {
 	}
 
 	return false
+}
+
+// parallelize runs the given functions in parallel.
+func parallelize(functions ...func()) {
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(len(functions))
+
+	defer waitGroup.Wait()
+
+	for _, function := range functions {
+		go func(copy func()) {
+			defer waitGroup.Done()
+			copy()
+		}(function)
+	}
 }

--- a/plugins/clickhouse/src/components/page/LogsToolbar.tsx
+++ b/plugins/clickhouse/src/components/page/LogsToolbar.tsx
@@ -22,13 +22,11 @@ const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({
   query,
   order,
   orderBy,
-  maxDocuments,
   fields,
   times,
   setOptions,
 }: ILogsToolbarProps) => {
   const [data, setData] = useState<IOptions>({
-    maxDocuments: maxDocuments,
     order: order,
     orderBy: orderBy,
     query: query,
@@ -59,14 +57,13 @@ const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({
     timeEnd: number,
     timeStart: number,
   ): void => {
-    if (additionalFields && additionalFields.length === 3) {
+    if (additionalFields && additionalFields.length === 2) {
       const tmpData = { ...data };
 
       if (refresh) {
         setOptions({
           ...tmpData,
           fields: fields,
-          maxDocuments: additionalFields[2].value,
           order: additionalFields[1].value,
           orderBy: additionalFields[0].value,
           times: { time: time, timeEnd: timeEnd, timeStart: timeStart },
@@ -75,7 +72,6 @@ const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({
 
       setData({
         ...tmpData,
-        maxDocuments: additionalFields[2].value,
         order: additionalFields[1].value,
         orderBy: additionalFields[0].value,
         times: { time: time, timeEnd: timeEnd, timeStart: timeStart },
@@ -112,12 +108,6 @@ const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({
                     type: 'select',
                     value: data.order,
                     values: ['ascending', 'descending'],
-                  },
-                  {
-                    label: 'Max Documents',
-                    name: 'maxDocuments',
-                    placeholder: '1000',
-                    value: data.maxDocuments,
                   },
                 ]}
                 time={data.times.time}

--- a/plugins/clickhouse/src/components/page/Page.tsx
+++ b/plugins/clickhouse/src/components/page/Page.tsx
@@ -20,11 +20,9 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
 
     history.push({
       pathname: location.pathname,
-      search: `?query=${opts.query}&order=${opts.order}&orderBy=${opts.orderBy}&maxDocuments=${
-        opts.maxDocuments
-      }&time=${opts.times.time}&timeEnd=${opts.times.timeEnd}&timeStart=${opts.times.timeStart}${
-        fields.length > 0 ? fields.join('') : ''
-      }`,
+      search: `?query=${opts.query}&order=${opts.order}&orderBy=${opts.orderBy}&time=${opts.times.time}&timeEnd=${
+        opts.times.timeEnd
+      }&timeStart=${opts.times.timeStart}${fields.length > 0 ? fields.join('') : ''}`,
     });
   };
 
@@ -71,7 +69,6 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
           query={options.query}
           order={options.order}
           orderBy={options.orderBy}
-          maxDocuments={options.maxDocuments}
           fields={options.fields}
           times={options.times}
           setOptions={changeOptions}
@@ -86,7 +83,6 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
             query={options.query}
             order={options.order}
             orderBy={options.orderBy}
-            maxDocuments={options.maxDocuments}
             addFilter={addFilter}
             selectField={selectField}
             times={options.times}

--- a/plugins/clickhouse/src/components/panel/LogsActions.tsx
+++ b/plugins/clickhouse/src/components/panel/LogsActions.tsx
@@ -1,4 +1,4 @@
-import { CardActions, Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
+import { CardActions, Dropdown, DropdownItem, KebabToggle, Spinner } from '@patternfly/react-core';
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -9,33 +9,43 @@ interface IActionsProps {
   name: string;
   queries: IQuery[];
   times: IPluginTimes;
+  isFetching: boolean;
 }
 
-export const Actions: React.FunctionComponent<IActionsProps> = ({ name, queries, times }: IActionsProps) => {
+export const Actions: React.FunctionComponent<IActionsProps> = ({
+  name,
+  queries,
+  times,
+  isFetching,
+}: IActionsProps) => {
   const [show, setShow] = useState<boolean>(false);
 
   return (
     <CardActions>
-      <Dropdown
-        toggle={<KebabToggle onToggle={(): void => setShow(!show)} />}
-        isOpen={show}
-        isPlain={true}
-        position="right"
-        dropdownItems={queries.map((query, index) => (
-          <DropdownItem
-            key={index}
-            component={
-              <Link
-                to={`/${name}?time=${times.time}&timeEnd=${times.timeEnd}&timeStart=${times.timeStart}&query=${
-                  query.query
-                }${query.fields ? query.fields.map((field) => `&field=${field}`).join('') : ''}`}
-              >
-                {query.name}
-              </Link>
-            }
-          />
-        ))}
-      />
+      {isFetching ? (
+        <Spinner size="md" />
+      ) : (
+        <Dropdown
+          toggle={<KebabToggle onToggle={(): void => setShow(!show)} />}
+          isOpen={show}
+          isPlain={true}
+          position="right"
+          dropdownItems={queries.map((query, index) => (
+            <DropdownItem
+              key={index}
+              component={
+                <Link
+                  to={`/${name}?time=${times.time}&timeEnd=${times.timeEnd}&timeStart=${times.timeStart}&query=${
+                    query.query
+                  }${query.fields ? query.fields.map((field) => `&field=${field}`).join('') : ''}`}
+                >
+                  {query.name}
+                </Link>
+              }
+            />
+          ))}
+        />
+      )}
     </CardActions>
   );
 };

--- a/plugins/clickhouse/src/components/panel/LogsDocument.tsx
+++ b/plugins/clickhouse/src/components/panel/LogsDocument.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { TableText, Td, Tr } from '@patternfly/react-table';
+import { TableText, Tbody, Td, Tr } from '@patternfly/react-table';
+import { InView } from 'react-intersection-observer';
 
 import { IDocument } from '../../utils/interfaces';
 import LogsDocumentDetails from './LogsDocumentDetails';
@@ -35,76 +36,100 @@ const LogsDocument: React.FunctionComponent<ILogsDocumentProps> = ({
   ];
 
   return (
-    <React.Fragment>
-      <Tr>
-        <Td
-          noPadding={true}
-          style={{ padding: 0 }}
-          expand={{ isExpanded: isExpanded, onToggle: (): void => setIsExpanded(!isExpanded), rowIndex: 0 }}
-        />
-        <Td className="pf-u-text-wrap pf-u-text-break-word" dataLabel="Time">
-          <TableText wrapModifier="nowrap">{formatTimeWrapper(document['timestamp'])}</TableText>
-        </Td>
-        {fields && fields.length > 0 ? (
-          fields.map((field, index) => (
-            <Td key={index} className="pf-u-text-wrap pf-u-text-break-word" dataLabel={field}>
-              {document[field]}
-            </Td>
-          ))
-        ) : (
-          <Td className="pf-u-text-wrap pf-u-text-break-word" dataLabel="Log">
-            <div className="kobsio-clickhouse-logs-preview">
-              <span className="pf-u-mr-sm pf-u-mb-sm">
-                <span className="pf-u-background-color-200 pf-u-p-xs">cluster:</span>
-                <span className="pf-u-p-xs"> {document['cluster']}</span>
-              </span>
-              <span className="pf-u-mr-sm pf-u-mb-sm">
-                <span className="pf-u-background-color-200 pf-u-p-xs">namespace:</span>
-                <span className="pf-u-p-xs"> {document['namespace']}</span>
-              </span>
-              <span className="pf-u-mr-sm pf-u-mb-sm">
-                <span className="pf-u-background-color-200 pf-u-p-xs">app:</span>
-                <span className="pf-u-p-xs"> {document['app']}</span>
-              </span>
-              <span className="pf-u-mr-sm pf-u-mb-sm">
-                <span className="pf-u-background-color-200 pf-u-p-xs">pod_name:</span>
-                <span className="pf-u-p-xs"> {document['pod_name']}</span>
-              </span>
-              <span className="pf-u-mr-sm pf-u-mb-sm">
-                <span className="pf-u-background-color-200 pf-u-p-xs">container_name:</span>
-                <span className="pf-u-p-xs"> {document['container_name']}</span>
-              </span>
-              <span className="pf-u-mr-sm pf-u-mb-sm">
-                <span className="pf-u-background-color-200 pf-u-p-xs">host:</span>
-                <span className="pf-u-p-xs"> {document['host']}</span>
-              </span>
+    <InView>
+      {({ inView, ref }): React.ReactNode => (
+        <Tbody ref={ref}>
+          {inView ? (
+            <React.Fragment>
+              <Tr>
+                <Td
+                  noPadding={true}
+                  style={{ padding: 0 }}
+                  expand={{ isExpanded: isExpanded, onToggle: (): void => setIsExpanded(!isExpanded), rowIndex: 0 }}
+                />
+                <Td className="pf-u-text-wrap pf-u-text-break-word" dataLabel="Time">
+                  <TableText wrapModifier="nowrap">{formatTimeWrapper(document['timestamp'])}</TableText>
+                </Td>
+                {fields && fields.length > 0 ? (
+                  fields.map((field, index) => (
+                    <Td key={index} className="pf-u-text-wrap pf-u-text-break-word" dataLabel={field}>
+                      {document[field]}
+                    </Td>
+                  ))
+                ) : (
+                  <Td className="pf-u-text-wrap pf-u-text-break-word" dataLabel="Log">
+                    <div className="kobsio-clickhouse-logs-preview">
+                      <span className="pf-u-mr-sm pf-u-mb-sm">
+                        <span className="pf-u-background-color-200 pf-u-p-xs">cluster:</span>
+                        <span className="pf-u-p-xs"> {document['cluster']}</span>
+                      </span>
+                      <span className="pf-u-mr-sm pf-u-mb-sm">
+                        <span className="pf-u-background-color-200 pf-u-p-xs">namespace:</span>
+                        <span className="pf-u-p-xs"> {document['namespace']}</span>
+                      </span>
+                      <span className="pf-u-mr-sm pf-u-mb-sm">
+                        <span className="pf-u-background-color-200 pf-u-p-xs">app:</span>
+                        <span className="pf-u-p-xs"> {document['app']}</span>
+                      </span>
+                      <span className="pf-u-mr-sm pf-u-mb-sm">
+                        <span className="pf-u-background-color-200 pf-u-p-xs">pod_name:</span>
+                        <span className="pf-u-p-xs"> {document['pod_name']}</span>
+                      </span>
+                      <span className="pf-u-mr-sm pf-u-mb-sm">
+                        <span className="pf-u-background-color-200 pf-u-p-xs">container_name:</span>
+                        <span className="pf-u-p-xs"> {document['container_name']}</span>
+                      </span>
+                      <span className="pf-u-mr-sm pf-u-mb-sm">
+                        <span className="pf-u-background-color-200 pf-u-p-xs">host:</span>
+                        <span className="pf-u-p-xs"> {document['host']}</span>
+                      </span>
 
-              {Object.keys(document)
-                .filter((key) => key.startsWith('content.') && document[key].length < 128)
-                .map((key) => (
-                  <span key={key} className="pf-u-mr-sm pf-u-mb-sm">
-                    <span className="pf-u-background-color-200 pf-u-p-xs">{key}:</span>
-                    <span className="pf-u-p-xs"> {document[key]}</span>
-                  </span>
-                ))}
+                      {Object.keys(document)
+                        .filter((key) => key.startsWith('content.') && document[key].length < 128)
+                        .map((key) => (
+                          <span key={key} className="pf-u-mr-sm pf-u-mb-sm">
+                            <span className="pf-u-background-color-200 pf-u-p-xs">{key}:</span>
+                            <span className="pf-u-p-xs"> {document[key]}</span>
+                          </span>
+                        ))}
 
-              <span className="pf-u-mr-sm pf-u-mb-sm">
-                <span className="pf-u-background-color-200 pf-u-p-xs">log:</span>
-                <span className="pf-u-p-xs"> {document['log']}</span>
-              </span>
-            </div>
-          </Td>
-        )}
-        <Td noPadding={true} style={{ padding: 0 }} actions={{ items: defaultActions }} />
-      </Tr>
-      <Tr isExpanded={isExpanded}>
-        <Td />
-        <Td colSpan={fields && fields.length > 0 ? fields.length + 1 : 2}>
-          {isExpanded && <LogsDocumentDetails document={document} addFilter={addFilter} selectField={selectField} />}
-        </Td>
-        <Td />
-      </Tr>
-    </React.Fragment>
+                      <span className="pf-u-mr-sm pf-u-mb-sm">
+                        <span className="pf-u-background-color-200 pf-u-p-xs">log:</span>
+                        <span className="pf-u-p-xs"> {document['log']}</span>
+                      </span>
+
+                      {Object.keys(document).filter((key) => key.startsWith('content.') && document[key].length < 128)
+                        .length === 0
+                        ? Object.keys(document)
+                            .filter((key) => key.startsWith('kubernetes.'))
+                            .map((key) => (
+                              <span key={key} className="pf-u-mr-sm pf-u-mb-sm">
+                                <span className="pf-u-background-color-200 pf-u-p-xs">{key}:</span>
+                                <span className="pf-u-p-xs"> {document[key]}</span>
+                              </span>
+                            ))
+                        : null}
+                    </div>
+                  </Td>
+                )}
+                <Td noPadding={true} style={{ padding: 0 }} actions={{ items: defaultActions }} />
+              </Tr>
+              <Tr isExpanded={isExpanded}>
+                <Td />
+                <Td colSpan={fields && fields.length > 0 ? fields.length + 1 : 2}>
+                  {isExpanded && (
+                    <LogsDocumentDetails document={document} addFilter={addFilter} selectField={selectField} />
+                  )}
+                </Td>
+                <Td />
+              </Tr>
+            </React.Fragment>
+          ) : (
+            <Tr style={{ height: fields && fields.length > 0 ? '38px' : '135px' }}></Tr>
+          )}
+        </Tbody>
+      )}
+    </InView>
   );
 };
 

--- a/plugins/clickhouse/src/components/panel/LogsDocuments.tsx
+++ b/plugins/clickhouse/src/components/panel/LogsDocuments.tsx
@@ -1,18 +1,18 @@
-import { TableComposable, TableVariant, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
+import { TableComposable, TableVariant, Th, Thead, Tr } from '@patternfly/react-table';
 import React from 'react';
 
-import { ILogsData } from '../../utils/interfaces';
+import { IDocument } from '../../utils/interfaces';
 import LogsDocument from './LogsDocument';
 
 interface ILogsDocumentsProps {
-  pages: ILogsData[];
+  documents?: IDocument[];
   fields?: string[];
   addFilter?: (filter: string) => void;
   selectField?: (field: string) => void;
 }
 
 const LogsDocuments: React.FunctionComponent<ILogsDocumentsProps> = ({
-  pages,
+  documents,
   fields,
   addFilter,
   selectField,
@@ -31,21 +31,17 @@ const LogsDocuments: React.FunctionComponent<ILogsDocumentsProps> = ({
           <Th />
         </Tr>
       </Thead>
-      <Tbody>
-        {pages.map((page, pageIndex) =>
-          page.documents
-            ? page.documents.map((document, documentIndex) => (
-                <LogsDocument
-                  key={`${pageIndex}_${documentIndex}`}
-                  document={document}
-                  fields={fields}
-                  addFilter={addFilter}
-                  selectField={selectField}
-                />
-              ))
-            : null,
-        )}
-      </Tbody>
+      {documents
+        ? documents.map((document, index) => (
+            <LogsDocument
+              key={index}
+              document={document}
+              fields={fields}
+              addFilter={addFilter}
+              selectField={selectField}
+            />
+          ))
+        : null}
     </TableComposable>
   );
 };

--- a/plugins/clickhouse/src/utils/helpers.ts
+++ b/plugins/clickhouse/src/utils/helpers.ts
@@ -5,7 +5,6 @@ import { IOptions } from './interfaces';
 export const getOptionsFromSearch = (search: string): IOptions => {
   const params = new URLSearchParams(search);
   const fields = params.getAll('field');
-  const maxDocuments = params.get('maxDocuments');
   const order = params.get('order');
   const orderBy = params.get('orderBy');
   const query = params.get('query');
@@ -15,7 +14,6 @@ export const getOptionsFromSearch = (search: string): IOptions => {
 
   return {
     fields: fields.length > 0 ? fields : undefined,
-    maxDocuments: maxDocuments ? maxDocuments : '',
     order: order ? order : 'ascending',
     orderBy: orderBy ? orderBy : '',
     query: query ? query : '',

--- a/plugins/clickhouse/src/utils/interfaces.ts
+++ b/plugins/clickhouse/src/utils/interfaces.ts
@@ -7,7 +7,6 @@ export interface IOptions {
   fields?: string[];
   order: string;
   orderBy: string;
-  maxDocuments: string;
   query: string;
   times: IPluginTimes;
 }
@@ -24,7 +23,6 @@ export interface IQuery {
   fields?: string[];
   order?: string;
   orderBy?: string;
-  maxDocuments?: string;
 }
 
 // ILogsData is the interface of the data returned from our Go API for the logs view of the ClickHouse plugin.


### PR DESCRIPTION
Instead of just changing the start time for the raw logs query, we are
now running the raw logs query only for buckets which are containing
documents, to improve the query performance for queries which are
returning a low number of documents.

We also improved the performance of the React UI by using the
Intersection Observer API to render the table with the returned log
documents.

Finally we have removed the property to specify the maximum number of
documents and always returning 1000 documents. For that we also removed
the pagination / load more documents logic.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
