### PR TITLE
[core] Make time selection more intuitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 ### Changed
 
 - [#179](https://github.com/kobsio/kobs/pull/179): [clickhouse] Add sorting and show milliseconds in time column.
+- [#181](https://github.com/kobsio/kobs/pull/181): :warning: _Breaking change:_ :warning: [core] Make the time selection across all plugins more intuitive. For that we removed the `time` property from the Options component and showing the formatted timestamp instead.
 
 ## [v0.6.0](https://github.com/kobsio/kobs/releases/tag/v0.6.0) (2021-10-11)
 

--- a/plugins/applications/src/components/panel/ApplicationsGallery.tsx
+++ b/plugins/applications/src/components/panel/ApplicationsGallery.tsx
@@ -19,7 +19,6 @@ const ApplicationsGallery: React.FunctionComponent<IApplicationsGalleryProps> = 
   team,
 }: IApplicationsGalleryProps) => {
   const times: IPluginTimes = {
-    time: 'last15Minutes',
     timeEnd: Math.floor(Date.now() / 1000),
     timeStart: Math.floor(Date.now() / 1000) - 900,
   };

--- a/plugins/clickhouse/src/components/page/LogsPage.tsx
+++ b/plugins/clickhouse/src/components/page/LogsPage.tsx
@@ -36,9 +36,9 @@ const LogsPage: React.FunctionComponent<ILogsPageProps> = ({ name, displayName, 
 
     history.push({
       pathname: location.pathname,
-      search: `?query=${encodeURIComponent(opts.query)}&order=${opts.order}&orderBy=${opts.orderBy}&time=${
-        opts.times.time
-      }&timeEnd=${opts.times.timeEnd}&timeStart=${opts.times.timeStart}${fields.length > 0 ? fields.join('') : ''}`,
+      search: `?query=${encodeURIComponent(opts.query)}&order=${opts.order}&orderBy=${opts.orderBy}&timeEnd=${
+        opts.times.timeEnd
+      }&timeStart=${opts.times.timeStart}${fields.length > 0 ? fields.join('') : ''}`,
     });
   };
 

--- a/plugins/clickhouse/src/components/page/LogsToolbar.tsx
+++ b/plugins/clickhouse/src/components/page/LogsToolbar.tsx
@@ -11,7 +11,7 @@ import {
 import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
 import React, { useEffect, useState } from 'react';
 
-import { IOptionsAdditionalFields, Options, TTime } from '@kobsio/plugin-core';
+import { IOptionsAdditionalFields, Options } from '@kobsio/plugin-core';
 import { IOptions } from '../../utils/interfaces';
 
 interface ILogsToolbarProps extends IOptions {
@@ -53,7 +53,6 @@ const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({
   const changeOptions = (
     refresh: boolean,
     additionalFields: IOptionsAdditionalFields[] | undefined,
-    time: TTime,
     timeEnd: number,
     timeStart: number,
   ): void => {
@@ -66,7 +65,7 @@ const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({
           fields: fields,
           order: additionalFields[1].value,
           orderBy: additionalFields[0].value,
-          times: { time: time, timeEnd: timeEnd, timeStart: timeStart },
+          times: { timeEnd: timeEnd, timeStart: timeStart },
         });
       }
 
@@ -74,7 +73,7 @@ const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({
         ...tmpData,
         order: additionalFields[1].value,
         orderBy: additionalFields[0].value,
-        times: { time: time, timeEnd: timeEnd, timeStart: timeStart },
+        times: { timeEnd: timeEnd, timeStart: timeStart },
       });
     }
   };
@@ -110,7 +109,6 @@ const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({
                     values: ['ascending', 'descending'],
                   },
                 ]}
-                time={data.times.time}
                 timeEnd={data.times.timeEnd}
                 timeStart={data.times.timeStart}
                 setOptions={changeOptions}

--- a/plugins/clickhouse/src/components/page/VisualizationPage.tsx
+++ b/plugins/clickhouse/src/components/page/VisualizationPage.tsx
@@ -43,7 +43,7 @@ const VisualizationPage: React.FunctionComponent<IVisualizationPageProps> = ({
   const changeOptions = (): void => {
     history.push({
       pathname: location.pathname,
-      search: `?query=${tmpOptions.query}&time=${tmpOptions.times.time}&timeEnd=${tmpOptions.times.timeEnd}&timeStart=${tmpOptions.times.timeStart}&chart=${tmpOptions.chart}&limit=${tmpOptions.limit}&groupBy=${tmpOptions.groupBy}&operation=${tmpOptions.operation}&operationField=${tmpOptions.operationField}&order=${tmpOptions.order}`,
+      search: `?query=${tmpOptions.query}&timeEnd=${tmpOptions.times.timeEnd}&timeStart=${tmpOptions.times.timeStart}&chart=${tmpOptions.chart}&limit=${tmpOptions.limit}&groupBy=${tmpOptions.groupBy}&operation=${tmpOptions.operation}&operationField=${tmpOptions.operationField}&order=${tmpOptions.order}`,
     });
   };
 

--- a/plugins/clickhouse/src/components/page/VisualizationToolbar.tsx
+++ b/plugins/clickhouse/src/components/page/VisualizationToolbar.tsx
@@ -9,7 +9,7 @@ import {
 import { FilterIcon } from '@patternfly/react-icons';
 import React from 'react';
 
-import { IOptionsAdditionalFields, Options, TTime } from '@kobsio/plugin-core';
+import { IOptionsAdditionalFields, Options } from '@kobsio/plugin-core';
 import { IVisualizationOptions } from '../../utils/interfaces';
 
 interface IVisualizationToolbarProps {
@@ -31,11 +31,10 @@ const VisualizationToolbar: React.FunctionComponent<IVisualizationToolbarProps> 
   const changeOptions = (
     refresh: boolean,
     additionalFields: IOptionsAdditionalFields[] | undefined,
-    time: TTime,
     timeEnd: number,
     timeStart: number,
   ): void => {
-    setOptions({ ...options, times: { time: time, timeEnd: timeEnd, timeStart: timeStart } });
+    setOptions({ ...options, times: { timeEnd: timeEnd, timeStart: timeStart } });
   };
 
   return (
@@ -47,12 +46,7 @@ const VisualizationToolbar: React.FunctionComponent<IVisualizationToolbarProps> 
               <TextInput aria-label="Query" type="text" value={options.query} onChange={changeQuery} />
             </ToolbarItem>
             <ToolbarItem>
-              <Options
-                time={options.times.time}
-                timeEnd={options.times.timeEnd}
-                timeStart={options.times.timeStart}
-                setOptions={changeOptions}
-              />
+              <Options timeEnd={options.times.timeEnd} timeStart={options.times.timeStart} setOptions={changeOptions} />
             </ToolbarItem>
           </ToolbarGroup>
         </ToolbarToggleGroup>

--- a/plugins/clickhouse/src/components/panel/LogsActions.tsx
+++ b/plugins/clickhouse/src/components/panel/LogsActions.tsx
@@ -35,9 +35,9 @@ export const Actions: React.FunctionComponent<IActionsProps> = ({
               key={index}
               component={
                 <Link
-                  to={`/${name}?time=${times.time}&timeEnd=${times.timeEnd}&timeStart=${times.timeStart}&query=${
-                    query.query
-                  }${query.fields ? query.fields.map((field) => `&field=${field}`).join('') : ''}`}
+                  to={`/${name}?timeEnd=${times.timeEnd}&timeStart=${times.timeStart}&query=${query.query}${
+                    query.fields ? query.fields.map((field) => `&field=${field}`).join('') : ''
+                  }`}
                 >
                   {query.name}
                 </Link>

--- a/plugins/clickhouse/src/components/panel/LogsChart.tsx
+++ b/plugins/clickhouse/src/components/panel/LogsChart.tsx
@@ -53,7 +53,6 @@ const LogsChart: React.FunctionComponent<ILogsChartProps> = ({ buckets, changeTi
             onBrushDomainChangeEnd={(domain: IDomain): void => {
               if (changeTime && domain.x.length === 2) {
                 changeTime({
-                  time: 'custom',
                   timeEnd: Math.floor(domain.x[1].getTime() / 1000),
                   timeStart: Math.floor(domain.x[0].getTime() / 1000),
                 });

--- a/plugins/core/src/components/misc/Options.tsx
+++ b/plugins/core/src/components/misc/Options.tsx
@@ -36,8 +36,7 @@ export interface IOptionsAdditionalFields {
 // TTime is the type with all possible values for the time property. A value of "custom" identifies that a user
 // specified a custom start and end time via the text input fields. The other values are used for the quick select
 // options.
-export type TTime =
-  | 'custom'
+type TTime =
   | 'last12Hours'
   | 'last15Minutes'
   | 'last1Day'
@@ -52,26 +51,6 @@ export type TTime =
   | 'last6Months'
   | 'last7Days'
   | 'last90Days';
-
-// TTimeOptions is an array with all available type for TTime. It is used to verify that the value of a string is an
-//valid option for the TTime type.
-export const TTimeOptions = [
-  'custom',
-  'last12Hours',
-  'last15Minutes',
-  'last1Day',
-  'last1Hour',
-  'last1Year',
-  'last2Days',
-  'last30Days',
-  'last30Minutes',
-  'last3Hours',
-  'last5Minutes',
-  'last6Hours',
-  'last6Months',
-  'last7Days',
-  'last90Days',
-];
 
 // ITime is the interface for a time in the times map. It contains a label which should be displayed in the Options
 // component and the seconds between the start and the end time.
@@ -110,13 +89,11 @@ const times: ITimes = {
 // properties in the parent component.
 interface IOptionsProps {
   additionalFields?: IOptionsAdditionalFields[];
-  time: TTime;
   timeEnd: number;
   timeStart: number;
   setOptions: (
     refresh: boolean,
     additionalFields: IOptionsAdditionalFields[] | undefined,
-    time: TTime,
     timeEnd: number,
     timeStart: number,
   ) => void;
@@ -130,7 +107,6 @@ interface IOptionsProps {
 // second button can be used to refresh the start and end time for the current selection.
 export const Options: React.FunctionComponent<IOptionsProps> = ({
   additionalFields,
-  time,
   timeEnd,
   timeStart,
   setOptions,
@@ -148,21 +124,6 @@ export const Options: React.FunctionComponent<IOptionsProps> = ({
   // change the start and end time to the new values. If the string couldn't be parsed, the user will see an error below
   // the corresponding input field.
   const apply = (): void => {
-    // If the time wasn't changed by the user, we keep the selected time interval and only refresh the time for the
-    // selected interval and change the additional fields. This allows a user to adjust an additional field without
-    // switching to a custom time interval.
-    if (customTimeEnd === formatTime(timeEnd) && customTimeStart === formatTime(timeStart) && time !== 'custom') {
-      setOptions(
-        false,
-        additionalFields,
-        time,
-        Math.floor(Date.now() / 1000),
-        Math.floor(Date.now() / 1000) - times[time].seconds,
-      );
-      setShow(false);
-      return;
-    }
-
     // Get a new date object for the users current timezone. This allows us to ignore the timezone, while parsing the
     // provided time string. The parsed date object will be in UTC, to transform the parsed date into the users timezone
     // we have to add the minutes between UTC and the users timezon (getTimezoneOffset()).
@@ -186,7 +147,6 @@ export const Options: React.FunctionComponent<IOptionsProps> = ({
       setOptions(
         false,
         additionalFields,
-        'custom',
         Math.floor(parsedTimeEnd.getTime() / 1000),
         Math.floor(parsedTimeStart.getTime() / 1000),
       );
@@ -200,7 +160,6 @@ export const Options: React.FunctionComponent<IOptionsProps> = ({
     setOptions(
       false,
       additionalFields,
-      t,
       Math.floor(Date.now() / 1000),
       Math.floor(Date.now() / 1000) - times[t].seconds,
     );
@@ -219,15 +178,12 @@ export const Options: React.FunctionComponent<IOptionsProps> = ({
   // refreshTimes is used to refresh the start and end time, when the user selected a time range from the quick
   // selection list.
   const refreshTimes = (): void => {
-    if (time !== 'custom') {
-      setOptions(
-        true,
-        additionalFields,
-        time,
-        Math.floor(Date.now() / 1000),
-        Math.floor(Date.now() / 1000) - times[time].seconds,
-      );
-    }
+    setOptions(
+      true,
+      additionalFields,
+      Math.floor(Date.now() / 1000),
+      Math.floor(Date.now() / 1000) - (timeEnd - timeStart),
+    );
   };
 
   // useEffect is used to update the UI, every time a property changes.
@@ -240,7 +196,7 @@ export const Options: React.FunctionComponent<IOptionsProps> = ({
   return (
     <React.Fragment>
       <Button variant={ButtonVariant.control} onClick={(): void => setShow(true)}>
-        {time === 'custom' ? `${formatTime(timeStart)} to ${formatTime(timeEnd)}` : times[time].label}
+        {formatTime(timeStart)} to {formatTime(timeEnd)}
       </Button>
 
       <Button variant={ButtonVariant.control} onClick={refreshTimes}>

--- a/plugins/core/src/context/PluginsContext.tsx
+++ b/plugins/core/src/context/PluginsContext.tsx
@@ -2,8 +2,6 @@ import { Alert, AlertActionLink, AlertVariant, Spinner } from '@patternfly/react
 import { QueryObserverResult, useQuery } from 'react-query';
 import React from 'react';
 
-import { TTime } from '../components/misc/Options';
-
 // IPluginDefaults is the interface which is used for the default property of the plugin panel components. This is
 // required, so that a user must not define a cluster or namespace in a plugin. Instead we will use the cluster or
 // namespace of the parent team or application.
@@ -17,7 +15,6 @@ export interface IPluginDefaults {
 // only data for a selected time range in a plugin. For example the Prometheus uses these properties to show only
 // metrics for the selected time range.
 export interface IPluginTimes {
-  time: TTime;
   timeEnd: number;
   timeStart: number;
 }

--- a/plugins/core/src/utils/time.ts
+++ b/plugins/core/src/utils/time.ts
@@ -1,4 +1,3 @@
-import { TTime, TTimeOptions } from '../components/misc/Options';
 import { IPluginTimes } from '../context/PluginsContext';
 
 // timeDifference calculates the difference of two given timestamps and returns a human readable string for the
@@ -34,17 +33,11 @@ export const formatTime = (timestamp: number): string => {
 
 // getTimeParams returns a times object for the parsed time parameters from a URL.
 export const getTimeParams = (params: URLSearchParams): IPluginTimes => {
-  const time = params.get('time');
   const timeEnd = params.get('timeEnd');
   const timeStart = params.get('timeStart');
 
   return {
-    time: time && TTimeOptions.includes(time) ? (time as TTime) : 'last15Minutes',
-    timeEnd:
-      time && TTimeOptions.includes(time) && timeEnd ? parseInt(timeEnd as string) : Math.floor(Date.now() / 1000),
-    timeStart:
-      time && TTimeOptions.includes(time) && timeStart
-        ? parseInt(timeStart as string)
-        : Math.floor(Date.now() / 1000) - 900,
+    timeEnd: timeEnd ? parseInt(timeEnd as string) : Math.floor(Date.now() / 1000),
+    timeStart: timeStart ? parseInt(timeStart as string) : Math.floor(Date.now() / 1000) - 900,
   };
 };

--- a/plugins/dashboards/src/components/dashboards/Dashboard.tsx
+++ b/plugins/dashboards/src/components/dashboards/Dashboard.tsx
@@ -45,7 +45,6 @@ const Dashboard: React.FunctionComponent<IDashboardProps> = ({
   // times is the state for the users selected time. The default value will always be the last 15 minutes. This is
   // required for some plugins (e.g. the Prometheus plugin), which making use of a time range.
   const [times, setTimes] = useState<IPluginTimes>({
-    time: 'last15Minutes',
     timeEnd: Math.floor(Date.now() / 1000),
     timeStart: Math.floor(Date.now() / 1000) - 900,
   });

--- a/plugins/dashboards/src/components/dashboards/DashboardToolbar.tsx
+++ b/plugins/dashboards/src/components/dashboards/DashboardToolbar.tsx
@@ -2,7 +2,7 @@ import { Card, Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem, ToolbarToggle
 import { FilterIcon } from '@patternfly/react-icons';
 import React from 'react';
 
-import { IOptionsAdditionalFields, IPluginTimes, Options, TTime } from '@kobsio/plugin-core';
+import { IOptionsAdditionalFields, IPluginTimes, Options } from '@kobsio/plugin-core';
 import DashboardToolbarVariable from './DashboardToolbarVariable';
 import { IVariableValues } from '../../utils/interfaces';
 
@@ -48,16 +48,14 @@ const DashboardToolbar: React.FunctionComponent<IDashboardToolbarProps> = ({
             <ToolbarGroup style={{ width: '100%' }}>
               <ToolbarItem alignment={{ default: 'alignRight' }}>
                 <Options
-                  time={times.time}
                   timeEnd={times.timeEnd}
                   timeStart={times.timeStart}
                   setOptions={(
                     refresh: boolean,
                     additionalFields: IOptionsAdditionalFields[] | undefined,
-                    time: TTime,
                     timeEnd: number,
                     timeStart: number,
-                  ): void => setTimes({ time: time, timeEnd: timeEnd, timeStart: timeStart })}
+                  ): void => setTimes({ timeEnd: timeEnd, timeStart: timeStart })}
                 />
               </ToolbarItem>
             </ToolbarGroup>

--- a/plugins/elasticsearch/src/components/page/Page.tsx
+++ b/plugins/elasticsearch/src/components/page/Page.tsx
@@ -27,9 +27,9 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
 
     history.push({
       pathname: location.pathname,
-      search: `?query=${opts.query}&time=${opts.times.time}&timeEnd=${opts.times.timeEnd}&timeStart=${
-        opts.times.timeStart
-      }${fields.length > 0 ? fields.join('') : ''}`,
+      search: `?query=${opts.query}&timeEnd=${opts.times.timeEnd}&timeStart=${opts.times.timeStart}${
+        fields.length > 0 ? fields.join('') : ''
+      }`,
     });
   };
 

--- a/plugins/elasticsearch/src/components/page/PageToolbar.tsx
+++ b/plugins/elasticsearch/src/components/page/PageToolbar.tsx
@@ -11,7 +11,7 @@ import {
 import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
 import React, { useState } from 'react';
 
-import { IOptionsAdditionalFields, Options, TTime } from '@kobsio/plugin-core';
+import { IOptionsAdditionalFields, Options } from '@kobsio/plugin-core';
 import { IOptions } from '../../utils/interfaces';
 
 interface IPageToolbarProps extends IOptions {
@@ -51,7 +51,6 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({
   const changeOptions = (
     refresh: boolean,
     additionalFields: IOptionsAdditionalFields[] | undefined,
-    time: TTime,
     timeEnd: number,
     timeStart: number,
   ): void => {
@@ -61,13 +60,13 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({
       setOptions({
         ...tmpData,
         fields: fields,
-        times: { time: time, timeEnd: timeEnd, timeStart: timeStart },
+        times: { timeEnd: timeEnd, timeStart: timeStart },
       });
     }
 
     setData({
       ...tmpData,
-      times: { time: time, timeEnd: timeEnd, timeStart: timeStart },
+      times: { timeEnd: timeEnd, timeStart: timeStart },
     });
   };
 
@@ -80,12 +79,7 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({
               <TextInput aria-label="Query" type="text" value={data.query} onChange={changeQuery} onKeyDown={onEnter} />
             </ToolbarItem>
             <ToolbarItem>
-              <Options
-                time={data.times.time}
-                timeEnd={data.times.timeEnd}
-                timeStart={data.times.timeStart}
-                setOptions={changeOptions}
-              />
+              <Options timeEnd={data.times.timeEnd} timeStart={data.times.timeStart} setOptions={changeOptions} />
             </ToolbarItem>
             <ToolbarItem>
               <Button

--- a/plugins/elasticsearch/src/components/panel/LogsActions.tsx
+++ b/plugins/elasticsearch/src/components/panel/LogsActions.tsx
@@ -26,9 +26,9 @@ export const Actions: React.FunctionComponent<IActionsProps> = ({ name, queries,
             key={index}
             component={
               <Link
-                to={`/${name}?time=${times.time}&timeEnd=${times.timeEnd}&timeStart=${times.timeStart}&query=${
-                  query.query
-                }${query.fields ? query.fields.map((field) => `&field=${field}`).join('') : ''}`}
+                to={`/${name}?timeEnd=${times.timeEnd}&timeStart=${times.timeStart}&query=${query.query}${
+                  query.fields ? query.fields.map((field) => `&field=${field}`).join('') : ''
+                }`}
               >
                 {query.name}
               </Link>

--- a/plugins/istio/src/components/page/Application.tsx
+++ b/plugins/istio/src/components/page/Application.tsx
@@ -43,7 +43,7 @@ const Team: React.FunctionComponent<IApplicationProps> = ({ name, pluginOptions 
   const changeOptions = (tmpTimes: IPluginTimes): void => {
     history.push({
       pathname: location.pathname,
-      search: `?time=${tmpTimes.time}&timeEnd=${tmpTimes.timeEnd}&timeStart=${tmpTimes.timeStart}`,
+      search: `?timeEnd=${tmpTimes.timeEnd}&timeStart=${tmpTimes.timeStart}`,
     });
   };
 

--- a/plugins/istio/src/components/page/ApplicationToolbar.tsx
+++ b/plugins/istio/src/components/page/ApplicationToolbar.tsx
@@ -2,7 +2,7 @@ import { Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem, ToolbarToggleGroup 
 import { FilterIcon } from '@patternfly/react-icons';
 import React from 'react';
 
-import { IOptionsAdditionalFields, IPluginTimes, Options, TTime } from '@kobsio/plugin-core';
+import { IOptionsAdditionalFields, IPluginTimes, Options } from '@kobsio/plugin-core';
 
 interface IApplicationToolbarProps {
   name: string;
@@ -18,11 +18,10 @@ const ApplicationToolbar: React.FunctionComponent<IApplicationToolbarProps> = ({
   const changeOptions = (
     refresh: boolean,
     additionalFields: IOptionsAdditionalFields[] | undefined,
-    time: TTime,
     timeEnd: number,
     timeStart: number,
   ): void => {
-    setOptions({ time: time, timeEnd: timeEnd, timeStart: timeStart });
+    setOptions({ timeEnd: timeEnd, timeStart: timeStart });
   };
 
   return (
@@ -32,12 +31,7 @@ const ApplicationToolbar: React.FunctionComponent<IApplicationToolbarProps> = ({
           <ToolbarGroup style={{ width: '100%' }}>
             <ToolbarItem style={{ width: '100%' }}></ToolbarItem>
             <ToolbarItem>
-              <Options
-                time={times.time}
-                timeEnd={times.timeEnd}
-                timeStart={times.timeStart}
-                setOptions={changeOptions}
-              />
+              <Options timeEnd={times.timeEnd} timeStart={times.timeStart} setOptions={changeOptions} />
             </ToolbarItem>
           </ToolbarGroup>
         </ToolbarToggleGroup>

--- a/plugins/istio/src/components/page/Applications.tsx
+++ b/plugins/istio/src/components/page/Applications.tsx
@@ -42,7 +42,7 @@ const Applications: React.FunctionComponent<IApplicationsProps> = ({
 
     history.push({
       pathname: location.pathname,
-      search: `?time=${opts.times.time}&timeEnd=${opts.times.timeEnd}&timeStart=${opts.times.timeStart}${
+      search: `?timeEnd=${opts.times.timeEnd}&timeStart=${opts.times.timeStart}${
         namespaces.length > 0 ? namespaces.join('') : ''
       }`,
     });

--- a/plugins/istio/src/components/page/ApplicationsToolbar.tsx
+++ b/plugins/istio/src/components/page/ApplicationsToolbar.tsx
@@ -15,7 +15,7 @@ import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
 import React, { useState } from 'react';
 import { useQuery } from 'react-query';
 
-import { IOptionsAdditionalFields, IPluginTimes, Options, TTime } from '@kobsio/plugin-core';
+import { IOptionsAdditionalFields, IPluginTimes, Options } from '@kobsio/plugin-core';
 import { IOptions } from '../../utils/interfaces';
 
 interface IPageToolbarProps extends IOptions {
@@ -73,22 +73,17 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({
   const changeOptions = (
     refresh: boolean,
     additionalFields: IOptionsAdditionalFields[] | undefined,
-    time: TTime,
     timeEnd: number,
     timeStart: number,
   ): void => {
     if (refresh) {
       setOptions({
         namespaces: selectedNamespaces,
-        times: { time: time, timeEnd: timeEnd, timeStart: timeStart },
+        times: { timeEnd: timeEnd, timeStart: timeStart },
       });
     }
 
-    setSelectedTimes({
-      time: time,
-      timeEnd: timeEnd,
-      timeStart: timeStart,
-    });
+    setSelectedTimes({ timeEnd: timeEnd, timeStart: timeStart });
   };
 
   return (
@@ -125,12 +120,7 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({
               )}
             </ToolbarItem>
             <ToolbarItem>
-              <Options
-                time={selectedTimes.time}
-                timeEnd={selectedTimes.timeEnd}
-                timeStart={selectedTimes.timeStart}
-                setOptions={changeOptions}
-              />
+              <Options timeEnd={selectedTimes.timeEnd} timeStart={selectedTimes.timeStart} setOptions={changeOptions} />
             </ToolbarItem>
             <ToolbarItem>
               <Button

--- a/plugins/jaeger/src/components/page/Traces.tsx
+++ b/plugins/jaeger/src/components/page/Traces.tsx
@@ -33,9 +33,7 @@ const Traces: React.FunctionComponent<ITracesProps> = ({ name, displayName, desc
       pathname: location.pathname,
       search: `?limit=${opts.limit}&maxDuration=${opts.maxDuration}&minDuration=${opts.minDuration}&operation=${
         opts.operation === 'All Operations' ? '' : opts.operation
-      }&service=${opts.service}&tags=${opts.tags}&time=${opts.times.time}&timeEnd=${opts.times.timeEnd}&timeStart=${
-        opts.times.timeStart
-      }`,
+      }&service=${opts.service}&tags=${opts.tags}&timeEnd=${opts.times.timeEnd}&timeStart=${opts.times.timeStart}`,
     });
   };
 

--- a/plugins/jaeger/src/components/page/TracesToolbar.tsx
+++ b/plugins/jaeger/src/components/page/TracesToolbar.tsx
@@ -11,7 +11,7 @@ import {
 import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
 import React, { useState } from 'react';
 
-import { IOptionsAdditionalFields, Options, TTime } from '@kobsio/plugin-core';
+import { IOptionsAdditionalFields, Options } from '@kobsio/plugin-core';
 import { IOptions } from '../../utils/interfaces';
 import TracesToolbarOperations from './TracesToolbarOperations';
 import TracesToolbarServices from './TracesToolbarServices';
@@ -45,7 +45,6 @@ const TracesToolbar: React.FunctionComponent<ITracesToolbarProps> = ({
   const changeOptions = (
     refresh: boolean,
     additionalFields: IOptionsAdditionalFields[] | undefined,
-    time: TTime,
     timeEnd: number,
     timeStart: number,
   ): void => {
@@ -58,7 +57,7 @@ const TracesToolbar: React.FunctionComponent<ITracesToolbarProps> = ({
           limit: additionalFields[0].value,
           maxDuration: additionalFields[1].value,
           minDuration: additionalFields[2].value,
-          times: { time: time, timeEnd: timeEnd, timeStart: timeStart },
+          times: { timeEnd: timeEnd, timeStart: timeStart },
         });
       }
 
@@ -67,7 +66,7 @@ const TracesToolbar: React.FunctionComponent<ITracesToolbarProps> = ({
         limit: additionalFields[0].value,
         maxDuration: additionalFields[1].value,
         minDuration: additionalFields[2].value,
-        times: { time: time, timeEnd: timeEnd, timeStart: timeStart },
+        times: { timeEnd: timeEnd, timeStart: timeStart },
       });
     }
   };
@@ -126,7 +125,6 @@ const TracesToolbar: React.FunctionComponent<ITracesToolbarProps> = ({
                     value: data.minDuration,
                   },
                 ]}
-                time={data.times.time}
                 timeEnd={data.times.timeEnd}
                 timeStart={data.times.timeStart}
                 setOptions={changeOptions}

--- a/plugins/jaeger/src/components/panel/TracesActions.tsx
+++ b/plugins/jaeger/src/components/panel/TracesActions.tsx
@@ -32,9 +32,9 @@ export const TracesActions: React.FunctionComponent<ITracesActionsProps> = ({
               <Link
                 to={`/${name}?limit=${query.limit || '20'}&maxDuration=${query.maxDuration || ''}&minDuration=${
                   query.minDuration || ''
-                }&operation=${query.operation || ''}&service=${query.service || ''}&tags=${query.tags || ''}&time=${
-                  times.time
-                }&timeEnd=${times.timeEnd}&timeStart=${times.timeStart}`}
+                }&operation=${query.operation || ''}&service=${query.service || ''}&tags=${query.tags || ''}&timeEnd=${
+                  times.timeEnd
+                }&timeStart=${times.timeStart}`}
               >
                 {query.name}
               </Link>

--- a/plugins/kiali/src/components/page/Page.tsx
+++ b/plugins/kiali/src/components/page/Page.tsx
@@ -28,7 +28,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
 
     history.push({
       pathname: location.pathname,
-      search: `?time=${opts.times.time}&timeStart=${opts.times.timeStart}&timeEnd=${opts.times.timeEnd}${
+      search: `?timeStart=${opts.times.timeStart}&timeEnd=${opts.times.timeEnd}${
         namespaces.length > 0 ? namespaces.join('') : ''
       }`,
     });

--- a/plugins/kiali/src/components/page/PageToolbar.tsx
+++ b/plugins/kiali/src/components/page/PageToolbar.tsx
@@ -10,7 +10,7 @@ import {
 import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
 import React, { useState } from 'react';
 
-import { IOptionsAdditionalFields, Options, TTime } from '@kobsio/plugin-core';
+import { IOptionsAdditionalFields, Options } from '@kobsio/plugin-core';
 import { IOptions } from '../../utils/interfaces';
 import PageToolbarNamespaces from './PageToolbarNamespaces';
 
@@ -51,7 +51,6 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({
   const changeOptions = (
     refresh: boolean,
     additionalFields: IOptionsAdditionalFields[] | undefined,
-    time: TTime,
     timeEnd: number,
     timeStart: number,
   ): void => {
@@ -60,13 +59,13 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({
     if (refresh) {
       setOptions({
         ...tmpData,
-        times: { time: time, timeEnd: timeEnd, timeStart: timeStart },
+        times: { timeEnd: timeEnd, timeStart: timeStart },
       });
     }
 
     setData({
       ...tmpData,
-      times: { time: time, timeEnd: timeEnd, timeStart: timeStart },
+      times: { timeEnd: timeEnd, timeStart: timeStart },
     });
   };
 
@@ -79,12 +78,7 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({
               <PageToolbarNamespaces name={name} namespaces={data.namespaces || []} selectNamespace={selectNamespace} />
             </ToolbarItem>
             <ToolbarItem>
-              <Options
-                time={data.times.time}
-                timeEnd={data.times.timeEnd}
-                timeStart={data.times.timeStart}
-                setOptions={changeOptions}
-              />
+              <Options timeEnd={data.times.timeEnd} timeStart={data.times.timeStart} setOptions={changeOptions} />
             </ToolbarItem>
             <ToolbarItem>
               <Button variant={ButtonVariant.primary} icon={<SearchIcon />} onClick={(): void => setOptions(data)}>

--- a/plugins/kiali/src/components/panel/GraphActions.tsx
+++ b/plugins/kiali/src/components/panel/GraphActions.tsx
@@ -29,11 +29,7 @@ export const GraphActions: React.FunctionComponent<IGraphActionsProps> = ({
           <DropdownItem
             key={0}
             component={
-              <Link
-                to={`/${name}?time=${times.time}&timeStart=${times.timeStart}&timeEnd${
-                  times.timeEnd
-                }${namespaceParams.join('')}`}
-              >
+              <Link to={`/${name}?timeStart=${times.timeStart}&timeEnd${times.timeEnd}${namespaceParams.join('')}`}>
                 Explore
               </Link>
             }

--- a/plugins/opsgenie/src/components/page/Page.tsx
+++ b/plugins/opsgenie/src/components/page/Page.tsx
@@ -27,7 +27,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
   const changeOptions = (opts: IOptions): void => {
     history.push({
       pathname: location.pathname,
-      search: `?query=${opts.query}&type=${opts.type}&time=${opts.times.time}&timeEnd=${opts.times.timeEnd}&timeStart=${opts.times.timeStart}`,
+      search: `?query=${opts.query}&type=${opts.type}&timeEnd=${opts.times.timeEnd}&timeStart=${opts.times.timeStart}`,
     });
   };
 

--- a/plugins/opsgenie/src/components/page/PageToolbar.tsx
+++ b/plugins/opsgenie/src/components/page/PageToolbar.tsx
@@ -13,7 +13,7 @@ import {
 import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
 import React, { useState } from 'react';
 
-import { IOptionsAdditionalFields, Options, TTime } from '@kobsio/plugin-core';
+import { IOptionsAdditionalFields, Options } from '@kobsio/plugin-core';
 import { IOptions } from '../../utils/interfaces';
 
 interface IPageToolbarProps extends IOptions {
@@ -51,7 +51,6 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({
   const changeOptions = (
     refresh: boolean,
     additionalFields: IOptionsAdditionalFields[] | undefined,
-    time: TTime,
     timeEnd: number,
     timeStart: number,
   ): void => {
@@ -60,13 +59,13 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({
     if (refresh) {
       setOptions({
         ...tmpData,
-        times: { time: time, timeEnd: timeEnd, timeStart: timeStart },
+        times: { timeEnd: timeEnd, timeStart: timeStart },
       });
     }
 
     setData({
       ...tmpData,
-      times: { time: time, timeEnd: timeEnd, timeStart: timeStart },
+      times: { timeEnd: timeEnd, timeStart: timeStart },
     });
   };
 
@@ -93,12 +92,7 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({
               </ToggleGroup>
             </ToolbarItem>
             <ToolbarItem>
-              <Options
-                time={data.times.time}
-                timeEnd={data.times.timeEnd}
-                timeStart={data.times.timeStart}
-                setOptions={changeOptions}
-              />
+              <Options timeEnd={data.times.timeEnd} timeStart={data.times.timeStart} setOptions={changeOptions} />
             </ToolbarItem>
             <ToolbarItem>
               <Button variant={ButtonVariant.primary} icon={<SearchIcon />} onClick={(): void => setOptions(data)}>

--- a/plugins/prometheus/src/components/page/Page.tsx
+++ b/plugins/prometheus/src/components/page/Page.tsx
@@ -20,9 +20,9 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
 
     history.push({
       pathname: location.pathname,
-      search: `?resolution=${opts.resolution}&time=${opts.times.time}&timeEnd=${opts.times.timeEnd}&timeStart=${
-        opts.times.timeStart
-      }${queries.length > 0 ? queries.join('') : ''}`,
+      search: `?resolution=${opts.resolution}&timeEnd=${opts.times.timeEnd}&timeStart=${opts.times.timeStart}${
+        queries.length > 0 ? queries.join('') : ''
+      }`,
     });
   };
 

--- a/plugins/prometheus/src/components/page/PageToolbar.tsx
+++ b/plugins/prometheus/src/components/page/PageToolbar.tsx
@@ -13,7 +13,7 @@ import {
 import { FilterIcon, MinusIcon, PlusIcon, SearchIcon } from '@patternfly/react-icons';
 import React, { useState } from 'react';
 
-import { IOptionsAdditionalFields, Options, TTime } from '@kobsio/plugin-core';
+import { IOptionsAdditionalFields, Options } from '@kobsio/plugin-core';
 import { IOptions } from '../../utils/interfaces';
 import { PageToolbarAutocomplete } from './PageToolbarAutocomplete';
 
@@ -62,7 +62,6 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({
   const changeOptions = (
     refresh: boolean,
     additionalFields: IOptionsAdditionalFields[] | undefined,
-    time: TTime,
     timeEnd: number,
     timeStart: number,
   ): void => {
@@ -73,14 +72,14 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({
         setOptions({
           ...tmpData,
           resolution: additionalFields[0].value,
-          times: { time: time, timeEnd: timeEnd, timeStart: timeStart },
+          times: { timeEnd: timeEnd, timeStart: timeStart },
         });
       }
 
       setData({
         ...tmpData,
         resolution: additionalFields[0].value,
-        times: { time: time, timeEnd: timeEnd, timeStart: timeStart },
+        times: { timeEnd: timeEnd, timeStart: timeStart },
       });
     }
   };
@@ -135,7 +134,6 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({
                     value: data.resolution,
                   },
                 ]}
-                time={data.times.time}
                 timeEnd={data.times.timeEnd}
                 timeStart={data.times.timeStart}
                 setOptions={changeOptions}

--- a/plugins/prometheus/src/components/panel/Actions.tsx
+++ b/plugins/prometheus/src/components/panel/Actions.tsx
@@ -36,7 +36,7 @@ export const Actions: React.FunctionComponent<IActionsProps> = ({
               key={0}
               component={
                 <Link
-                  to={`/${name}?time=${times.time}&timeEnd=${times.timeEnd}&timeStart=${times.timeStart}${
+                  to={`/${name}?timeEnd=${times.timeEnd}&timeStart=${times.timeStart}${
                     queryParams.length > 0 ? queryParams.join('') : ''
                   }`}
                 >


### PR DESCRIPTION
Sometimes the shown time from the Options component in a toolbar was not
very meaningful. Especially when a user opened a shared URL, were the
user select a last x minutes interval, we showed this text, instead of
the correct time range, also when the last x minutes referred to an very
old time.

Now we are always showing the formatted timestamp, so that this problem
can not occure anymore. It is still possible to refresh a time range, so
that the current time is used as end time with the formaly selected diff
between the start and end time.

If you are using the options component in one of your plugins, you have
to adjust the passed in values, so that your plugin works with the next
release of kobs.

NOTE: Maybe we can also remove some duplicated code for the toolbar and
the state handling via the URL in the future.

Fixes #178.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
