### PR TITLE
[clickhouse] Add option to download aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#183](https://github.com/kobsio/kobs/pull/183): [istio] Add panels and documentation and use the `destination_app` label instead of `destination_workload` for the Prometheus metrics.
 - [#184](https://github.com/kobsio/kobs/pull/184): [clickhouse] Add aggregations to visualize logs.
 - [#187](https://github.com/kobsio/kobs/pull/187): [clickhouse] Add options to download returned logs as `.log` or `.csv` file.
+- [#192](https://github.com/kobsio/kobs/pull/192): [clickhouse] Add options to download aggregation results as `.csv` file.
 
 ### Fixed
 

--- a/plugins/clickhouse/src/components/page/Aggregation.tsx
+++ b/plugins/clickhouse/src/components/page/Aggregation.tsx
@@ -1,9 +1,10 @@
-import { Alert, AlertActionLink, AlertVariant, Card, CardBody, Spinner } from '@patternfly/react-core';
+import { Alert, AlertActionLink, AlertVariant, Card, CardBody, CardHeader, Spinner } from '@patternfly/react-core';
 import { QueryObserverResult, useQuery } from 'react-query';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { IAggregationData, IAggregationOptions } from '../../utils/interfaces';
+import AggregationActions from './AggregationActions';
 import AggregationChart from '../panel/AggregationChart';
 
 interface IAggregationProps {
@@ -14,7 +15,7 @@ interface IAggregationProps {
 const Aggregation: React.FunctionComponent<IAggregationProps> = ({ name, options }: IAggregationProps) => {
   const history = useHistory();
 
-  const { isError, isLoading, data, error, refetch } = useQuery<IAggregationData, Error>(
+  const { isError, isFetching, isLoading, data, error, refetch } = useQuery<IAggregationData, Error>(
     ['clickhouse/aggregation', name, options],
     async () => {
       try {
@@ -40,6 +41,9 @@ const Aggregation: React.FunctionComponent<IAggregationProps> = ({ name, options
       } catch (err) {
         throw err;
       }
+    },
+    {
+      keepPreviousData: true,
     },
   );
 
@@ -76,6 +80,15 @@ const Aggregation: React.FunctionComponent<IAggregationProps> = ({ name, options
 
   return (
     <Card isCompact={true} style={{ height: '100%' }}>
+      <CardHeader>
+        <AggregationActions
+          name={name}
+          query={options.query}
+          times={options.times}
+          data={data}
+          isFetching={isFetching}
+        />
+      </CardHeader>
       <CardBody>
         <AggregationChart minHeight={500} options={options} data={data} />
       </CardBody>

--- a/plugins/clickhouse/src/components/page/AggregationActions.tsx
+++ b/plugins/clickhouse/src/components/page/AggregationActions.tsx
@@ -1,0 +1,76 @@
+import { CardActions, Dropdown, DropdownItem, KebabToggle, Spinner } from '@patternfly/react-core';
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import { IPluginTimes, fileDownload } from '@kobsio/plugin-core';
+import { IAggregationData } from '../../utils/interfaces';
+
+interface IAggregationActionsProps {
+  name: string;
+  query: string;
+  times: IPluginTimes;
+  data?: IAggregationData;
+  isFetching: boolean;
+}
+
+export const AggregationActions: React.FunctionComponent<IAggregationActionsProps> = ({
+  name,
+  query,
+  times,
+  data,
+  isFetching,
+}: IAggregationActionsProps) => {
+  const [show, setShow] = useState<boolean>(false);
+
+  const downloadCSV = (): void => {
+    if (data && data.columns && data.rows) {
+      let csv = '';
+
+      for (const row of data.rows) {
+        for (const column of data.columns) {
+          csv = csv + (row.hasOwnProperty(column) ? row[column] : '-') + ';';
+        }
+
+        csv = csv + '\r\n';
+      }
+
+      fileDownload(csv, 'kobs-export-aggregation.csv');
+    }
+
+    setShow(false);
+  };
+
+  return (
+    <CardActions>
+      {isFetching ? (
+        <Spinner size="md" />
+      ) : (
+        <Dropdown
+          toggle={<KebabToggle onToggle={(): void => setShow(!show)} />}
+          isOpen={show}
+          isPlain={true}
+          position="right"
+          dropdownItems={[
+            <DropdownItem
+              key={0}
+              component={
+                <Link
+                  to={`/${name}?timeEnd=${times.timeEnd}&timeStart=${times.timeStart}&query=${encodeURIComponent(
+                    query,
+                  )}`}
+                >
+                  Logs
+                </Link>
+              }
+            />,
+            <DropdownItem key={1} isDisabled={!data || !data.columns || !data.rows} onClick={(): void => downloadCSV()}>
+              Download CSV
+            </DropdownItem>,
+          ]}
+        />
+      )}
+    </CardActions>
+  );
+};
+
+export default AggregationActions;

--- a/plugins/clickhouse/src/components/page/AggregationPage.tsx
+++ b/plugins/clickhouse/src/components/page/AggregationPage.tsx
@@ -41,7 +41,7 @@ const AggregationPage: React.FunctionComponent<IAggregationPageProps> = ({
   const changeOptions = (): void => {
     history.push({
       pathname: location.pathname,
-      search: `?query=${tmpOptions.query}&timeEnd=${tmpOptions.times.timeEnd}&timeStart=${
+      search: `?query=${encodeURIComponent(tmpOptions.query)}&timeEnd=${tmpOptions.times.timeEnd}&timeStart=${
         tmpOptions.times.timeStart
       }&chart=${tmpOptions.chart}&aggregation=${encodeURIComponent(JSON.stringify(tmpOptions.options))}`,
     });

--- a/plugins/clickhouse/src/components/page/LogsActions.tsx
+++ b/plugins/clickhouse/src/components/page/LogsActions.tsx
@@ -75,7 +75,11 @@ export const LogsActions: React.FunctionComponent<ILogsActionsProps> = ({
             <DropdownItem
               key={0}
               component={
-                <Link to={`/${name}/aggregation?timeEnd=${times.timeEnd}&timeStart=${times.timeStart}&query=${query}`}>
+                <Link
+                  to={`/${name}/aggregation?timeEnd=${times.timeEnd}&timeStart=${
+                    times.timeStart
+                  }&query=${encodeURIComponent(query)}`}
+                >
                   Aggregation
                 </Link>
               }

--- a/plugins/clickhouse/src/components/panel/AggregationChartPie.tsx
+++ b/plugins/clickhouse/src/components/panel/AggregationChartPie.tsx
@@ -28,6 +28,7 @@ const AggregationChartPie: React.FunctionComponent<IAggregationChartPieProps> = 
       arcLabelsSkipAngle={10}
       arcLabelsTextColor="#151515"
       arcLinkLabelsColor={{ from: 'color' }}
+      arcLinkLabelsSkipAngle={10}
       arcLinkLabelsTextColor="#151515"
       arcLinkLabelsThickness={2}
       borderColor={{ from: 'color', modifiers: [['darker', 1.6]] }}


### PR DESCRIPTION
It is now possible to download the data returned by our API for an
aggregation result. The data can be downloaded as ".csv" file.

We also added some missing "encodeURIComponent" calls for the query,
which results in a bug where the URLs for an aggregation could not be
shared.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
