### PR TITLE
[clickhouse] Add options to download returned logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#182](https://github.com/kobsio/kobs/pull/182): [istio] Add top and tap commands and add details view for metrics.
 - [#183](https://github.com/kobsio/kobs/pull/183): [istio] Add panels and documentation and use the `destination_app` label instead of `destination_workload` for the Prometheus metrics.
 - [#184](https://github.com/kobsio/kobs/pull/184): [clickhouse] Add aggregations to visualize logs.
+- [#187](https://github.com/kobsio/kobs/pull/187): [clickhouse] Add options to download returned logs as `.log` or `.csv` file.
 
 ### Fixed
 

--- a/plugins/clickhouse/src/components/page/Logs.tsx
+++ b/plugins/clickhouse/src/components/page/Logs.tsx
@@ -3,7 +3,6 @@ import {
   AlertActionLink,
   AlertVariant,
   Card,
-  CardActions,
   CardBody,
   CardHeader,
   CardHeaderMain,
@@ -18,6 +17,7 @@ import { useHistory } from 'react-router-dom';
 
 import { ILogsData } from '../../utils/interfaces';
 import { IPluginTimes } from '@kobsio/plugin-core';
+import LogsActions from './LogsActions';
 import LogsChart from '../panel/LogsChart';
 import LogsDocuments from '../panel/LogsDocuments';
 import LogsFields from './LogsFields';
@@ -137,7 +137,14 @@ const Logs: React.FunctionComponent<ILogsProps> = ({
                 {data.count} Documents in {data.took} Milliseconds
               </CardTitle>
             </CardHeaderMain>
-            <CardActions>{isFetching && <Spinner size="md" />}</CardActions>
+            <LogsActions
+              name={name}
+              query={query}
+              times={times}
+              documents={data.documents}
+              fields={fields}
+              isFetching={isFetching}
+            />
           </CardHeader>
           <CardBody>
             <LogsChart buckets={data.buckets} changeTime={changeTime} />

--- a/plugins/clickhouse/src/components/page/LogsActions.tsx
+++ b/plugins/clickhouse/src/components/page/LogsActions.tsx
@@ -1,0 +1,100 @@
+import { CardActions, Dropdown, DropdownItem, KebabToggle, Spinner } from '@patternfly/react-core';
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import { IPluginTimes, fileDownload } from '@kobsio/plugin-core';
+import { IDocument } from '../../utils/interfaces';
+import { formatTime } from '../../utils/helpers';
+
+interface ILogsActionsProps {
+  name: string;
+  query: string;
+  times: IPluginTimes;
+  documents?: IDocument[];
+  fields?: string[];
+  isFetching: boolean;
+}
+
+export const LogsActions: React.FunctionComponent<ILogsActionsProps> = ({
+  name,
+  query,
+  times,
+  documents,
+  fields,
+  isFetching,
+}: ILogsActionsProps) => {
+  const [show, setShow] = useState<boolean>(false);
+
+  // downloadLogs lets a user download the returned documents as raw logs.
+  const downloadLogs = (documents?: IDocument[]): void => {
+    if (documents) {
+      let log = '';
+
+      for (const document of documents) {
+        log = log + document['log'];
+      }
+
+      fileDownload(log, 'kobs-export-logs.log');
+    }
+
+    setShow(false);
+  };
+
+  // downloadCSV lets a user donwload the returned documents as csv file, with the selected fields as columns.
+  const downloadCSV = (documents?: IDocument[], fields?: string[]): void => {
+    if (documents && fields) {
+      let csv = '';
+
+      for (const document of documents) {
+        csv = csv + formatTime(document['timestamp']);
+
+        for (const field of fields) {
+          csv = csv + ';' + field;
+        }
+
+        csv = csv + '\r\n';
+      }
+
+      fileDownload(csv, 'kobs-export-logs.csv');
+    }
+
+    setShow(false);
+  };
+
+  return (
+    <CardActions>
+      {isFetching ? (
+        <Spinner size="md" />
+      ) : (
+        <Dropdown
+          toggle={<KebabToggle onToggle={(): void => setShow(!show)} />}
+          isOpen={show}
+          isPlain={true}
+          position="right"
+          dropdownItems={[
+            <DropdownItem
+              key={0}
+              component={
+                <Link to={`/${name}/aggregation?timeEnd=${times.timeEnd}&timeStart=${times.timeStart}&query=${query}`}>
+                  Aggregation
+                </Link>
+              }
+            />,
+            <DropdownItem key={1} isDisabled={!documents} onClick={(): void => downloadLogs(documents)}>
+              Download Logs
+            </DropdownItem>,
+            <DropdownItem
+              key={2}
+              isDisabled={!documents || !fields}
+              onClick={(): void => downloadCSV(documents, fields)}
+            >
+              Download CSV
+            </DropdownItem>,
+          ]}
+        />
+      )}
+    </CardActions>
+  );
+};
+
+export default LogsActions;

--- a/plugins/core/src/index.ts
+++ b/plugins/core/src/index.ts
@@ -28,6 +28,7 @@ export * from './crds/user';
 
 export * from './utils/chart';
 export * from './utils/colors';
+export * from './utils/fileDownload';
 export * from './utils/gravatar';
 export * from './utils/manifests';
 export * from './utils/resources';

--- a/plugins/core/src/utils/fileDownload.ts
+++ b/plugins/core/src/utils/fileDownload.ts
@@ -1,0 +1,26 @@
+// fileDownloads can be used to download the given data as file.
+// See: https://github.com/kennethjiang/js-file-download
+export const fileDownload = (data: string, filename: string): void => {
+  const blob = new Blob([data]);
+
+  const blobURL =
+    window.URL && window.URL.createObjectURL
+      ? window.URL.createObjectURL(blob)
+      : window.webkitURL.createObjectURL(blob);
+  const tempLink = document.createElement('a');
+  tempLink.style.display = 'none';
+  tempLink.href = blobURL;
+  tempLink.setAttribute('download', filename);
+
+  if (typeof tempLink.download === 'undefined') {
+    tempLink.setAttribute('target', '_blank');
+  }
+
+  document.body.appendChild(tempLink);
+  tempLink.click();
+
+  setTimeout(function () {
+    document.body.removeChild(tempLink);
+    window.URL.revokeObjectURL(blobURL);
+  }, 200);
+};


### PR DESCRIPTION
It is now possible to download the returned logs as ".log" or ".csv"
file. The ".csv" option is only available, when the user selected at
least one field, which should be displayed in the results table. The csv
file than contains the time column and all other selected fields as
columns.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
