### PR TITLE
Speed up GitHub Action for the Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 .github
 .vscode
-app/build
 app/node_modules
 bin
 deploy

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -2,10 +2,10 @@ name: Docker
 
 on:
   push:
-    branches:
-      - main
-    tags:
-      - v*
+    # branches:
+    #   - main
+    # tags:
+    #   - v*
 
 jobs:
   docker:
@@ -17,6 +17,32 @@ jobs:
         with:
           fetch-depth: 0
 
+      # To speed up our pipeline for building the Docker image, we are building the frontend in the GitHub action and
+      # not within the Dockerfile, so that we do this only once and not for every platform.
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+
+      - name: Cache Node.js
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            */node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: React UI
+        run: |
+          yarn install --frozen-lockfile
+          yarn lint
+          yarn build
+
+      # Now we define the tag for our Docker image, setting up all GitHub actions and we build the image using the
+      # Dockerfile.github-action Dockerfile.
       - name: Set Docker Tag
         id: tag
         run: |
@@ -51,9 +77,10 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: true
+          # push: true
+          push: false
           context: .
-          file: ./cmd/kobs/Dockerfile
+          file: ./cmd/kobs/Dockerfile.github-action
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8
           tags: kobsio/kobs:${{ steps.tag.outputs.tag }}
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,7 +61,7 @@ jobs:
 
       - name: React UI
         run: |
-          yarn install
+          yarn install --frozen-lockfile
           yarn lint
           yarn build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#194](https://github.com/kobsio/kobs/pull/194): [elasticsearch] Use pagination instead of infinite scrolling to display logs.
 - [#195](https://github.com/kobsio/kobs/pull/195): [istio] Display upstream cluster instead of authority in the React UI and ignore query string in path.
 - [#197](https://github.com/kobsio/kobs/pull/197): [clickhouse] Change break down filter for aggregation, to allow more complex filters.
+- [#203](https://github.com/kobsio/kobs/pull/203): Speed up GitHub Action for building the Docker image for kobs.
 
 ## [v0.6.0](https://github.com/kobsio/kobs/releases/tag/v0.6.0) (2021-10-11)
 

--- a/cmd/kobs/Dockerfile.github-action
+++ b/cmd/kobs/Dockerfile.github-action
@@ -1,0 +1,22 @@
+# This Dockerfile should only be used in our GitHub Action pipeline to speed up the build process for our multi platform
+# image. If you want to build the Docker image for kobs locally, you can use the other Dockerfile in this directory,
+# so that you do not have to run "yarn install" and "yarn build" locally.
+FROM golang:1.17.3-alpine3.14 as api
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "Building on $BUILDPLATFORM, for $TARGETPLATFORM" > /log
+RUN apk update && apk add git make
+WORKDIR /kobs
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN make build
+
+FROM alpine:3.14.2
+RUN apk update && apk add --no-cache ca-certificates
+RUN mkdir /kobs
+COPY app/build /kobs/app/build
+COPY --from=api /kobs/bin/kobs /kobs
+WORKDIR /kobs
+USER nobody
+ENTRYPOINT  [ "/kobs/kobs" ]


### PR DESCRIPTION
Currently the GitHub Action for building our Docker image runs between
1 and 2 hours. To speed up this process we are now building the React UI
within the GitHub Action and not in the Docker image, so that this
only must be done once.

For that we introduced another Dockerfile which should only be used in
the GitHub action. This Dockerfile uses the same steps as the main
Dockerfile, but omits the build step for the React UI.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
