### PR TITLE
[prometheus] Fix tooltip when no unit is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 ### Fixed
 
+- [#175](https://github.com/kobsio/kobs/pull/175): [prometheus] Fix tooltip when no unit is provided.
+
 ### Changed
 
 ## [v0.6.0](https://github.com/kobsio/kobs/releases/tag/v0.6.0) (2021-10-11)

--- a/plugins/kiali/src/components/panel/details/Chart.tsx
+++ b/plugins/kiali/src/components/panel/details/Chart.tsx
@@ -45,7 +45,7 @@ export const Chart: React.FunctionComponent<IChartProps> = ({ times, chart }: IC
                 color={tooltip.point.color}
                 label={`${chart.series.filter((serie) => serie.id === tooltip.point.serieId)[0].label}: ${
                   tooltip.point.data.yFormatted
-                } ${chart.unit}`}
+                } ${chart.unit && chart.unit}`}
                 title={tooltip.point.data.xFormatted.toString()}
               />
             )}

--- a/plugins/prometheus/src/components/panel/Chart.tsx
+++ b/plugins/prometheus/src/components/panel/Chart.tsx
@@ -78,7 +78,9 @@ export const Chart: React.FunctionComponent<IChartProps> = ({
           <ChartTooltip
             anchor={isFirstHalf ? 'right' : 'left'}
             color={tooltip.point.color}
-            label={`${labels[tooltip.point.id.split('.')[0]]}: ${tooltip.point.data.yFormatted} ${options.unit}`}
+            label={`${labels[tooltip.point.id.split('.')[0]]}: ${tooltip.point.data.yFormatted} ${
+              options.unit && options.unit
+            }`}
             position={[0, 20]}
             title={tooltip.point.data.xFormatted.toString()}
           />


### PR DESCRIPTION
When a user defined a chart without a unit, we displayed "undefined" in
the tooltip, because we didn't check if the unit was provided when
building the tooltip label value. This should now be fixed, so that no
unit is displayed when not provided.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
