### PR TITLE
[harbor] Add support for multi-arch images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#219](https://github.com/kobsio/kobs/pull/219): [azure] Add permissions for Azure plugin, so that access to resources and actions can be restricted based on resource groups.
 - [#220](https://github.com/kobsio/kobs/pull/220): [azure] Add auto formatting for the returned metrics of an container instance and fix the tooltip positioning in the metrics chart.
 - [#221](https://github.com/kobsio/kobs/pull/221): [azure] :warning: _Breaking change:_ :warning: Add support for kubernetes services and refactor various places in the Azure plugin.
+- [#224](https://github.com/kobsio/kobs/pull/224): [harbor] Add support for multi-arch images.
 
 ### Fixed
 

--- a/plugins/harbor/pkg/instance/instance.go
+++ b/plugins/harbor/pkg/instance/instance.go
@@ -42,6 +42,8 @@ func (i *Instance) doRequest(ctx context.Context, url string) ([]byte, int64, er
 		return nil, 0, err
 	}
 
+	req.Header.Set("X-Accept-Vulnerabilities", "application/vnd.security.vulnerability.report; version=1.1, application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0")
+
 	resp, err := i.client.Do(req)
 	if err != nil {
 		return nil, 0, err
@@ -146,6 +148,23 @@ func (i *Instance) GetArtifacts(ctx context.Context, projectName, repositoryName
 		Artifacts: artifacts,
 		Total:     total,
 	}, nil
+}
+
+// GetArtifact returns a single artifact from the Harbor instance.
+func (i *Instance) GetArtifact(ctx context.Context, projectName, repositoryName, artifactReference string) (*Artifact, error) {
+	repositoryName = url.PathEscape(repositoryName)
+
+	body, _, err := i.doRequest(ctx, fmt.Sprintf("projects/%s/repositories/%s/artifacts/%s", projectName, repositoryName, artifactReference))
+	if err != nil {
+		return nil, err
+	}
+
+	var artifact Artifact
+	if err := json.Unmarshal(body, &artifact); err != nil {
+		return nil, err
+	}
+
+	return &artifact, nil
 }
 
 // GetVulnerabilities returns a list of artifacts for a repository from the Harbor instance.

--- a/plugins/harbor/pkg/instance/structs.go
+++ b/plugins/harbor/pkg/instance/structs.go
@@ -85,12 +85,24 @@ type Artifact struct {
 	ProjectID         int64                           `json:"project_id"`
 	PullTime          time.Time                       `json:"pull_time"`
 	PushTime          time.Time                       `json:"push_time"`
-	References        interface{}                     `json:"references"`
+	References        []ArtifactReference             `json:"references"`
 	RepositoryID      int64                           `json:"repository_id"`
 	ScanOverview      map[string]ArtifactScanOverview `json:"scan_overview"`
 	Size              int64                           `json:"size"`
 	Tags              []ArtifactTag                   `json:"tags"`
 	Type              string                          `json:"type"`
+}
+
+type ArtifactReference struct {
+	ChildDigest string `json:"child_digest"`
+	ChildID     int64  `json:"child_id"`
+	ParentID    int64  `json:"parent_id"`
+	Platform    struct {
+		OsFeatures   []string `json:"OsFeatures"`
+		Architecture string   `json:"architecture"`
+		Os           string   `json:"os"`
+	} `json:"platform"`
+	Urls []string `json:"urls"`
 }
 
 type ArtifactScanOverview struct {

--- a/plugins/harbor/src/components/panel/details/Overview.tsx
+++ b/plugins/harbor/src/components/panel/details/Overview.tsx
@@ -1,0 +1,107 @@
+import { Card, CardBody, CardTitle } from '@patternfly/react-core';
+import { TableComposable, TableVariant, Tbody, Td, Tr } from '@patternfly/react-table';
+import React from 'react';
+
+import { formatBytes, formatTime } from '../../../utils/helpers';
+import { IArtifact } from '../../../utils/interfaces';
+
+interface IOverviewProps {
+  artifact: IArtifact;
+}
+
+const Overview: React.FunctionComponent<IOverviewProps> = ({ artifact }: IOverviewProps) => {
+  return (
+    <Card isCompact={true}>
+      <CardTitle>Overview</CardTitle>
+      <CardBody>
+        <TableComposable aria-label="Details" variant={TableVariant.compact} borders={false}>
+          <Tbody>
+            {artifact.extra_attrs.created && (
+              <Tr key="created">
+                <Td>Created</Td>
+                <Td>{formatTime(artifact.extra_attrs.created)}</Td>
+              </Tr>
+            )}
+            {artifact.size && (
+              <Tr key="size">
+                <Td>Size</Td>
+                <Td>{formatBytes(artifact.size)}</Td>
+              </Tr>
+            )}
+            {artifact.extra_attrs.author && (
+              <Tr key="author">
+                <Td>Author</Td>
+                <Td>{artifact.extra_attrs.author}</Td>
+              </Tr>
+            )}
+            {artifact.extra_attrs.architecture && (
+              <Tr key="architecture">
+                <Td>Architecture</Td>
+                <Td>{artifact.extra_attrs.architecture}</Td>
+              </Tr>
+            )}
+            {artifact.extra_attrs.os && (
+              <Tr key="os">
+                <Td>OS</Td>
+                <Td>{artifact.extra_attrs.os}</Td>
+              </Tr>
+            )}
+            {artifact.extra_attrs.config.Cmd && (
+              <Tr key="cmd">
+                <Td>Cmd</Td>
+                <Td style={{ whiteSpace: 'pre-wrap' }}>{artifact.extra_attrs.config.Cmd.join('\n')}</Td>
+              </Tr>
+            )}
+            {artifact.extra_attrs.config.Entrypoint && (
+              <Tr key="entrypoint">
+                <Td>Entrypoint</Td>
+                <Td style={{ whiteSpace: 'pre-wrap' }}>{artifact.extra_attrs.config.Entrypoint.join('\n')}</Td>
+              </Tr>
+            )}
+            {artifact.extra_attrs.config.Env && (
+              <Tr key="env">
+                <Td>Env</Td>
+                <Td style={{ whiteSpace: 'pre-wrap' }}>{artifact.extra_attrs.config.Env.join('\n')}</Td>
+              </Tr>
+            )}
+            {artifact.extra_attrs.config.ExposedPorts && (
+              <Tr key="ports">
+                <Td>Ports</Td>
+                <Td style={{ whiteSpace: 'pre-wrap' }}>
+                  {Object.keys(artifact.extra_attrs.config.ExposedPorts).join('\n')}
+                </Td>
+              </Tr>
+            )}
+            {artifact.extra_attrs.config.Labels && (
+              <Tr key="labels">
+                <Td>Labels</Td>
+                <Td style={{ whiteSpace: 'pre-wrap' }}>
+                  {Object.keys(artifact.extra_attrs.config.Labels)
+                    .map(
+                      (key) =>
+                        `${key}=${artifact.extra_attrs.config.Labels && artifact.extra_attrs.config.Labels[key]}`,
+                    )
+                    .join('\n')}
+                </Td>
+              </Tr>
+            )}
+            {artifact.extra_attrs.config.User && (
+              <Tr key="user">
+                <Td>User</Td>
+                <Td>{artifact.extra_attrs.config.User}</Td>
+              </Tr>
+            )}
+            {artifact.extra_attrs.config.WorkingDir && (
+              <Tr key="workingdir">
+                <Td>Workind Dir</Td>
+                <Td>{artifact.extra_attrs.config.WorkingDir}</Td>
+              </Tr>
+            )}
+          </Tbody>
+        </TableComposable>
+      </CardBody>
+    </Card>
+  );
+};
+
+export default Overview;

--- a/plugins/harbor/src/components/panel/details/Reference.tsx
+++ b/plugins/harbor/src/components/panel/details/Reference.tsx
@@ -1,0 +1,109 @@
+import { Alert, AlertActionLink, AlertVariant, Spinner } from '@patternfly/react-core';
+import { QueryObserverResult, useQuery } from 'react-query';
+import React from 'react';
+
+import BuildHistory from './BuildHistory';
+import { IArtifact } from '../../../utils/interfaces';
+import Overview from './Overview';
+import Vulnerabilities from './Vulnerabilities';
+
+interface IReferenceProps {
+  name: string;
+  projectName: string;
+  repositoryName: string;
+  artifactReference: string;
+}
+
+const Reference: React.FunctionComponent<IReferenceProps> = ({
+  name,
+  projectName,
+  repositoryName,
+  artifactReference,
+}: IReferenceProps) => {
+  const { isError, isLoading, error, data, refetch } = useQuery<IArtifact, Error>(
+    ['harbor/artifact', name, projectName, repositoryName, artifactReference],
+    async () => {
+      try {
+        const response = await fetch(
+          `/api/plugins/harbor/artifact/${name}?projectName=${projectName}&repositoryName=${repositoryName}&artifactReference=${artifactReference}`,
+          {
+            method: 'get',
+          },
+        );
+        const json = await response.json();
+
+        if (response.status >= 200 && response.status < 300) {
+          return json;
+        } else {
+          if (json.error) {
+            throw new Error(json.error);
+          } else {
+            throw new Error('An unknown error occured');
+          }
+        }
+      } catch (err) {
+        throw err;
+      }
+    },
+  );
+
+  if (isLoading) {
+    return (
+      <div className="pf-u-text-align-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Alert
+        variant={AlertVariant.danger}
+        isInline={true}
+        title="Could not get artifact"
+        actionLinks={
+          <React.Fragment>
+            <AlertActionLink onClick={(): Promise<QueryObserverResult<IArtifact, Error>> => refetch()}>
+              Retry
+            </AlertActionLink>
+          </React.Fragment>
+        }
+      >
+        <p>{error?.message}</p>
+      </Alert>
+    );
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return (
+    <div>
+      {data.extra_attrs && (
+        <div>
+          <Overview artifact={data} />
+          <p>&nbsp;</p>
+        </div>
+      )}
+
+      <BuildHistory
+        name={name}
+        projectName={projectName}
+        repositoryName={repositoryName}
+        artifactReference={artifactReference}
+      />
+      <p>&nbsp;</p>
+
+      <Vulnerabilities
+        name={name}
+        projectName={projectName}
+        repositoryName={repositoryName}
+        artifactReference={artifactReference}
+      />
+      <p>&nbsp;</p>
+    </div>
+  );
+};
+
+export default Reference;

--- a/plugins/harbor/src/utils/interfaces.ts
+++ b/plugins/harbor/src/utils/interfaces.ts
@@ -115,7 +115,7 @@ export interface IArtifact {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   push_time: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  references: any;
+  references?: IArtifactReference[];
   // eslint-disable-next-line @typescript-eslint/naming-convention
   repository_id: number;
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -123,6 +123,21 @@ export interface IArtifact {
   size: number;
   tags: IArtifactTag[];
   type: string;
+}
+
+export interface IArtifactReference {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  child_digest: string;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  child_id: number;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  parent_id: number;
+  platform: {
+    OsFeatures: string[];
+    architecture: string;
+    os: string;
+  };
+  urls: string[];
 }
 
 export interface IArtifactScanOverview {


### PR DESCRIPTION
This commits adds better support for multi-arch images, which are saved
in Harbor. Until now, we only were showing the parent artifact for
multi-arch image, without the build history and vulnerabilities. Now we
are using the reference array from this artifact to get more information
for all of the child artifacts. In this case one artifact represents one
architecture/os for the image.

To get the vulnerabilities for these artifacts we had to add the
"X-Accept-Vulnerabilities" header to the requests. If this header isn't
present the vulnerabilities are missing for multi-arch images.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
