### PR TITLE
[klogs] Add option to sort fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#221](https://github.com/kobsio/kobs/pull/221): [azure] :warning: _Breaking change:_ :warning: Add support for kubernetes services and refactor various places in the Azure plugin.
 - [#222](https://github.com/kobsio/kobs/pull/222): [azure] Simple cost management on subscription level
 - [#224](https://github.com/kobsio/kobs/pull/224): [harbor] Add support for multi-arch images.
+- [#226](https://github.com/kobsio/kobs/pull/226): [klogs] Add option to sort fields.
 
 ### Fixed
 

--- a/plugins/klogs/src/components/page/Logs.tsx
+++ b/plugins/klogs/src/components/page/Logs.tsx
@@ -32,6 +32,7 @@ interface ILogsProps {
   changeTime: (times: IPluginTimes) => void;
   changeOrder: (order: string, orderBy: string) => void;
   selectField: (field: string) => void;
+  changeFieldOrder: (oldIndex: number, newIndex: number) => void;
   times: IPluginTimes;
 }
 
@@ -45,6 +46,7 @@ const Logs: React.FunctionComponent<ILogsProps> = ({
   changeTime,
   changeOrder,
   selectField,
+  changeFieldOrder,
   times,
 }: ILogsProps) => {
   const history = useHistory();
@@ -126,7 +128,12 @@ const Logs: React.FunctionComponent<ILogsProps> = ({
     <Grid hasGutter={true}>
       <GridItem sm={12} md={12} lg={3} xl={2} xl2={2}>
         <Card>
-          <LogsFields fields={data.fields} selectField={selectField} selectedFields={fields} />
+          <LogsFields
+            fields={data.fields}
+            selectField={selectField}
+            selectedFields={fields}
+            changeFieldOrder={changeFieldOrder}
+          />
         </Card>
       </GridItem>
       <GridItem sm={12} md={12} lg={9} xl={10} xl2={10}>

--- a/plugins/klogs/src/components/page/LogsFields.tsx
+++ b/plugins/klogs/src/components/page/LogsFields.tsx
@@ -1,20 +1,24 @@
 import { SimpleList, SimpleListGroup, SimpleListItem } from '@patternfly/react-core';
 import React from 'react';
 
-export interface IPageLogsFieldsProps {
+import LogsFieldsItem from './LogsFieldsItem';
+
+export interface ILogsFieldsProps {
   fields?: string[];
   selectedFields?: string[];
   selectField: (field: string) => void;
+  changeFieldOrder: (oldIndex: number, newIndex: number) => void;
 }
 
-// PageLogsFields is used to show the list of parsed and selected fields. When a user selects a field from the fields
-// list, this field is added to the list of selected fields. When the user selects a field from the selected fields list
-// this field will be removed from this list.
-const PageLogsFields: React.FunctionComponent<IPageLogsFieldsProps> = ({
+// LogsFields is used to show the list of parsed and selected fields. When a user selects a field from the fields list,
+// this field is added to the list of selected fields. When the user selects a field from the selected fields list this
+// field will be removed from this list.
+const LogsFields: React.FunctionComponent<ILogsFieldsProps> = ({
   fields,
   selectedFields,
   selectField,
-}: IPageLogsFieldsProps) => {
+  changeFieldOrder,
+}: ILogsFieldsProps) => {
   if ((!selectedFields || selectedFields.length === 0) && (!fields || fields.length === 0)) {
     return null;
   }
@@ -24,9 +28,14 @@ const PageLogsFields: React.FunctionComponent<IPageLogsFieldsProps> = ({
       {selectedFields && selectedFields.length > 0 ? (
         <SimpleListGroup title="Selected Fields">
           {selectedFields.map((selectedField, index) => (
-            <SimpleListItem key={index} onClick={(): void => selectField(selectedField)} isActive={false}>
-              {selectedField}
-            </SimpleListItem>
+            <LogsFieldsItem
+              key={index}
+              index={index}
+              length={selectedFields.length}
+              field={selectedField}
+              selectField={selectField}
+              changeFieldOrder={changeFieldOrder}
+            />
           ))}
         </SimpleListGroup>
       ) : null}
@@ -44,4 +53,4 @@ const PageLogsFields: React.FunctionComponent<IPageLogsFieldsProps> = ({
   );
 };
 
-export default PageLogsFields;
+export default LogsFields;

--- a/plugins/klogs/src/components/page/LogsFieldsItem.tsx
+++ b/plugins/klogs/src/components/page/LogsFieldsItem.tsx
@@ -1,0 +1,92 @@
+import { Button, ButtonVariant, SimpleListItem, Tooltip } from '@patternfly/react-core';
+import { CopyIcon, LongArrowAltDownIcon, LongArrowAltUpIcon, TrashIcon } from '@patternfly/react-icons';
+import React, { useState } from 'react';
+
+export interface ILogsFieldsItemProps {
+  index: number;
+  length: number;
+  field: string;
+  selectField: (field: string) => void;
+  changeFieldOrder: (oldIndex: number, newIndex: number) => void;
+}
+
+const LogsFieldsItem: React.FunctionComponent<ILogsFieldsItemProps> = ({
+  index,
+  length,
+  field,
+  selectField,
+  changeFieldOrder,
+}: ILogsFieldsItemProps) => {
+  const [showActions, setShowActions] = useState<boolean>(false);
+
+  const copyField = (field: string): void => {
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(field);
+    }
+  };
+
+  return (
+    <SimpleListItem key={index} isActive={false}>
+      <div onMouseEnter={(): void => setShowActions(true)} onMouseLeave={(): void => setShowActions(false)}>
+        {field}
+        {showActions && (
+          <div style={{ float: 'right' }}>
+            {index !== length - 1 ? (
+              <Tooltip content={<div>Move Down</div>}>
+                <Button
+                  style={{ padding: '0', paddingRight: '3px' }}
+                  variant={ButtonVariant.plain}
+                  aria-label="Move Down"
+                  isSmall={true}
+                  onClick={(): void => changeFieldOrder(index, index + 1)}
+                >
+                  <LongArrowAltDownIcon />
+                </Button>
+              </Tooltip>
+            ) : null}
+
+            {index !== 0 ? (
+              <Tooltip content={<div>Move Up</div>}>
+                <Button
+                  style={{ padding: '0', paddingRight: '3px' }}
+                  variant={ButtonVariant.plain}
+                  aria-label="Move Up"
+                  isSmall={true}
+                  onClick={(): void => changeFieldOrder(index, index - 1)}
+                >
+                  <LongArrowAltUpIcon />
+                </Button>
+              </Tooltip>
+            ) : null}
+
+            <Tooltip content={<div>Copy</div>}>
+              <Button
+                style={{ padding: '0', paddingRight: '3px' }}
+                variant={ButtonVariant.plain}
+                aria-label="Copy"
+                isSmall={true}
+                onClick={(): void => copyField(field)}
+              >
+                <CopyIcon />
+              </Button>
+            </Tooltip>
+
+            <Tooltip content={<div>Remove</div>}>
+              <Button
+                style={{ padding: '0', paddingRight: '3px' }}
+                variant={ButtonVariant.plain}
+                aria-label="Remove"
+                isSmall={true}
+                onClick={(): void => selectField(field)}
+              >
+                <TrashIcon />
+              </Button>
+            </Tooltip>
+          </div>
+        )}
+      </div>
+    </SimpleListItem>
+  );
+};
+
+export default LogsFieldsItem;

--- a/plugins/klogs/src/components/page/LogsPage.tsx
+++ b/plugins/klogs/src/components/page/LogsPage.tsx
@@ -61,6 +61,18 @@ const LogsPage: React.FunctionComponent<ILogsPageProps> = ({ name, displayName, 
     changeOptions({ ...options, fields: tmpFields });
   };
 
+  const changeFieldOrder = (oldIndex: number, newIndex: number): void => {
+    if (options.fields) {
+      const tmpFields = [...options.fields];
+      const tmpField = tmpFields[oldIndex];
+
+      tmpFields[oldIndex] = tmpFields[newIndex];
+      tmpFields[newIndex] = tmpField;
+
+      changeOptions({ ...options, fields: tmpFields });
+    }
+  };
+
   // addFilter adds the given filter as string to the query, so that it can be used to filter down an existing query.
   const addFilter = (filter: string): void => {
     changeOptions({ ...options, query: `${options.query} ${filter}` });
@@ -115,6 +127,7 @@ const LogsPage: React.FunctionComponent<ILogsPageProps> = ({ name, displayName, 
                   changeTime={changeTime}
                   changeOrder={changeOrder}
                   selectField={selectField}
+                  changeFieldOrder={changeFieldOrder}
                   times={options.times}
                 />
               ) : null}


### PR DESCRIPTION
It is now possible to sort the list of selected fields in the klogs
plugin. For that a list of action buttons is displayed when the user
hovers over a field. These actions can be used to move a field one
position up or down or to delete it from the list of selected fields.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
