### PR TITLE
Allow users to sort logs via the documents table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#151](https://github.com/kobsio/kobs/pull/151): Add actions for in log details view of the ClickHouse, so that users can filter based on the value of a field.
 - [#156](https://github.com/kobsio/kobs/pull/156): Add tags for applications.
 - [#159](https://github.com/kobsio/kobs/pull/159): Allow users to select a time range within the logs chart in the ClickHouse plugin.
+- [#160](https://github.com/kobsio/kobs/pull/160): Allow users to sort the returned logs within the documents table in the ClickHouse plugin.
 
 ### Fixed
 

--- a/plugins/clickhouse/src/components/page/Logs.tsx
+++ b/plugins/clickhouse/src/components/page/Logs.tsx
@@ -30,6 +30,7 @@ interface IPageLogsProps {
   query: string;
   addFilter: (filter: string) => void;
   changeTime: (times: IPluginTimes) => void;
+  changeOrder: (order: string, orderBy: string) => void;
   selectField: (field: string) => void;
   times: IPluginTimes;
 }
@@ -41,8 +42,9 @@ const PageLogs: React.FunctionComponent<IPageLogsProps> = ({
   orderBy,
   query,
   addFilter,
-  selectField,
   changeTime,
+  changeOrder,
+  selectField,
   times,
 }: IPageLogsProps) => {
   const history = useHistory();
@@ -146,7 +148,15 @@ const PageLogs: React.FunctionComponent<IPageLogsProps> = ({
 
         <Card isCompact={true} style={{ maxWidth: '100%', overflowX: 'scroll' }}>
           <CardBody>
-            <LogsDocuments documents={data.documents} fields={fields} addFilter={addFilter} selectField={selectField} />
+            <LogsDocuments
+              documents={data.documents}
+              fields={fields}
+              order={order}
+              orderBy={orderBy}
+              addFilter={addFilter}
+              changeOrder={changeOrder}
+              selectField={selectField}
+            />
           </CardBody>
         </Card>
       </GridItem>

--- a/plugins/clickhouse/src/components/page/LogsToolbar.tsx
+++ b/plugins/clickhouse/src/components/page/LogsToolbar.tsx
@@ -80,9 +80,9 @@ const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({
   };
 
   useEffect(() => {
-    setData({ ...data, query: query, times: times });
+    setData({ ...data, order: order, orderBy: orderBy, query: query, times: times });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query, times]);
+  }, [order, orderBy, query, times]);
 
   return (
     <Toolbar id="clickhouse-logs-toolbar" style={{ paddingBottom: '0px', zIndex: 300 }}>

--- a/plugins/clickhouse/src/components/page/Page.tsx
+++ b/plugins/clickhouse/src/components/page/Page.tsx
@@ -51,6 +51,10 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
     changeOptions({ ...options, times: times });
   };
 
+  const changeOrder = (order: string, orderBy: string): void => {
+    changeOptions({ ...options, order: order, orderBy: orderBy });
+  };
+
   // useEffect is used to set the options every time the search location for the current URL changes. The URL is changed
   // via the changeOptions function. When the search location is changed we modify the options state.
   useEffect(() => {
@@ -89,6 +93,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
             orderBy={options.orderBy}
             addFilter={addFilter}
             changeTime={changeTime}
+            changeOrder={changeOrder}
             selectField={selectField}
             times={options.times}
           />

--- a/plugins/clickhouse/src/components/panel/Logs.tsx
+++ b/plugins/clickhouse/src/components/panel/Logs.tsx
@@ -136,7 +136,12 @@ const Logs: React.FunctionComponent<ILogsProps> = ({ name, title, description, q
             <LogsChart buckets={data.buckets} />
             <p>&nbsp;</p>
 
-            <LogsDocuments documents={data.documents} fields={selectedQuery.fields} />
+            <LogsDocuments
+              documents={data.documents}
+              fields={selectedQuery.fields}
+              order={selectedQuery.order}
+              orderBy={selectedQuery.orderBy}
+            />
           </div>
         ) : null}
       </div>

--- a/plugins/clickhouse/src/components/panel/LogsChart.tsx
+++ b/plugins/clickhouse/src/components/panel/LogsChart.tsx
@@ -18,8 +18,8 @@ interface ILogsChartProps {
 
 const LogsChart: React.FunctionComponent<ILogsChartProps> = ({ buckets, changeTime }: ILogsChartProps) => {
   const refChart = useRef<HTMLDivElement>(null);
-  const [width, setWidth] = useState<number>(0);
-  const [height, setHeight] = useState<number>(0);
+  const [width, setWidth] = useState<number>(1);
+  const [height, setHeight] = useState<number>(1);
 
   // useEffect is executed on every render of this component. This is needed, so that we are able to use a width of 100%
   // and a static height for the chart.
@@ -30,9 +30,9 @@ const LogsChart: React.FunctionComponent<ILogsChartProps> = ({ buckets, changeTi
     }
   }, []);
 
-  const data: IDatum[] | undefined =
+  const data: IDatum[] =
     !buckets || buckets.length === 0
-      ? undefined
+      ? []
       : buckets.map((bucket) => {
           return {
             x: new Date(bucket.interval * 1000),
@@ -40,17 +40,11 @@ const LogsChart: React.FunctionComponent<ILogsChartProps> = ({ buckets, changeTi
           };
         });
 
-  if (!data) {
-    return <div style={{ height: '250px' }}></div>;
-  }
-
-  const CursorVoronoiContainer = changeTime
-    ? createContainer('voronoi', 'brush')
-    : createContainer('voronoi', 'cursor');
+  const CursorVoronoiContainer = createContainer('voronoi', 'brush');
   const legendData = [{ childName: 'count', name: 'Document Count' }];
 
   return (
-    <div style={{ height: '250px' }} ref={refChart}>
+    <div style={{ height: '250px', width: '100%' }} ref={refChart}>
       <Chart
         containerComponent={
           <CursorVoronoiContainer
@@ -60,7 +54,9 @@ const LogsChart: React.FunctionComponent<ILogsChartProps> = ({ buckets, changeTi
             labelComponent={
               <ChartLegendTooltip
                 legendData={legendData}
-                title={(datum: IDatum): string => formatTime(Math.floor(datum.x.getTime() / 1000))}
+                title={(datum: IDatum): string =>
+                  data.length > 0 ? formatTime(Math.floor(datum.x.getTime() / 1000)) : ''
+                }
               />
             }
             mouseFollowTooltips={true}
@@ -94,7 +90,7 @@ const LogsChart: React.FunctionComponent<ILogsChartProps> = ({ buckets, changeTi
           }
           showGrid={false}
         />
-        <ChartBar data={data} name="count" barWidth={width / data.length} />
+        <ChartBar data={data} name="count" barWidth={data && width / data.length} />
       </Chart>
     </div>
   );

--- a/plugins/clickhouse/src/components/panel/LogsDocuments.tsx
+++ b/plugins/clickhouse/src/components/panel/LogsDocuments.tsx
@@ -1,4 +1,12 @@
-import { TableComposable, TableVariant, Th, Thead, Tr } from '@patternfly/react-table';
+import {
+  IExtraColumnData,
+  SortByDirection,
+  TableComposable,
+  TableVariant,
+  Th,
+  Thead,
+  Tr,
+} from '@patternfly/react-table';
 import React from 'react';
 
 import { IDocument } from '../../utils/interfaces';
@@ -7,16 +15,25 @@ import LogsDocument from './LogsDocument';
 interface ILogsDocumentsProps {
   documents?: IDocument[];
   fields?: string[];
+  order?: string;
+  orderBy?: string;
   addFilter?: (filter: string) => void;
+  changeOrder?: (order: string, orderBy: string) => void;
   selectField?: (field: string) => void;
 }
 
 const LogsDocuments: React.FunctionComponent<ILogsDocumentsProps> = ({
   documents,
   fields,
+  order,
+  orderBy,
   addFilter,
+  changeOrder,
   selectField,
 }: ILogsDocumentsProps) => {
+  const activeSortIndex = fields && orderBy ? fields?.indexOf(orderBy) : -1;
+  const activeSortDirection = order === 'descending' ? 'desc' : 'asc';
+
   return (
     <TableComposable aria-label="Logs" variant={TableVariant.compact} borders={false}>
       <Thead>
@@ -24,7 +41,27 @@ const LogsDocuments: React.FunctionComponent<ILogsDocumentsProps> = ({
           <Th />
           <Th>Time</Th>
           {fields && fields.length > 0 ? (
-            fields.map((selectedField, index) => <Th key={index}>{selectedField}</Th>)
+            fields.map((field, index) => (
+              <Th
+                key={index}
+                sort={{
+                  columnIndex: index,
+                  onSort: (
+                    event: React.MouseEvent,
+                    columnIndex: number,
+                    sortByDirection: SortByDirection,
+                    extraData: IExtraColumnData,
+                  ): void => {
+                    if (changeOrder) {
+                      changeOrder(sortByDirection === 'desc' ? 'descending' : 'ascending', field);
+                    }
+                  },
+                  sortBy: { direction: activeSortDirection, index: activeSortIndex },
+                }}
+              >
+                {field}
+              </Th>
+            ))
           ) : (
             <Th>Log</Th>
           )}


### PR DESCRIPTION
We are now showing the selected sort order in the table with the
returned logs in the ClickHouse plugin. Besides that a user can now also
change the order of the returned documents in this table.

This commit also fixes a bug in the logs chart, where the chart wasn't
rendered, when it was used in a dashboard.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
