### PR TITLE
Add support to visualize logs in ClickHouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#159](https://github.com/kobsio/kobs/pull/159): Allow users to select a time range within the logs chart in the ClickHouse plugin.
 - [#160](https://github.com/kobsio/kobs/pull/160): Allow users to sort the returned logs within the documents table in the ClickHouse plugin.
 - [#161](https://github.com/kobsio/kobs/pull/161): Add support for materialized columns, to improve query performance for most frequently queried field.
+- [#162](https://github.com/kobsio/kobs/pull/162): Add support to visualize logs in the ClickHouse plugin.
 
 ### Fixed
 

--- a/plugins/clickhouse/package.json
+++ b/plugins/clickhouse/package.json
@@ -11,6 +11,9 @@
   },
   "dependencies": {
     "@kobsio/plugin-core": "*",
+    "@nivo/bar": "^0.73.1",
+    "@nivo/pie": "^0.73.0",
+    "@nivo/tooltip": "^0.73.0",
     "@patternfly/react-charts": "^6.15.23",
     "@patternfly/react-core": "^4.128.2",
     "@patternfly/react-icons": "^4.10.11",

--- a/plugins/clickhouse/pkg/instance/structs.go
+++ b/plugins/clickhouse/pkg/instance/structs.go
@@ -36,3 +36,9 @@ type Bucket struct {
 	Interval int64 `json:"interval"`
 	Count    int64 `json:"count"`
 }
+
+// VisualizationRow is the structure of a single row for a visualization.
+type VisualizationRow struct {
+	Label string  `json:"label"`
+	Value float64 `json:"value"`
+}

--- a/plugins/clickhouse/pkg/instance/visualization.go
+++ b/plugins/clickhouse/pkg/instance/visualization.go
@@ -1,0 +1,37 @@
+package instance
+
+import (
+	"fmt"
+	"strings"
+)
+
+// formatField returns the SQL syntax for the given field. If the field is of type string and not in the default fields
+// or materialized columns list it must be wrapped in single quotes.
+func formatField(field string, materializedColumns []string) string {
+	field = strings.TrimSpace(field)
+
+	if contains(defaultFields, field) || contains(materializedColumns, field) {
+		return field
+	}
+
+	if string(field[0]) == "'" && string(field[len(field)-1]) == "'" {
+		field = field[1 : len(field)-1]
+
+		if contains(defaultFields, field) || contains(materializedColumns, field) {
+			return field
+		}
+
+		return fmt.Sprintf("fields_string.value[indexOf(fields_string.key, '%s')]", field)
+	}
+
+	return fmt.Sprintf("fields_number.value[indexOf(fields_number.key, '%s')]", field)
+}
+
+// formatOrder returns the order key word which can be used in the SQL query for the given input.
+func formatOrder(order string) string {
+	if order == "descending" {
+		return "DESC"
+	}
+
+	return "ASC"
+}

--- a/plugins/clickhouse/pkg/instance/visualization_test.go
+++ b/plugins/clickhouse/pkg/instance/visualization_test.go
@@ -1,0 +1,40 @@
+package instance
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatField(t *testing.T) {
+	for _, tc := range []struct {
+		field  string
+		expect string
+	}{
+		{field: "namespace", expect: "namespace"},
+		{field: "'namespace'", expect: "namespace"},
+		{field: "'content.method'", expect: "fields_string.value[indexOf(fields_string.key, 'content.method')]"},
+		{field: "content.duration", expect: "fields_number.value[indexOf(fields_number.key, 'content.duration')]"},
+	} {
+		t.Run(tc.field, func(t *testing.T) {
+			actual := formatField(tc.field, nil)
+			require.Equal(t, tc.expect, actual)
+		})
+	}
+}
+
+func TestFormatOrder(t *testing.T) {
+	for _, tc := range []struct {
+		order  string
+		expect string
+	}{
+		{order: "descending", expect: "DESC"},
+		{order: "ascending", expect: "ASC"},
+		{order: "foo bar", expect: "ASC"},
+	} {
+		t.Run(tc.order, func(t *testing.T) {
+			actual := formatOrder(tc.order)
+			require.Equal(t, tc.expect, actual)
+		})
+	}
+}

--- a/plugins/clickhouse/src/components/page/Logs.tsx
+++ b/plugins/clickhouse/src/components/page/Logs.tsx
@@ -22,7 +22,7 @@ import LogsChart from '../panel/LogsChart';
 import LogsDocuments from '../panel/LogsDocuments';
 import LogsFields from './LogsFields';
 
-interface IPageLogsProps {
+interface ILogsProps {
   name: string;
   fields?: string[];
   order: string;
@@ -35,7 +35,7 @@ interface IPageLogsProps {
   times: IPluginTimes;
 }
 
-const PageLogs: React.FunctionComponent<IPageLogsProps> = ({
+const Logs: React.FunctionComponent<ILogsProps> = ({
   name,
   fields,
   order,
@@ -46,11 +46,11 @@ const PageLogs: React.FunctionComponent<IPageLogsProps> = ({
   changeOrder,
   selectField,
   times,
-}: IPageLogsProps) => {
+}: ILogsProps) => {
   const history = useHistory();
 
   const { isError, isFetching, isLoading, data, error, refetch } = useQuery<ILogsData, Error>(
-    ['clickhouse/logs', query, order, orderBy, times],
+    ['clickhouse/logs', name, query, order, orderBy, times],
     async () => {
       try {
         const response = await fetch(
@@ -165,4 +165,4 @@ const PageLogs: React.FunctionComponent<IPageLogsProps> = ({
   );
 };
 
-export default PageLogs;
+export default Logs;

--- a/plugins/clickhouse/src/components/page/LogsPage.tsx
+++ b/plugins/clickhouse/src/components/page/LogsPage.tsx
@@ -1,0 +1,120 @@
+import { Divider, Flex, FlexItem, PageSection, PageSectionVariants, Title } from '@patternfly/react-core';
+import { Link, useHistory, useLocation } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+
+import { IOptions } from '../../utils/interfaces';
+import { IPluginTimes } from '@kobsio/plugin-core';
+import Logs from './Logs';
+import LogsToolbar from './LogsToolbar';
+import { getOptionsFromSearch } from '../../utils/helpers';
+
+interface ILogsPageProps {
+  name: string;
+  displayName: string;
+  description: string;
+}
+
+const LogsPage: React.FunctionComponent<ILogsPageProps> = ({ name, displayName, description }: ILogsPageProps) => {
+  const location = useLocation();
+  const history = useHistory();
+  const [options, setOptions] = useState<IOptions>(getOptionsFromSearch(location.search));
+
+  // changeOptions is used to change the options for an ClickHouse query. Instead of directly modifying the options
+  // state we change the URL parameters.
+  const changeOptions = (opts: IOptions): void => {
+    const fields = opts.fields ? opts.fields.map((field) => `&field=${field}`) : [];
+
+    history.push({
+      pathname: location.pathname,
+      search: `?query=${opts.query}&order=${opts.order}&orderBy=${opts.orderBy}&time=${opts.times.time}&timeEnd=${
+        opts.times.timeEnd
+      }&timeStart=${opts.times.timeStart}${fields.length > 0 ? fields.join('') : ''}`,
+    });
+  };
+
+  // selectField is used to add a field as parameter, when it isn't present and to remove a fields from as parameter,
+  // when it is already present via the changeOptions function.
+  const selectField = (field: string): void => {
+    let tmpFields: string[] = [];
+    if (options.fields) {
+      tmpFields = [...options.fields];
+    }
+
+    if (tmpFields.includes(field)) {
+      tmpFields = tmpFields.filter((f) => f !== field);
+    } else {
+      tmpFields.push(field);
+    }
+
+    changeOptions({ ...options, fields: tmpFields });
+  };
+
+  const addFilter = (filter: string): void => {
+    changeOptions({ ...options, query: `${options.query} ${filter}` });
+  };
+
+  const changeTime = (times: IPluginTimes): void => {
+    changeOptions({ ...options, times: times });
+  };
+
+  const changeOrder = (order: string, orderBy: string): void => {
+    changeOptions({ ...options, order: order, orderBy: orderBy });
+  };
+
+  // useEffect is used to set the options every time the search location for the current URL changes. The URL is changed
+  // via the changeOptions function. When the search location is changed we modify the options state.
+  useEffect(() => {
+    setOptions(getOptionsFromSearch(location.search));
+  }, [location.search]);
+
+  return (
+    <React.Fragment>
+      <PageSection variant={PageSectionVariants.light}>
+        <Title headingLevel="h6" size="xl">
+          {displayName}
+          <span className="pf-u-font-size-md pf-u-font-weight-normal" style={{ float: 'right' }}>
+            <Flex>
+              <FlexItem>
+                <Link to={`/${name}/visualization`}>Visualization</Link>
+              </FlexItem>
+              <Divider isVertical={true} />
+              <FlexItem>
+                <a href="https://kobs.io/plugins/clickhouse/" target="_blank" rel="noreferrer">
+                  Documentation
+                </a>
+              </FlexItem>
+            </Flex>
+          </span>
+        </Title>
+        <p>{description}</p>
+        <LogsToolbar
+          query={options.query}
+          order={options.order}
+          orderBy={options.orderBy}
+          fields={options.fields}
+          times={options.times}
+          setOptions={changeOptions}
+        />
+      </PageSection>
+
+      <PageSection style={{ minHeight: '100%' }} variant={PageSectionVariants.default}>
+        {options.query.length > 0 ? (
+          <Logs
+            name={name}
+            fields={options.fields}
+            query={options.query}
+            order={options.order}
+            orderBy={options.orderBy}
+            addFilter={addFilter}
+            changeTime={changeTime}
+            changeOrder={changeOrder}
+            selectField={selectField}
+            times={options.times}
+          />
+        ) : null}
+      </PageSection>
+    </React.Fragment>
+  );
+};
+
+export default LogsPage;

--- a/plugins/clickhouse/src/components/page/Page.tsx
+++ b/plugins/clickhouse/src/components/page/Page.tsx
@@ -1,105 +1,20 @@
-import { PageSection, PageSectionVariants, Title } from '@patternfly/react-core';
-import React, { useEffect, useState } from 'react';
-import { useHistory, useLocation } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
+import React from 'react';
 
-import { IPluginPageProps, IPluginTimes } from '@kobsio/plugin-core';
-import { IOptions } from '../../utils/interfaces';
-import Logs from './Logs';
-import LogsToolbar from './LogsToolbar';
-import { getOptionsFromSearch } from '../../utils/helpers';
+import { IPluginPageProps } from '@kobsio/plugin-core';
+import LogsPage from './LogsPage';
+import VisualizationPage from './VisualizationPage';
 
 const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, description }: IPluginPageProps) => {
-  const location = useLocation();
-  const history = useHistory();
-  const [options, setOptions] = useState<IOptions>(getOptionsFromSearch(location.search));
-
-  // changeOptions is used to change the options for an ClickHouse query. Instead of directly modifying the options
-  // state we change the URL parameters.
-  const changeOptions = (opts: IOptions): void => {
-    const fields = opts.fields ? opts.fields.map((field) => `&field=${field}`) : [];
-
-    history.push({
-      pathname: location.pathname,
-      search: `?query=${opts.query}&order=${opts.order}&orderBy=${opts.orderBy}&time=${opts.times.time}&timeEnd=${
-        opts.times.timeEnd
-      }&timeStart=${opts.times.timeStart}${fields.length > 0 ? fields.join('') : ''}`,
-    });
-  };
-
-  // selectField is used to add a field as parameter, when it isn't present and to remove a fields from as parameter,
-  // when it is already present via the changeOptions function.
-  const selectField = (field: string): void => {
-    let tmpFields: string[] = [];
-    if (options.fields) {
-      tmpFields = [...options.fields];
-    }
-
-    if (tmpFields.includes(field)) {
-      tmpFields = tmpFields.filter((f) => f !== field);
-    } else {
-      tmpFields.push(field);
-    }
-
-    changeOptions({ ...options, fields: tmpFields });
-  };
-
-  const addFilter = (filter: string): void => {
-    changeOptions({ ...options, query: `${options.query} ${filter}` });
-  };
-
-  const changeTime = (times: IPluginTimes): void => {
-    changeOptions({ ...options, times: times });
-  };
-
-  const changeOrder = (order: string, orderBy: string): void => {
-    changeOptions({ ...options, order: order, orderBy: orderBy });
-  };
-
-  // useEffect is used to set the options every time the search location for the current URL changes. The URL is changed
-  // via the changeOptions function. When the search location is changed we modify the options state.
-  useEffect(() => {
-    setOptions(getOptionsFromSearch(location.search));
-  }, [location.search]);
-
   return (
-    <React.Fragment>
-      <PageSection variant={PageSectionVariants.light}>
-        <Title headingLevel="h6" size="xl">
-          {displayName}
-          <span className="pf-u-font-size-md pf-u-font-weight-normal" style={{ float: 'right' }}>
-            <a href="https://kobs.io/plugins/clickhouse/" target="_blank" rel="noreferrer">
-              Documentation
-            </a>
-          </span>
-        </Title>
-        <p>{description}</p>
-        <LogsToolbar
-          query={options.query}
-          order={options.order}
-          orderBy={options.orderBy}
-          fields={options.fields}
-          times={options.times}
-          setOptions={changeOptions}
-        />
-      </PageSection>
-
-      <PageSection style={{ minHeight: '100%' }} variant={PageSectionVariants.default}>
-        {options.query.length > 0 ? (
-          <Logs
-            name={name}
-            fields={options.fields}
-            query={options.query}
-            order={options.order}
-            orderBy={options.orderBy}
-            addFilter={addFilter}
-            changeTime={changeTime}
-            changeOrder={changeOrder}
-            selectField={selectField}
-            times={options.times}
-          />
-        ) : null}
-      </PageSection>
-    </React.Fragment>
+    <Switch>
+      <Route exact={true} path={`/${name}`}>
+        <LogsPage name={name} displayName={displayName} description={description} />
+      </Route>
+      <Route exact={true} path={`/${name}/visualization`}>
+        <VisualizationPage name={name} displayName={displayName} description={description} />
+      </Route>
+    </Switch>
   );
 };
 

--- a/plugins/clickhouse/src/components/page/Visualization.tsx
+++ b/plugins/clickhouse/src/components/page/Visualization.tsx
@@ -1,0 +1,92 @@
+import { Alert, AlertActionLink, AlertVariant, Card, CardBody, Spinner } from '@patternfly/react-core';
+import { QueryObserverResult, useQuery } from 'react-query';
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+
+import { IVisualizationData, IVisualizationOptions } from '../../utils/interfaces';
+import VisualizationChart from '../panel/VisualizationChart';
+
+interface IVisualizationProps {
+  name: string;
+  options: IVisualizationOptions;
+}
+
+const Visualization: React.FunctionComponent<IVisualizationProps> = ({ name, options }: IVisualizationProps) => {
+  const history = useHistory();
+
+  const { isError, isLoading, data, error, refetch } = useQuery<IVisualizationData[], Error>(
+    ['clickhouse/visualization', name, options],
+    async () => {
+      try {
+        const response = await fetch(
+          `/api/plugins/clickhouse/visualization/${name}?query=${encodeURIComponent(options.query)}&timeStart=${
+            options.times.timeStart
+          }&timeEnd=${options.times.timeEnd}&limit=${options.limit}&groupBy=${options.groupBy}&operation=${
+            options.operation
+          }&operationField=${options.operationField}&order=${options.order}`,
+          {
+            method: 'get',
+          },
+        );
+        const json = await response.json();
+
+        if (response.status >= 200 && response.status < 300) {
+          if (json.error) {
+            throw new Error(json.error);
+          }
+
+          return json;
+        } else {
+          if (json.error) {
+            throw new Error(json.error);
+          } else {
+            throw new Error('An unknown error occured');
+          }
+        }
+      } catch (err) {
+        throw err;
+      }
+    },
+  );
+
+  if (isLoading) {
+    return (
+      <div className="pf-u-text-align-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Alert
+        variant={AlertVariant.danger}
+        title="Could not get visualization data"
+        actionLinks={
+          <React.Fragment>
+            <AlertActionLink onClick={(): void => history.push('/')}>Home</AlertActionLink>
+            <AlertActionLink onClick={(): Promise<QueryObserverResult<IVisualizationData[], Error>> => refetch()}>
+              Retry
+            </AlertActionLink>
+          </React.Fragment>
+        }
+      >
+        <p>{error?.message}</p>
+      </Alert>
+    );
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return (
+    <Card isCompact={true} style={{ height: '100%' }}>
+      <CardBody>
+        <VisualizationChart chart={options.chart} operation={options.operation} data={data} />
+      </CardBody>
+    </Card>
+  );
+};
+
+export default Visualization;

--- a/plugins/clickhouse/src/components/page/VisualizationOptions.tsx
+++ b/plugins/clickhouse/src/components/page/VisualizationOptions.tsx
@@ -1,0 +1,125 @@
+import {
+  Button,
+  Card,
+  CardBody,
+  Form,
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+  TextInput,
+} from '@patternfly/react-core';
+import React from 'react';
+
+import { IVisualizationOptions } from '../../utils/interfaces';
+
+interface IVisualizationOptionsProps {
+  options: IVisualizationOptions;
+  setOptions: (data: IVisualizationOptions) => void;
+  changeOptions: () => void;
+}
+
+const VisualizationOptions: React.FunctionComponent<IVisualizationOptionsProps> = ({
+  options,
+  setOptions,
+  changeOptions,
+}: IVisualizationOptionsProps) => {
+  return (
+    <Card isCompact={true}>
+      <CardBody>
+        <Form>
+          <FormGroup
+            label="Operation Field"
+            fieldId="vis-options-operation-field"
+            helperText="Use single quotes for fields of type string, e.g. 'namespace'."
+          >
+            <TextInput
+              value={options.operationField}
+              isRequired={true}
+              type="text"
+              id="vis-options-operation-field"
+              aria-describedby="vis-options-operation-field"
+              name="vis-options-operation-field"
+              onChange={(value): void => setOptions({ ...options, operationField: value })}
+            />
+          </FormGroup>
+
+          <FormGroup label="Operation" fieldId="vis-options-operation">
+            <FormSelect
+              value={options.operation}
+              onChange={(value): void => setOptions({ ...options, operation: value })}
+              id="vis-options-operation"
+              name="vis-options-operation"
+              aria-label="Operation"
+            >
+              <FormSelectOption value="count" label="count" />
+              <FormSelectOption value="min" label="min" />
+              <FormSelectOption value="max" label="max" />
+              <FormSelectOption value="sum" label="sum" />
+              <FormSelectOption value="avg" label="avg" />
+            </FormSelect>
+          </FormGroup>
+
+          <FormGroup
+            label="Group By"
+            fieldId="vis-options-group-by"
+            helperText="Use single quotes for fields of type string, e.g. 'namespace'."
+          >
+            <TextInput
+              value={options.groupBy}
+              isRequired={true}
+              type="text"
+              id="vis-options-group-by"
+              aria-describedby="vis-options-group-by"
+              name="vis-options-group-by"
+              onChange={(value): void => setOptions({ ...options, groupBy: value })}
+            />
+          </FormGroup>
+
+          <FormGroup label="Order" fieldId="vis-options-order">
+            <FormSelect
+              value={options.order}
+              onChange={(value): void => setOptions({ ...options, order: value })}
+              id="vis-options-order"
+              name="vis-options-order"
+              aria-label="Order"
+            >
+              <FormSelectOption value="ascending" label="ascending" />
+              <FormSelectOption value="descending" label="descending" />
+            </FormSelect>
+          </FormGroup>
+
+          <FormGroup label="Limit" fieldId="vis-options-limit">
+            <TextInput
+              value={options.limit}
+              isRequired={true}
+              type="text"
+              id="vis-options-limit"
+              aria-describedby="vis-options-limit"
+              name="vis-options-limit"
+              onChange={(value): void => setOptions({ ...options, limit: value })}
+            />
+          </FormGroup>
+
+          <FormGroup label="Chart" fieldId="vis-options-chart">
+            <FormSelect
+              value={options.chart}
+              onChange={(value): void => setOptions({ ...options, chart: value })}
+              id="vis-options-chart"
+              name="vis-options-chart"
+              aria-label="Chart"
+            >
+              <FormSelectOption value="bar" label="Bar Chart" />
+              <FormSelectOption value="pie" label="Pie Chart" />
+            </FormSelect>
+          </FormGroup>
+
+          <Button type="button" variant="primary" onClick={(): void => changeOptions()}>
+            Visualize
+          </Button>
+        </Form>
+      </CardBody>
+    </Card>
+  );
+};
+
+export default VisualizationOptions;

--- a/plugins/clickhouse/src/components/page/VisualizationPage.tsx
+++ b/plugins/clickhouse/src/components/page/VisualizationPage.tsx
@@ -1,0 +1,93 @@
+import {
+  Divider,
+  Flex,
+  FlexItem,
+  Grid,
+  GridItem,
+  PageSection,
+  PageSectionVariants,
+  Title,
+} from '@patternfly/react-core';
+import { Link, useHistory, useLocation } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+
+import { IVisualizationOptions } from '../../utils/interfaces';
+import Visualization from './Visualization';
+import VisualizationOptions from './VisualizationOptions';
+import VisualizationToolbar from './VisualizationToolbar';
+import { getVisualizationOptionsFromSearch } from '../../utils/helpers';
+
+interface IVisualizationPageProps {
+  name: string;
+  displayName: string;
+  description: string;
+}
+
+const VisualizationPage: React.FunctionComponent<IVisualizationPageProps> = ({
+  name,
+  displayName,
+  description,
+}: IVisualizationPageProps) => {
+  const location = useLocation();
+  const history = useHistory();
+  const [tmpOptions, setTmpOptions] = useState<IVisualizationOptions>(
+    getVisualizationOptionsFromSearch(location.search),
+  );
+  const [options, setOptions] = useState<IVisualizationOptions>(getVisualizationOptionsFromSearch(location.search));
+
+  // changeOptions is used to change the options for an ClickHouse query. Instead of directly modifying the options
+  // state we change the URL parameters.
+  const changeOptions = (): void => {
+    history.push({
+      pathname: location.pathname,
+      search: `?query=${tmpOptions.query}&time=${tmpOptions.times.time}&timeEnd=${tmpOptions.times.timeEnd}&timeStart=${tmpOptions.times.timeStart}&chart=${tmpOptions.chart}&limit=${tmpOptions.limit}&groupBy=${tmpOptions.groupBy}&operation=${tmpOptions.operation}&operationField=${tmpOptions.operationField}&order=${tmpOptions.order}`,
+    });
+  };
+
+  // useEffect is used to set the options every time the search location for the current URL changes. The URL is changed
+  // via the changeOptions function. When the search location is changed we modify the options state.
+  useEffect(() => {
+    setOptions(getVisualizationOptionsFromSearch(location.search));
+  }, [location.search]);
+
+  return (
+    <React.Fragment>
+      <PageSection variant={PageSectionVariants.light}>
+        <Title headingLevel="h6" size="xl">
+          {displayName}
+          <span className="pf-u-font-size-md pf-u-font-weight-normal" style={{ float: 'right' }}>
+            <Flex>
+              <FlexItem>
+                <Link to={`/${name}`}>Logs</Link>
+              </FlexItem>
+              <Divider isVertical={true} />
+              <FlexItem>
+                <a href="https://kobs.io/plugins/clickhouse/" target="_blank" rel="noreferrer">
+                  Documentation
+                </a>
+              </FlexItem>
+            </Flex>
+          </span>
+        </Title>
+        <p>{description}</p>
+        <VisualizationToolbar options={tmpOptions} setOptions={setTmpOptions} />
+      </PageSection>
+
+      <PageSection style={{ minHeight: '100%' }} variant={PageSectionVariants.default}>
+        <Grid hasGutter={true}>
+          <GridItem sm={12} md={12} lg={3} xl={4} xl2={3}>
+            <VisualizationOptions options={tmpOptions} setOptions={setTmpOptions} changeOptions={changeOptions} />
+          </GridItem>
+          <GridItem sm={12} md={12} lg={9} xl={8} xl2={9}>
+            {options.query !== '' && options.operationField !== '' ? (
+              <Visualization name={name} options={options} />
+            ) : null}
+          </GridItem>
+          <p>&nbsp;</p>
+        </Grid>
+      </PageSection>
+    </React.Fragment>
+  );
+};
+
+export default VisualizationPage;

--- a/plugins/clickhouse/src/components/page/VisualizationToolbar.tsx
+++ b/plugins/clickhouse/src/components/page/VisualizationToolbar.tsx
@@ -1,0 +1,64 @@
+import {
+  TextInput,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+  ToolbarToggleGroup,
+} from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons';
+import React from 'react';
+
+import { IOptionsAdditionalFields, Options, TTime } from '@kobsio/plugin-core';
+import { IVisualizationOptions } from '../../utils/interfaces';
+
+interface IVisualizationToolbarProps {
+  options: IVisualizationOptions;
+  setOptions: (data: IVisualizationOptions) => void;
+}
+
+const VisualizationToolbar: React.FunctionComponent<IVisualizationToolbarProps> = ({
+  options,
+  setOptions,
+}: IVisualizationToolbarProps) => {
+  const changeQuery = (value: string): void => {
+    setOptions({ ...options, query: value });
+  };
+
+  // changeOptions changes the ClickHouse option. If the options are changed via the refresh button of the Options
+  // component we directly modify the options of the parent component, if not we only change the data of the toolbar
+  // component and the user can trigger an action via the search button.
+  const changeOptions = (
+    refresh: boolean,
+    additionalFields: IOptionsAdditionalFields[] | undefined,
+    time: TTime,
+    timeEnd: number,
+    timeStart: number,
+  ): void => {
+    setOptions({ ...options, times: { time: time, timeEnd: timeEnd, timeStart: timeStart } });
+  };
+
+  return (
+    <Toolbar id="clickhouse-visualization-toolbar" style={{ paddingBottom: '0px', zIndex: 300 }}>
+      <ToolbarContent style={{ padding: '0px' }}>
+        <ToolbarToggleGroup style={{ width: '100%' }} toggleIcon={<FilterIcon />} breakpoint="lg">
+          <ToolbarGroup style={{ alignItems: 'flex-start', width: '100%' }}>
+            <ToolbarItem style={{ width: '100%' }}>
+              <TextInput aria-label="Query" type="text" value={options.query} onChange={changeQuery} />
+            </ToolbarItem>
+            <ToolbarItem>
+              <Options
+                time={options.times.time}
+                timeEnd={options.times.timeEnd}
+                timeStart={options.times.timeStart}
+                setOptions={changeOptions}
+              />
+            </ToolbarItem>
+          </ToolbarGroup>
+        </ToolbarToggleGroup>
+      </ToolbarContent>
+    </Toolbar>
+  );
+};
+
+export default VisualizationToolbar;

--- a/plugins/clickhouse/src/components/panel/VisualizationChart.tsx
+++ b/plugins/clickhouse/src/components/panel/VisualizationChart.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { IVisualizationData } from '../../utils/interfaces';
+import VisualizationChartBar from './VisualizationChartBar';
+import VisualizationChartPie from './VisualizationChartPie';
+
+interface IVisualizationChartProps {
+  chart: string;
+  operation: string;
+  data: IVisualizationData[];
+}
+
+const VisualizationChart: React.FunctionComponent<IVisualizationChartProps> = ({
+  chart,
+  operation,
+  data,
+}: IVisualizationChartProps) => {
+  if (chart === 'bar') {
+    return <VisualizationChartBar operation={operation} data={data} />;
+  } else if (chart === 'pie') {
+    return <VisualizationChartPie operation={operation} data={data} />;
+  } else {
+    return null;
+  }
+};
+
+export default VisualizationChart;

--- a/plugins/clickhouse/src/components/panel/VisualizationChartBar.tsx
+++ b/plugins/clickhouse/src/components/panel/VisualizationChartBar.tsx
@@ -1,0 +1,99 @@
+import { BarDatum, ResponsiveBarCanvas } from '@nivo/bar';
+import React, { useRef } from 'react';
+import { SquareIcon } from '@patternfly/react-icons';
+import { TooltipWrapper } from '@nivo/tooltip';
+
+import { COLOR_SCALE } from '../../utils/colors';
+import { IVisualizationData } from '../../utils/interfaces';
+import { useDimensions } from '@kobsio/plugin-core';
+
+interface IVisualizationChartBarProps {
+  operation: string;
+  data: IVisualizationData[];
+}
+
+const VisualizationChartBar: React.FunctionComponent<IVisualizationChartBarProps> = ({
+  operation,
+  data,
+}: IVisualizationChartBarProps) => {
+  const refChartContainer = useRef<HTMLDivElement>(null);
+  const chartContainerSize = useDimensions(refChartContainer);
+
+  const barData: BarDatum[] = data.map((datum) => {
+    return {
+      label: datum.label,
+      value: datum.value,
+    };
+  });
+
+  return (
+    <div ref={refChartContainer} style={{ height: '100%', width: '100%' }}>
+      <div style={{ height: `${chartContainerSize.height}px`, width: '100%' }}>
+        <ResponsiveBarCanvas
+          axisLeft={{
+            format: '>-.0s',
+            legend: '',
+            legendOffset: -40,
+            legendPosition: 'middle',
+          }}
+          axisBottom={{
+            legend: '',
+            tickRotation: 45,
+          }}
+          borderColor={{ from: 'color', modifiers: [['darker', 1.6]] }}
+          borderRadius={0}
+          borderWidth={0}
+          colorBy="indexValue"
+          colors={COLOR_SCALE}
+          data={barData}
+          enableLabel={false}
+          enableGridX={false}
+          enableGridY={true}
+          groupMode="stacked"
+          indexBy="label"
+          indexScale={{ round: true, type: 'band' }}
+          isInteractive={true}
+          keys={['value']}
+          layout="vertical"
+          margin={{ bottom: 100, left: 50, right: 0, top: 0 }}
+          maxValue="auto"
+          minValue="auto"
+          reverse={false}
+          theme={{
+            background: '#ffffff',
+            fontFamily: 'RedHatDisplay, Overpass, overpass, helvetica, arial, sans-serif',
+            fontSize: 10,
+            textColor: '#000000',
+          }}
+          // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+          tooltip={(tooltip) => {
+            const isFirstHalf = tooltip.index < barData.length / 2;
+
+            return (
+              <TooltipWrapper anchor={isFirstHalf ? 'right' : 'left'} position={[0, 5]}>
+                <div
+                  style={{
+                    background: '#151515',
+                    color: '#f0f0f0',
+                    fontFamily: '"RedHatText", "Overpass", overpass, helvetica, arial, sans-serif',
+                    fontSize: '14px',
+                    padding: '8px',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  <div>
+                    <SquareIcon color={tooltip.color} /> {tooltip.data.label}: {tooltip.data.value}
+                  </div>
+                </div>
+              </TooltipWrapper>
+            );
+          }}
+          valueFormat=""
+          valueScale={{ type: 'linear' }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default VisualizationChartBar;

--- a/plugins/clickhouse/src/components/panel/VisualizationChartPie.tsx
+++ b/plugins/clickhouse/src/components/panel/VisualizationChartPie.tsx
@@ -1,0 +1,74 @@
+import React, { useRef } from 'react';
+import { ResponsivePieCanvas } from '@nivo/pie';
+import { SquareIcon } from '@patternfly/react-icons';
+import { TooltipWrapper } from '@nivo/tooltip';
+
+import { COLOR_SCALE } from '../../utils/colors';
+import { IVisualizationData } from '../../utils/interfaces';
+import { useDimensions } from '@kobsio/plugin-core';
+
+interface IVisualizationChartPieProps {
+  operation: string;
+  data: IVisualizationData[];
+}
+
+const VisualizationChartPie: React.FunctionComponent<IVisualizationChartPieProps> = ({
+  operation,
+  data,
+}: IVisualizationChartPieProps) => {
+  const refChartContainer = useRef<HTMLDivElement>(null);
+  const chartContainerSize = useDimensions(refChartContainer);
+
+  return (
+    <div ref={refChartContainer} style={{ height: '100%', width: '100%' }}>
+      <div style={{ height: `${chartContainerSize.height}px`, width: '100%' }}>
+        <ResponsivePieCanvas
+          arcLabelsSkipAngle={10}
+          arcLabelsTextColor="#151515"
+          arcLinkLabelsColor={{ from: 'color' }}
+          arcLinkLabelsSkipAngle={10}
+          arcLinkLabelsTextColor="#151515"
+          arcLinkLabelsThickness={2}
+          borderColor={{ from: 'color', modifiers: [['darker', 1.6]] }}
+          borderWidth={0}
+          colors={COLOR_SCALE}
+          data={data}
+          id="label"
+          innerRadius={0}
+          isInteractive={true}
+          margin={{ bottom: 25, left: 25, right: 25, top: 25 }}
+          theme={{
+            background: '#ffffff',
+            fontFamily: 'RedHatDisplay, Overpass, overpass, helvetica, arial, sans-serif',
+            fontSize: 10,
+            textColor: '#000000',
+          }}
+          // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+          tooltip={(tooltip) => {
+            return (
+              <TooltipWrapper anchor="right" position={[0, 5]}>
+                <div
+                  style={{
+                    background: '#151515',
+                    color: '#f0f0f0',
+                    fontFamily: '"RedHatText", "Overpass", overpass, helvetica, arial, sans-serif',
+                    fontSize: '14px',
+                    padding: '8px',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  <div>
+                    <SquareIcon color={tooltip.datum.color} /> {tooltip.datum.label}: {tooltip.datum.value}
+                  </div>
+                </div>
+              </TooltipWrapper>
+            );
+          }}
+          value="value"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default VisualizationChartPie;

--- a/plugins/clickhouse/src/utils/colors.ts
+++ b/plugins/clickhouse/src/utils/colors.ts
@@ -1,0 +1,61 @@
+import chart_color_blue_100 from '@patternfly/react-tokens/dist/js/chart_color_blue_100';
+import chart_color_blue_200 from '@patternfly/react-tokens/dist/js/chart_color_blue_200';
+import chart_color_blue_300 from '@patternfly/react-tokens/dist/js/chart_color_blue_300';
+import chart_color_blue_400 from '@patternfly/react-tokens/dist/js/chart_color_blue_400';
+import chart_color_blue_500 from '@patternfly/react-tokens/dist/js/chart_color_blue_500';
+import chart_color_cyan_100 from '@patternfly/react-tokens/dist/js/chart_color_cyan_100';
+import chart_color_cyan_200 from '@patternfly/react-tokens/dist/js/chart_color_cyan_200';
+import chart_color_cyan_300 from '@patternfly/react-tokens/dist/js/chart_color_cyan_300';
+import chart_color_cyan_400 from '@patternfly/react-tokens/dist/js/chart_color_cyan_400';
+import chart_color_cyan_500 from '@patternfly/react-tokens/dist/js/chart_color_cyan_500';
+import chart_color_gold_100 from '@patternfly/react-tokens/dist/js/chart_color_gold_100';
+import chart_color_gold_200 from '@patternfly/react-tokens/dist/js/chart_color_gold_200';
+import chart_color_gold_300 from '@patternfly/react-tokens/dist/js/chart_color_gold_300';
+import chart_color_gold_400 from '@patternfly/react-tokens/dist/js/chart_color_gold_400';
+import chart_color_gold_500 from '@patternfly/react-tokens/dist/js/chart_color_gold_500';
+import chart_color_green_100 from '@patternfly/react-tokens/dist/js/chart_color_green_100';
+import chart_color_green_200 from '@patternfly/react-tokens/dist/js/chart_color_green_200';
+import chart_color_green_300 from '@patternfly/react-tokens/dist/js/chart_color_green_300';
+import chart_color_green_400 from '@patternfly/react-tokens/dist/js/chart_color_green_400';
+import chart_color_green_500 from '@patternfly/react-tokens/dist/js/chart_color_green_500';
+import chart_color_orange_100 from '@patternfly/react-tokens/dist/js/chart_color_orange_100';
+import chart_color_orange_200 from '@patternfly/react-tokens/dist/js/chart_color_orange_200';
+import chart_color_orange_300 from '@patternfly/react-tokens/dist/js/chart_color_orange_300';
+import chart_color_orange_400 from '@patternfly/react-tokens/dist/js/chart_color_orange_400';
+import chart_color_orange_500 from '@patternfly/react-tokens/dist/js/chart_color_orange_500';
+
+// We are using the multi color ordered theme from Patternfly for the charts.
+// See: https://github.com/patternfly/patternfly-react/blob/main/packages/react-charts/src/components/ChartTheme/themes/light/multi-color-ordered-theme.ts
+export const COLOR_SCALE = [
+  chart_color_blue_300.value,
+  chart_color_green_300.value,
+  chart_color_cyan_300.value,
+  chart_color_gold_300.value,
+  chart_color_orange_300.value,
+  chart_color_blue_100.value,
+  chart_color_green_500.value,
+  chart_color_cyan_100.value,
+  chart_color_gold_100.value,
+  chart_color_orange_500.value,
+  chart_color_blue_500.value,
+  chart_color_green_100.value,
+  chart_color_cyan_500.value,
+  chart_color_gold_500.value,
+  chart_color_orange_100.value,
+  chart_color_blue_200.value,
+  chart_color_green_400.value,
+  chart_color_cyan_200.value,
+  chart_color_gold_200.value,
+  chart_color_orange_400.value,
+  chart_color_blue_400.value,
+  chart_color_green_200.value,
+  chart_color_cyan_400.value,
+  chart_color_gold_400.value,
+  chart_color_orange_200.value,
+];
+
+// getColor returns the correct color for a given index. The function is mainly used by the legend for an chart, so that
+// we can split the legend and chart into separate components.
+export const getColor = (index: number): string => {
+  return COLOR_SCALE[index % COLOR_SCALE.length];
+};

--- a/plugins/clickhouse/src/utils/helpers.ts
+++ b/plugins/clickhouse/src/utils/helpers.ts
@@ -1,5 +1,5 @@
+import { IOptions, IVisualizationOptions } from './interfaces';
 import { TTime, TTimeOptions, formatTime } from '@kobsio/plugin-core';
-import { IOptions } from './interfaces';
 
 // getOptionsFromSearch is used to get the ClickHouse options from a given search location.
 export const getOptionsFromSearch = (search: string): IOptions => {
@@ -16,6 +16,41 @@ export const getOptionsFromSearch = (search: string): IOptions => {
     fields: fields.length > 0 ? fields : undefined,
     order: order ? order : 'ascending',
     orderBy: orderBy ? orderBy : '',
+    query: query ? query : '',
+    times: {
+      time: time && TTimeOptions.includes(time) ? (time as TTime) : 'last15Minutes',
+      timeEnd:
+        time && TTimeOptions.includes(time) && timeEnd ? parseInt(timeEnd as string) : Math.floor(Date.now() / 1000),
+      timeStart:
+        time && TTimeOptions.includes(time) && timeStart
+          ? parseInt(timeStart as string)
+          : Math.floor(Date.now() / 1000) - 900,
+    },
+  };
+};
+
+// getOptionsFromSearch is used to get the ClickHouse options for a visualization from a given search location.
+export const getVisualizationOptionsFromSearch = (search: string): IVisualizationOptions => {
+  const params = new URLSearchParams(search);
+
+  const chart = params.get('chart');
+  const limit = params.get('limit');
+  const groupBy = params.get('groupBy');
+  const operation = params.get('operation');
+  const operationField = params.get('operationField');
+  const order = params.get('order');
+  const query = params.get('query');
+  const time = params.get('time');
+  const timeEnd = params.get('timeEnd');
+  const timeStart = params.get('timeStart');
+
+  return {
+    chart: chart ? chart : 'bar',
+    groupBy: groupBy ? groupBy : '',
+    limit: limit ? limit : '10',
+    operation: operation ? operation : 'count',
+    operationField: operationField ? operationField : '',
+    order: order ? order : 'ascending',
     query: query ? query : '',
     times: {
       time: time && TTimeOptions.includes(time) ? (time as TTime) : 'last15Minutes',

--- a/plugins/clickhouse/src/utils/interfaces.ts
+++ b/plugins/clickhouse/src/utils/interfaces.ts
@@ -9,6 +9,18 @@ export interface IOptions {
   times: IPluginTimes;
 }
 
+// IVisualizationOptions is the interface for all options, which can be set to visualize an aggregation query.
+export interface IVisualizationOptions {
+  query: string;
+  times: IPluginTimes;
+  operationField: string;
+  operation: string;
+  groupBy: string;
+  order: string;
+  limit: string;
+  chart: string;
+}
+
 // IPanelOptions are the options for the panel component of the ClickHouse plugin.
 export interface IPanelOptions {
   type: string;
@@ -59,4 +71,10 @@ export interface ILabel {
 export interface IDomain {
   x: Date[];
   y: number[];
+}
+
+// IVisualizationData is the data returned by ClickHouse to render a chart.
+export interface IVisualizationData {
+  label: string;
+  value: number;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2185,6 +2185,15 @@
     "@react-spring/web" "9.2.4"
     lodash "^4.17.21"
 
+"@nivo/arcs@0.73.0":
+  version "0.73.0"
+  resolved "https://registry.yarnpkg.com/@nivo/arcs/-/arcs-0.73.0.tgz#2211a0c41e8f6ed67374aeebdad607fbb3a1db2f"
+  integrity sha512-jIjqr3McQUrDWoP6X4CZh8Tg0HphLZdU6K1IDfna2nkG8Dkr2LcB7Ejt5SFbhff+0SC/hjvjNC//h8vcynl7yA==
+  dependencies:
+    "@nivo/colors" "0.73.0"
+    "@react-spring/web" "9.2.4"
+    d3-shape "^1.3.5"
+
 "@nivo/axes@0.73.0":
   version "0.73.0"
   resolved "https://registry.yarnpkg.com/@nivo/axes/-/axes-0.73.0.tgz#d4982bda3c21d318507e4c61b9cce31549f8c894"
@@ -2260,6 +2269,17 @@
     "@nivo/tooltip" "0.73.0"
     "@nivo/voronoi" "0.73.0"
     "@react-spring/web" "9.2.4"
+    d3-shape "^1.3.5"
+
+"@nivo/pie@^0.73.0":
+  version "0.73.0"
+  resolved "https://registry.yarnpkg.com/@nivo/pie/-/pie-0.73.0.tgz#4370bfdaaded5b0ba159cc544548b02373baf55a"
+  integrity sha512-CWwpK9NSs1hfqvhcVvYJMTk+qD/tuxKDloURjfgJglUOs5m2NT1osDJN64jr02aZ6wZyplkP6WvJuc4K6mej6Q==
+  dependencies:
+    "@nivo/arcs" "0.73.0"
+    "@nivo/colors" "0.73.0"
+    "@nivo/legends" "0.73.0"
+    "@nivo/tooltip" "0.73.0"
     d3-shape "^1.3.5"
 
 "@nivo/recompose@0.73.0":


### PR DESCRIPTION
It is now possible to visualize logs from ClickHouse via bar or pie
charts. For that a new link to the visualization page was added to the
logs page.

To generate a pie or bar chart a user must provide a query and a time
range. Besides these two option a user can also select the operation
which should be used for the visualization, the field on which this
operation should be run, a field to group the results, a sorting order
and a limit.

NOTE: Currently the user must now if he uses a string or number field.
Maybe we can get a list of fields from ClickHouse in the future and the
let the user select the field via a select box, where we also now if the
field is a number or a string.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
