### PR TITLE
[opsgenie] Allow overwrite of the selected time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 - [#217](https://github.com/kobsio/kobs/pull/217): [azure] Use resource groups to get a list of container instances.
 - [#225](https://github.com/kobsio/kobs/pull/225): [core] :warning: _Breaking change:_ :warning: Change options handling accross all plugins and re-add `time` property.
+- [#229](https://github.com/kobsio/kobs/pull/229): [opsgenie] Allow users to overwrite the selected time range in a dashboard for an Opsgenie panel via the new `interval` property.
 
 ## [v0.7.0](https://github.com/kobsio/kobs/releases/tag/v0.7.0) (2021-11-19)
 

--- a/docs/plugins/opsgenie.md
+++ b/docs/plugins/opsgenie.md
@@ -45,6 +45,7 @@ The following options can be used for a panel with the Opsgenie plugin:
 | ----- | ---- | ----------- | -------- |
 | type | string | Specify if you want to show `alerts` or `incidents`. The default value is `alerts`. | No |
 | query | string | The Opsgenie query. The documentation for the query language can be found in the [Opsgenie Documentation](https://support.atlassian.com/opsgenie/docs/search-queries-for-alerts/). | No |
+| interval | number | An optional interval in seconds, which should be used instead of the selected time range in the Dashboard to get the alerts / incidents for. | No |
 
 For example the following dashboard shows all open alerts and incidents.
 
@@ -74,3 +75,5 @@ spec:
 
 !!! note
     kobs automatically adds the `createdAt >= <selected-start-time> AND createdAt <= <selected-end-time>` to all Opsgenie queries, so that only results for the selected time range are shown.
+
+    This behaviour can be overwritten with the `interval` property. If the `interval` property is provided, we add `createdAt >= <now - interval> AND createdAt <= <now>`.

--- a/plugins/opsgenie/src/components/panel/Alerts.tsx
+++ b/plugins/opsgenie/src/components/panel/Alerts.tsx
@@ -10,18 +10,22 @@ import { queryWithTime } from '../../utils/helpers';
 interface IAlertsProps {
   name: string;
   query: string;
+  interval?: number;
   times: IPluginTimes;
   setDetails?: (details: React.ReactNode) => void;
 }
 
-const Alerts: React.FunctionComponent<IAlertsProps> = ({ name, query, times, setDetails }: IAlertsProps) => {
+const Alerts: React.FunctionComponent<IAlertsProps> = ({ name, query, interval, times, setDetails }: IAlertsProps) => {
   const { isError, isLoading, error, data, refetch } = useQuery<IAlert[], Error>(
-    ['opsgenie/alerts', name, query, times],
+    ['opsgenie/alerts', name, query, interval, times],
     async () => {
       try {
-        const response = await fetch(`/api/plugins/opsgenie/alerts/${name}?query=${queryWithTime(query, times)}`, {
-          method: 'get',
-        });
+        const response = await fetch(
+          `/api/plugins/opsgenie/alerts/${name}?query=${queryWithTime(query, times, interval)}`,
+          {
+            method: 'get',
+          },
+        );
         const json = await response.json();
 
         if (response.status >= 200 && response.status < 300) {

--- a/plugins/opsgenie/src/components/panel/Incidents.tsx
+++ b/plugins/opsgenie/src/components/panel/Incidents.tsx
@@ -10,18 +10,28 @@ import { queryWithTime } from '../../utils/helpers';
 interface IIncidentsProps {
   name: string;
   query: string;
+  interval?: number;
   times: IPluginTimes;
   setDetails?: (details: React.ReactNode) => void;
 }
 
-const Incidents: React.FunctionComponent<IIncidentsProps> = ({ name, query, times, setDetails }: IIncidentsProps) => {
+const Incidents: React.FunctionComponent<IIncidentsProps> = ({
+  name,
+  query,
+  interval,
+  times,
+  setDetails,
+}: IIncidentsProps) => {
   const { isError, isLoading, error, data, refetch } = useQuery<IIncident[], Error>(
-    ['opsgenie/incidents', name, query, times],
+    ['opsgenie/incidents', name, query, interval, times],
     async () => {
       try {
-        const response = await fetch(`/api/plugins/opsgenie/incidents/${name}?query=${queryWithTime(query, times)}`, {
-          method: 'get',
-        });
+        const response = await fetch(
+          `/api/plugins/opsgenie/incidents/${name}?query=${queryWithTime(query, times, interval)}`,
+          {
+            method: 'get',
+          },
+        );
         const json = await response.json();
 
         if (response.status >= 200 && response.status < 300) {

--- a/plugins/opsgenie/src/components/panel/Panel.tsx
+++ b/plugins/opsgenie/src/components/panel/Panel.tsx
@@ -38,7 +38,13 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
         transparent={true}
         actions={<IncidentsActions name={name} query={options.query || ''} times={times} type="incidents" />}
       >
-        <Incidents name={name} query={options.query || ''} times={times} setDetails={showDetails} />
+        <Incidents
+          name={name}
+          query={options.query || ''}
+          interval={options.interval}
+          times={times}
+          setDetails={showDetails}
+        />
       </PluginCard>
     );
   }
@@ -50,7 +56,13 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
       transparent={true}
       actions={<AlertsActions name={name} query={options.query || ''} times={times} type="alerts" />}
     >
-      <Alerts name={name} query={options.query || ''} times={times} setDetails={showDetails} />
+      <Alerts
+        name={name}
+        query={options.query || ''}
+        interval={options.interval}
+        times={times}
+        setDetails={showDetails}
+      />
     </PluginCard>
   );
 };

--- a/plugins/opsgenie/src/utils/helpers.ts
+++ b/plugins/opsgenie/src/utils/helpers.ts
@@ -18,7 +18,16 @@ export const formatTimeWrapper = (time: string): string => {
   return formatTime(Math.floor(new Date(time).getTime() / 1000));
 };
 
-export const queryWithTime = (query: string, times: IPluginTimes): string => {
+export const queryWithTime = (query: string, times: IPluginTimes, interval?: number): string => {
+  if (interval) {
+    const timeEnd = Math.floor(Date.now() / 1000);
+    const timeStart = Math.floor(Date.now() / 1000) - interval;
+
+    return query
+      ? `${query} AND createdAt >= ${timeStart} AND createdAt <= ${timeEnd}`
+      : `createdAt >= ${timeStart} AND createdAt <= ${timeEnd}`;
+  }
+
   return query
     ? `${query} AND createdAt >= ${times.timeStart} AND createdAt <= ${times.timeEnd}`
     : `createdAt >= ${times.timeStart} AND createdAt <= ${times.timeEnd}`;

--- a/plugins/opsgenie/src/utils/interfaces.ts
+++ b/plugins/opsgenie/src/utils/interfaces.ts
@@ -13,6 +13,7 @@ export interface IOptions {
 export interface IPanelOptions {
   type?: string;
   query?: string;
+  interval?: number;
 }
 
 // IAlert implements the structure of an Opsgenie alert, how it is returned from the Opsgenie API.


### PR DESCRIPTION
It is now possible to overwrite the selected time in a dashboard for
Opsgenie panels via the new "interval" property. This allows users to
show all open alerts from the last x seconds also when the selected time
range in a dashboard is set to 15 minutes or so.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
