### PR TITLE
[techdocs] Ignore comments from code blocks in toc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 ### Fixed
 
+- [#227](https://github.com/kobsio/kobs/pull/227): [techdocs] Ignore comments in code blocks in table of contents.
+
 ### Changed
 
 - [#217](https://github.com/kobsio/kobs/pull/217): [azure] Use resource groups to get a list of container instances.

--- a/plugins/techdocs/pkg/shared/shared.go
+++ b/plugins/techdocs/pkg/shared/shared.go
@@ -40,20 +40,30 @@ func ParseIndex(content []byte) (Index, error) {
 // GenerateTOC generates a simple markdown list, which can be used as TOC for the given markdown file.
 func GenerateTOC(markdown string) string {
 	var toc string
+	var isCodeBlock bool
 
 	for _, line := range strings.Split(markdown, "\n") {
 		line = strings.TrimSpace(line)
 
-		if len(line) > 7 && line[0:7] == "###### " {
-			toc += fmt.Sprintf("        - [%s](#%s)\n", strings.Trim(line, "###### "), slugifyRe.ReplaceAllString(strings.ToLower(strings.Trim(line, "###### ")), "-"))
-		} else if len(line) > 6 && line[0:6] == "##### " {
-			toc += fmt.Sprintf("      - [%s](#%s)\n", strings.Trim(line, "##### "), slugifyRe.ReplaceAllString(strings.ToLower(strings.Trim(line, "##### ")), "-"))
-		} else if len(line) > 5 && line[0:5] == "#### " {
-			toc += fmt.Sprintf("    - [%s](#%s)\n", strings.Trim(line, "#### "), slugifyRe.ReplaceAllString(strings.ToLower(strings.Trim(line, "#### ")), "-"))
-		} else if len(line) > 4 && line[0:4] == "### " {
-			toc += fmt.Sprintf("  - [%s](#%s)\n", strings.Trim(line, "### "), slugifyRe.ReplaceAllString(strings.ToLower(strings.Trim(line, "### ")), "-"))
-		} else if len(line) > 3 && line[0:3] == "## " {
-			toc += fmt.Sprintf("- [%s](#%s)\n", strings.Trim(line, "## "), slugifyRe.ReplaceAllString(strings.ToLower(strings.Trim(line, "## ")), "-"))
+		// We check if the line starts with ``` for a comment block. If this is the case we are setting the isCodeBlock
+		// variable to true and when the code block ends to false. This is required so that we do not add a comment from
+		// a code block to the table of contents.
+		if strings.HasPrefix(line, "```") {
+			isCodeBlock = !isCodeBlock
+		}
+
+		if !isCodeBlock {
+			if len(line) > 7 && line[0:7] == "###### " {
+				toc += fmt.Sprintf("        - [%s](#%s)\n", strings.Trim(line, "###### "), slugifyRe.ReplaceAllString(strings.ToLower(strings.Trim(line, "###### ")), "-"))
+			} else if len(line) > 6 && line[0:6] == "##### " {
+				toc += fmt.Sprintf("      - [%s](#%s)\n", strings.Trim(line, "##### "), slugifyRe.ReplaceAllString(strings.ToLower(strings.Trim(line, "##### ")), "-"))
+			} else if len(line) > 5 && line[0:5] == "#### " {
+				toc += fmt.Sprintf("    - [%s](#%s)\n", strings.Trim(line, "#### "), slugifyRe.ReplaceAllString(strings.ToLower(strings.Trim(line, "#### ")), "-"))
+			} else if len(line) > 4 && line[0:4] == "### " {
+				toc += fmt.Sprintf("  - [%s](#%s)\n", strings.Trim(line, "### "), slugifyRe.ReplaceAllString(strings.ToLower(strings.Trim(line, "### ")), "-"))
+			} else if len(line) > 3 && line[0:3] == "## " {
+				toc += fmt.Sprintf("- [%s](#%s)\n", strings.Trim(line, "## "), slugifyRe.ReplaceAllString(strings.ToLower(strings.Trim(line, "## ")), "-"))
+			}
 		}
 	}
 


### PR DESCRIPTION
This commit fixes a bug, where the comment from a code block which
starts with "##" was displayed in the table of contents of a page. We
are not ignoring these lines now by checking if we are inside a code
block while looping through the lines of a page.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
