### PR TITLE
[istio] Change upstream cluster and path handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#188](https://github.com/kobsio/kobs/pull/188): [sql] Replace the `GetQueryResults` function with the implemention used in the Clickhouse plugin, to have a proper handling for float values.
 - [#190](https://github.com/kobsio/kobs/pull/190): [core] Unify list layout across plugin.
 - [#194](https://github.com/kobsio/kobs/pull/194): [elasticsearch] Use pagination instead of infinite scrolling to display logs.
+- [#195](https://github.com/kobsio/kobs/pull/195): [istio] Display upstream cluster instead of authority in the React UI and ignore query string in path.
 
 ## [v0.6.0](https://github.com/kobsio/kobs/releases/tag/v0.6.0) (2021-10-11)
 

--- a/plugins/istio/istio.go
+++ b/plugins/istio/istio.go
@@ -253,11 +253,11 @@ func (router *Router) getTap(w http.ResponseWriter, r *http.Request) {
 	timeEnd := r.URL.Query().Get("timeEnd")
 	application := r.URL.Query().Get("application")
 	namespace := r.URL.Query().Get("namespace")
-	filterName := r.URL.Query().Get("filterName")
+	filterUpstreamCluster := r.URL.Query().Get("filterUpstreamCluster")
 	filterMethod := r.URL.Query().Get("filterMethod")
 	filterPath := r.URL.Query().Get("filterPath")
 
-	log.WithFields(logrus.Fields{"name": name, "timeStart": timeStart, "timeEnd": timeEnd, "application": application, "namespace": namespace, "filterName": filterName, "filterMethod": filterMethod, "filterPath": filterPath}).Tracef("getTap")
+	log.WithFields(logrus.Fields{"name": name, "timeStart": timeStart, "timeEnd": timeEnd, "application": application, "namespace": namespace, "filterUpstreamCluster": filterUpstreamCluster, "filterMethod": filterMethod, "filterPath": filterPath}).Tracef("getTap")
 
 	i := router.getInstance(name)
 	if i == nil {
@@ -277,7 +277,7 @@ func (router *Router) getTap(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logs, err := i.Tap(r.Context(), namespace, application, filterName, filterMethod, filterPath, parsedTimeStart, parsedTimeEnd)
+	logs, err := i.Tap(r.Context(), namespace, application, filterUpstreamCluster, filterMethod, filterPath, parsedTimeStart, parsedTimeEnd)
 	if err != nil {
 		errresponse.Render(w, r, err, http.StatusBadRequest, "Could not get logs")
 		return
@@ -293,13 +293,13 @@ func (router *Router) getTop(w http.ResponseWriter, r *http.Request) {
 	timeEnd := r.URL.Query().Get("timeEnd")
 	application := r.URL.Query().Get("application")
 	namespace := r.URL.Query().Get("namespace")
-	filterName := r.URL.Query().Get("filterName")
+	filterUpstreamCluster := r.URL.Query().Get("filterUpstreamCluster")
 	filterMethod := r.URL.Query().Get("filterMethod")
 	filterPath := r.URL.Query().Get("filterPath")
 	sortBy := r.URL.Query().Get("sortBy")
 	sortDirection := r.URL.Query().Get("sortDirection")
 
-	log.WithFields(logrus.Fields{"name": name, "timeStart": timeStart, "timeEnd": timeEnd, "application": application, "namespace": namespace, "filterName": filterName, "filterMethod": filterMethod, "filterPath": filterPath}).Tracef("getTop")
+	log.WithFields(logrus.Fields{"name": name, "timeStart": timeStart, "timeEnd": timeEnd, "application": application, "namespace": namespace, "filterUpstreamCluster": filterUpstreamCluster, "filterMethod": filterMethod, "filterPath": filterPath}).Tracef("getTop")
 
 	i := router.getInstance(name)
 	if i == nil {
@@ -319,7 +319,7 @@ func (router *Router) getTop(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logs, err := i.Top(r.Context(), namespace, application, filterName, filterMethod, filterPath, sortBy, sortDirection, parsedTimeStart, parsedTimeEnd)
+	logs, err := i.Top(r.Context(), namespace, application, filterUpstreamCluster, filterMethod, filterPath, sortBy, sortDirection, parsedTimeStart, parsedTimeEnd)
 	if err != nil {
 		errresponse.Render(w, r, err, http.StatusBadRequest, "Could not get logs")
 		return
@@ -336,11 +336,10 @@ func (router *Router) getTopDetails(w http.ResponseWriter, r *http.Request) {
 	application := r.URL.Query().Get("application")
 	namespace := r.URL.Query().Get("namespace")
 	upstreamCluster := r.URL.Query().Get("upstreamCluster")
-	authority := r.URL.Query().Get("authority")
 	method := r.URL.Query().Get("method")
 	path := r.URL.Query().Get("path")
 
-	log.WithFields(logrus.Fields{"name": name, "timeStart": timeStart, "timeEnd": timeEnd, "application": application, "namespace": namespace, "upstreamCluster": upstreamCluster, "authority": authority, "method": method, "path": path}).Tracef("getTopDetails")
+	log.WithFields(logrus.Fields{"name": name, "timeStart": timeStart, "timeEnd": timeEnd, "application": application, "namespace": namespace, "upstreamCluster": upstreamCluster, "method": method, "path": path}).Tracef("getTopDetails")
 
 	i := router.getInstance(name)
 	if i == nil {
@@ -360,7 +359,7 @@ func (router *Router) getTopDetails(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	metrics, err := i.TopDetails(r.Context(), namespace, application, upstreamCluster, authority, method, path, parsedTimeStart, parsedTimeEnd)
+	metrics, err := i.TopDetails(r.Context(), namespace, application, upstreamCluster, method, path, parsedTimeStart, parsedTimeEnd)
 	if err != nil {
 		errresponse.Render(w, r, err, http.StatusBadRequest, "Could not get success rate")
 		return

--- a/plugins/istio/src/components/page/Application.tsx
+++ b/plugins/istio/src/components/page/Application.tsx
@@ -33,9 +33,11 @@ const Application: React.FunctionComponent<IApplicationProps> = ({ name, pluginO
       pathname: location.pathname,
       search: `?timeEnd=${tmpOptions.times.timeEnd}&timeStart=${tmpOptions.times.timeStart}&view=${
         tmpOptions.view
-      }&filterName=${encodeURIComponent(tmpOptions.filters.name)}&filterMethod=${encodeURIComponent(
-        tmpOptions.filters.method,
-      )}&filterPath=${encodeURIComponent(tmpOptions.filters.path)}`,
+      }&filterUpstreamCluster=${encodeURIComponent(
+        tmpOptions.filters.upstreamCluster,
+      )}&filterMethod=${encodeURIComponent(tmpOptions.filters.method)}&filterPath=${encodeURIComponent(
+        tmpOptions.filters.path,
+      )}`,
     });
   };
 
@@ -44,7 +46,7 @@ const Application: React.FunctionComponent<IApplicationProps> = ({ name, pluginO
       pathname: location.pathname,
       search: `?timeEnd=${options.times.timeEnd}&timeStart=${options.times.timeStart}&view=${
         options.view
-      }&filterName=${encodeURIComponent(filters.name)}&filterMethod=${encodeURIComponent(
+      }&filterUpstreamCluster=${encodeURIComponent(filters.upstreamCluster)}&filterMethod=${encodeURIComponent(
         filters.method,
       )}&filterPath=${encodeURIComponent(filters.path)}`,
     });

--- a/plugins/istio/src/components/page/ApplicationActions.tsx
+++ b/plugins/istio/src/components/page/ApplicationActions.tsx
@@ -36,7 +36,7 @@ const ApplicationActions: React.FunctionComponent<IApplicationActionsProps> = ({
   const [internalFilters, setInternalFilters] = useState<IFilters>(filters);
 
   const clearFilter = (): void => {
-    setFilters({ method: '', name: '', path: '' });
+    setFilters({ method: '', path: '', upstreamCluster: '' });
     setShowDropdown(false);
   };
 
@@ -106,15 +106,15 @@ const ApplicationActions: React.FunctionComponent<IApplicationActionsProps> = ({
         ]}
       >
         <Form isHorizontal={true}>
-          <FormGroup label="Name" fieldId="form-tab-name">
+          <FormGroup label="Upstream Cluster" fieldId="form-tab-upstreamcluster">
             <TextInput
-              value={internalFilters.name}
+              value={internalFilters.upstreamCluster}
               isRequired
               type="text"
-              id="form-tab-name"
-              aria-describedby="form-tab-name"
-              name="form-tab-name"
-              onChange={(value): void => setInternalFilters({ ...internalFilters, name: value })}
+              id="form-tab-upstreamcluster"
+              aria-describedby="form-tab-upstreamcluster"
+              name="form-tab-upstreamcluster"
+              onChange={(value): void => setInternalFilters({ ...internalFilters, upstreamCluster: value })}
             />
           </FormGroup>
           <FormGroup label="Method" fieldId="form-tab-method">

--- a/plugins/istio/src/components/panel/Panel.tsx
+++ b/plugins/istio/src/components/panel/Panel.tsx
@@ -172,8 +172,8 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
   ) {
     const filters = {
       method: options.filters && options.filters.method ? options.filters.method : '',
-      name: options.filters && options.filters.name ? options.filters.name : '',
       path: options.filters && options.filters.path ? options.filters.path : '',
+      upstreamCluster: options.filters && options.filters.upstreamCluster ? options.filters.upstreamCluster : '',
     };
 
     return (
@@ -185,9 +185,9 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
           <PanelActions
             link={`/${name}/${options.namespaces[0]}/${options.application}?timeEnd=${times.timeEnd}&timeStart=${
               times.timeStart
-            }&view=top&filterName=${encodeURIComponent(filters.name)}&filterMethod=${encodeURIComponent(
-              filters.method,
-            )}&filterPath=${encodeURIComponent(filters.path)}`}
+            }&view=top&filterUpstreamCluster=${encodeURIComponent(
+              filters.upstreamCluster,
+            )}&filterMethod=${encodeURIComponent(filters.method)}&filterPath=${encodeURIComponent(filters.path)}`}
           />
         }
       >
@@ -215,8 +215,8 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
   ) {
     const filters = {
       method: options.filters && options.filters.method ? options.filters.method : '',
-      name: options.filters && options.filters.name ? options.filters.name : '',
       path: options.filters && options.filters.path ? options.filters.path : '',
+      upstreamCluster: options.filters && options.filters.upstreamCluster ? options.filters.upstreamCluster : '',
     };
 
     return (
@@ -228,9 +228,9 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
           <PanelActions
             link={`/${name}/${options.namespaces[0]}/${options.application}?timeEnd=${times.timeEnd}&timeStart=${
               times.timeStart
-            }&view=tap&filterName=${encodeURIComponent(filters.name)}&filterMethod=${encodeURIComponent(
-              filters.method,
-            )}&filterPath=${encodeURIComponent(filters.path)}`}
+            }&view=tap&filterUpstreamCluster=${encodeURIComponent(
+              filters.upstreamCluster,
+            )}&filterMethod=${encodeURIComponent(filters.method)}&filterPath=${encodeURIComponent(filters.path)}`}
           />
         }
       >

--- a/plugins/istio/src/components/panel/Tap.tsx
+++ b/plugins/istio/src/components/panel/Tap.tsx
@@ -44,8 +44,8 @@ const Tap: React.FunctionComponent<ITapProps> = ({
           : times.timeStart;
 
         const response = await fetch(
-          `/api/plugins/istio/tap/${name}?timeStart=${timeStart}&timeEnd=${timeEnd}&application=${application}&namespace=${namespace}&filterName=${encodeURIComponent(
-            filters.name,
+          `/api/plugins/istio/tap/${name}?timeStart=${timeStart}&timeEnd=${timeEnd}&application=${application}&namespace=${namespace}&filterUpstreamCluster=${encodeURIComponent(
+            filters.upstreamCluster,
           )}&filterMethod=${encodeURIComponent(filters.method)}&filterPath=${encodeURIComponent(filters.path)}`,
           {
             method: 'get',
@@ -129,7 +129,9 @@ const Tap: React.FunctionComponent<ITapProps> = ({
             <Td dataLabel="Direction">
               {line.hasOwnProperty('content.upstream_cluster') ? getDirection(line['content.upstream_cluster']) : '-'}
             </Td>
-            <Td dataLabel="Name">{line.hasOwnProperty('content.authority') ? line['content.authority'] : '-'}</Td>
+            <Td dataLabel="Upstream Cluster">
+              {line.hasOwnProperty('content.upstream_cluster') ? line['content.upstream_cluster'] : '-'}
+            </Td>
             <Td dataLabel="Method">{line.hasOwnProperty('content.method') ? line['content.method'] : '-'}</Td>
             <Td className="pf-u-text-wrap pf-u-text-break-word" dataLabel="Path">
               {line.hasOwnProperty('content.path') ? line['content.path'] : '-'}

--- a/plugins/istio/src/components/panel/Top.tsx
+++ b/plugins/istio/src/components/panel/Top.tsx
@@ -79,8 +79,8 @@ const Top: React.FunctionComponent<ITopProps> = ({
         const response = await fetch(
           `/api/plugins/istio/top/${name}?timeStart=${
             times.timeStart
-          }&timeEnd=${timeEnd}&application=${application}&namespace=${namespace}&filterName=${encodeURIComponent(
-            filters.name,
+          }&timeEnd=${timeEnd}&application=${application}&namespace=${namespace}&filterUpstreamCluster=${encodeURIComponent(
+            filters.upstreamCluster,
           )}&filterMethod=${encodeURIComponent(filters.method)}&filterPath=${encodeURIComponent(
             filters.path,
           )}&sortBy=${sortBy}&sortDirection=${sortDirection}`,
@@ -190,40 +190,40 @@ const Top: React.FunctionComponent<ITopProps> = ({
             <Td dataLabel="Direction" onClick={(): void => onTdClick(row)}>
               {getDirection(row[0]) || '-'}
             </Td>
-            <Td dataLabel="Name" onClick={(): void => onTdClick(row)}>
-              {row[1] || '-'}
+            <Td dataLabel="Upstream Cluster" onClick={(): void => onTdClick(row)}>
+              {row[0] || '-'}
             </Td>
             <Td dataLabel="Method" onClick={(): void => onTdClick(row)}>
-              {row[2] || '-'}
+              {row[1] || '-'}
             </Td>
             <Td className="pf-u-text-wrap pf-u-text-break-word" dataLabel="Path" onClick={(): void => onTdClick(row)}>
-              {row[3] || '-'}
+              {row[2] || '-'}
             </Td>
             <Td className="pf-u-text-nowrap" dataLabel="Count" onClick={(): void => onTdClick(row)}>
-              {formatNumber(row[4])}
+              {formatNumber(row[3])}
             </Td>
             <Td className="pf-u-text-nowrap" dataLabel="Best" onClick={(): void => onTdClick(row)}>
-              {formatNumber(row[5], 'ms', 0)}
+              {formatNumber(row[4], 'ms', 0)}
             </Td>
             <Td className="pf-u-text-nowrap" dataLabel="Worst" onClick={(): void => onTdClick(row)}>
-              {formatNumber(row[6], 'ms', 0)}
+              {formatNumber(row[5], 'ms', 0)}
             </Td>
             <Td className="pf-u-text-nowrap" dataLabel="Avg" onClick={(): void => onTdClick(row)}>
-              {formatNumber(row[7], 'ms', 0)}
+              {formatNumber(row[6], 'ms', 0)}
             </Td>
             <Td className="pf-u-text-nowrap" dataLabel="Last" onClick={(): void => onTdClick(row)}>
-              {formatNumber(row[8], 'ms', 0)}
+              {formatNumber(row[7], 'ms', 0)}
             </Td>
             <Td className="pf-u-text-nowrap" dataLabel="SR" onClick={(): void => onTdClick(row)}>
-              {formatNumber(row[9], '%', 2)}
+              {formatNumber(row[8], '%', 2)}
             </Td>
             <Td noPadding={true} style={{ padding: 0 }}>
               <Link
                 to={`/${name}/${namespace}/${application}?view=tap&timeStart=${times.timeStart}&timeEnd=${
                   times.timeEnd
-                }&filterName=${encodeURIComponent(row[1])}&filterMethod=${encodeURIComponent(
-                  row[2],
-                )}&filterPath=${encodeURIComponent(escapeRegExp(row[3]))}`}
+                }&filterUpstreamCluster=${encodeURIComponent(row[0])}&filterMethod=${encodeURIComponent(
+                  row[1],
+                )}&filterPath=${encodeURIComponent(escapeRegExp(row[2]))}`}
               >
                 <Button variant={ButtonVariant.plain}>
                   <MicroscopeIcon />

--- a/plugins/istio/src/components/panel/details/DetailsTop.tsx
+++ b/plugins/istio/src/components/panel/details/DetailsTop.tsx
@@ -43,8 +43,8 @@ const DetailsTop: React.FunctionComponent<IDetailsTopProps> = ({
             times.timeEnd
           }&application=${application}&namespace=${namespace}&upstreamCluster=${encodeURIComponent(
             row[0],
-          )}&authority=${encodeURIComponent(row[1])}&method=${encodeURIComponent(row[2])}&path=${encodeURIComponent(
-            row[3],
+          )}&authority=${encodeURIComponent(row[1])}&method=${encodeURIComponent(row[1])}&path=${encodeURIComponent(
+            row[2],
           )}`,
           {
             method: 'get',
@@ -78,8 +78,8 @@ const DetailsTop: React.FunctionComponent<IDetailsTopProps> = ({
     <DrawerPanelContent minSize="50%">
       <DrawerHead>
         <Title
-          title={`${getDirection(row[0]) || '-'}: ${row[1] || '-'}`}
-          subtitle={`${row[2] || '-'}: ${row[3] || '-'}`}
+          title={`${getDirection(row[0]) || '-'}: ${row[0] || '-'}`}
+          subtitle={`${row[1] || '-'}: ${row[2] || '-'}`}
           size="lg"
         />
         <DrawerActions style={{ padding: 0 }}>

--- a/plugins/istio/src/utils/helpers.ts
+++ b/plugins/istio/src/utils/helpers.ts
@@ -18,15 +18,15 @@ export const getApplicationsOptionsFromSearch = (search: string): IApplicationsO
 export const getApplicationOptionsFromSearch = (search: string): IApplicationOptions => {
   const params = new URLSearchParams(search);
   const view = params.get('view');
-  const filterName = params.get('filterName');
+  const filterUpstreamCluster = params.get('filterUpstreamCluster');
   const filterMethod = params.get('filterMethod');
   const filterPath = params.get('filterPath');
 
   return {
     filters: {
       method: filterMethod ? filterMethod : '',
-      name: filterName ? filterName : '',
       path: filterPath ? filterPath : '',
+      upstreamCluster: filterUpstreamCluster ? filterUpstreamCluster : '',
     },
     times: getTimeParams(params),
     view: view ? view : 'metrics',

--- a/plugins/istio/src/utils/interfaces.ts
+++ b/plugins/istio/src/utils/interfaces.ts
@@ -24,7 +24,7 @@ export interface IApplicationOptions {
 
 // IFilters is the interface to specify filters for the tab and top view of an Istio application.
 export interface IFilters {
-  name: string;
+  upstreamCluster: string;
   method: string;
   path: string;
 }


### PR DESCRIPTION
This commit changes the handling of the upstream cluster and path field
in the Istio access logs.

We are now using the upstream cluster in the React UI instead of the
authority. For that we also removed the authority from the grouping
condition in the SQL query for Clickhouse.

When getting the path from Clickhouse we are now ignoring the query
string.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
