### PR TITLE
[clickhouse] Use pagination to display logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 ### Changed
 
 - [#179](https://github.com/kobsio/kobs/pull/179): [clickhouse] Add sorting and show milliseconds in time column.
-- [#181](https://github.com/kobsio/kobs/pull/181): :warning: _Breaking change:_ :warning: [core] Make the time selection across all plugins more intuitive. For that we removed the `time` property from the Options component and showing the formatted timestamp instead.
+- [#181](https://github.com/kobsio/kobs/pull/181): [core] :warning: _Breaking change:_ :warning: Make the time selection across all plugins more intuitive. For that we removed the `time` property from the Options component and showing the formatted timestamp instead.
+- [#185](https://github.com/kobsio/kobs/pull/185): [clickhouse] Use pagination instead of Intersection Observer API to display logs.
 
 ## [v0.6.0](https://github.com/kobsio/kobs/releases/tag/v0.6.0) (2021-10-11)
 

--- a/plugins/clickhouse/package.json
+++ b/plugins/clickhouse/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@kobsio/plugin-core": "*",
     "@nivo/bar": "^0.73.1",
+    "@nivo/line": "^0.74.0",
     "@nivo/pie": "^0.73.0",
     "@patternfly/react-charts": "^6.15.23",
     "@patternfly/react-core": "^4.128.2",
@@ -22,7 +23,6 @@
     "@types/react-router-dom": "^5.1.7",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-intersection-observer": "^8.32.1",
     "react-query": "^3.17.2",
     "react-router-dom": "^5.2.0",
     "typescript": "^4.3.4"

--- a/plugins/clickhouse/src/components/panel/LogsDocument.tsx
+++ b/plugins/clickhouse/src/components/panel/LogsDocument.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { TableText, Tbody, Td, Tr } from '@patternfly/react-table';
-import { InView } from 'react-intersection-observer';
 
 import { IDocument } from '../../utils/interfaces';
 import LogsDocumentDetails from './LogsDocumentDetails';
@@ -36,100 +35,88 @@ const LogsDocument: React.FunctionComponent<ILogsDocumentProps> = ({
   ];
 
   return (
-    <InView>
-      {({ inView, ref }): React.ReactNode => (
-        <Tbody ref={ref}>
-          {inView ? (
-            <React.Fragment>
-              <Tr>
-                <Td
-                  noPadding={true}
-                  style={{ padding: 0 }}
-                  expand={{ isExpanded: isExpanded, onToggle: (): void => setIsExpanded(!isExpanded), rowIndex: 0 }}
-                />
-                <Td className="pf-u-text-wrap pf-u-text-break-word" dataLabel="Time">
-                  <TableText wrapModifier="nowrap">{formatTime(document['timestamp'])}</TableText>
-                </Td>
-                {fields && fields.length > 0 ? (
-                  fields.map((field, index) => (
-                    <Td key={index} className="pf-u-text-wrap pf-u-text-break-word" dataLabel={field}>
-                      {document[field]}
-                    </Td>
-                  ))
-                ) : (
-                  <Td className="pf-u-text-wrap pf-u-text-break-word" dataLabel="Log">
-                    <div className="kobsio-clickhouse-logs-preview">
-                      <span className="pf-u-mr-sm pf-u-mb-sm">
-                        <span className="pf-u-background-color-200 pf-u-p-xs">cluster:</span>
-                        <span className="pf-u-p-xs"> {document['cluster']}</span>
-                      </span>
-                      <span className="pf-u-mr-sm pf-u-mb-sm">
-                        <span className="pf-u-background-color-200 pf-u-p-xs">namespace:</span>
-                        <span className="pf-u-p-xs"> {document['namespace']}</span>
-                      </span>
-                      <span className="pf-u-mr-sm pf-u-mb-sm">
-                        <span className="pf-u-background-color-200 pf-u-p-xs">app:</span>
-                        <span className="pf-u-p-xs"> {document['app']}</span>
-                      </span>
-                      <span className="pf-u-mr-sm pf-u-mb-sm">
-                        <span className="pf-u-background-color-200 pf-u-p-xs">pod_name:</span>
-                        <span className="pf-u-p-xs"> {document['pod_name']}</span>
-                      </span>
-                      <span className="pf-u-mr-sm pf-u-mb-sm">
-                        <span className="pf-u-background-color-200 pf-u-p-xs">container_name:</span>
-                        <span className="pf-u-p-xs"> {document['container_name']}</span>
-                      </span>
-                      <span className="pf-u-mr-sm pf-u-mb-sm">
-                        <span className="pf-u-background-color-200 pf-u-p-xs">host:</span>
-                        <span className="pf-u-p-xs"> {document['host']}</span>
-                      </span>
+    <Tbody>
+      <Tr>
+        <Td
+          noPadding={true}
+          style={{ padding: 0 }}
+          expand={{ isExpanded: isExpanded, onToggle: (): void => setIsExpanded(!isExpanded), rowIndex: 0 }}
+        />
+        <Td className="pf-u-text-wrap pf-u-text-break-word" dataLabel="Time">
+          <TableText wrapModifier="nowrap">{formatTime(document['timestamp'])}</TableText>
+        </Td>
+        {fields && fields.length > 0 ? (
+          fields.map((field, index) => (
+            <Td key={index} className="pf-u-text-wrap pf-u-text-break-word" dataLabel={field}>
+              {document[field]}
+            </Td>
+          ))
+        ) : (
+          <Td className="pf-u-text-wrap pf-u-text-break-word" dataLabel="Log">
+            <div className="kobsio-clickhouse-logs-preview">
+              <span className="pf-u-mr-sm pf-u-mb-sm">
+                <span className="pf-u-background-color-200 pf-u-p-xs">cluster:</span>
+                <span className="pf-u-p-xs"> {document['cluster']}</span>
+              </span>
+              <span className="pf-u-mr-sm pf-u-mb-sm">
+                <span className="pf-u-background-color-200 pf-u-p-xs">namespace:</span>
+                <span className="pf-u-p-xs"> {document['namespace']}</span>
+              </span>
+              <span className="pf-u-mr-sm pf-u-mb-sm">
+                <span className="pf-u-background-color-200 pf-u-p-xs">app:</span>
+                <span className="pf-u-p-xs"> {document['app']}</span>
+              </span>
+              <span className="pf-u-mr-sm pf-u-mb-sm">
+                <span className="pf-u-background-color-200 pf-u-p-xs">pod_name:</span>
+                <span className="pf-u-p-xs"> {document['pod_name']}</span>
+              </span>
+              <span className="pf-u-mr-sm pf-u-mb-sm">
+                <span className="pf-u-background-color-200 pf-u-p-xs">container_name:</span>
+                <span className="pf-u-p-xs"> {document['container_name']}</span>
+              </span>
+              <span className="pf-u-mr-sm pf-u-mb-sm">
+                <span className="pf-u-background-color-200 pf-u-p-xs">host:</span>
+                <span className="pf-u-p-xs"> {document['host']}</span>
+              </span>
 
-                      {Object.keys(document)
-                        .filter((key) => key.startsWith('content.') && document[key].length < 128)
-                        .map((key) => (
-                          <span key={key} className="pf-u-mr-sm pf-u-mb-sm">
-                            <span className="pf-u-background-color-200 pf-u-p-xs">{key}:</span>
-                            <span className="pf-u-p-xs"> {document[key]}</span>
-                          </span>
-                        ))}
+              {Object.keys(document)
+                .filter((key) => key.startsWith('content.') && document[key].length < 128)
+                .map((key) => (
+                  <span key={key} className="pf-u-mr-sm pf-u-mb-sm">
+                    <span className="pf-u-background-color-200 pf-u-p-xs">{key}:</span>
+                    <span className="pf-u-p-xs"> {document[key]}</span>
+                  </span>
+                ))}
 
-                      <span className="pf-u-mr-sm pf-u-mb-sm">
-                        <span className="pf-u-background-color-200 pf-u-p-xs">log:</span>
-                        <span className="pf-u-p-xs"> {document['log']}</span>
+              <span className="pf-u-mr-sm pf-u-mb-sm">
+                <span className="pf-u-background-color-200 pf-u-p-xs">log:</span>
+                <span className="pf-u-p-xs"> {document['log']}</span>
+              </span>
+
+              {Object.keys(document).filter((key) => key.startsWith('content.') && document[key].length < 128)
+                .length === 0
+                ? Object.keys(document)
+                    .filter((key) => key.startsWith('kubernetes.'))
+                    .map((key) => (
+                      <span key={key} className="pf-u-mr-sm pf-u-mb-sm">
+                        <span className="pf-u-background-color-200 pf-u-p-xs">{key}:</span>
+                        <span className="pf-u-p-xs"> {document[key]}</span>
                       </span>
-
-                      {Object.keys(document).filter((key) => key.startsWith('content.') && document[key].length < 128)
-                        .length === 0
-                        ? Object.keys(document)
-                            .filter((key) => key.startsWith('kubernetes.'))
-                            .map((key) => (
-                              <span key={key} className="pf-u-mr-sm pf-u-mb-sm">
-                                <span className="pf-u-background-color-200 pf-u-p-xs">{key}:</span>
-                                <span className="pf-u-p-xs"> {document[key]}</span>
-                              </span>
-                            ))
-                        : null}
-                    </div>
-                  </Td>
-                )}
-                <Td noPadding={true} style={{ padding: 0 }} actions={{ items: defaultActions }} />
-              </Tr>
-              <Tr isExpanded={isExpanded}>
-                <Td />
-                <Td colSpan={fields && fields.length > 0 ? fields.length + 1 : 2}>
-                  {isExpanded && (
-                    <LogsDocumentDetails document={document} addFilter={addFilter} selectField={selectField} />
-                  )}
-                </Td>
-                <Td />
-              </Tr>
-            </React.Fragment>
-          ) : (
-            <Tr style={{ height: fields && fields.length > 0 ? '38px' : '135px' }}></Tr>
-          )}
-        </Tbody>
-      )}
-    </InView>
+                    ))
+                : null}
+            </div>
+          </Td>
+        )}
+        <Td noPadding={true} style={{ padding: 0 }} actions={{ items: defaultActions }} />
+      </Tr>
+      <Tr isExpanded={isExpanded}>
+        <Td />
+        <Td colSpan={fields && fields.length > 0 ? fields.length + 1 : 2}>
+          {isExpanded && <LogsDocumentDetails document={document} addFilter={addFilter} selectField={selectField} />}
+        </Td>
+        <Td />
+      </Tr>
+    </Tbody>
   );
 };
 

--- a/plugins/clickhouse/src/components/panel/LogsDocuments.tsx
+++ b/plugins/clickhouse/src/components/panel/LogsDocuments.tsx
@@ -3,14 +3,22 @@ import {
   SortByDirection,
   TableComposable,
   TableVariant,
+  Tbody,
+  Td,
   Th,
   Thead,
   Tr,
 } from '@patternfly/react-table';
-import React from 'react';
+import { Pagination, PaginationVariant } from '@patternfly/react-core';
+import React, { useEffect, useState } from 'react';
 
 import { IDocument } from '../../utils/interfaces';
 import LogsDocument from './LogsDocument';
+
+interface IPage {
+  page: number;
+  perPage: number;
+}
 
 interface ILogsDocumentsProps {
   documents?: IDocument[];
@@ -31,8 +39,14 @@ const LogsDocuments: React.FunctionComponent<ILogsDocumentsProps> = ({
   changeOrder,
   selectField,
 }: ILogsDocumentsProps) => {
+  const [page, setPage] = useState<IPage>({ page: 1, perPage: 100 });
+
   const activeSortIndex = fields && orderBy && orderBy !== 'timestamp' ? fields?.indexOf(orderBy) : -1;
   const activeSortDirection = order === 'ascending' ? 'asc' : 'desc';
+
+  useEffect(() => {
+    setPage({ page: 1, perPage: 100 });
+  }, [documents]);
 
   return (
     <TableComposable aria-label="Logs" variant={TableVariant.compact} borders={false}>
@@ -86,16 +100,55 @@ const LogsDocuments: React.FunctionComponent<ILogsDocumentsProps> = ({
         </Tr>
       </Thead>
       {documents
-        ? documents.map((document, index) => (
-            <LogsDocument
-              key={index}
-              document={document}
-              fields={fields}
-              addFilter={addFilter}
-              selectField={selectField}
-            />
-          ))
+        ? documents
+            .slice((page.page - 1) * page.perPage, page.page * page.perPage)
+            .map((document, index) => (
+              <LogsDocument
+                key={index}
+                document={document}
+                fields={fields}
+                addFilter={addFilter}
+                selectField={selectField}
+              />
+            ))
         : null}
+
+      {documents && (
+        <Tbody>
+          <Tr>
+            <Td />
+            <Td colSpan={fields && fields.length > 0 ? fields.length + 1 : 2}>
+              <Pagination
+                itemCount={documents.length}
+                widgetId="pagination-options-menu-bottom"
+                perPage={page.perPage}
+                page={page.page}
+                variant={PaginationVariant.bottom}
+                onSetPage={(event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPage: number): void =>
+                  setPage({ page: newPage, perPage: page.perPage })
+                }
+                onPerPageSelect={(
+                  event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+                  newPerPage: number,
+                ): void => setPage({ page: page.page, perPage: newPerPage })}
+                onFirstClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+                  setPage({ page: newPage, perPage: page.perPage })
+                }
+                onLastClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+                  setPage({ page: newPage, perPage: page.perPage })
+                }
+                onNextClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+                  setPage({ page: newPage, perPage: page.perPage })
+                }
+                onPreviousClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+                  setPage({ page: newPage, perPage: page.perPage })
+                }
+              />
+            </Td>
+            <Td />
+          </Tr>
+        </Tbody>
+      )}
     </TableComposable>
   );
 };


### PR DESCRIPTION
To display the logs in the table we are now using pagination, instead of
the Intersection Observer API, to avoid flickering while scrolling
through the logs.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
