### PR TITLE
Add auth settings to Helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#162](https://github.com/kobsio/kobs/pull/162): Add support to visualize logs in the ClickHouse plugin.
 - [#170](https://github.com/kobsio/kobs/pull/170): Add Custom Resource Definition for Users.
 - [#171](https://github.com/kobsio/kobs/pull/171): :warning: _Breaking change:_ :warning: Add authentication and authorization mechanism for plugins and resources. These settings are configured via the `--api.auth.<SETTING>` flags. Permissions are always granted on a team level. A users gets all permissions of the team where he is a member of.
+- [#172](https://github.com/kobsio/kobs/pull/172): Add authentication and authorization settings to Helm chart.
 
 ### Fixed
 

--- a/deploy/helm/kobs/Chart.yaml
+++ b/deploy/helm/kobs/Chart.yaml
@@ -4,5 +4,5 @@ description: Kubernetes Observability Platform
 type: application
 home: https://kobs.io
 icon: https://kobs.io/assets/images/logo.svg
-version: 0.7.1
+version: 0.7.2
 appVersion: v0.5.0

--- a/deploy/helm/kobs/templates/deployment.yaml
+++ b/deploy/helm/kobs/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
           image: "{{ .Values.kobs.image.repository }}:{{ .Values.kobs.image.tag }}"
           imagePullPolicy: {{ .Values.kobs.image.pullPolicy }}
           args:
+            - --api.auth.default-team={{ .Values.kobs.settings.auth.defaultTeam }}
+            - --api.auth.enabled={{ .Values.kobs.settings.auth.enabled }}
+            - --api.auth.header={{ .Values.kobs.settings.auth.header }}
+            - --api.auth.interval={{ .Values.kobs.settings.auth.interval }}
             - --clusters.cache-duration.namespaces={{ .Values.kobs.settings.clustersCacheDurationNamespaces }}
             - --log.format={{ .Values.kobs.settings.logFormat }}
             - --log.level={{ .Values.kobs.settings.logLevel }}

--- a/deploy/helm/kobs/values.yaml
+++ b/deploy/helm/kobs/values.yaml
@@ -83,6 +83,11 @@ kobs:
   ## Specify some settings like log level, log format, etc. for kobs.
   ##
   settings:
+    auth:
+      enabled: false
+      defaultTeam: ""
+      header: X-Auth-Request-Email
+      interval: 1h0m0s
     clustersCacheDurationNamespaces: 5m
     logFormat: plain
     logLevel: info

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -64,6 +64,10 @@ helm upgrade kobs kobs/kobs
 | `kobs.securityContext` | Specify security settings for the kobs Container. They override settings made at the Pod level via the `podSecurityContext` when there is overlap. | `{}` |
 | `kobs.resources` | Set cpu and memory requests and limits for the kobs container. | `{}` |
 | `kobs.env` | Set additional environment variables for the kobs container. | `[]` |
+| `kobs.settings.auth.enabled` | Enable the authentication and authorization middleware. | `false` |
+| `kobs.settings.auth.defaultTeam` | The name of the team, which should be used for a users permissions when a user hasn't any teams. The team is specified in the following format: `cluster,namespace,name`. | `""` |
+| `kobs.settings.auth.header` | The header, which contains the details about the authenticated user. | `X-Auth-Request-Email` |
+| `kobs.settings.auth.interval` | The interval to refresh the internal users list and there permissions. | `1h0m0s` |
 | `kobs.settings.clustersCacheDurationNamespaces` | The duration for how long the list of namespaces for each cluster should be cached. | `5m` |
 | `kobs.settings.logFormat` | Set the output format of the logs. Must be `plain` or `json`. | `plain` |
 | `kobs.settings.logLevel` | Set the log level. Must be `trace`, `debug`, `info`, `warn`, `error`, `fatal` or `panic`. | `info` |


### PR DESCRIPTION
It is now possible to set the settings for authentication and
authorization in the Helm chart.

<!--
  Keep PR title verbose enough.
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [x] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
