### PR TITLE
[sql] Replace GetQueryResults function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#179](https://github.com/kobsio/kobs/pull/179): [clickhouse] Add sorting and show milliseconds in time column.
 - [#181](https://github.com/kobsio/kobs/pull/181): [core] :warning: _Breaking change:_ :warning: Make the time selection across all plugins more intuitive. For that we removed the `time` property from the Options component and showing the formatted timestamp instead.
 - [#185](https://github.com/kobsio/kobs/pull/185): [clickhouse] Use pagination instead of Intersection Observer API to display logs.
+- [#188](https://github.com/kobsio/kobs/pull/188): [sql] Replace the `GetQueryResults` function with the implemention used in the Clickhouse plugin, to have a proper handling for float values.
 
 ## [v0.6.0](https://github.com/kobsio/kobs/releases/tag/v0.6.0) (2021-10-11)
 

--- a/plugins/sql/sql.go
+++ b/plugins/sql/sql.go
@@ -59,8 +59,8 @@ func (router *Router) getQueryResults(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := struct {
-		Rows    [][]interface{} `json:"rows"`
-		Columns []string        `json:"columns"`
+		Rows    []map[string]interface{} `json:"rows"`
+		Columns []string                 `json:"columns"`
 	}{
 		rows,
 		columns,

--- a/plugins/sql/src/components/panel/SQLTable.tsx
+++ b/plugins/sql/src/components/panel/SQLTable.tsx
@@ -2,6 +2,7 @@ import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patter
 import React from 'react';
 
 import { ISQLData } from '../../utils/interfaces';
+import { renderCellValue } from '../../utils/helpers';
 
 type ISQLTableProps = ISQLData;
 
@@ -20,11 +21,13 @@ const SQLTable: React.FunctionComponent<ISQLTableProps> = ({ rows, columns }: IS
         </Tr>
       </Thead>
       <Tbody>
-        {rows
+        {rows && rows.length > 0
           ? rows.map((row, rowIndex) => (
               <Tr key={rowIndex}>
-                {row.map((column, columnIndex) => (
-                  <Td key={`${rowIndex}_${columnIndex}`}>{column}</Td>
+                {columns.map((column, columnIndex) => (
+                  <Td key={`${rowIndex}_${columnIndex}`}>
+                    {row.hasOwnProperty(column) ? renderCellValue(row[column]) : ''}
+                  </Td>
                 ))}
               </Tr>
             ))

--- a/plugins/sql/src/utils/helpers.ts
+++ b/plugins/sql/src/utils/helpers.ts
@@ -4,3 +4,11 @@ export const getQueryFromSearch = (search: string): string => {
   const query = params.get('query');
   return query ? query : '';
 };
+
+export const renderCellValue = (value: string | number | string[] | number[]): string => {
+  if (Array.isArray(value)) {
+    return `[${value.join(', ')}]`;
+  }
+
+  return `${value}`;
+};

--- a/plugins/sql/src/utils/interfaces.ts
+++ b/plugins/sql/src/utils/interfaces.ts
@@ -17,5 +17,9 @@ export interface IQuery {
 // ISQLData is the interface of the data returned from our Go API for the get query results call.
 export interface ISQLData {
   columns?: string[];
-  rows?: string[][];
+  rows?: ISQLDataRow[];
+}
+
+export interface ISQLDataRow {
+  [key: string]: string | number | string[] | number[];
 }


### PR DESCRIPTION
This commit replaces the GetQueryResults function used in the SQL
plugin with the implementation we are already using in the Clickhouse
plugin, so that we have a proper handling for float values.

Background: The original function would fail, when the SQL query
returned a float value with "NaN" or "Inf" as value, because then the
json encoding would fail.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
