### PR TITLE
[clickhouse] Fix download of .csv files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 - [#175](https://github.com/kobsio/kobs/pull/175): [prometheus] Fix tooltip when no unit is provided.
 - [#186](https://github.com/kobsio/kobs/pull/186): [jaeger] Fix tooltip position in traces chart.
+- [#189](https://github.com/kobsio/kobs/pull/189): [clickhouse] Fix download of `.csv` fiels.
 
 ### Changed
 

--- a/plugins/clickhouse/src/components/page/LogsActions.tsx
+++ b/plugins/clickhouse/src/components/page/LogsActions.tsx
@@ -26,7 +26,7 @@ export const LogsActions: React.FunctionComponent<ILogsActionsProps> = ({
   const [show, setShow] = useState<boolean>(false);
 
   // downloadLogs lets a user download the returned documents as raw logs.
-  const downloadLogs = (documents?: IDocument[]): void => {
+  const downloadLogs = (): void => {
     if (documents) {
       let log = '';
 
@@ -41,7 +41,7 @@ export const LogsActions: React.FunctionComponent<ILogsActionsProps> = ({
   };
 
   // downloadCSV lets a user donwload the returned documents as csv file, with the selected fields as columns.
-  const downloadCSV = (documents?: IDocument[], fields?: string[]): void => {
+  const downloadCSV = (): void => {
     if (documents && fields) {
       let csv = '';
 
@@ -49,7 +49,7 @@ export const LogsActions: React.FunctionComponent<ILogsActionsProps> = ({
         csv = csv + formatTime(document['timestamp']);
 
         for (const field of fields) {
-          csv = csv + ';' + field;
+          csv = csv + ';' + (document.hasOwnProperty(field) ? document[field] : '-');
         }
 
         csv = csv + '\r\n';
@@ -80,14 +80,10 @@ export const LogsActions: React.FunctionComponent<ILogsActionsProps> = ({
                 </Link>
               }
             />,
-            <DropdownItem key={1} isDisabled={!documents} onClick={(): void => downloadLogs(documents)}>
+            <DropdownItem key={1} isDisabled={!documents} onClick={(): void => downloadLogs()}>
               Download Logs
             </DropdownItem>,
-            <DropdownItem
-              key={2}
-              isDisabled={!documents || !fields}
-              onClick={(): void => downloadCSV(documents, fields)}
-            >
+            <DropdownItem key={2} isDisabled={!documents || !fields} onClick={(): void => downloadCSV()}>
               Download CSV
             </DropdownItem>,
           ]}


### PR DESCRIPTION
There was a bug, where the downloaded .csv files in the Clickhouse
plugin contained only the field names and not the values of the field.
This should now be fixed.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
