### PR TITLE
[resources] Add support to download/upload files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#201](https://github.com/kobsio/kobs/pull/201): [sonarqube] Add SonarQube plugin to view projects and their measures within kobs.
 - [#202](https://github.com/kobsio/kobs/pull/202): [core] Add tooltip to refresh button to show selected time interval.
 - [#204](https://github.com/kobsio/kobs/pull/204): [grafana] Add Grafana plugin, to show dashboards from a Grafana instance and to embed Grafana panels into kobs dashboards.
+- [#205](https://github.com/kobsio/kobs/pull/205): [resources] Add support to download/upload files from/to a container.
 
 ### Fixed
 

--- a/pkg/api/clusters/cluster/copy/copy.go
+++ b/pkg/api/clusters/cluster/copy/copy.go
@@ -1,0 +1,73 @@
+package copy
+
+import (
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+var (
+	log = logrus.WithFields(logrus.Fields{"package": "clusters"})
+)
+
+// FileFromPod let a user download a file from a container.
+func FileFromPod(w http.ResponseWriter, config *rest.Config, reqURL *url.URL) error {
+	reader, outStream := io.Pipe()
+
+	exec, err := remotecommand.NewSPDYExecutor(config, "POST", reqURL)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		defer outStream.Close()
+		err = exec.Stream(remotecommand.StreamOptions{
+			Stdin:  os.Stdin,
+			Stdout: outStream,
+			Stderr: os.Stderr,
+			Tty:    false,
+		})
+		if err != nil {
+			log.WithError(err).Errorf("could not copy file from pod")
+		}
+	}()
+
+	if _, err := io.Copy(w, reader); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// FileToPod let a user upload a file to a container.
+func FileToPod(config *rest.Config, reqURL *url.URL, srcFile multipart.File, destPath string) error {
+	reader, writer := io.Pipe()
+
+	go func() {
+		defer writer.Close()
+		io.Copy(writer, srcFile)
+	}()
+
+	exec, err := remotecommand.NewSPDYExecutor(config, "POST", reqURL)
+	if err != nil {
+		return err
+	}
+
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:  reader,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+		Tty:    false,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/plugins/core/src/utils/fileDownload.ts
+++ b/plugins/core/src/utils/fileDownload.ts
@@ -1,8 +1,12 @@
-// fileDownloads can be used to download the given data as file.
-// See: https://github.com/kennethjiang/js-file-download
+// fileDownload is a wrapper for the blodDownload function, but allows users to specify the data as string.
 export const fileDownload = (data: string, filename: string): void => {
   const blob = new Blob([data]);
+  blobDownload(blob, filename);
+};
 
+// blobDownload can be used to download the given data as file.
+// See: https://github.com/kennethjiang/js-file-download
+export const blobDownload = (blob: Blob, filename: string): void => {
   const blobURL =
     window.URL && window.URL.createObjectURL
       ? window.URL.createObjectURL(blob)

--- a/plugins/resources/src/components/panel/details/Actions.tsx
+++ b/plugins/resources/src/components/panel/details/Actions.tsx
@@ -5,6 +5,7 @@ import { IRow } from '@patternfly/react-table';
 import CreateEphemeralContainer from './actions/CreateEphemeralContainer';
 import CreateJob from './actions/CreateJob';
 import Delete from './actions/Delete';
+import DownloadFile from './actions/DownloadFile';
 import Edit from './actions/Edit';
 import { IAlert } from '../../../utils/interfaces';
 import { IResource } from '@kobsio/plugin-core';
@@ -12,6 +13,7 @@ import Logs from './actions/Logs';
 import Restart from './actions/Restart';
 import Scale from './actions/Scale';
 import Terminal from './actions/Terminal';
+import UploadFile from './actions/UploadFile';
 
 interface IActionProps {
   request: IResource;
@@ -27,6 +29,8 @@ const Actions: React.FunctionComponent<IActionProps> = ({ request, resource, ref
   const [showCreateJob, setShowCreateJob] = useState<boolean>(false);
   const [showLogs, setShowLogs] = useState<boolean>(false);
   const [showTerminal, setShowTerminal] = useState<boolean>(false);
+  const [showDownloadFile, setShowDownloadFile] = useState<boolean>(false);
+  const [showUploadFile, setShowUploadFile] = useState<boolean>(false);
   const [showCreateEphemeralContainer, setShowCreateEphemeralContainer] = useState<boolean>(false);
   const [showEdit, setShowEdit] = useState<boolean>(false);
   const [showDelete, setShowDelete] = useState<boolean>(false);
@@ -108,6 +112,34 @@ const Actions: React.FunctionComponent<IActionProps> = ({ request, resource, ref
         }}
       >
         Terminal
+      </DropdownItem>,
+    );
+  }
+
+  if (request.resource === 'pods') {
+    dropdownItems.push(
+      <DropdownItem
+        key="donwloadfile"
+        onClick={(): void => {
+          setShowDropdown(false);
+          setShowDownloadFile(true);
+        }}
+      >
+        Download File
+      </DropdownItem>,
+    );
+  }
+
+  if (request.resource === 'pods') {
+    dropdownItems.push(
+      <DropdownItem
+        key="uploadfile"
+        onClick={(): void => {
+          setShowDropdown(false);
+          setShowUploadFile(true);
+        }}
+      >
+        Upload File
       </DropdownItem>,
     );
   }
@@ -203,6 +235,20 @@ const Actions: React.FunctionComponent<IActionProps> = ({ request, resource, ref
       <Logs request={request} resource={resource} show={showLogs} setShow={setShowLogs} />
 
       <Terminal request={request} resource={resource} show={showTerminal} setShow={setShowTerminal} />
+
+      <DownloadFile
+        resource={resource}
+        show={showDownloadFile}
+        setShow={setShowDownloadFile}
+        setAlert={(alert: IAlert): void => setAlerts([...alerts, alert])}
+      />
+
+      <UploadFile
+        resource={resource}
+        show={showUploadFile}
+        setShow={setShowUploadFile}
+        setAlert={(alert: IAlert): void => setAlerts([...alerts, alert])}
+      />
 
       <CreateEphemeralContainer
         request={request}

--- a/plugins/resources/src/components/panel/details/actions/DownloadFile.tsx
+++ b/plugins/resources/src/components/panel/details/actions/DownloadFile.tsx
@@ -1,0 +1,144 @@
+import {
+  AlertVariant,
+  Button,
+  ButtonVariant,
+  Form,
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+  Modal,
+  ModalVariant,
+  TextInput,
+} from '@patternfly/react-core';
+import React, { useState } from 'react';
+import { IRow } from '@patternfly/react-table';
+import { V1Pod } from '@kubernetes/client-node';
+
+import { IAlert } from '../../../../utils/interfaces';
+import { blobDownload } from '@kobsio/plugin-core';
+
+// getContainers returns a list with all container names for the given Pod. It contains all specified init containers
+// and the "normal" containers.
+const getContainers = (pod: V1Pod): string[] => {
+  const containers: string[] = [];
+
+  if (pod.spec?.initContainers) {
+    for (const container of pod.spec?.initContainers) {
+      containers.push(container.name);
+    }
+  }
+
+  if (pod.spec?.containers) {
+    for (const container of pod.spec?.containers) {
+      containers.push(container.name);
+    }
+  }
+
+  if (pod.spec?.ephemeralContainers) {
+    for (const container of pod.spec?.ephemeralContainers) {
+      containers.push(container.name);
+    }
+  }
+
+  return containers;
+};
+
+interface IDownloadFileProps {
+  resource: IRow;
+  show: boolean;
+  setShow: (value: boolean) => void;
+  setAlert: (alert: IAlert) => void;
+}
+
+const DownloadFile: React.FunctionComponent<IDownloadFileProps> = ({
+  resource,
+  show,
+  setShow,
+  setAlert,
+}: IDownloadFileProps) => {
+  const containers = getContainers(resource.props);
+
+  const [container, setContainer] = useState<string>(containers[0]);
+  const [sourcePath, setSourcePath] = useState<string>('');
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const downloadFile = async (): Promise<void> => {
+    setIsLoading(true);
+
+    try {
+      const response = await fetch(
+        `/api/plugins/resources/file?cluster=${resource.cluster.title}${
+          resource.namespace ? `&namespace=${resource.namespace.title}` : ''
+        }&name=${resource.name.title}&container=${container}&srcPath=${sourcePath}`,
+        { method: 'get' },
+      );
+
+      if (response.status >= 200 && response.status < 300) {
+        const data = await response.blob();
+        blobDownload(data, `${resource.name.title}__${container}.tar`);
+
+        setIsLoading(false);
+        setShow(false);
+      } else {
+        const json = await response.json();
+
+        if (json.error) {
+          throw new Error(json.error);
+        } else {
+          throw new Error('An unknown error occured');
+        }
+      }
+    } catch (err) {
+      setIsLoading(false);
+      setShow(false);
+      setAlert({ title: err.message, variant: AlertVariant.danger });
+    }
+  };
+
+  return (
+    <Modal
+      variant={ModalVariant.small}
+      title="Download File"
+      isOpen={show}
+      onClose={(): void => setShow(false)}
+      actions={[
+        <Button key="download" variant={ButtonVariant.primary} isLoading={isLoading} onClick={downloadFile}>
+          Download
+        </Button>,
+        <Button key="cancel" variant={ButtonVariant.link} onClick={(): void => setShow(false)}>
+          Cancel
+        </Button>,
+      ]}
+    >
+      <Form isHorizontal={true}>
+        <FormGroup label="Container" fieldId="download-form-container">
+          <FormSelect
+            value={container}
+            onChange={(value): void => setContainer(value)}
+            id="download-form-container"
+            name="download-form-container"
+            aria-label="Container"
+          >
+            {containers.map((container, index) => (
+              <FormSelectOption key={index} value={container} label={container} />
+            ))}
+          </FormSelect>
+        </FormGroup>
+
+        <FormGroup label="Source Path" fieldId="download-form-source-path">
+          <TextInput
+            value={sourcePath}
+            isRequired
+            type="text"
+            id="download-form-source-path"
+            aria-describedby="download-form-source-path"
+            name="download-form-source-path"
+            onChange={(value): void => setSourcePath(value)}
+          />
+        </FormGroup>
+      </Form>
+    </Modal>
+  );
+};
+
+export default DownloadFile;

--- a/plugins/resources/src/components/panel/details/actions/UploadFile.tsx
+++ b/plugins/resources/src/components/panel/details/actions/UploadFile.tsx
@@ -1,0 +1,169 @@
+import {
+  AlertVariant,
+  Button,
+  ButtonVariant,
+  FileUpload,
+  Form,
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+  Modal,
+  ModalVariant,
+  TextInput,
+} from '@patternfly/react-core';
+import React, { useState } from 'react';
+import { IRow } from '@patternfly/react-table';
+import { V1Pod } from '@kubernetes/client-node';
+
+import { IAlert } from '../../../../utils/interfaces';
+
+interface ISourceFile {
+  filename: string;
+  value?: string | File;
+}
+
+// getContainers returns a list with all container names for the given Pod. It contains all specified init containers
+// and the "normal" containers.
+const getContainers = (pod: V1Pod): string[] => {
+  const containers: string[] = [];
+
+  if (pod.spec?.initContainers) {
+    for (const container of pod.spec?.initContainers) {
+      containers.push(container.name);
+    }
+  }
+
+  if (pod.spec?.containers) {
+    for (const container of pod.spec?.containers) {
+      containers.push(container.name);
+    }
+  }
+
+  if (pod.spec?.ephemeralContainers) {
+    for (const container of pod.spec?.ephemeralContainers) {
+      containers.push(container.name);
+    }
+  }
+
+  return containers;
+};
+
+interface IUploadFileProps {
+  resource: IRow;
+  show: boolean;
+  setShow: (value: boolean) => void;
+  setAlert: (alert: IAlert) => void;
+}
+
+const UploadFile: React.FunctionComponent<IUploadFileProps> = ({
+  resource,
+  show,
+  setShow,
+  setAlert,
+}: IUploadFileProps) => {
+  const containers = getContainers(resource.props);
+
+  const [container, setContainer] = useState<string>(containers[0]);
+  const [sourceFile, setSourceFile] = useState<ISourceFile>({ filename: '', value: undefined });
+  const [destinationPath, setDestinationPath] = useState<string>('');
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const uploadFile = async (): Promise<void> => {
+    setIsLoading(true);
+
+    try {
+      if (!sourceFile.value) {
+        throw new Error('Source file is missing');
+      }
+
+      const formData = new FormData();
+      formData.append('file', sourceFile.value);
+
+      const response = await fetch(
+        `/api/plugins/resources/file?cluster=${resource.cluster.title}${
+          resource.namespace ? `&namespace=${resource.namespace.title}` : ''
+        }&name=${resource.name.title}&container=${container}&destPath=${destinationPath}`,
+        {
+          body: formData,
+          method: 'post',
+        },
+      );
+
+      const json = await response.json();
+
+      if (response.status >= 200 && response.status < 300) {
+        setIsLoading(false);
+        setShow(false);
+        setAlert({ title: 'File was uploaded', variant: AlertVariant.success });
+      } else {
+        if (json.error) {
+          throw new Error(json.error);
+        } else {
+          throw new Error('An unknown error occured');
+        }
+      }
+    } catch (err) {
+      setIsLoading(false);
+      setShow(false);
+      setAlert({ title: err.message, variant: AlertVariant.danger });
+    }
+  };
+
+  return (
+    <Modal
+      variant={ModalVariant.small}
+      title="Upload File"
+      isOpen={show}
+      onClose={(): void => setShow(false)}
+      actions={[
+        <Button key="upload" variant={ButtonVariant.primary} isLoading={isLoading} onClick={uploadFile}>
+          Upload
+        </Button>,
+        <Button key="cancel" variant={ButtonVariant.link} onClick={(): void => setShow(false)}>
+          Cancel
+        </Button>,
+      ]}
+    >
+      <Form isHorizontal={true}>
+        <FormGroup label="Container" fieldId="upload-form-container">
+          <FormSelect
+            value={container}
+            onChange={(value): void => setContainer(value)}
+            id="upload-form-container"
+            name="upload-form-container"
+            aria-label="Container"
+          >
+            {containers.map((container, index) => (
+              <FormSelectOption key={index} value={container} label={container} />
+            ))}
+          </FormSelect>
+        </FormGroup>
+
+        <FormGroup label="Destination Path" fieldId="upload-form-source-file">
+          <FileUpload
+            id="upload-form-source-file"
+            value={sourceFile.value}
+            filename={sourceFile.filename}
+            filenamePlaceholder="Select a File"
+            browseButtonText="Select File"
+            onChange={(value, filename, event): void => setSourceFile({ filename: filename, value: value })}
+          />
+        </FormGroup>
+
+        <FormGroup label="Destination Path" fieldId="upload-form-destination-path">
+          <TextInput
+            value={destinationPath}
+            isRequired
+            type="text"
+            id="upload-form-destination-path"
+            aria-describedby="upload-form-destination-path"
+            name="upload-form-destination-path"
+            onChange={(value): void => setDestinationPath(value)}
+          />
+        </FormGroup>
+      </Form>
+    </Modal>
+  );
+};
+
+export default UploadFile;


### PR DESCRIPTION
It is now possible to download/upload files from/to a container. For
that we added two new actions for Pods. The "Download File" action can
be used to download a file from a container by setting the source path
of the file from the container. The "Upload File" action can be used to
upload a file from your local machine to a container. For that the
source file must be selected and the destination path, where the file
should be created must be provided.

Note: Currently it is not possible to download a whole directory,
because we are receiving a "Truncated tar archive" for the downloaded
archive.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
