### PR TITLE
[azure] Add auto fomatting for metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#213](https://github.com/kobsio/kobs/pull/213): [techdocs] Add TechDocs plugin, to access the documentation for your services within kobs.
 - [#215](https://github.com/kobsio/kobs/pull/215): [azure] Add Azure plugin, to monitor your Azure resources.
 - [#219](https://github.com/kobsio/kobs/pull/219): [azure] Add permissions for Azure plugin, so that access to resources and actions can be restricted based on resource groups.
+- [#220](https://github.com/kobsio/kobs/pull/220): [azure] Add auto formatting for the returned metrics of an container instance and fix the tooltip positioning in the metrics chart.
 
 ### Fixed
 

--- a/plugins/azure/src/components/containerinstances/Details.tsx
+++ b/plugins/azure/src/components/containerinstances/Details.tsx
@@ -62,7 +62,7 @@ const Details: React.FunctionComponent<IDetailsProps> = ({
             mountOnEnter={true}
           >
             <Tab eventKey="details" title={<TabTitleText>Details</TabTitleText>}>
-              <div style={{ maxWidth: '100%', overflowX: 'scroll', padding: '24px 24px' }}>
+              <div style={{ maxWidth: '100%', padding: '24px 24px' }}>
                 <Card isCompact={true}>
                   <CardBody>
                     <DetailsContainerGroup name={name} resourceGroup={resourceGroup} containerGroup={containerGroup} />
@@ -72,20 +72,13 @@ const Details: React.FunctionComponent<IDetailsProps> = ({
             </Tab>
 
             <Tab eventKey="metrics" title={<TabTitleText>Metrics</TabTitleText>}>
-              <div style={{ maxWidth: '100%', overflowX: 'scroll', padding: '24px 24px' }}>
+              <div style={{ maxWidth: '100%', padding: '24px 24px' }}>
                 <DetailsMetrics name={name} resourceGroup={resourceGroup} containerGroup={containerGroup} />
               </div>
             </Tab>
 
             <Tab eventKey="logs" title={<TabTitleText>Logs</TabTitleText>}>
-              <div
-                style={{
-                  height: `${tabsWrapperSize.height - 32}px`,
-                  maxWidth: '100%',
-                  overflowX: 'scroll',
-                  padding: '24px 24px',
-                }}
-              >
+              <div style={{ height: `${tabsWrapperSize.height - 32}px`, maxWidth: '100%', padding: '24px 24px' }}>
                 <Card isCompact={true} style={{ height: '100%' }}>
                   <CardBody>
                     <DetailsLogs

--- a/plugins/azure/src/components/containerinstances/DetailsLogs.tsx
+++ b/plugins/azure/src/components/containerinstances/DetailsLogs.tsx
@@ -61,8 +61,6 @@ const DetailsLogs: React.FunctionComponent<IDetailsLogsProps> = ({
     },
   );
 
-  console.log(wrapperSize);
-
   return (
     <div style={{ height: '100%', maxWidth: '100%', overflow: 'scroll' }} ref={refWrapper}>
       <Select

--- a/plugins/azure/src/utils/helpers.ts
+++ b/plugins/azure/src/utils/helpers.ts
@@ -3,6 +3,9 @@ import { Serie } from '@nivo/line';
 import { IMetric } from './interfaces';
 import { formatTime as formatTimeCore } from '@kobsio/plugin-core';
 
+// getResourceGroupFromID returns the resource group name from a given Azure ID. For that we are splitting the ID by "/"
+// and looking for the resourceGroups parameter. Then the next parameter must be the name of the resource group. If the
+// ID isn't available we return an empty string.
 export const getResourceGroupFromID = (id: string): string => {
   const parts = id.split('/');
   const index = parts.indexOf('resourceGroups');
@@ -14,14 +17,16 @@ export const getResourceGroupFromID = (id: string): string => {
   return '';
 };
 
+// formatTime is a wrapper around the formatTime function from the core package, which is needed because the time is
+// returned as string and not as timestamp from Azure.
 export const formatTime = (time: string): string => {
   return formatTimeCore(Math.floor(new Date(time).getTime() / 1000));
 };
 
 // formatAxisBottom calculates the format for the bottom axis based on the specified start and end time.
 export const formatAxisBottom = (timeStart: number, timeEnd: number): string => {
-  timeStart = Math.floor(timeStart / 1000);
-  timeEnd = Math.floor(timeEnd / 1000);
+  timeStart = Math.floor(timeStart);
+  timeEnd = Math.floor(timeEnd);
 
   if (timeEnd - timeStart < 3600) {
     return '%H:%M:%S';
@@ -34,18 +39,80 @@ export const formatAxisBottom = (timeStart: number, timeEnd: number): string => 
   return '%m-%d';
 };
 
-// formatMetrics returns the metrics from the Azure API in the format required for nivo charts.
-export const formatMetrics = (metrics: IMetric): Serie[] => {
+// convertMetric returns the metric from the Azure API in the format required for nivo charts.
+export const convertMetric = (metric: IMetric): Serie[] => {
   const series: Serie[] = [];
 
-  if (metrics.timeseries.length === 1) {
+  for (let i = 0; i < metric.timeseries.length; i++) {
     series.push({
-      data: metrics.timeseries[0].data.map((datum) => {
+      data: metric.timeseries[i].data.map((datum) => {
         return { x: new Date(datum.timeStamp), y: datum.average === undefined ? null : datum.average };
       }),
-      id: 'metric',
+      id: `${i + 1}. ${metric.name.localizedValue}`,
     });
   }
 
   return series;
+};
+
+// formatMetric is used to auto format the values of a metric. When the unit of a metric is "Bytes" we auto format the
+// values to KB, MB, GB, etc.
+export const formatMetric = (metric: IMetric): IMetric => {
+  // If the unit isn't "Bytes" we use the metric as it was returned by the Azure API.
+  if (metric.unit !== 'Bytes') {
+    return metric;
+  }
+
+  // In the first step we have to determine the minimum and maximum value of all the returned timeseries in the metric,
+  let min = 0;
+  let max = 0;
+
+  for (let i = 0; i < metric.timeseries.length; i++) {
+    for (let j = 0; j < metric.timeseries[i].data.length; j++) {
+      const average = metric.timeseries[i].data[j].average;
+
+      if (i === 0 && j === 0 && average !== undefined) {
+        min = average;
+        max = average;
+      }
+
+      if (average !== undefined && average < min) {
+        min = average;
+      }
+
+      if (average !== undefined && average > max) {
+        max = average;
+      }
+    }
+  }
+
+  // Now we are using the maximum value to get the exponent. If the exponent is 0 we can directly return the metric,
+  // because the given unit ("Bytes") fits very well. If the exponent is larger then 8 we use 8 as exponent, because YB
+  // is the largest unit we can display.
+  let exponent = Math.floor(Math.log(max) / Math.log(1024));
+
+  if (exponent === 0) {
+    return metric;
+  }
+
+  if (exponent > 8) {
+    exponent = 8;
+  }
+
+  // Now we have to loop again through all data points to format all the values. After that we set the new unit based on
+  // the exponent so that we can return the metric.
+  for (let i = 0; i < metric.timeseries.length; i++) {
+    for (let j = 0; j < metric.timeseries[i].data.length; j++) {
+      const average = metric.timeseries[i].data[j].average;
+
+      if (average !== undefined) {
+        metric.timeseries[i].data[j].average = average / Math.pow(1024, exponent);
+      }
+    }
+  }
+
+  const sizes = ['Bytes', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
+  metric.unit = sizes[exponent];
+
+  return metric;
 };


### PR DESCRIPTION
The returned metrics for an container instance are now auto fomatted.
This means, if the metrics is returned with the unit "Bytes" we try to
format the values in a unit which fits more (KiB, MiB, GiB, etc.).

This commit also fixes a bug, where the tooltip for an chart wasn't
displayed correctly, when the chart with the Azure metrics was rendered
in the drawer. This was caused by the "overflowX" property in the Tabs
component. Without this property the tooltip is rendered correctly.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
