### PR TITLE
[elasticsearch] Use pagination instead for results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#185](https://github.com/kobsio/kobs/pull/185): [clickhouse] Use pagination instead of Intersection Observer API to display logs.
 - [#188](https://github.com/kobsio/kobs/pull/188): [sql] Replace the `GetQueryResults` function with the implemention used in the Clickhouse plugin, to have a proper handling for float values.
 - [#190](https://github.com/kobsio/kobs/pull/190): [core] Unify list layout across plugin.
+- [#194](https://github.com/kobsio/kobs/pull/194): [elasticsearch] Use pagination instead of infinite scrolling to display logs.
 
 ## [v0.6.0](https://github.com/kobsio/kobs/releases/tag/v0.6.0) (2021-10-11)
 

--- a/plugins/elasticsearch/elasticsearch.go
+++ b/plugins/elasticsearch/elasticsearch.go
@@ -43,17 +43,16 @@ func (router *Router) getInstance(name string) *instance.Instance {
 
 // getLogs returns the raw documents for a given query from Elasticsearch. The result also contains the distribution of
 // the documents in the given time range. The name of the Elasticsearch instance must be set via the name path
-// parameter, all other values like the query, scrollID, start and end time are set via query parameters. These
+// parameter, all other values like the query, start and end time are set via query parameters. These
 // parameters are then passed to the GetLogs function of the Elasticsearch instance, which returns the documents and
 // buckets.
 func (router *Router) getLogs(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	query := r.URL.Query().Get("query")
-	scrollID := r.URL.Query().Get("scrollID")
 	timeStart := r.URL.Query().Get("timeStart")
 	timeEnd := r.URL.Query().Get("timeEnd")
 
-	log.WithFields(logrus.Fields{"name": name, "query": query, "scrollID": scrollID, "timeStart": timeStart, "timeEnd": timeEnd}).Tracef("getLogs")
+	log.WithFields(logrus.Fields{"name": name, "query": query, "timeStart": timeStart, "timeEnd": timeEnd}).Tracef("getLogs")
 
 	i := router.getInstance(name)
 	if i == nil {
@@ -73,7 +72,7 @@ func (router *Router) getLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data, err := i.GetLogs(r.Context(), query, scrollID, parsedTimeStart, parsedTimeEnd)
+	data, err := i.GetLogs(r.Context(), query, parsedTimeStart, parsedTimeEnd)
 	if err != nil {
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get logs")
 		return

--- a/plugins/elasticsearch/pkg/instance/structs.go
+++ b/plugins/elasticsearch/pkg/instance/structs.go
@@ -50,9 +50,8 @@ type ResponseError struct {
 }
 
 // Data is the transformed Response result, which is passed to the React UI. It contains only the important fields, like
-// the scrollID, the time a request took, the number of hits, the documents and the buckets.
+// the time a request took, the number of hits, the documents and the buckets.
 type Data struct {
-	ScrollID  string                   `json:"scrollID"`
 	Took      int64                    `json:"took"`
 	Hits      int64                    `json:"hits"`
 	Documents []map[string]interface{} `json:"documents"`

--- a/plugins/elasticsearch/src/components/panel/LogsActions.tsx
+++ b/plugins/elasticsearch/src/components/panel/LogsActions.tsx
@@ -1,4 +1,4 @@
-import { CardActions, Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
+import { CardActions, Dropdown, DropdownItem, KebabToggle, Spinner } from '@patternfly/react-core';
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -9,33 +9,43 @@ interface IActionsProps {
   name: string;
   queries: IQuery[];
   times: IPluginTimes;
+  isFetching: boolean;
 }
 
-export const Actions: React.FunctionComponent<IActionsProps> = ({ name, queries, times }: IActionsProps) => {
+export const Actions: React.FunctionComponent<IActionsProps> = ({
+  name,
+  queries,
+  times,
+  isFetching,
+}: IActionsProps) => {
   const [show, setShow] = useState<boolean>(false);
 
   return (
     <CardActions>
-      <Dropdown
-        toggle={<KebabToggle onToggle={(): void => setShow(!show)} />}
-        isOpen={show}
-        isPlain={true}
-        position="right"
-        dropdownItems={queries.map((query, index) => (
-          <DropdownItem
-            key={index}
-            component={
-              <Link
-                to={`/${name}?timeEnd=${times.timeEnd}&timeStart=${times.timeStart}&query=${query.query}${
-                  query.fields ? query.fields.map((field) => `&field=${field}`).join('') : ''
-                }`}
-              >
-                {query.name}
-              </Link>
-            }
-          />
-        ))}
-      />
+      {isFetching ? (
+        <Spinner size="md" />
+      ) : (
+        <Dropdown
+          toggle={<KebabToggle onToggle={(): void => setShow(!show)} />}
+          isOpen={show}
+          isPlain={true}
+          position="right"
+          dropdownItems={queries.map((query, index) => (
+            <DropdownItem
+              key={index}
+              component={
+                <Link
+                  to={`/${name}?timeEnd=${times.timeEnd}&timeStart=${times.timeStart}&query=${query.query}${
+                    query.fields ? query.fields.map((field) => `&field=${field}`).join('') : ''
+                  }`}
+                >
+                  {query.name}
+                </Link>
+              }
+            />
+          ))}
+        />
+      )}
     </CardActions>
   );
 };

--- a/plugins/elasticsearch/src/components/panel/LogsDocuments.tsx
+++ b/plugins/elasticsearch/src/components/panel/LogsDocuments.tsx
@@ -1,22 +1,30 @@
-import { TableComposable, TableVariant, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
-import React from 'react';
+import { Pagination, PaginationVariant } from '@patternfly/react-core';
+import React, { useState } from 'react';
+import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
-import { ILogsData } from '../../utils/interfaces';
+import { IDocument } from '../../utils/interfaces';
 import LogsDocument from './LogsDocument';
 
+interface IPage {
+  page: number;
+  perPage: number;
+}
+
 interface ILogsDocumentsProps {
-  pages: ILogsData[];
+  documents: IDocument[];
   fields?: string[];
   addFilter?: (filter: string) => void;
   selectField?: (field: string) => void;
 }
 
 const LogsDocuments: React.FunctionComponent<ILogsDocumentsProps> = ({
-  pages,
+  documents,
   fields,
   addFilter,
   selectField,
 }: ILogsDocumentsProps) => {
+  const [page, setPage] = useState<IPage>({ page: 1, perPage: 100 });
+
   return (
     <TableComposable aria-label="Logs" variant={TableVariant.compact} borders={false}>
       <Thead>
@@ -32,18 +40,56 @@ const LogsDocuments: React.FunctionComponent<ILogsDocumentsProps> = ({
         </Tr>
       </Thead>
       <Tbody>
-        {pages.map((page, pageIndex) =>
-          page.documents.map((document, documentIndex) => (
-            <LogsDocument
-              key={`${pageIndex}_${documentIndex}`}
-              document={document}
-              fields={fields}
-              addFilter={addFilter}
-              selectField={selectField}
-            />
-          )),
-        )}
+        {documents
+          ? documents
+              .slice((page.page - 1) * page.perPage, page.page * page.perPage)
+              .map((document, index) => (
+                <LogsDocument
+                  key={index}
+                  document={document}
+                  fields={fields}
+                  addFilter={addFilter}
+                  selectField={selectField}
+                />
+              ))
+          : null}
       </Tbody>
+      {documents && (
+        <Tbody>
+          <Tr>
+            <Td />
+            <Td colSpan={fields && fields.length > 0 ? fields.length + 1 : 2}>
+              <Pagination
+                itemCount={documents.length}
+                widgetId="pagination-options-menu-bottom"
+                perPage={page.perPage}
+                page={page.page}
+                variant={PaginationVariant.bottom}
+                onSetPage={(event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPage: number): void =>
+                  setPage({ page: newPage, perPage: page.perPage })
+                }
+                onPerPageSelect={(
+                  event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+                  newPerPage: number,
+                ): void => setPage({ page: page.page, perPage: newPerPage })}
+                onFirstClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+                  setPage({ page: newPage, perPage: page.perPage })
+                }
+                onLastClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+                  setPage({ page: newPage, perPage: page.perPage })
+                }
+                onNextClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+                  setPage({ page: newPage, perPage: page.perPage })
+                }
+                onPreviousClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+                  setPage({ page: newPage, perPage: page.perPage })
+                }
+              />
+            </Td>
+            <Td />
+          </Tr>
+        </Tbody>
+      )}
     </TableComposable>
   );
 };

--- a/plugins/elasticsearch/src/components/preview/Chart.tsx
+++ b/plugins/elasticsearch/src/components/preview/Chart.tsx
@@ -16,7 +16,7 @@ interface IChartProps {
 export const Chart: React.FunctionComponent<IChartProps> = ({ name, times, title, options }: IChartProps) => {
   const { isError, isLoading, data, error } = useQuery<ILogsData, Error>(
     ['elasticsearch/logs', name, options, times],
-    async ({ pageParam }) => {
+    async () => {
       try {
         if (
           !options ||
@@ -29,7 +29,7 @@ export const Chart: React.FunctionComponent<IChartProps> = ({ name, times, title
         }
 
         const response = await fetch(
-          `/api/plugins/elasticsearch/logs/${name}?query=${options.queries[0].query}&timeStart=${times.timeStart}&timeEnd=${times.timeEnd}&scrollID=`,
+          `/api/plugins/elasticsearch/logs/${name}?query=${options.queries[0].query}&timeStart=${times.timeStart}&timeEnd=${times.timeEnd}`,
           {
             method: 'get',
           },
@@ -50,7 +50,6 @@ export const Chart: React.FunctionComponent<IChartProps> = ({ name, times, title
       }
     },
     {
-      getNextPageParam: (lastPage, pages) => lastPage.scrollID,
       keepPreviousData: true,
     },
   );

--- a/plugins/elasticsearch/src/utils/interfaces.ts
+++ b/plugins/elasticsearch/src/utils/interfaces.ts
@@ -24,7 +24,6 @@ export interface IQuery {
 // ILogsData is the interface of the data returned from our Go API for the Elasticsearch plugin. The interface must
 // have the same fields as the Data struct from the Go implementation.
 export interface ILogsData {
-  scrollID: string;
   took: number;
   hits: number;
   documents: IDocument[];


### PR DESCRIPTION
Instead if infinite scrolling (via the load more button) we are now
using pagination to display the documents returned by our API. For that
we can remove the depracated scroll API and directly request 1000
documents from the Elasticsearch API.

Using pagination instead of infite scrolling improves the performance of
our react UI when the user wants to view a lot of documents, e.g. when
the user wants to show 500 documents, the UI becomes laggy with infinite
scrolling. This problem can be avoided with pagination.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
