### PR TITLE
[elasticsearch] Fix number of documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#186](https://github.com/kobsio/kobs/pull/186): [jaeger] Fix tooltip position in traces chart.
 - [#189](https://github.com/kobsio/kobs/pull/189): [clickhouse] Fix download of `.csv` fiels.
 - [#191](https://github.com/kobsio/kobs/pull/191): [clickhouse] Fix returned logs, when user selected a custom order.
+- [#196](https://github.com/kobsio/kobs/pull/196): [elasticsearch] Fix number of documents.
 
 ### Changed
 

--- a/plugins/elasticsearch/pkg/instance/instance.go
+++ b/plugins/elasticsearch/pkg/instance/instance.go
@@ -68,9 +68,14 @@ func (i *Instance) GetLogs(ctx context.Context, query string, timeStart, timeEnd
 			return nil, err
 		}
 
+		var hits int64
+		for _, bucket := range res.Aggregations.LogCount.Buckets {
+			hits = hits + bucket.DocCount
+		}
+
 		data := &Data{
 			Took:      res.Took,
-			Hits:      res.Hits.Total.Value,
+			Hits:      hits,
 			Documents: res.Hits.Hits,
 			Buckets:   res.Aggregations.LogCount.Buckets,
 		}


### PR DESCRIPTION
After the latest changes, we showed the wrong number of documents in the
React UI for the number of documents for a query. This should now be
fixed be calculating the number of documents from the buckets, instead
of using the hits field from Elasticsearch.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
