### PR TITLE
Rework home page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#158](https://github.com/kobsio/kobs/pull/158): Improve Pormetheus HTTP metrics and create a metric to find the most used fields in queries.
 - [#164](https://github.com/kobsio/kobs/pull/164): Improve chart handling across plugins.
 - [#167](https://github.com/kobsio/kobs/pull/167): Improve styling across plugins.
+- [#169](https://github.com/kobsio/kobs/pull/169): Rework home page to include plugins, applications and teams.
 
 ## [v0.5.0](https://github.com/kobsio/kobs/releases/tag/v0.5.0) (2021-08-03)
 

--- a/pkg/api/plugins/plugin/plugin.go
+++ b/pkg/api/plugins/plugin/plugin.go
@@ -7,6 +7,7 @@ type Plugin struct {
 	Name        string                 `json:"name"`
 	DisplayName string                 `json:"displayName"`
 	Description string                 `json:"description"`
+	Home        bool                   `json:"home"`
 	Type        string                 `json:"type"`
 	Options     map[string]interface{} `json:"options"`
 }

--- a/plugins/applications/applications.go
+++ b/plugins/applications/applications.go
@@ -217,6 +217,7 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 		Name:        "applications",
 		DisplayName: "Applications",
 		Description: "Monitor your Kubernetes workloads.",
+		Home:        true,
 		Type:        "applications",
 	})
 

--- a/plugins/applications/src/components/home/Home.tsx
+++ b/plugins/applications/src/components/home/Home.tsx
@@ -1,0 +1,151 @@
+import {
+  Alert,
+  AlertActionLink,
+  AlertVariant,
+  Badge,
+  Card,
+  CardBody,
+  CardTitle,
+  Gallery,
+  GalleryItem,
+  Spinner,
+  TextInput,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import { QueryObserverResult, useQuery } from 'react-query';
+import React, { useContext, useState } from 'react';
+
+import { ClustersContext, IClusterContext, IPluginPageProps, LinkWrapper, useDebounce } from '@kobsio/plugin-core';
+import { IApplication } from '../../utils/interfaces';
+
+const Home: React.FunctionComponent<IPluginPageProps> = () => {
+  const [searchTerm, setSearchTerm] = useState<string>('');
+  const debouncedSearchTerm = useDebounce(searchTerm, 500);
+  const clustersContext = useContext<IClusterContext>(ClustersContext);
+
+  const { isError, isLoading, error, data, refetch } = useQuery<IApplication[], Error>(
+    ['applications/applications', 'gallery', clustersContext.clusters],
+    async () => {
+      try {
+        const clusterParams = clustersContext.clusters.map((cluster) => `cluster=${cluster}`).join('&');
+
+        const response = await fetch(`/api/plugins/applications/applications?view=gallery&${clusterParams}`, {
+          method: 'get',
+        });
+        const json = await response.json();
+
+        if (response.status >= 200 && response.status < 300) {
+          return json;
+        } else {
+          if (json.error) {
+            throw new Error(json.error);
+          } else {
+            throw new Error('An unknown error occured');
+          }
+        }
+      } catch (err) {
+        throw err;
+      }
+    },
+  );
+
+  if (isLoading) {
+    return (
+      <div className="pf-u-text-align-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Alert
+        variant={AlertVariant.danger}
+        title="Could not get applications"
+        actionLinks={
+          <React.Fragment>
+            <AlertActionLink onClick={(): Promise<QueryObserverResult<IApplication[], Error>> => refetch()}>
+              Retry
+            </AlertActionLink>
+          </React.Fragment>
+        }
+      >
+        <p>{error?.message}</p>
+      </Alert>
+    );
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return (
+    <React.Fragment>
+      <Card>
+        <Toolbar id="applications-toolbar">
+          <ToolbarContent>
+            <ToolbarGroup style={{ alignItems: 'flex-start', width: '100%' }}>
+              <ToolbarItem style={{ width: '100%' }}>
+                <TextInput
+                  aria-label="Search"
+                  placeholder="Search"
+                  type="text"
+                  value={searchTerm}
+                  onChange={setSearchTerm}
+                />
+              </ToolbarItem>
+            </ToolbarGroup>
+          </ToolbarContent>
+        </Toolbar>
+      </Card>
+
+      <p>&nbsp;</p>
+
+      <Gallery hasGutter={true}>
+        {data
+          .filter((application) =>
+            !debouncedSearchTerm
+              ? true
+              : application.cluster.includes(debouncedSearchTerm) ||
+                application.namespace.includes(debouncedSearchTerm) ||
+                application.name.includes(debouncedSearchTerm) ||
+                application.description?.includes(debouncedSearchTerm),
+          )
+          .map((application, index) => (
+            <GalleryItem key={index}>
+              <LinkWrapper link={`/applications/${application.cluster}/${application.namespace}/${application.name}`}>
+                <Card style={{ cursor: 'pointer' }} isHoverable={true}>
+                  <CardTitle className="pf-u-text-truncate">
+                    {application.name}
+                    <br />
+                    <span className="pf-u-font-size-sm pf-u-color-400">
+                      {application.namespace} ({application.cluster})
+                    </span>
+                  </CardTitle>
+                  <CardBody style={{ height: '150px', maxHeight: '150px', minHeight: '150px' }}>
+                    <div style={{ height: '124px', overflow: 'scroll' }}>
+                      {application.tags && (
+                        <p>
+                          {application.tags.map((tag) => (
+                            <Badge key={tag} className="pf-u-mr-sm">
+                              {tag.toLowerCase()}
+                            </Badge>
+                          ))}
+                        </p>
+                      )}
+                      {application.description && <p>{application.description}</p>}
+                    </div>
+                  </CardBody>
+                </Card>
+              </LinkWrapper>
+            </GalleryItem>
+          ))}
+      </Gallery>
+    </React.Fragment>
+  );
+};
+
+export default Home;

--- a/plugins/applications/src/index.ts
+++ b/plugins/applications/src/index.ts
@@ -4,11 +4,13 @@ import './assets/applications.css';
 
 import icon from './assets/icon.png';
 
+import Home from './components/home/Home';
 import Page from './components/page/Page';
 import Panel from './components/panel/Panel';
 
 const applicationsPlugin: IPluginComponents = {
   applications: {
+    home: Home,
     icon: icon,
     page: Page,
     panel: Panel,

--- a/plugins/core/src/components/app/HomePage.tsx
+++ b/plugins/core/src/components/app/HomePage.tsx
@@ -1,22 +1,93 @@
-import { Gallery, GalleryItem, PageSection, PageSectionVariants } from '@patternfly/react-core';
-import React, { useContext } from 'react';
+import {
+  Gallery,
+  GalleryItem,
+  Grid,
+  GridItem,
+  Menu,
+  MenuContent,
+  MenuItem,
+  MenuList,
+  PageSection,
+  PageSectionVariants,
+} from '@patternfly/react-core';
+import React, { useContext, useEffect, useState } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
 
 import { IPluginsContext, PluginsContext } from '../../context/PluginsContext';
 import HomeItem from './HomeItem';
 
 // HomePage renders a list of all registered plugin instances via the HomeItem component.
 const HomePage: React.FunctionComponent = () => {
+  const history = useHistory();
+  const location = useLocation();
+
   const pluginsContext = useContext<IPluginsContext>(PluginsContext);
+  const pluginHome = pluginsContext.getPluginHome();
+  const [activePage, setActivePage] = useState<string>('plugins');
+
+  const pluginDetails = pluginsContext.getPluginDetails(activePage);
+  const Component =
+    pluginDetails && pluginsContext.components.hasOwnProperty(pluginDetails.type)
+      ? pluginsContext.components[pluginDetails.type].home
+      : undefined;
+
+  const changeActivePage = (
+    event?: React.MouseEvent<Element, MouseEvent> | undefined,
+    itemId?: string | number | undefined,
+  ): void => {
+    if (itemId) {
+      history.push({
+        pathname: location.pathname,
+        search: `?page=${itemId}`,
+      });
+    }
+  };
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const page = params.get('page');
+
+    if (page) {
+      setActivePage(page);
+    }
+  }, [location.search]);
 
   return (
     <PageSection variant={PageSectionVariants.default}>
-      <Gallery hasGutter={true}>
-        {pluginsContext.plugins.map((plugin) => (
-          <GalleryItem key={plugin.name}>
-            <HomeItem plugin={plugin} />
-          </GalleryItem>
-        ))}
-      </Gallery>
+      <Grid hasGutter={true}>
+        <GridItem sm={12} md={12} lg={3} xl={2} xl2={2}>
+          <Menu activeItemId={activePage} onSelect={changeActivePage}>
+            <MenuContent>
+              <MenuList>
+                <MenuItem itemId="plugins">Plugins</MenuItem>
+                {pluginHome.map((plugin, index) => (
+                  <MenuItem key={index} itemId={plugin.name}>
+                    {plugin.displayName}
+                  </MenuItem>
+                ))}
+              </MenuList>
+            </MenuContent>
+          </Menu>
+        </GridItem>
+        <GridItem sm={12} md={12} lg={9} xl={10} xl2={10}>
+          {activePage !== 'plugins' && pluginDetails && Component ? (
+            <Component
+              name={pluginDetails.name}
+              displayName={pluginDetails.displayName}
+              description={pluginDetails.description}
+              options={pluginDetails.options}
+            />
+          ) : (
+            <Gallery hasGutter={true}>
+              {pluginsContext.plugins.map((plugin) => (
+                <GalleryItem key={plugin.name}>
+                  <HomeItem plugin={plugin} />
+                </GalleryItem>
+              ))}
+            </Gallery>
+          )}
+        </GridItem>
+      </Grid>
     </PageSection>
   );
 };

--- a/plugins/core/src/context/PluginsContext.tsx
+++ b/plugins/core/src/context/PluginsContext.tsx
@@ -28,6 +28,7 @@ export interface IPluginData {
   name: string;
   displayName: string;
   description: string;
+  home: boolean;
   type: string;
   options?: IPluginDataOptions;
 }
@@ -72,6 +73,7 @@ export interface IPluginPreviewProps {
 // IPluginComponent is the interface which must be implemented by each plugin. It must contain an icon and panel
 // component. The page and preview component is optional for each plugin.
 export interface IPluginComponent {
+  home?: React.FunctionComponent<IPluginPageProps>;
   icon: string;
   page?: React.FunctionComponent<IPluginPageProps>;
   panel: React.FunctionComponent<IPluginPanelProps>;
@@ -88,6 +90,7 @@ export interface IPluginComponents {
 export interface IPluginsContext {
   components: IPluginComponents;
   getPluginDetails: (name: string) => IPluginData | undefined;
+  getPluginHome: () => IPluginData[];
   getPluginIcon: (type: string) => string;
   plugins: IPluginData[];
 }
@@ -97,6 +100,9 @@ export const PluginsContext = React.createContext<IPluginsContext>({
   components: {},
   getPluginDetails: (name: string) => {
     return undefined;
+  },
+  getPluginHome: () => {
+    return [];
   },
   getPluginIcon: (type: string) => {
     return '';
@@ -161,6 +167,11 @@ export const PluginsContextProvider: React.FunctionComponent<IPluginsContextProv
     return undefined;
   };
 
+  const getPluginHome = (): IPluginData[] => {
+    const pluginHome = data?.filter((p) => p.home);
+    return pluginHome || [];
+  };
+
   const getPluginIcon = (type: string): string => {
     if (components.hasOwnProperty(type)) {
       return components[type].icon;
@@ -206,6 +217,7 @@ export const PluginsContextProvider: React.FunctionComponent<IPluginsContextProv
       value={{
         components: components,
         getPluginDetails: getPluginDetails,
+        getPluginHome: getPluginHome,
         getPluginIcon: getPluginIcon,
         plugins: data,
       }}

--- a/plugins/teams/src/components/home/Home.tsx
+++ b/plugins/teams/src/components/home/Home.tsx
@@ -1,0 +1,123 @@
+import {
+  Alert,
+  AlertActionLink,
+  AlertVariant,
+  Card,
+  Gallery,
+  GalleryItem,
+  Spinner,
+  TextInput,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import { QueryObserverResult, useQuery } from 'react-query';
+import React, { useState } from 'react';
+
+import { IPluginPageProps, useDebounce } from '@kobsio/plugin-core';
+import { ITeam } from '../../utils/interfaces';
+import TeamsItem from '../page/TeamsItem';
+
+const Home: React.FunctionComponent<IPluginPageProps> = () => {
+  const [searchTerm, setSearchTerm] = useState<string>('');
+  const debouncedSearchTerm = useDebounce(searchTerm, 500);
+
+  const { isError, isLoading, error, data, refetch } = useQuery<ITeam[], Error>(['teams/teams'], async () => {
+    try {
+      const response = await fetch(`/api/plugins/teams/teams`, { method: 'get' });
+      const json = await response.json();
+
+      if (response.status >= 200 && response.status < 300) {
+        return json;
+      } else {
+        if (json.error) {
+          throw new Error(json.error);
+        } else {
+          throw new Error('An unknown error occured');
+        }
+      }
+    } catch (err) {
+      throw err;
+    }
+  });
+
+  if (isLoading) {
+    return (
+      <div className="pf-u-text-align-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Alert
+        variant={AlertVariant.danger}
+        title="Could not get teams"
+        actionLinks={
+          <React.Fragment>
+            <AlertActionLink onClick={(): Promise<QueryObserverResult<ITeam[], Error>> => refetch()}>
+              Retry
+            </AlertActionLink>
+          </React.Fragment>
+        }
+      >
+        <p>{error?.message}</p>
+      </Alert>
+    );
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return (
+    <React.Fragment>
+      <Card>
+        <Toolbar id="applications-toolbar">
+          <ToolbarContent>
+            <ToolbarGroup style={{ alignItems: 'flex-start', width: '100%' }}>
+              <ToolbarItem style={{ width: '100%' }}>
+                <TextInput
+                  aria-label="Search"
+                  placeholder="Search"
+                  type="text"
+                  value={searchTerm}
+                  onChange={setSearchTerm}
+                />
+              </ToolbarItem>
+            </ToolbarGroup>
+          </ToolbarContent>
+        </Toolbar>
+      </Card>
+
+      <p>&nbsp;</p>
+
+      <Gallery hasGutter={true}>
+        {data
+          .filter((team) =>
+            !debouncedSearchTerm
+              ? true
+              : team.cluster.includes(debouncedSearchTerm) ||
+                team.namespace.includes(debouncedSearchTerm) ||
+                team.name.includes(debouncedSearchTerm) ||
+                team.description?.includes(debouncedSearchTerm),
+          )
+          .map((team, index) => (
+            <GalleryItem key={index}>
+              <TeamsItem
+                cluster={team.cluster}
+                namespace={team.namespace}
+                name={team.name}
+                description={team.description}
+                logo={team.logo}
+              />
+            </GalleryItem>
+          ))}
+      </Gallery>
+    </React.Fragment>
+  );
+};
+
+export default Home;

--- a/plugins/teams/src/index.ts
+++ b/plugins/teams/src/index.ts
@@ -2,11 +2,13 @@ import { IPluginComponents } from '@kobsio/plugin-core';
 
 import icon from './assets/icon.png';
 
+import Home from './components/home/Home';
 import Page from './components/page/Page';
 import Panel from './components/panel/Panel';
 
 const teamsPlugin: IPluginComponents = {
   teams: {
+    home: Home,
     icon: icon,
     page: Page,
     panel: Panel,

--- a/plugins/teams/teams.go
+++ b/plugins/teams/teams.go
@@ -82,6 +82,7 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 		Name:        "teams",
 		DisplayName: "Teams",
 		Description: "Define an ownership for your Kubernetes resources.",
+		Home:        true,
 		Type:        "teams",
 	})
 


### PR DESCRIPTION
The home page of kobs now includes a list of plugins, applications and
teams. For that we added a new "home" parameter to the plugins data, so
that in the future also other plugins can be displayed on the home page.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
