### PR TITLE
[clickhouse] Add sorting and show milliseconds in time column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 ### Changed
 
+- [#179](https://github.com/kobsio/kobs/pull/179): [clickhouse] Add sorting and show milliseconds in time column.
+
 ## [v0.6.0](https://github.com/kobsio/kobs/releases/tag/v0.6.0) (2021-10-11)
 
 ### Added

--- a/plugins/clickhouse/src/components/panel/LogsDocument.tsx
+++ b/plugins/clickhouse/src/components/panel/LogsDocument.tsx
@@ -4,7 +4,7 @@ import { InView } from 'react-intersection-observer';
 
 import { IDocument } from '../../utils/interfaces';
 import LogsDocumentDetails from './LogsDocumentDetails';
-import { formatTimeWrapper } from '../../utils/helpers';
+import { formatTime } from '../../utils/helpers';
 
 interface ILogsDocumentProps {
   document: IDocument;
@@ -48,7 +48,7 @@ const LogsDocument: React.FunctionComponent<ILogsDocumentProps> = ({
                   expand={{ isExpanded: isExpanded, onToggle: (): void => setIsExpanded(!isExpanded), rowIndex: 0 }}
                 />
                 <Td className="pf-u-text-wrap pf-u-text-break-word" dataLabel="Time">
-                  <TableText wrapModifier="nowrap">{formatTimeWrapper(document['timestamp'])}</TableText>
+                  <TableText wrapModifier="nowrap">{formatTime(document['timestamp'])}</TableText>
                 </Td>
                 {fields && fields.length > 0 ? (
                   fields.map((field, index) => (

--- a/plugins/clickhouse/src/components/panel/LogsDocuments.tsx
+++ b/plugins/clickhouse/src/components/panel/LogsDocuments.tsx
@@ -32,14 +32,31 @@ const LogsDocuments: React.FunctionComponent<ILogsDocumentsProps> = ({
   selectField,
 }: ILogsDocumentsProps) => {
   const activeSortIndex = fields && orderBy ? fields?.indexOf(orderBy) : -1;
-  const activeSortDirection = order === 'descending' ? 'desc' : 'asc';
+  const activeSortDirection = order === 'ascending' ? 'asc' : 'desc';
 
   return (
     <TableComposable aria-label="Logs" variant={TableVariant.compact} borders={false}>
       <Thead>
         <Tr>
           <Th />
-          <Th>Time</Th>
+          <Th
+            sort={{
+              columnIndex: -1,
+              onSort: (
+                event: React.MouseEvent,
+                columnIndex: number,
+                sortByDirection: SortByDirection,
+                extraData: IExtraColumnData,
+              ): void => {
+                if (changeOrder) {
+                  changeOrder(sortByDirection === 'asc' ? 'ascending' : 'descending', 'timestamp');
+                }
+              },
+              sortBy: { direction: activeSortDirection, index: activeSortIndex },
+            }}
+          >
+            Time
+          </Th>
           {fields && fields.length > 0 ? (
             fields.map((field, index) => (
               <Th
@@ -53,7 +70,7 @@ const LogsDocuments: React.FunctionComponent<ILogsDocumentsProps> = ({
                     extraData: IExtraColumnData,
                   ): void => {
                     if (changeOrder) {
-                      changeOrder(sortByDirection === 'desc' ? 'descending' : 'ascending', field);
+                      changeOrder(sortByDirection === 'asc' ? 'ascending' : 'descending', field);
                     }
                   },
                   sortBy: { direction: activeSortDirection, index: activeSortIndex },

--- a/plugins/clickhouse/src/utils/helpers.ts
+++ b/plugins/clickhouse/src/utils/helpers.ts
@@ -1,5 +1,5 @@
 import { IOptions, IVisualizationOptions } from './interfaces';
-import { TTime, TTimeOptions, formatTime } from '@kobsio/plugin-core';
+import { TTime, TTimeOptions } from '@kobsio/plugin-core';
 
 // getOptionsFromSearch is used to get the ClickHouse options from a given search location.
 export const getOptionsFromSearch = (search: string): IOptions => {
@@ -64,8 +64,13 @@ export const getVisualizationOptionsFromSearch = (search: string): IVisualizatio
   };
 };
 
-// formatTimeWrapper is a wrapper for our shared formatTime function. It is needed to convert a given time string to the
-// corresponding timestamp representation, which we need for the formatTime function.
-export const formatTimeWrapper = (time: string): string => {
-  return formatTime(Math.floor(new Date(time).getTime() / 1000));
+// formatTime formate the given time string. We do not use the formatTime function from the core package, because we
+// also want to include milliseconds in the logs timestamp, which we show.
+export const formatTime = (time: string): string => {
+  const d = new Date(time);
+  return `${d.getFullYear()}-${('0' + (d.getMonth() + 1)).slice(-2)}-${('0' + d.getDate()).slice(-2)} ${(
+    '0' + d.getHours()
+  ).slice(-2)}:${('0' + d.getMinutes()).slice(-2)}:${('0' + d.getSeconds()).slice(-2)}.${(
+    '00' + d.getMilliseconds()
+  ).slice(-3)}`;
 };

--- a/plugins/elasticsearch/src/components/panel/LogsDocument.tsx
+++ b/plugins/elasticsearch/src/components/panel/LogsDocument.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { TableText, Td, Tr } from '@patternfly/react-table';
 
-import { formatTimeWrapper, getProperty } from '../../utils/helpers';
+import { formatTime, getProperty } from '../../utils/helpers';
 import { IDocument } from '../../utils/interfaces';
 import LogsDocumentDetails from './LogsDocumentDetails';
 import LogsDocumentPreview from './LogsDocumentPreview';
@@ -37,7 +37,7 @@ const LogsDocument: React.FunctionComponent<ILogsDocumentProps> = ({ document, f
           expand={{ isExpanded: isExpanded, onToggle: (): void => setIsExpanded(!isExpanded), rowIndex: 0 }}
         />
         <Td className="pf-u-text-wrap pf-u-text-break-word" dataLabel="Time">
-          <TableText wrapModifier="nowrap"> {formatTimeWrapper(document['_source']['@timestamp'])}</TableText>
+          <TableText wrapModifier="nowrap"> {formatTime(document['_source']['@timestamp'])}</TableText>
         </Td>
         {fields && fields.length > 0 ? (
           fields.map((field, index) => (

--- a/plugins/elasticsearch/src/components/panel/details/Details.tsx
+++ b/plugins/elasticsearch/src/components/panel/details/Details.tsx
@@ -15,7 +15,7 @@ import { Editor, Title } from '@kobsio/plugin-core';
 import Actions from './Actions';
 import Document from './Document';
 import { IDocument } from '../../../utils/interfaces';
-import { formatTimeWrapper } from '../../../utils/helpers';
+import { formatTime } from '../../../utils/helpers';
 
 export interface IDetailsProps {
   document: IDocument;
@@ -31,7 +31,7 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ document, close }: ID
     <DrawerPanelContent minSize="50%">
       <DrawerHead>
         <Title
-          title={formatTimeWrapper(document['_source']['@timestamp'])}
+          title={formatTime(document['_source']['@timestamp'])}
           subtitle={`${document['_id']} (${document['_index']})`}
           size="lg"
         />

--- a/plugins/elasticsearch/src/utils/helpers.ts
+++ b/plugins/elasticsearch/src/utils/helpers.ts
@@ -1,5 +1,5 @@
 import { IDocument, IKeyValue, IOptions } from './interfaces';
-import { TTime, TTimeOptions, formatTime } from '@kobsio/plugin-core';
+import { TTime, TTimeOptions } from '@kobsio/plugin-core';
 
 // getOptionsFromSearch is used to get the Elasticsearch options from a given search location.
 export const getOptionsFromSearch = (search: string): IOptions => {
@@ -57,10 +57,15 @@ export const getFields = (documents: IDocument[]): string[] => {
   return uniqueFields;
 };
 
-// formatTimeWrapper is a wrapper for our shared formatTime function. It is needed to convert a given time string to the
-// corresponding timestamp representation, which we need for the formatTime function.
-export const formatTimeWrapper = (time: string): string => {
-  return formatTime(Math.floor(new Date(time).getTime() / 1000));
+// formatTime formate the given time string. We do not use the formatTime function from the core package, because we
+// also want to include milliseconds in the logs timestamp, which we show.
+export const formatTime = (time: string): string => {
+  const d = new Date(time);
+  return `${d.getFullYear()}-${('0' + (d.getMonth() + 1)).slice(-2)}-${('0' + d.getDate()).slice(-2)} ${(
+    '0' + d.getHours()
+  ).slice(-2)}:${('0' + d.getMinutes()).slice(-2)}:${('0' + d.getSeconds()).slice(-2)}.${(
+    '00' + d.getMilliseconds()
+  ).slice(-3)}`;
 };
 
 // getProperty returns the property of an object for a given key.


### PR DESCRIPTION
Once a user selected another column then the default timestamp column
for sorting the logs lines, he must go to the options menu to sort the
columns for the timestamp column. Now he can directly go back to the
default by clicking the sort icon next to the time column.

The time column now uses a custom function to format the timestamp, so
that we can also display the milliseconds for the log line.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
