### PR TITLE
[azure] Use resource groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 ### Added
 
 - [#213](https://github.com/kobsio/kobs/pull/213): [techdocs] Add TechDocs plugin, to access the documentation for your services within kobs.
+- [#215](https://github.com/kobsio/kobs/pull/215): [azure] Add Azure plugin, to monitor your Azure resources.
 
 ### Fixed
 
 ### Changed
+
+- [#217](https://github.com/kobsio/kobs/pull/217): [azure] Use resource groups to get a list of container instances.
 
 ## [v0.7.0](https://github.com/kobsio/kobs/releases/tag/v0.7.0) (2021-11-19)
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,9 @@ go 1.17
 
 require (
 	github.com/Azure/azure-sdk-for-go v59.3.0+incompatible
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.20.0
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.12.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v0.2.0
 	github.com/Azure/go-autorest/autorest v0.11.19
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.9
 	github.com/ClickHouse/clickhouse-go v1.5.1
@@ -34,6 +37,7 @@ require (
 )
 
 require (
+	github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.1 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.14 // indirect
 	github.com/Azure/go-autorest/autorest/azure/cli v0.4.2 // indirect
@@ -85,6 +89,7 @@ require (
 	github.com/nitishm/engarde v0.1.1 // indirect
 	github.com/openshift/api v0.0.0-20200221181648-8ce0047d664f // indirect
 	github.com/opentracing/opentracing-go v1.1.0 // indirect
+	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
@@ -94,7 +99,7 @@ require (
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/vjeantet/grok v1.0.0 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
-	golang.org/x/net v0.0.0-20210525063256-abc453219eb5 // indirect
+	golang.org/x/net v0.0.0-20210610132358-84b48f89b13b // indirect
 	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,20 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/Azure/azure-sdk-for-go v59.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v59.3.0+incompatible h1:dPIm0BO4jsMXFcCI/sLTPkBtE7mk8WMuRHA0JeWhlcQ=
 github.com/Azure/azure-sdk-for-go v59.3.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0/go.mod h1:h6H6c8enJmmocHUbLiiGY6sx7f9i+X3m1CHdd5c6Rdw=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.20.0 h1:KQgdWmEOmaJKxaUUZwHAYh12t+b+ZJf8q3friycK1kA=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.20.0/go.mod h1:ZPW/Z0kLCTdDZaDbYTetxc9Cxl/2lNqxYHYNOF2bti0=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0/go.mod h1:HcM1YX14R7CJcghJGOYCgdezslRSVzqwLf/q+4Y2r/0=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.12.0 h1:VBvHGLJbaY0+c66NZHdS9cgjHVYSH6DDa0XJMyrblsI=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.12.0/go.mod h1:GJzjM4SR9T0KyX5gKCVyz1ytD8FeWeUPCwtFCt1AyfE=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0/go.mod h1:yqy467j36fJxcRV2TzfVZ1pCb5vxm4BtZPUdYWe/Xo8=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.1 h1:BUYIbDf/mMZ8945v3QkG3OuqGVyS4Iek0AOLwdRAYoc=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.1/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v0.2.0 h1:SdyLrG1OreJ3X8CoPgQnKU847+61sJ9TVfvtrdjX6rI=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v0.2.0/go.mod h1:aSuRFfpDntiZkIh+XmoL9EV4FS4ViptLBwFRytECG/8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-ansiterm v0.0.0-20210608223527-2377c96fe795/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
@@ -159,6 +171,8 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
+github.com/dnaeon/go-vcr v1.1.0/go.mod h1:M7tiix8f0r6mKKJ3Yq/kqU1OYf3MnfmBWVbPx/yU9ko=
+github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
@@ -482,6 +496,7 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3PzxT8aQXRPkAt8xlV/e7d7w8GM5g0fa5F0D8=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
@@ -548,6 +563,8 @@ github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
+github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -723,6 +740,7 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5UtiO8tQHbUSXxL+pnGRANg=
@@ -797,6 +815,7 @@ golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20201010224723-4f7140c49acb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -806,8 +825,9 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20210525063256-abc453219eb5 h1:wjuX4b5yYQnEQHzd+CBcrcC6OVR2J1CN6mUy0oSxIPo=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210610132358-84b48f89b13b h1:k+E048sYJHyVnsr1GDrRZWQ32D2C7lWs9JRc0bel53A=
+golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/plugins/azure/azure.go
+++ b/plugins/azure/azure.go
@@ -64,6 +64,8 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 		instances,
 	}
 
+	router.Get("/resourcegroups/{name}", router.getResourceGroups)
+
 	router.Route("/containerinstances", func(r chi.Router) {
 		r.Get("/containergroups/{name}", router.getContainerGroups)
 		r.Get("/containergroup/details/{name}", router.getContainerGroup)

--- a/plugins/azure/pkg/instance/containerinstances/containerinstances.go
+++ b/plugins/azure/pkg/instance/containerinstances/containerinstances.go
@@ -24,16 +24,16 @@ type Client struct {
 
 // ContainerGroupListResult the container group list response that contains the container group properties.
 type ContainerGroupListResult struct {
-	Value    *[]map[string]interface{} `json:"value,omitempty"`
-	NextLink *string                   `json:"nextLink,omitempty"`
+	Value    []map[string]interface{} `json:"value,omitempty"`
+	NextLink string                   `json:"nextLink,omitempty"`
 }
 
 // ListContainerGroups list all container groups in a subscription.
 //
 // We can not use the containerGroupsClient for this request, because the result is missing some important fields like
 // the ids of the returned resources.
-func (c *Client) ListContainerGroups(ctx context.Context) (*[]map[string]interface{}, error) {
-	req, err := http.NewRequestWithContext(context.Background(), "GET", containerinstance.DefaultBaseURI+"/subscriptions/"+c.subscriptionID+"/providers/Microsoft.ContainerInstance/containerGroups?api-version=2021-07-01", nil)
+func (c *Client) ListContainerGroups(ctx context.Context, resourceGroup string) ([]map[string]interface{}, error) {
+	req, err := http.NewRequestWithContext(context.Background(), "GET", containerinstance.DefaultBaseURI+"/subscriptions/"+c.subscriptionID+"/resourceGroups/"+resourceGroup+"/providers/Microsoft.ContainerInstance/containerGroups?api-version=2021-07-01", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/azure/pkg/instance/resourcegroups/resourcegroups.go
+++ b/plugins/azure/pkg/instance/resourcegroups/resourcegroups.go
@@ -1,0 +1,38 @@
+package resourcegroups
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+)
+
+// Client is the client to interact with the container instance API.
+type Client struct {
+	resourceGroupsClient *armresources.ResourceGroupsClient
+}
+
+// ListResourceGroups lists all resource groups for the configured subscription.
+func (c *Client) ListResourceGroups(ctx context.Context) ([]*armresources.ResourceGroup, error) {
+	pager := c.resourceGroupsClient.List(&armresources.ResourceGroupsListOptions{Top: nil})
+
+	var resourceGroups []*armresources.ResourceGroup
+	for pager.NextPage(ctx) {
+		resp := pager.PageResponse()
+		if resp.ResourceGroupListResult.Value != nil {
+			resourceGroups = append(resourceGroups, resp.ResourceGroupListResult.Value...)
+		}
+	}
+
+	return resourceGroups, pager.Err()
+}
+
+// New returns a new client to interact with the container instances API.
+func New(subscriptionID string, credentials *azidentity.DefaultAzureCredential) *Client {
+	resourceGroupsClient := armresources.NewResourceGroupsClient(subscriptionID, credentials, &arm.ClientOptions{})
+
+	return &Client{
+		resourceGroupsClient: resourceGroupsClient,
+	}
+}

--- a/plugins/azure/resourcegroups.go
+++ b/plugins/azure/resourcegroups.go
@@ -1,0 +1,31 @@
+package azure
+
+import (
+	"net/http"
+
+	"github.com/kobsio/kobs/pkg/api/middleware/errresponse"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	"github.com/sirupsen/logrus"
+)
+
+func (router *Router) getResourceGroups(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "name")
+
+	log.WithFields(logrus.Fields{"name": name}).Tracef("getResourceGroups")
+
+	i := router.getInstance(name)
+	if i == nil {
+		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
+		return
+	}
+
+	resourceGroups, err := i.ResourceGroups.ListResourceGroups(r.Context())
+	if err != nil {
+		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not list resource groups")
+		return
+	}
+
+	render.JSON(w, r, resourceGroups)
+}

--- a/plugins/azure/src/components/containerinstances/ContainerGroups.tsx
+++ b/plugins/azure/src/components/containerinstances/ContainerGroups.tsx
@@ -7,20 +7,27 @@ import { IContainerGroup } from './interfaces';
 
 interface IContainerGroupsProps {
   name: string;
+  resourceGroups: string[];
   setDetails?: (details: React.ReactNode) => void;
 }
 
 const ContainerGroups: React.FunctionComponent<IContainerGroupsProps> = ({
   name,
+  resourceGroups,
   setDetails,
 }: IContainerGroupsProps) => {
   const { isError, isLoading, error, data, refetch } = useQuery<IContainerGroup[], Error>(
-    ['azure/containergroups/containergroups', name],
+    ['azure/containergroups/containergroups', name, resourceGroups],
     async () => {
       try {
-        const response = await fetch(`/api/plugins/azure/containerinstances/containergroups/${name}`, {
-          method: 'get',
-        });
+        const resourceGroupsParams = resourceGroups.map((resourceGroup) => `resourceGroup=${resourceGroup}`).join('&');
+
+        const response = await fetch(
+          `/api/plugins/azure/containerinstances/containergroups/${name}?${resourceGroupsParams}`,
+          {
+            method: 'get',
+          },
+        );
         const json = await response.json();
 
         if (response.status >= 200 && response.status < 300) {

--- a/plugins/azure/src/components/containerinstances/Page.tsx
+++ b/plugins/azure/src/components/containerinstances/Page.tsx
@@ -10,11 +10,13 @@ const service = 'containerinstances';
 interface IContainerInstancesPageProps {
   name: string;
   displayName: string;
+  resourceGroups: string[];
 }
 
 const ContainerInstancesPage: React.FunctionComponent<IContainerInstancesPageProps> = ({
   name,
   displayName,
+  resourceGroups,
 }: IContainerInstancesPageProps) => {
   const [details, setDetails] = useState<React.ReactNode>(undefined);
 
@@ -29,7 +31,7 @@ const ContainerInstancesPage: React.FunctionComponent<IContainerInstancesPagePro
         <DrawerContent panelContent={details}>
           <DrawerContentBody>
             <PageSection style={{ minHeight: '100%' }} variant={PageSectionVariants.default}>
-              <ContainerGroups name={name} setDetails={setDetails} />
+              <ContainerGroups name={name} resourceGroups={resourceGroups} setDetails={setDetails} />
             </PageSection>
           </DrawerContentBody>
         </DrawerContent>

--- a/plugins/azure/src/components/page/Page.tsx
+++ b/plugins/azure/src/components/page/Page.tsx
@@ -1,3 +1,5 @@
+import { Alert, AlertActionLink, AlertVariant, Spinner } from '@patternfly/react-core';
+import { QueryObserverResult, useQuery } from 'react-query';
 import { Route, Switch } from 'react-router-dom';
 import React from 'react';
 
@@ -5,14 +7,73 @@ import ContainerInstancesPage from '../containerinstances/Page';
 import { IPluginPageProps } from '@kobsio/plugin-core';
 import OverviewPage from './OverviewPage';
 
+// IResourceGroup is the interface for a resource group returned by the Azure API. This interface is only required for
+// the returned data, because we are only passing the name of the resource group to the other components.
+interface IResourceGroup {
+  id: string;
+  location: string;
+  name: string;
+  type: string;
+  tags: { [key: string]: string };
+}
+
 const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, description }: IPluginPageProps) => {
+  const { isError, isLoading, error, data, refetch } = useQuery<string[], Error>(
+    ['azure/resourcegroups', name],
+    async () => {
+      try {
+        const response = await fetch(`/api/plugins/azure/resourcegroups/${name}`, { method: 'get' });
+        const json = await response.json();
+
+        if (response.status >= 200 && response.status < 300) {
+          return json.map((resourceGroup: IResourceGroup) => resourceGroup.name);
+        } else {
+          if (json.error) {
+            throw new Error(json.error);
+          } else {
+            throw new Error('An unknown error occured');
+          }
+        }
+      } catch (err) {
+        throw err;
+      }
+    },
+  );
+
+  if (isLoading) {
+    return <Spinner style={{ left: '50%', position: 'fixed', top: '50%', transform: 'translate(-50%, -50%)' }} />;
+  }
+
+  if (isError) {
+    return (
+      <Alert
+        style={{ left: '50%', position: 'fixed', top: '50%', transform: 'translate(-50%, -50%)' }}
+        variant={AlertVariant.danger}
+        title="Could not get resource groups"
+        actionLinks={
+          <React.Fragment>
+            <AlertActionLink onClick={(): Promise<QueryObserverResult<string[], Error>> => refetch()}>
+              Retry
+            </AlertActionLink>
+          </React.Fragment>
+        }
+      >
+        <p>{error?.message}</p>
+      </Alert>
+    );
+  }
+
+  if (!data) {
+    return null;
+  }
+
   return (
     <Switch>
       <Route exact={true} path={`/${name}`}>
         <OverviewPage name={name} displayName={displayName} description={description} />
       </Route>
       <Route exact={true} path={`/${name}/containerinstances`}>
-        <ContainerInstancesPage name={name} displayName={displayName} />
+        <ContainerInstancesPage name={name} displayName={displayName} resourceGroups={data} />
       </Route>
     </Switch>
   );

--- a/plugins/azure/src/components/panel/Panel.tsx
+++ b/plugins/azure/src/components/panel/Panel.tsx
@@ -25,11 +25,16 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
     options?.type &&
     options?.type === 'containerinstances' &&
     options.containerinstances &&
-    options.containerinstances.type === 'list'
+    options.containerinstances.type === 'list' &&
+    options.containerinstances.resourceGroups
   ) {
     return (
       <PluginCard title={title} description={description} transparent={true}>
-        <CIContainerGroups name={name} setDetails={showDetails} />
+        <CIContainerGroups
+          name={name}
+          resourceGroups={options.containerinstances.resourceGroups}
+          setDetails={showDetails}
+        />
       </PluginCard>
     );
   }

--- a/plugins/azure/src/utils/interfaces.ts
+++ b/plugins/azure/src/utils/interfaces.ts
@@ -3,6 +3,7 @@ export interface IPanelOptions {
   type?: string;
   containerinstances?: {
     type?: string;
+    resourceGroups?: string[];
     resourceGroup?: string;
     containerGroup?: string;
     containers?: string[];


### PR DESCRIPTION
We are now returning all resource groups for the configured subscription
in the Azure plugin. The returned resource groups can then be passed to
all components of the Azure plugin.

That way we can now list all container instances per resource group
instead of listing all container instances in the subscription.

In the future this allows us to restrict the access for user to a
resource group instead of allowing users to access all resources in the
configured Azure subscription.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
