### PR TITLE
Add support for volumes and volumeMounts in Helm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ lib-esm
 # test files
 /config.yaml
 /test.yaml
+/values.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#189](https://github.com/kobsio/kobs/pull/189): [clickhouse] Fix download of `.csv` fiels.
 - [#191](https://github.com/kobsio/kobs/pull/191): [clickhouse] Fix returned logs, when user selected a custom order.
 - [#196](https://github.com/kobsio/kobs/pull/196): [elasticsearch] Fix number of documents.
+- [#199](https://github.com/kobsio/kobs/pull/199): Add `volumes` and `volumeMounts` properties to the Helm chart, to support the kubeconfig provider.
 
 ### Changed
 

--- a/deploy/helm/kobs/Chart.yaml
+++ b/deploy/helm/kobs/Chart.yaml
@@ -4,5 +4,5 @@ description: Kubernetes Observability Platform
 type: application
 home: https://kobs.io
 icon: https://kobs.io/assets/images/logo.svg
-version: 0.7.3
+version: 0.8.0
 appVersion: v0.6.0

--- a/deploy/helm/kobs/templates/deployment.yaml
+++ b/deploy/helm/kobs/templates/deployment.yaml
@@ -32,6 +32,7 @@ spec:
           image: "{{ .Values.kobs.image.repository }}:{{ .Values.kobs.image.tag }}"
           imagePullPolicy: {{ .Values.kobs.image.pullPolicy }}
           args:
+            - --development={{ .Values.kobs.settings.development }}
             - --api.auth.default-team={{ .Values.kobs.settings.auth.defaultTeam }}
             - --api.auth.enabled={{ .Values.kobs.settings.auth.enabled }}
             - --api.auth.header={{ .Values.kobs.settings.auth.header }}
@@ -68,10 +69,16 @@ spec:
               mountPath: /kobs/config.yaml
               subPath: config.yaml
               readOnly: true
+            {{- if .Values.kobs.volumeMounts }}
+            {{- toYaml .Values.kobs.volumeMounts | nindent 12 }}
+            {{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ include "kobs.fullname" . }}
+        {{- if .Values.volumes }}
+        {{- toYaml .Values.volumes | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/kobs/values.yaml
+++ b/deploy/helm/kobs/values.yaml
@@ -36,6 +36,17 @@ tolerations: []
 ##
 affinity: {}
 
+## Specify additional volumes for the kobs deployment.
+## See: https://kubernetes.io/docs/concepts/storage/volumes/
+##
+## For example this can be used to mount a kubeconfig from a ConfigMap, so that we can use the kubeconfig provider
+## within the Helm chart. A complete example can be found in the documentation at https://kobs.io/installation/helm/.
+##
+volumes: []
+  # - name: kubeconfig
+  #   configMap:
+  #     name: kubeconfig
+
 ## Specify all infromation for the kobs pods.
 ##
 kobs:
@@ -43,7 +54,7 @@ kobs:
   ##
   image:
     repository: kobsio/kobs
-    tag: v0.5.0
+    tag: v0.6.0
     pullPolicy: IfNotPresent
 
   ## Specify additional labels and annotations for the created Pods.
@@ -76,6 +87,15 @@ kobs:
     #   cpu: 100m
     #   memory: 128Mi
 
+  ## Specify additional volumeMounts for the kobs container.
+  ## See: https://kubernetes.io/docs/concepts/storage/volumes/
+  ##
+  volumeMounts: []
+    # - name: kubeconfig
+    #   mountPath: /kobs/kubeconfig.yaml
+    #   subPath: kubeconfig.yaml
+    #   readOnly: true
+
   ## Specify additional environment variables for the kobs container.
   ##
   env: []
@@ -83,6 +103,7 @@ kobs:
   ## Specify some settings like log level, log format, etc. for kobs.
   ##
   settings:
+    development: false
     auth:
       enabled: false
       defaultTeam: ""


### PR DESCRIPTION
When a user deploys kobs via the Helm chart it is now possible to set
additional volumes and volumeMounts in the Helm chart. This way a user
can also mount a kubeconfig and use the kubeconfig provider for kobs.

We also added the development setting to the Helm chart, so that we can
test the Helm chart without installing a Ingress Controller in a
cluster.

Fixes #198 

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [x] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
