### PR TITLE
[core] Add default handling for time parameters

### DIFF
--- a/plugins/clickhouse/src/components/panel/LogsDocuments.tsx
+++ b/plugins/clickhouse/src/components/panel/LogsDocuments.tsx
@@ -31,7 +31,7 @@ const LogsDocuments: React.FunctionComponent<ILogsDocumentsProps> = ({
   changeOrder,
   selectField,
 }: ILogsDocumentsProps) => {
-  const activeSortIndex = fields && orderBy ? fields?.indexOf(orderBy) : -1;
+  const activeSortIndex = fields && orderBy && orderBy !== 'timestamp' ? fields?.indexOf(orderBy) : -1;
   const activeSortDirection = order === 'ascending' ? 'asc' : 'desc';
 
   return (

--- a/plugins/clickhouse/src/utils/helpers.ts
+++ b/plugins/clickhouse/src/utils/helpers.ts
@@ -1,5 +1,5 @@
 import { IOptions, IVisualizationOptions } from './interfaces';
-import { TTime, TTimeOptions } from '@kobsio/plugin-core';
+import { getTimeParams } from '@kobsio/plugin-core';
 
 // getOptionsFromSearch is used to get the ClickHouse options from a given search location.
 export const getOptionsFromSearch = (search: string): IOptions => {
@@ -8,24 +8,13 @@ export const getOptionsFromSearch = (search: string): IOptions => {
   const order = params.get('order');
   const orderBy = params.get('orderBy');
   const query = params.get('query');
-  const time = params.get('time');
-  const timeEnd = params.get('timeEnd');
-  const timeStart = params.get('timeStart');
 
   return {
     fields: fields.length > 0 ? fields : undefined,
-    order: order ? order : 'ascending',
+    order: order ? order : 'descending',
     orderBy: orderBy ? orderBy : '',
     query: query ? query : '',
-    times: {
-      time: time && TTimeOptions.includes(time) ? (time as TTime) : 'last15Minutes',
-      timeEnd:
-        time && TTimeOptions.includes(time) && timeEnd ? parseInt(timeEnd as string) : Math.floor(Date.now() / 1000),
-      timeStart:
-        time && TTimeOptions.includes(time) && timeStart
-          ? parseInt(timeStart as string)
-          : Math.floor(Date.now() / 1000) - 900,
-    },
+    times: getTimeParams(params),
   };
 };
 
@@ -40,9 +29,6 @@ export const getVisualizationOptionsFromSearch = (search: string): IVisualizatio
   const operationField = params.get('operationField');
   const order = params.get('order');
   const query = params.get('query');
-  const time = params.get('time');
-  const timeEnd = params.get('timeEnd');
-  const timeStart = params.get('timeStart');
 
   return {
     chart: chart ? chart : 'bar',
@@ -50,17 +36,9 @@ export const getVisualizationOptionsFromSearch = (search: string): IVisualizatio
     limit: limit ? limit : '10',
     operation: operation ? operation : 'count',
     operationField: operationField ? operationField : '',
-    order: order ? order : 'ascending',
+    order: order ? order : 'descending',
     query: query ? query : '',
-    times: {
-      time: time && TTimeOptions.includes(time) ? (time as TTime) : 'last15Minutes',
-      timeEnd:
-        time && TTimeOptions.includes(time) && timeEnd ? parseInt(timeEnd as string) : Math.floor(Date.now() / 1000),
-      timeStart:
-        time && TTimeOptions.includes(time) && timeStart
-          ? parseInt(timeStart as string)
-          : Math.floor(Date.now() / 1000) - 900,
-    },
+    times: getTimeParams(params),
   };
 };
 

--- a/plugins/core/src/utils/time.ts
+++ b/plugins/core/src/utils/time.ts
@@ -1,3 +1,6 @@
+import { TTime, TTimeOptions } from '../components/misc/Options';
+import { IPluginTimes } from '../context/PluginsContext';
+
 // timeDifference calculates the difference of two given timestamps and returns a human readable string for the
 // difference. It is used to get the same style for the age of resources like it is displayed by kubectl.
 export const timeDifference = (current: number, previous: number): string => {
@@ -27,4 +30,21 @@ export const formatTime = (timestamp: number): string => {
   return `${d.getFullYear()}-${('0' + (d.getMonth() + 1)).slice(-2)}-${('0' + d.getDate()).slice(-2)} ${(
     '0' + d.getHours()
   ).slice(-2)}:${('0' + d.getMinutes()).slice(-2)}:${('0' + d.getSeconds()).slice(-2)}`;
+};
+
+// getTimeParams returns a times object for the parsed time parameters from a URL.
+export const getTimeParams = (params: URLSearchParams): IPluginTimes => {
+  const time = params.get('time');
+  const timeEnd = params.get('timeEnd');
+  const timeStart = params.get('timeStart');
+
+  return {
+    time: time && TTimeOptions.includes(time) ? (time as TTime) : 'last15Minutes',
+    timeEnd:
+      time && TTimeOptions.includes(time) && timeEnd ? parseInt(timeEnd as string) : Math.floor(Date.now() / 1000),
+    timeStart:
+      time && TTimeOptions.includes(time) && timeStart
+        ? parseInt(timeStart as string)
+        : Math.floor(Date.now() / 1000) - 900,
+  };
 };

--- a/plugins/elasticsearch/src/utils/helpers.ts
+++ b/plugins/elasticsearch/src/utils/helpers.ts
@@ -1,27 +1,16 @@
 import { IDocument, IKeyValue, IOptions } from './interfaces';
-import { TTime, TTimeOptions } from '@kobsio/plugin-core';
+import { getTimeParams } from '@kobsio/plugin-core';
 
 // getOptionsFromSearch is used to get the Elasticsearch options from a given search location.
 export const getOptionsFromSearch = (search: string): IOptions => {
   const params = new URLSearchParams(search);
   const fields = params.getAll('field');
   const query = params.get('query');
-  const time = params.get('time');
-  const timeEnd = params.get('timeEnd');
-  const timeStart = params.get('timeStart');
 
   return {
     fields: fields.length > 0 ? fields : undefined,
     query: query ? query : '',
-    times: {
-      time: time && TTimeOptions.includes(time) ? (time as TTime) : 'last15Minutes',
-      timeEnd:
-        time && TTimeOptions.includes(time) && timeEnd ? parseInt(timeEnd as string) : Math.floor(Date.now() / 1000),
-      timeStart:
-        time && TTimeOptions.includes(time) && timeStart
-          ? parseInt(timeStart as string)
-          : Math.floor(Date.now() / 1000) - 900,
-    },
+    times: getTimeParams(params),
   };
 };
 

--- a/plugins/istio/src/utils/helpers.ts
+++ b/plugins/istio/src/utils/helpers.ts
@@ -1,44 +1,21 @@
-import { IPluginTimes, TTime, TTimeOptions } from '@kobsio/plugin-core';
+import { IPluginTimes, getTimeParams } from '@kobsio/plugin-core';
 import { IOptions } from './interfaces';
 
 // getApplicationsOptionsFromSearch is used to get the Istio options from a given search location.
 export const getApplicationsOptionsFromSearch = (search: string): IOptions => {
   const params = new URLSearchParams(search);
   const namespaces = params.getAll('namespace');
-  const time = params.get('time');
-  const timeEnd = params.get('timeEnd');
-  const timeStart = params.get('timeStart');
 
   return {
     namespaces: namespaces.length > 0 ? namespaces : [],
-    times: {
-      time: time && TTimeOptions.includes(time) ? (time as TTime) : 'last15Minutes',
-      timeEnd:
-        time && TTimeOptions.includes(time) && timeEnd ? parseInt(timeEnd as string) : Math.floor(Date.now() / 1000),
-      timeStart:
-        time && TTimeOptions.includes(time) && timeStart
-          ? parseInt(timeStart as string)
-          : Math.floor(Date.now() / 1000) - 900,
-    },
+    times: getTimeParams(params),
   };
 };
 
 // getApplicationOptionsFromSearch is used to get the Istio options from a given search location.
 export const getApplicationOptionsFromSearch = (search: string): IPluginTimes => {
   const params = new URLSearchParams(search);
-  const time = params.get('time');
-  const timeEnd = params.get('timeEnd');
-  const timeStart = params.get('timeStart');
-
-  return {
-    time: time && TTimeOptions.includes(time) ? (time as TTime) : 'last15Minutes',
-    timeEnd:
-      time && TTimeOptions.includes(time) && timeEnd ? parseInt(timeEnd as string) : Math.floor(Date.now() / 1000),
-    timeStart:
-      time && TTimeOptions.includes(time) && timeStart
-        ? parseInt(timeStart as string)
-        : Math.floor(Date.now() / 1000) - 900,
-  };
+  return getTimeParams(params);
 };
 
 // formatNumber brings the given value returned by Prometheus as string into a format we can use in our ui.

--- a/plugins/jaeger/src/utils/helpers.ts
+++ b/plugins/jaeger/src/utils/helpers.ts
@@ -1,5 +1,5 @@
 import { IDeduplicateTags, IKeyValuePair, IOptions, ISpan, ITrace } from './interfaces';
-import { IPluginTimes, TTime, TTimeOptions, formatTime } from '@kobsio/plugin-core';
+import { IPluginTimes, formatTime, getTimeParams } from '@kobsio/plugin-core';
 import TreeNode from './TreeNode';
 
 // getOptionsFromSearch is used to get the Jaeger options from a given search location.
@@ -11,9 +11,6 @@ export const getOptionsFromSearch = (search: string): IOptions => {
   const operation = params.get('operation');
   const service = params.get('service');
   const tags = params.get('tags');
-  const time = params.get('time');
-  const timeEnd = params.get('timeEnd');
-  const timeStart = params.get('timeStart');
 
   return {
     limit: limit ? limit : '20',
@@ -22,15 +19,7 @@ export const getOptionsFromSearch = (search: string): IOptions => {
     operation: operation ? operation : '',
     service: service ? service : '',
     tags: tags ? tags : '',
-    times: {
-      time: time && TTimeOptions.includes(time) ? (time as TTime) : 'last15Minutes',
-      timeEnd:
-        time && TTimeOptions.includes(time) && timeEnd ? parseInt(timeEnd as string) : Math.floor(Date.now() / 1000),
-      timeStart:
-        time && TTimeOptions.includes(time) && timeStart
-          ? parseInt(timeStart as string)
-          : Math.floor(Date.now() / 1000) - 900,
-    },
+    times: getTimeParams(params),
   };
 };
 

--- a/plugins/kiali/src/utils/helpers.ts
+++ b/plugins/kiali/src/utils/helpers.ts
@@ -1,25 +1,14 @@
 import { IMetric, INodeData, IOptions, ISerie } from './interfaces';
-import { IPluginTimes, TTime, TTimeOptions } from '@kobsio/plugin-core';
+import { IPluginTimes, getTimeParams } from '@kobsio/plugin-core';
 
 // getOptionsFromSearch is used to get the Kiali options from a given search location.
 export const getOptionsFromSearch = (search: string): IOptions => {
   const params = new URLSearchParams(search);
   const namespaces = params.getAll('namespace');
-  const time = params.get('time');
-  const timeEnd = params.get('timeEnd');
-  const timeStart = params.get('timeStart');
 
   return {
     namespaces: namespaces.length > 0 ? namespaces : undefined,
-    times: {
-      time: time && TTimeOptions.includes(time) ? (time as TTime) : 'last15Minutes',
-      timeEnd:
-        time && TTimeOptions.includes(time) && timeEnd ? parseInt(timeEnd as string) : Math.floor(Date.now() / 1000),
-      timeStart:
-        time && TTimeOptions.includes(time) && timeStart
-          ? parseInt(timeStart as string)
-          : Math.floor(Date.now() / 1000) - 900,
-    },
+    times: getTimeParams(params),
   };
 };
 

--- a/plugins/opsgenie/src/utils/helpers.ts
+++ b/plugins/opsgenie/src/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { IPluginTimes, TTime, TTimeOptions, formatTime } from '@kobsio/plugin-core';
+import { IPluginTimes, formatTime, getTimeParams } from '@kobsio/plugin-core';
 import { IOptions } from './interfaces';
 
 // getOptionsFromSearch is used to get the Jaeger options from a given search location.
@@ -6,21 +6,10 @@ export const getOptionsFromSearch = (search: string): IOptions => {
   const params = new URLSearchParams(search);
   const query = params.get('query');
   const type = params.get('type');
-  const time = params.get('time');
-  const timeEnd = params.get('timeEnd');
-  const timeStart = params.get('timeStart');
 
   return {
     query: query === null ? 'status: open' : query,
-    times: {
-      time: time && TTimeOptions.includes(time) ? (time as TTime) : 'last15Minutes',
-      timeEnd:
-        time && TTimeOptions.includes(time) && timeEnd ? parseInt(timeEnd as string) : Math.floor(Date.now() / 1000),
-      timeStart:
-        time && TTimeOptions.includes(time) && timeStart
-          ? parseInt(timeStart as string)
-          : Math.floor(Date.now() / 1000) - 900,
-    },
+    times: getTimeParams(params),
     type: type ? type : 'alerts',
   };
 };

--- a/plugins/prometheus/src/utils/helpers.ts
+++ b/plugins/prometheus/src/utils/helpers.ts
@@ -1,7 +1,7 @@
 import { DatumValue, Serie } from '@nivo/line';
 
 import { ILabels, IMappings, IMetric, IOptions, ISeries } from './interfaces';
-import { TTime, TTimeOptions } from '@kobsio/plugin-core';
+import { getTimeParams } from '@kobsio/plugin-core';
 
 // getOptionsFromSearch is used to parse the given search location and return is as options for Prometheus. This is
 // needed, so that a user can explore his Prometheus data from a chart. When the user selects the explore action, we
@@ -10,22 +10,11 @@ export const getOptionsFromSearch = (search: string): IOptions => {
   const params = new URLSearchParams(search);
   const queries = params.getAll('query');
   const resolution = params.get('resolution');
-  const time = params.get('time');
-  const timeEnd = params.get('timeEnd');
-  const timeStart = params.get('timeStart');
 
   return {
     queries: queries.length > 0 ? queries : [''],
     resolution: resolution ? resolution : '',
-    times: {
-      time: time && TTimeOptions.includes(time) ? (time as TTime) : 'last15Minutes',
-      timeEnd:
-        time && TTimeOptions.includes(time) && timeEnd ? parseInt(timeEnd as string) : Math.floor(Date.now() / 1000),
-      timeStart:
-        time && TTimeOptions.includes(time) && timeStart
-          ? parseInt(timeStart as string)
-          : Math.floor(Date.now() / 1000) - 900,
-    },
+    times: getTimeParams(params),
   };
 };
 


### PR DESCRIPTION
Instead of using the same logic across all plugins to parse the time
parameters from the current url, we are moving this function to the core
package, so that we can use it from there in all plugins.

This also fixes a small bug, which was introduced in the previous
commit. There we added a sorting option for the times column in the
ClickHouse plugin, which showed the wrong sort order for the times
column. This should be fixed now.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
