### PR TITLE
Add support for materialized columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#156](https://github.com/kobsio/kobs/pull/156): Add tags for applications.
 - [#159](https://github.com/kobsio/kobs/pull/159): Allow users to select a time range within the logs chart in the ClickHouse plugin.
 - [#160](https://github.com/kobsio/kobs/pull/160): Allow users to sort the returned logs within the documents table in the ClickHouse plugin.
+- [#161](https://github.com/kobsio/kobs/pull/161): Add support for materialized columns, to improve query performance for most frequently queried field.
 
 ### Fixed
 

--- a/docs/configuration/plugins.md
+++ b/docs/configuration/plugins.md
@@ -55,6 +55,7 @@ plugins:
 | address | string | Address of the ClickHouse instance. | Yes |
 | username | string | Username to access a ClickHouse instance. | No |
 | password | string | Password to access a ClickHouse instance. | No |
+| materializedColumns | []string | A list of materialized columns. See [kobsio/fluent-bit-clickhouse](https://github.com/kobsio/fluent-bit-clickhouse#configuration) for more information. | No |
 
 ## Elasticsearch
 

--- a/plugins/clickhouse/pkg/instance/logs.go
+++ b/plugins/clickhouse/pkg/instance/logs.go
@@ -24,7 +24,7 @@ var (
 // Then we are splitting the string again for the other operators "=", "!=", ">", ">=", "<", "<=" and "~" which are used
 // to check the value of a field.
 // Once we have build all the conditions we concate all the strings to the final sql statement for the where clause.
-func parseLogsQuery(query string) (string, error) {
+func parseLogsQuery(query string, materializedColumns []string) (string, error) {
 	var newOpenBrackets []string
 	openBrackets := strings.Split(query, "(")
 	for _, openBracket := range openBrackets {
@@ -40,7 +40,7 @@ func parseLogsQuery(query string) (string, error) {
 					var newOrs []string
 					ors := strings.Split(and, "_or_")
 					for _, or := range ors {
-						condition, err := splitOperator(or)
+						condition, err := splitOperator(or, materializedColumns)
 						if err != nil {
 							return "", err
 						}
@@ -63,54 +63,54 @@ func parseLogsQuery(query string) (string, error) {
 // result is a slice with two items we found the operator which was used by the user to check the value of a field. So
 // that we pass the key (first item), value (second item) and the operator to the handleConditionParts to build the
 // where condition.
-func splitOperator(condition string) (string, error) {
+func splitOperator(condition string, materializedColumns []string) (string, error) {
 	greaterThanOrEqual := strings.Split(condition, ">=")
 	if len(greaterThanOrEqual) == 2 {
-		return handleConditionParts(greaterThanOrEqual[0], greaterThanOrEqual[1], ">=")
+		return handleConditionParts(greaterThanOrEqual[0], greaterThanOrEqual[1], ">=", materializedColumns)
 	}
 
 	greaterThan := strings.Split(condition, ">")
 	if len(greaterThan) == 2 {
-		return handleConditionParts(greaterThan[0], greaterThan[1], ">")
+		return handleConditionParts(greaterThan[0], greaterThan[1], ">", materializedColumns)
 	}
 
 	lessThanOrEqual := strings.Split(condition, "<=")
 	if len(lessThanOrEqual) == 2 {
-		return handleConditionParts(lessThanOrEqual[0], lessThanOrEqual[1], "<=")
+		return handleConditionParts(lessThanOrEqual[0], lessThanOrEqual[1], "<=", materializedColumns)
 	}
 
 	lessThan := strings.Split(condition, "<")
 	if len(lessThan) == 2 {
-		return handleConditionParts(lessThan[0], lessThan[1], "<")
+		return handleConditionParts(lessThan[0], lessThan[1], "<", materializedColumns)
 	}
 
 	ilike := strings.Split(condition, "=~")
 	if len(ilike) == 2 {
-		return handleConditionParts(ilike[0], ilike[1], "=~")
+		return handleConditionParts(ilike[0], ilike[1], "=~", materializedColumns)
 	}
 
 	notEqual := strings.Split(condition, "!=")
 	if len(notEqual) == 2 {
-		return handleConditionParts(notEqual[0], notEqual[1], "!=")
+		return handleConditionParts(notEqual[0], notEqual[1], "!=", materializedColumns)
 	}
 
 	notIlike := strings.Split(condition, "!~")
 	if len(notIlike) == 2 {
-		return handleConditionParts(notIlike[0], notIlike[1], "!~")
+		return handleConditionParts(notIlike[0], notIlike[1], "!~", materializedColumns)
 	}
 
 	equal := strings.Split(condition, "=")
 	if len(equal) == 2 {
-		return handleConditionParts(equal[0], equal[1], "=")
+		return handleConditionParts(equal[0], equal[1], "=", materializedColumns)
 	}
 
 	regex := strings.Split(condition, "~")
 	if len(regex) == 2 {
-		return handleConditionParts(regex[0], regex[1], "~")
+		return handleConditionParts(regex[0], regex[1], "~", materializedColumns)
 	}
 
 	if strings.Contains(condition, "_exists_ ") {
-		return handleExistsCondition(strings.TrimLeft(strings.TrimSpace(condition), "_exists_ ")), nil
+		return handleExistsCondition(strings.TrimLeft(strings.TrimSpace(condition), "_exists_ "), materializedColumns), nil
 	}
 
 	if strings.TrimSpace(condition) == "" {
@@ -128,7 +128,7 @@ func splitOperator(condition string) (string, error) {
 //
 // See: https://gist.github.com/alexey-milovidov/d6ffc9e0bc0bc72dd7bca90e76e3b83b
 // See: https://clickhouse.tech/docs/en/sql-reference/functions/string-search-functions/#matchhaystack-pattern
-func handleConditionParts(key, value, operator string) (string, error) {
+func handleConditionParts(key, value, operator string, materializedColumns []string) (string, error) {
 	key = strings.TrimSpace(key)
 	value = strings.TrimSpace(value)
 
@@ -138,7 +138,7 @@ func handleConditionParts(key, value, operator string) (string, error) {
 	// ALTER TABLE logs.logs ON CLUSTER '{cluster}' ADD COLUMN <FIELD> String DEFAULT fields_number.value[indexOf(fields_number.key, '<FIELD>')];
 	fieldsMetric.WithLabelValues(key).Inc()
 
-	if contains(defaultFields, key) {
+	if contains(defaultFields, key) || contains(materializedColumns, key) {
 		if operator == "=~" {
 			return fmt.Sprintf("%s ILIKE %s", key, value), nil
 		}
@@ -185,15 +185,15 @@ func handleConditionParts(key, value, operator string) (string, error) {
 	return fmt.Sprintf("fields_number.value[indexOf(fields_number.key, '%s')] %s %s", key, operator, value), nil
 }
 
-func handleExistsCondition(key string) string {
-	if contains(defaultFields, key) {
+func handleExistsCondition(key string, materializedColumns []string) string {
+	if contains(defaultFields, key) || contains(materializedColumns, key) {
 		return fmt.Sprintf("%s IS NOT NULL", key)
 	}
 
 	return fmt.Sprintf("(has(fields_string.key, '%s') = 1 OR has(fields_number.key, '%s') = 1)", key, key)
 }
 
-func parseOrder(order, orderBy string) string {
+func parseOrder(order, orderBy string, materializedColumns []string) string {
 	if order == "" || orderBy == "" {
 		return "timestamp DESC"
 	}
@@ -205,7 +205,7 @@ func parseOrder(order, orderBy string) string {
 	}
 
 	orderBy = strings.TrimSpace(orderBy)
-	if contains(defaultFields, orderBy) {
+	if contains(defaultFields, orderBy) || contains(materializedColumns, orderBy) {
 		return fmt.Sprintf("%s %s", orderBy, order)
 	}
 

--- a/plugins/clickhouse/pkg/instance/logs_test.go
+++ b/plugins/clickhouse/pkg/instance/logs_test.go
@@ -19,7 +19,7 @@ func TestParseLogsQuery(t *testing.T) {
 		{query: "kubernetes.label_foo_bar ~ 'hello.*'", where: "match(fields_string.value[indexOf(fields_string.key, 'kubernetes.label_foo_bar')], 'hello.*')", isInvalid: false},
 	} {
 		t.Run(tc.query, func(t *testing.T) {
-			parsedWhere, err := parseLogsQuery(tc.query)
+			parsedWhere, err := parseLogsQuery(tc.query, nil)
 			if tc.isInvalid {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
It is now possible to set a list of materialized columns in the
ClickHouse plugin configuration. This allows users to speed up queries
for the most frequently used fields. The columns can be created via the
"ALTER TABLE ... ADD COLUMN ... DEFAULT" SQL command. These columns
should point to a nested string or numbers value. ClickHouse will then
automatically fall back to this fields when the materialized column
istn't present for older data.

We also improved the bucketing, so that buckets are also created for
time ranges with less then 30 seonds.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
