### PR TITLE
[core] Unify list layout across plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#181](https://github.com/kobsio/kobs/pull/181): [core] :warning: _Breaking change:_ :warning: Make the time selection across all plugins more intuitive. For that we removed the `time` property from the Options component and showing the formatted timestamp instead.
 - [#185](https://github.com/kobsio/kobs/pull/185): [clickhouse] Use pagination instead of Intersection Observer API to display logs.
 - [#188](https://github.com/kobsio/kobs/pull/188): [sql] Replace the `GetQueryResults` function with the implemention used in the Clickhouse plugin, to have a proper handling for float values.
+- [#190](https://github.com/kobsio/kobs/pull/190): [core] Unify list layout across plugin.
 
 ## [v0.6.0](https://github.com/kobsio/kobs/releases/tag/v0.6.0) (2021-10-11)
 

--- a/plugins/dashboards/src/components/page/Dashboards.tsx
+++ b/plugins/dashboards/src/components/page/Dashboards.tsx
@@ -2,8 +2,9 @@ import {
   Alert,
   AlertActionLink,
   AlertVariant,
-  Gallery,
-  GalleryItem,
+  Menu,
+  MenuContent,
+  MenuList,
   PageSection,
   PageSectionVariants,
   Spinner,
@@ -64,7 +65,7 @@ const Dashboards: React.FunctionComponent<IDashboardsProps> = ({ displayName, de
 
       <DashboardsModal dashboard={dashboard} setDashboard={setDashboard} />
 
-      <PageSection style={{ height: '100%', minHeight: '100%' }} variant={PageSectionVariants.default}>
+      <PageSection style={{ minHeight: '100%' }} variant={PageSectionVariants.default}>
         {isLoading ? (
           <div className="pf-u-text-align-center">
             <Spinner />
@@ -85,13 +86,19 @@ const Dashboards: React.FunctionComponent<IDashboardsProps> = ({ displayName, de
             <p>{error?.message}</p>
           </Alert>
         ) : data ? (
-          <Gallery hasGutter={true} maxWidths={{ default: '100%' }}>
-            {filterDashboards(data, debouncedSearchTerm).map((dashboard, index) => (
-              <GalleryItem key={index}>
-                <DashboardsItem dashboard={dashboard} setDashboard={setDashboard} />
-              </GalleryItem>
-            ))}
-          </Gallery>
+          <Menu>
+            <MenuContent>
+              <MenuList>
+                {filterDashboards(data, debouncedSearchTerm).map((dashboard) => (
+                  <DashboardsItem
+                    key={`${dashboard.cluster}-${dashboard.namespace}-${dashboard.name}`}
+                    dashboard={dashboard}
+                    setDashboard={setDashboard}
+                  />
+                ))}
+              </MenuList>
+            </MenuContent>
+          </Menu>
         ) : null}
       </PageSection>
     </React.Fragment>

--- a/plugins/dashboards/src/components/page/DashboardsItem.tsx
+++ b/plugins/dashboards/src/components/page/DashboardsItem.tsx
@@ -1,4 +1,4 @@
-import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
+import { MenuItem } from '@patternfly/react-core';
 import React from 'react';
 
 import { IDashboard } from '@kobsio/plugin-core';
@@ -13,22 +13,12 @@ const DashboardsItem: React.FunctionComponent<IDashboardsItemProps> = ({
   setDashboard,
 }: IDashboardsItemProps) => {
   return (
-    <Card
-      style={{ cursor: 'pointer' }}
-      isCompact={true}
-      isHoverable={true}
-      onClick={(): void => setDashboard(dashboard)}
-    >
-      <CardHeader>
-        <CardTitle>
-          {dashboard.name}
-          <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">
-            {dashboard.namespace} ({dashboard.cluster})
-          </span>
-        </CardTitle>
-      </CardHeader>
-      <CardBody>{dashboard.description}</CardBody>
-    </Card>
+    <MenuItem description={dashboard.description} onClick={(): void => setDashboard(dashboard)}>
+      {dashboard.name}
+      <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">
+        {dashboard.namespace} ({dashboard.cluster})
+      </span>
+    </MenuItem>
   );
 };
 

--- a/plugins/dashboards/src/components/panel/Panel.tsx
+++ b/plugins/dashboards/src/components/panel/Panel.tsx
@@ -1,4 +1,4 @@
-import { Gallery, GalleryItem } from '@patternfly/react-core';
+import { Menu, MenuContent, MenuList } from '@patternfly/react-core';
 import React, { memo } from 'react';
 
 import { IPluginPanelProps, IReference, PluginCard, PluginOptionsMissing } from '@kobsio/plugin-core';
@@ -23,13 +23,15 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({ defaults, title, d
 
   return (
     <PluginCard title={title} description={description} transparent={true}>
-      <Gallery hasGutter={true} maxWidths={{ default: '100%' }}>
-        {options.map((reference, index) => (
-          <GalleryItem key={index}>
-            <PanelItem defaults={defaults} reference={reference} />
-          </GalleryItem>
-        ))}
-      </Gallery>
+      <Menu>
+        <MenuContent>
+          <MenuList>
+            {options.map((reference, index) => (
+              <PanelItem key={index} defaults={defaults} reference={reference} />
+            ))}
+          </MenuList>
+        </MenuContent>
+      </Menu>
     </PluginCard>
   );
 };

--- a/plugins/dashboards/src/components/panel/PanelItem.tsx
+++ b/plugins/dashboards/src/components/panel/PanelItem.tsx
@@ -1,4 +1,4 @@
-import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
+import { MenuItem } from '@patternfly/react-core';
 import React from 'react';
 
 import { IPluginDefaults, IReference, LinkWrapper } from '@kobsio/plugin-core';
@@ -23,12 +23,7 @@ const PanelItem: React.FunctionComponent<IPanelItemProps> = ({ defaults, referen
         placeholderParams && placeholderParams.length > 0 ? placeholderParams.join('') : ''
       }`}
     >
-      <Card isCompact={true} isHoverable={true}>
-        <CardHeader>
-          <CardTitle>{reference.title}</CardTitle>
-        </CardHeader>
-        <CardBody>{reference.description || ''}</CardBody>
-      </Card>
+      <MenuItem description={reference.description}>{reference.title}</MenuItem>
     </LinkWrapper>
   );
 };

--- a/plugins/jaeger/src/assets/jaeger.css
+++ b/plugins/jaeger/src/assets/jaeger.css
@@ -5,3 +5,7 @@
   width: 100%;
   text-align: left;
 }
+
+.kobsio-jaeger-trace-list-item .pf-c-menu__item-description {
+  width: 100%;
+}

--- a/plugins/jaeger/src/components/panel/TracesList.tsx
+++ b/plugins/jaeger/src/components/panel/TracesList.tsx
@@ -1,3 +1,4 @@
+import { Menu, MenuContent, MenuList } from '@patternfly/react-core';
 import React from 'react';
 
 import { ITrace } from '../../utils/interfaces';
@@ -11,14 +12,15 @@ interface ITracesListProps {
 
 const TracesList: React.FunctionComponent<ITracesListProps> = ({ name, traces, showDetails }: ITracesListProps) => {
   return (
-    <React.Fragment>
-      {traces.map((trace, index) => (
-        <React.Fragment key={trace.traceID}>
-          <TracesListItem name={name} trace={trace} showDetails={showDetails} />
-          {index !== traces.length - 1 ? <p>&nbsp;</p> : null}
-        </React.Fragment>
-      ))}
-    </React.Fragment>
+    <Menu>
+      <MenuContent>
+        <MenuList>
+          {traces.map((trace, index) => (
+            <TracesListItem key={trace.traceID} name={name} trace={trace} showDetails={showDetails} />
+          ))}
+        </MenuList>
+      </MenuContent>
+    </Menu>
   );
 };
 

--- a/plugins/jaeger/src/components/panel/TracesListItem.tsx
+++ b/plugins/jaeger/src/components/panel/TracesListItem.tsx
@@ -1,4 +1,4 @@
-import { Badge, Card, CardActions, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
+import { Badge, MenuItem } from '@patternfly/react-core';
 import { ExclamationIcon } from '@patternfly/react-icons';
 import React from 'react';
 
@@ -20,59 +20,55 @@ const TracesListItem: React.FunctionComponent<ITracesListItemProps> = ({
   trace,
   showDetails,
 }: ITracesListItemProps) => {
-  const card = (
-    <Card
-      style={{ cursor: 'pointer' }}
-      isCompact={true}
-      isHoverable={true}
+  const item = (
+    <MenuItem
+      className="kobsio-jaeger-trace-list-item"
+      description={
+        <span>
+          <Badge className="pf-u-mr-xl" isRead={true}>
+            {trace.spans.length} Spans
+          </Badge>
+
+          {trace.services.map((service, index) => (
+            <Badge
+              key={index}
+              className="pf-u-ml-sm"
+              style={{ backgroundColor: getColorForService(trace.processes, service.name) }}
+            >
+              {service.name} ({service.numberOfSpans})
+            </Badge>
+          ))}
+
+          <span className="pf-u-float-right pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">
+            {formatTraceTime(trace.startTime)}
+          </span>
+        </span>
+      }
       onClick={
         showDetails
           ? (): void => showDetails(<Trace name={name} trace={trace} close={(): void => showDetails(undefined)} />)
           : undefined
       }
     >
-      <CardHeader>
-        <CardTitle>
-          {trace.traceName}
-          <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">
-            {trace.traceID}
-            {doesTraceContainsError(trace) ? (
-              <ExclamationIcon
-                className="pf-u-ml-sm pf-u-font-size-sm"
-                style={{ color: 'var(--pf-global--danger-color--100)' }}
-              />
-            ) : null}
-          </span>
-        </CardTitle>
-        <CardActions>
-          <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">{trace.duration / 1000}ms</span>
-        </CardActions>
-      </CardHeader>
-      <CardBody>
-        <Badge className="pf-u-mr-xl" isRead={true}>
-          {trace.spans.length} Spans
-        </Badge>
-
-        {trace.services.map((service, index) => (
-          <Badge
-            key={index}
-            className="pf-u-ml-sm"
-            style={{ backgroundColor: getColorForService(trace.processes, service.name) }}
-          >
-            {service.name} ({service.numberOfSpans})
-          </Badge>
-        ))}
-
-        <span style={{ float: 'right' }}>{formatTraceTime(trace.startTime)}</span>
-      </CardBody>
-    </Card>
+      {trace.traceName}
+      <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">
+        {trace.traceID}
+        {doesTraceContainsError(trace) ? (
+          <ExclamationIcon
+            className="pf-u-ml-sm pf-u-font-size-sm"
+            style={{ color: 'var(--pf-global--danger-color--100)' }}
+          />
+        ) : null}
+      </span>
+      <span className="pf-u-float-right pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">{trace.duration / 1000}ms</span>
+    </MenuItem>
   );
 
   if (!showDetails) {
-    return <LinkWrapper link={`/${name}/trace/${trace.traceID}`}>{card}</LinkWrapper>;
+    return <LinkWrapper link={`/${name}/trace/${trace.traceID}`}>{item}</LinkWrapper>;
   }
 
-  return card;
+  return item;
 };
 
 export default TracesListItem;

--- a/plugins/opsgenie/src/components/panel/Alerts.tsx
+++ b/plugins/opsgenie/src/components/panel/Alerts.tsx
@@ -1,4 +1,4 @@
-import { Alert, AlertActionLink, AlertVariant, Spinner } from '@patternfly/react-core';
+import { Alert, AlertActionLink, AlertVariant, Menu, MenuContent, MenuList, Spinner } from '@patternfly/react-core';
 import { QueryObserverResult, useQuery } from 'react-query';
 import React from 'react';
 
@@ -63,19 +63,20 @@ const Alerts: React.FunctionComponent<IAlertsProps> = ({ name, query, times, set
     </Alert>;
   }
 
-  if (!data) {
+  if (!data || data.length === 0) {
     return null;
   }
 
   return (
-    <div>
-      {data.map((alert, index) => (
-        <div key={alert.id}>
-          <AlertsItem name={name} alert={alert} setDetails={setDetails} />
-          {index !== data.length - 1 ? <p>&nbsp;</p> : null}
-        </div>
-      ))}
-    </div>
+    <Menu>
+      <MenuContent>
+        <MenuList>
+          {data.map((alert, index) => (
+            <AlertsItem key={alert.id} name={name} alert={alert} setDetails={setDetails} />
+          ))}
+        </MenuList>
+      </MenuContent>
+    </Menu>
   );
 };
 

--- a/plugins/opsgenie/src/components/panel/AlertsItem.tsx
+++ b/plugins/opsgenie/src/components/panel/AlertsItem.tsx
@@ -1,4 +1,4 @@
-import { Card, CardActions, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
+import { MenuItem } from '@patternfly/react-core';
 import React from 'react';
 
 import Alert from './details/alert/Alert';
@@ -14,28 +14,21 @@ interface IAlertsItemProps {
 
 const AlertsItem: React.FunctionComponent<IAlertsItemProps> = ({ name, alert, setDetails }: IAlertsItemProps) => {
   return (
-    <Card
-      style={{ cursor: 'pointer' }}
-      isCompact={true}
-      isHoverable={true}
+    <MenuItem
+      description={<Infos alert={alert} />}
       onClick={
         setDetails
           ? (): void => setDetails(<Alert name={name} alert={alert} close={(): void => setDetails(undefined)} />)
           : undefined
       }
     >
-      <CardHeader>
-        {alert.createdAt ? (
-          <CardActions>
-            <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">{formatTimeWrapper(alert.createdAt)}</span>
-          </CardActions>
-        ) : null}
-        <CardTitle>{alert.message}</CardTitle>
-      </CardHeader>
-      <CardBody>
-        <Infos alert={alert} />
-      </CardBody>
-    </Card>
+      {alert.message}
+      {alert.createdAt ? (
+        <span className="pf-u-float-right pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">
+          {formatTimeWrapper(alert.createdAt)}
+        </span>
+      ) : null}
+    </MenuItem>
   );
 };
 

--- a/plugins/opsgenie/src/components/panel/Incidents.tsx
+++ b/plugins/opsgenie/src/components/panel/Incidents.tsx
@@ -1,4 +1,4 @@
-import { Alert, AlertActionLink, AlertVariant, Spinner } from '@patternfly/react-core';
+import { Alert, AlertActionLink, AlertVariant, Menu, MenuContent, MenuList, Spinner } from '@patternfly/react-core';
 import { QueryObserverResult, useQuery } from 'react-query';
 import React from 'react';
 
@@ -63,19 +63,20 @@ const Incidents: React.FunctionComponent<IIncidentsProps> = ({ name, query, time
     </Alert>;
   }
 
-  if (!data) {
+  if (!data || data.length === 0) {
     return null;
   }
 
   return (
-    <div>
-      {data.map((incident, index) => (
-        <div key={incident.id}>
-          <IncidentsItem name={name} incident={incident} setDetails={setDetails} />
-          {index !== data.length - 1 ? <p>&nbsp;</p> : null}
-        </div>
-      ))}
-    </div>
+    <Menu>
+      <MenuContent>
+        <MenuList>
+          {data.map((incident, index) => (
+            <IncidentsItem key={incident.id} name={name} incident={incident} setDetails={setDetails} />
+          ))}
+        </MenuList>
+      </MenuContent>
+    </Menu>
   );
 };
 

--- a/plugins/opsgenie/src/components/panel/IncidentsItem.tsx
+++ b/plugins/opsgenie/src/components/panel/IncidentsItem.tsx
@@ -1,4 +1,4 @@
-import { Card, CardActions, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
+import { MenuItem } from '@patternfly/react-core';
 import React from 'react';
 
 import { IIncident } from '../../utils/interfaces';
@@ -18,10 +18,8 @@ const IncidentsItem: React.FunctionComponent<IIncidentsItemProps> = ({
   setDetails,
 }: IIncidentsItemProps) => {
   return (
-    <Card
-      style={{ cursor: 'pointer' }}
-      isCompact={true}
-      isHoverable={true}
+    <MenuItem
+      description={<Infos incident={incident} />}
       onClick={
         setDetails
           ? (): void =>
@@ -29,18 +27,13 @@ const IncidentsItem: React.FunctionComponent<IIncidentsItemProps> = ({
           : undefined
       }
     >
-      <CardHeader>
-        {incident.createdAt ? (
-          <CardActions>
-            <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">{formatTimeWrapper(incident.createdAt)}</span>
-          </CardActions>
-        ) : null}
-        <CardTitle>{incident.message}</CardTitle>
-      </CardHeader>
-      <CardBody>
-        <Infos incident={incident} />
-      </CardBody>
-    </Card>
+      {incident.message}
+      {incident.createdAt ? (
+        <span className="pf-u-float-right pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">
+          {formatTimeWrapper(incident.createdAt)}
+        </span>
+      ) : null}
+    </MenuItem>
   );
 };
 

--- a/plugins/rss/src/components/panel/Feed.tsx
+++ b/plugins/rss/src/components/panel/Feed.tsx
@@ -1,4 +1,4 @@
-import { Alert, AlertActionLink, AlertVariant, Spinner } from '@patternfly/react-core';
+import { Alert, AlertActionLink, AlertVariant, Menu, MenuContent, MenuList, Spinner } from '@patternfly/react-core';
 import { QueryObserverResult, useQuery } from 'react-query';
 import React from 'react';
 
@@ -67,14 +67,15 @@ const Alerts: React.FunctionComponent<IFeedProps> = ({ urls, sortBy, setDetails 
   }
 
   return (
-    <div>
-      {data.map((item, index) => (
-        <div key={index}>
-          <FeedItem item={item} setDetails={setDetails} />
-          {index !== data.length - 1 ? <p>&nbsp;</p> : null}
-        </div>
-      ))}
-    </div>
+    <Menu>
+      <MenuContent>
+        <MenuList>
+          {data.map((item, index) => (
+            <FeedItem key={index} item={item} setDetails={setDetails} />
+          ))}
+        </MenuList>
+      </MenuContent>
+    </Menu>
   );
 };
 

--- a/plugins/rss/src/components/panel/FeedItem.tsx
+++ b/plugins/rss/src/components/panel/FeedItem.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Card, CardBody, Split, SplitItem } from '@patternfly/react-core';
+import { Avatar, MenuItem } from '@patternfly/react-core';
 import React from 'react';
 
 import { IItem } from '../../utils/interfaces';
@@ -12,32 +12,19 @@ interface IFeedItemProps {
 
 const FeedItem: React.FunctionComponent<IFeedItemProps> = ({ item, setDetails }: IFeedItemProps) => {
   return (
-    <Card
-      style={{ cursor: 'pointer' }}
-      isCompact={true}
-      isHoverable={true}
+    <MenuItem
+      icon={
+        item.feedImage ? (
+          <Avatar src={item.feedImage} alt={item.title || ''} style={{ height: '16px', width: '16px' }} />
+        ) : undefined
+      }
+      description={item.published ? `${formatTime(item.published)} - ${item.feedTitle}` : item.feedTitle}
       onClick={
         setDetails ? (): void => setDetails(<Item item={item} close={(): void => setDetails(undefined)} />) : undefined
       }
     >
-      <CardBody>
-        <Split>
-          {item.feedImage && (
-            <SplitItem>
-              <Avatar src={item.feedImage} alt={item.title || ''} style={{ height: '42px', width: '42px' }} />
-            </SplitItem>
-          )}
-          <SplitItem className="pf-u-pl-md" style={{ maxWidth: '100%' }} isFilled={true}>
-            <p className="pf-u-text-truncate">
-              <strong>{item.title}</strong>
-            </p>
-            <p className="pf-u-text-truncate pf-u-font-size-sm pf-u-color-400">
-              {item.published ? `${formatTime(item.published)} - ${item.feedTitle}` : item.feedTitle}
-            </p>
-          </SplitItem>
-        </Split>
-      </CardBody>
-    </Card>
+      {item.title}
+    </MenuItem>
   );
 };
 


### PR DESCRIPTION
Most of the time we had used the Card component to render an item in a
list. We are now using the Menu components to render lists, so that the
lists across plugins looks better.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
