### PR TITLE
[clickhouse] Change filters in aggregations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#190](https://github.com/kobsio/kobs/pull/190): [core] Unify list layout across plugin.
 - [#194](https://github.com/kobsio/kobs/pull/194): [elasticsearch] Use pagination instead of infinite scrolling to display logs.
 - [#195](https://github.com/kobsio/kobs/pull/195): [istio] Display upstream cluster instead of authority in the React UI and ignore query string in path.
+- [#197](https://github.com/kobsio/kobs/pull/197): [clickhouse] Change break down filter for aggregation, to allow more complex filters.
 
 ## [v0.6.0](https://github.com/kobsio/kobs/releases/tag/v0.6.0) (2021-10-11)
 

--- a/docs/plugins/clickhouse.md
+++ b/docs/plugins/clickhouse.md
@@ -142,15 +142,7 @@ spec:
 | verticalAxisOperation | string | The operation for the vertical axis. This can be `count`, `min`, `max`, `sum` or `avg`. | No |
 | verticalAxisField | string | When the verticalAxisOperation is `min`, `max`, `sum` or `avg`, this must be the name of a field for the vertical axis. | No |
 | breakDownByFields | []string | A list of field names, which should be used to break down the data. | No |
-| breakDownByFilters | [[]Aggregation Filters](#aggregation-filters) | A list of filters, which should be used to break down the data. | No |
-
-### Aggregation Filters
-
-| Field | Type | Description | Required |
-| ----- | ---- | ----------- | -------- |
-| field | string | The name of the field, which should be used for the filter. | Yes |
-| operator | string | The operator, which should be used for comparing the field value. This can be `=`, `<`, `>`, `<=` or `>=`. | Yes |
-| value | string | The value against which the field should be compared for the filter. | Yes |
+| breakDownByFilters | []string | A list of filters, which should be used to break down the data. | No |
 
 ## Query Syntax
 

--- a/plugins/clickhouse/src/components/page/AggregationOptionsFilters.tsx
+++ b/plugins/clickhouse/src/components/page/AggregationOptionsFilters.tsx
@@ -11,7 +11,7 @@ import {
 } from '@patternfly/react-core';
 import React, { useState } from 'react';
 
-import { IAggregationOptions, IAggregationOptionsAggregationFilter } from '../../utils/interfaces';
+import { IAggregationOptions } from '../../utils/interfaces';
 
 interface IAggregationOptionsFiltersProps {
   options: IAggregationOptions;
@@ -23,7 +23,7 @@ const AggregationOptionsFilters: React.FunctionComponent<IAggregationOptionsFilt
   setOptions,
 }: IAggregationOptionsFiltersProps) => {
   const [show, setShow] = useState<boolean>(false);
-  const [state, setState] = useState<IAggregationOptionsAggregationFilter>({ field: '', operator: '', value: '' });
+  const [filter, setFilter] = useState<string>('');
 
   const addFilter = (): void => {
     setOptions({
@@ -31,11 +31,11 @@ const AggregationOptionsFilters: React.FunctionComponent<IAggregationOptionsFilt
       options: {
         ...options.options,
         breakDownByFilters: options.options?.breakDownByFilters
-          ? [...options.options?.breakDownByFilters, state]
-          : [state],
+          ? [...options.options?.breakDownByFilters, filter]
+          : [filter],
       },
     });
-    setState({ field: '', operator: '', value: '' });
+    setFilter('');
     setShow(false);
   };
 
@@ -58,9 +58,7 @@ const AggregationOptionsFilters: React.FunctionComponent<IAggregationOptionsFilt
           isFlat={true}
           onClick={(): void => removeFilter(index)}
         >
-          <CardBody>
-            {filter.field} {filter.operator} {filter.value}
-          </CardBody>
+          <CardBody>{filter}</CardBody>
         </Card>
       ))}
       <Card style={{ cursor: 'pointer' }} isCompact={true} isFlat={true} onClick={(): void => setShow(true)}>
@@ -82,39 +80,15 @@ const AggregationOptionsFilters: React.FunctionComponent<IAggregationOptionsFilt
         ]}
       >
         <Form isHorizontal={true}>
-          <FormGroup label="Field" fieldId="form-field">
+          <FormGroup label="Filter" fieldId="form-filter">
             <TextInput
-              value={state.field}
+              value={filter}
               isRequired
               type="text"
-              id="form-field"
-              aria-describedby="form-field"
-              name="form-field"
-              onChange={(value): void => setState({ ...state, field: value })}
-            />
-          </FormGroup>
-
-          <FormGroup label="Operator" fieldId="form-operator">
-            <TextInput
-              value={state.operator}
-              isRequired
-              type="text"
-              id="form-operator"
-              aria-describedby="form-operator"
-              name="form-operator"
-              onChange={(value): void => setState({ ...state, operator: value })}
-            />
-          </FormGroup>
-
-          <FormGroup label="Value" fieldId="form-value">
-            <TextInput
-              value={state.value}
-              isRequired
-              type="text"
-              id="form-value"
-              aria-describedby="form-value"
-              name="form-value"
-              onChange={(value): void => setState({ ...state, value: value })}
+              id="form-filter"
+              aria-describedby="form-filter"
+              name="form-filter"
+              onChange={(value): void => setFilter(value)}
             />
           </FormGroup>
         </Form>

--- a/plugins/clickhouse/src/components/panel/AggregationChartBarTime.tsx
+++ b/plugins/clickhouse/src/components/panel/AggregationChartBarTime.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { ResponsiveBarCanvas } from '@nivo/bar';
 
 import { CHART_THEME, COLOR_SCALE, ChartTooltip } from '@kobsio/plugin-core';
-import { IAggregationData, IAggregationOptionsAggregationFilter } from '../../utils/interfaces';
 import { convertToBarChartTimeData, formatFilter } from '../../utils/aggregation';
+import { IAggregationData } from '../../utils/interfaces';
 
 interface IAggregationChartBarTimeProps {
-  filters: IAggregationOptionsAggregationFilter[];
+  filters: string[];
   data: IAggregationData;
 }
 
@@ -66,7 +66,9 @@ const AggregationChartBarTime: React.FunctionComponent<IAggregationChartBarTimeP
           <ChartTooltip
             anchor={isFirstHalf ? 'right' : 'left'}
             color={tooltip.color}
-            label={`${label ? `${label} - ${formatFilter(filter, filters)}` : filter}: ${tooltip.value}`}
+            label={`${label ? `${label} - ${formatFilter(filter, filters)}` : formatFilter(filter, filters)}: ${
+              tooltip.value
+            }`}
             position={[0, 20]}
             title={tooltip.data.time as string}
           />

--- a/plugins/clickhouse/src/components/panel/AggregationChartBarTop.tsx
+++ b/plugins/clickhouse/src/components/panel/AggregationChartBarTop.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { ResponsiveBarCanvas } from '@nivo/bar';
 
 import { CHART_THEME, COLOR_SCALE, ChartTooltip } from '@kobsio/plugin-core';
-import { IAggregationData, IAggregationOptionsAggregationFilter } from '../../utils/interfaces';
 import { convertToBarChartTopData, formatFilter } from '../../utils/aggregation';
+import { IAggregationData } from '../../utils/interfaces';
 
 interface IAggregationChartBarTopProps {
-  filters: IAggregationOptionsAggregationFilter[];
+  filters: string[];
   data: IAggregationData;
 }
 

--- a/plugins/clickhouse/src/components/panel/AggregationChartLine.tsx
+++ b/plugins/clickhouse/src/components/panel/AggregationChartLine.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { ResponsiveLineCanvas } from '@nivo/line';
 
 import { CHART_THEME, COLOR_SCALE, ChartTooltip } from '@kobsio/plugin-core';
-import { IAggregationData, IAggregationOptionsAggregationFilter } from '../../utils/interfaces';
 import { convertToLineChartData, formatAxisBottom, formatFilter } from '../../utils/aggregation';
+import { IAggregationData } from '../../utils/interfaces';
 
 interface IAggregationChartLineProps {
   isArea: boolean;
   startTime: number;
   endTime: number;
-  filters: IAggregationOptionsAggregationFilter[];
+  filters: string[];
   data: IAggregationData;
 }
 

--- a/plugins/clickhouse/src/utils/interfaces.ts
+++ b/plugins/clickhouse/src/utils/interfaces.ts
@@ -94,16 +94,7 @@ export interface IAggregationOptionsAggregation {
   verticalAxisField: string;
 
   breakDownByFields: string[];
-  breakDownByFilters: IAggregationOptionsAggregationFilter[];
-}
-
-// IAggregationOptionsAggregationFilter are the filters which can be set for an aggregation. Each filter required the
-// name of a field, an operator like ">", "<", ">=", "<=" or "=" and a value against which the field value should be
-// compared.
-export interface IAggregationOptionsAggregationFilter {
-  field: string;
-  operator: string;
-  value: string;
+  breakDownByFilters: string[];
 }
 
 // IAggregationData is the data returned by the aggregation API call. It contains a list of columns and a list of rows.
@@ -116,5 +107,5 @@ export interface IAggregationData {
 // key and the cell value for the row/column as value. The value could be a string, for the selected fields in the
 // aggregation or a number for the value of the fields combination.
 export interface IAggregationDataRow {
-  [key: string]: string | number;
+  [key: string]: string | number | null;
 }


### PR DESCRIPTION
This commit changes the filters which can be used in aggregations to
allow more complex filters via our query syntax. With this change we can
use more then one field in a filter for comparision.

We also adjusted the intervals to not always return a datapoint every 30
seconds, instead we are returning a maximum of 100 datapoints and for
smaller intervals we are reducing the number of datapoints.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
