### PR TITLE
[core] Change options handling for various plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#229](https://github.com/kobsio/kobs/pull/229): [opsgenie] Allow users to overwrite the selected time range in a dashboard for an Opsgenie panel via the new `interval` property.
 - [#230](https://github.com/kobsio/kobs/pull/230): [dashboards] Add special variables `__timeStart` and `__timeEnd` for dashboards.
 - [#231](https://github.com/kobsio/kobs/pull/231): [klogs] Highlight expanded row and do not use index as key. The same changes were also applied for the Elasticsearch plugin.
+- [#232](https://github.com/kobsio/kobs/pull/232): [core] Change options handling for various plugins.
 
 ## [v0.7.0](https://github.com/kobsio/kobs/releases/tag/v0.7.0) (2021-11-19)
 

--- a/plugins/applications/src/components/page/ApplicationsToolbar.tsx
+++ b/plugins/applications/src/components/page/ApplicationsToolbar.tsx
@@ -1,43 +1,28 @@
-import {
-  Button,
-  ButtonVariant,
-  ToggleGroup,
-  ToggleGroupItem,
-  Toolbar,
-  ToolbarContent,
-  ToolbarGroup,
-  ToolbarItem,
-  ToolbarToggleGroup,
-} from '@patternfly/react-core';
-import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
 import React, { memo, useContext, useState } from 'react';
+import { ToggleGroup, ToggleGroupItem, ToolbarItem } from '@patternfly/react-core';
 
-import { ClustersContext, IClusterContext } from '@kobsio/plugin-core';
+import { ClustersContext, IClusterContext, IOptionsAdditionalFields, IPluginTimes, Toolbar } from '@kobsio/plugin-core';
+import { IOptions, TView } from '../../utils/interfaces';
 import ApplicationsToolbarItemClusters from './ApplicationsToolbarItemClusters';
 import ApplicationsToolbarItemNamespaces from './ApplicationsToolbarItemNamespaces';
-import { TView } from '../../utils/interfaces';
 
 interface IApplicationsToolbarProps {
-  clusters: string[];
-  namespaces: string[];
-  view: string;
-  changeData: (clusters: string[], namespaces: string[], view: string) => void;
+  options: IOptions;
+  setOptions: (data: IOptions) => void;
 }
 
 // ApplicationsToolbar is the toolbar, where the user can select a list of clusters and namespaces. When the user clicks
 // the search button the setScope function is called with the list of selected clusters and namespaces.
 const ApplicationsToolbar: React.FunctionComponent<IApplicationsToolbarProps> = ({
-  clusters,
-  namespaces,
-  view,
-  changeData,
+  options,
+  setOptions,
 }: IApplicationsToolbarProps) => {
   const clustersContext = useContext<IClusterContext>(ClustersContext);
   const [selectedClusters, setSelectedClusters] = useState<string[]>(
-    clusters.length > 0 ? clusters : [clustersContext.clusters[0]],
+    options.clusters.length > 0 ? options.clusters : [clustersContext.clusters[0]],
   );
-  const [selectedNamespaces, setSelectedNamespaces] = useState<string[]>(namespaces);
-  const [selectedView, setSelectedView] = useState<TView>(view ? (view as TView) : 'gallery');
+  const [selectedNamespaces, setSelectedNamespaces] = useState<string[]>(options.namespaces);
+  const [selectedView, setSelectedView] = useState<TView>(options.view ? (options.view as TView) : 'gallery');
 
   // selectCluster adds/removes the given cluster to the list of selected clusters. When the cluster value is an empty
   // string the selected clusters list is cleared.
@@ -67,51 +52,42 @@ const ApplicationsToolbar: React.FunctionComponent<IApplicationsToolbarProps> = 
     }
   };
 
+  // changeOptions changes the Prometheus option. It is used when the user clicks the search button or selects a new
+  // time range.
+  const changeOptions = (times: IPluginTimes, additionalFields: IOptionsAdditionalFields[] | undefined): void => {
+    setOptions({ clusters: selectedClusters, namespaces: selectedNamespaces, times: times, view: selectedView });
+  };
+
   return (
-    <Toolbar id="applications-toolbar" style={{ paddingBottom: '0px', zIndex: 300 }}>
-      <ToolbarContent style={{ padding: '0px' }}>
-        <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="lg">
-          <ToolbarGroup>
-            <ToolbarItem>
-              <ApplicationsToolbarItemClusters
-                clusters={clustersContext.clusters}
-                selectedClusters={selectedClusters}
-                selectCluster={selectCluster}
-              />
-            </ToolbarItem>
-            <ToolbarItem>
-              <ApplicationsToolbarItemNamespaces
-                selectedClusters={selectedClusters}
-                selectedNamespaces={selectedNamespaces}
-                selectNamespace={selectNamespace}
-              />
-            </ToolbarItem>
-            <ToolbarItem>
-              <ToggleGroup aria-label="View">
-                <ToggleGroupItem
-                  text="Gallery"
-                  isSelected={selectedView === 'gallery'}
-                  onChange={(): void => setSelectedView('gallery')}
-                />
-                <ToggleGroupItem
-                  text="Topology"
-                  isSelected={selectedView === 'topology'}
-                  onChange={(): void => setSelectedView('topology')}
-                />
-              </ToggleGroup>
-            </ToolbarItem>
-            <ToolbarItem>
-              <Button
-                variant={ButtonVariant.primary}
-                icon={<SearchIcon />}
-                onClick={(): void => changeData(selectedClusters, selectedNamespaces, selectedView)}
-              >
-                Search
-              </Button>
-            </ToolbarItem>
-          </ToolbarGroup>
-        </ToolbarToggleGroup>
-      </ToolbarContent>
+    <Toolbar times={options.times} showOptions={false} showSearchButton={true} setOptions={changeOptions}>
+      <ToolbarItem style={{ width: '100%' }}>
+        <ApplicationsToolbarItemClusters
+          clusters={clustersContext.clusters}
+          selectedClusters={selectedClusters}
+          selectCluster={selectCluster}
+        />
+      </ToolbarItem>
+      <ToolbarItem style={{ width: '100%' }}>
+        <ApplicationsToolbarItemNamespaces
+          selectedClusters={selectedClusters}
+          selectedNamespaces={selectedNamespaces}
+          selectNamespace={selectNamespace}
+        />
+      </ToolbarItem>
+      <ToolbarItem>
+        <ToggleGroup aria-label="View">
+          <ToggleGroupItem
+            text="Gallery"
+            isSelected={selectedView === 'gallery'}
+            onChange={(): void => setSelectedView('gallery')}
+          />
+          <ToggleGroupItem
+            text="Topology"
+            isSelected={selectedView === 'topology'}
+            onChange={(): void => setSelectedView('topology')}
+          />
+        </ToggleGroup>
+      </ToolbarItem>
     </Toolbar>
   );
 };

--- a/plugins/applications/src/components/panel/ApplicationsGallery.tsx
+++ b/plugins/applications/src/components/panel/ApplicationsGallery.tsx
@@ -10,6 +10,7 @@ interface IApplicationsGalleryProps {
   clusters: string[];
   namespaces: string[];
   team?: IApplicationReference;
+  times: IPluginTimes;
 }
 
 // ApplicationsGallery is the component to display all applications inside a gallery view.
@@ -17,16 +18,12 @@ const ApplicationsGallery: React.FunctionComponent<IApplicationsGalleryProps> = 
   clusters,
   namespaces,
   team,
+  times,
 }: IApplicationsGalleryProps) => {
-  const times: IPluginTimes = {
-    time: 'last15Minutes',
-    timeEnd: Math.floor(Date.now() / 1000),
-    timeStart: Math.floor(Date.now() / 1000) - 900,
-  };
   const history = useHistory();
 
   const { isError, isLoading, error, data, refetch } = useQuery<IApplication[], Error>(
-    ['applications/applications', 'gallery', clusters, namespaces, team],
+    ['applications/applications', 'gallery', clusters, namespaces, team, times],
     async () => {
       try {
         const clusterParams = clusters.map((cluster) => `cluster=${cluster}`).join('&');

--- a/plugins/applications/src/components/panel/ApplicationsTopology.tsx
+++ b/plugins/applications/src/components/panel/ApplicationsTopology.tsx
@@ -5,6 +5,7 @@ import { useHistory } from 'react-router-dom';
 
 import { IEdge, INode } from '../../utils/interfaces';
 import ApplicationsTopologyGraph from './ApplicationsTopologyGraph';
+import { IPluginTimes } from '@kobsio/plugin-core';
 
 interface IDataState {
   edges: IEdge[];
@@ -14,6 +15,7 @@ interface IDataState {
 interface IApplicationsTopologyProps {
   clusters: string[];
   namespaces: string[];
+  times: IPluginTimes;
   showDetails?: (details: React.ReactNode) => void;
 }
 
@@ -23,12 +25,13 @@ interface IApplicationsTopologyProps {
 const ApplicationsTopology: React.FunctionComponent<IApplicationsTopologyProps> = ({
   clusters,
   namespaces,
+  times,
   showDetails,
 }: IApplicationsTopologyProps) => {
   const history = useHistory();
 
   const { isError, isLoading, error, data, refetch } = useQuery<IDataState, Error>(
-    ['applications/applications', 'topology', clusters, namespaces],
+    ['applications/applications', 'topology', clusters, namespaces, times],
     async () => {
       try {
         const clusterParams = clusters.map((cluster) => `cluster=${cluster}`).join('&');

--- a/plugins/applications/src/components/panel/Panel.tsx
+++ b/plugins/applications/src/components/panel/Panel.tsx
@@ -18,11 +18,12 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
   title,
   description,
   options,
+  times,
   showDetails,
 }: IPanelProps) => {
   // We have to validate that the required options object was provided in the Application CR by a user. This is
   // important so that the React UI doesn't crash, when the user didn't use the plugin correctly.
-  if (!options) {
+  if (!options || !times) {
     return (
       <PluginOptionsMissing
         title={title}
@@ -42,6 +43,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
       <ApplicationsTopology
         clusters={options.clusters || [defaults.cluster]}
         namespaces={options.namespaces || [defaults.namespace]}
+        times={times}
         showDetails={showDetails}
       />
     );
@@ -75,6 +77,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
       clusters={options.clusters || [defaults.cluster]}
       namespaces={options.namespaces || [defaults.namespace]}
       team={options.team}
+      times={times}
     />
   );
 

--- a/plugins/applications/src/utils/helpers.ts
+++ b/plugins/applications/src/utils/helpers.ts
@@ -1,0 +1,17 @@
+import { IOptions, TView } from './interfaces';
+import { getTimeParams } from '@kobsio/plugin-core';
+
+// getInitialOptions returns the initial options for the applications page from the url.
+export const getInitialOptions = (): IOptions => {
+  const params = new URLSearchParams(window.location.search);
+  const clusters = params.getAll('cluster');
+  const namespaces = params.getAll('namespace');
+  const view = params.get('view');
+
+  return {
+    clusters: clusters,
+    namespaces: namespaces,
+    times: getTimeParams(params),
+    view: view ? (view as TView) : 'gallery',
+  };
+};

--- a/plugins/applications/src/utils/interfaces.ts
+++ b/plugins/applications/src/utils/interfaces.ts
@@ -1,6 +1,14 @@
 import cytoscape from 'cytoscape';
 
-import { IApplication, IApplicationReference } from '@kobsio/plugin-core';
+import { IApplication, IApplicationReference, IPluginTimes } from '@kobsio/plugin-core';
+
+// IOptions is the interface for all options for the applications page.
+export interface IOptions {
+  clusters: string[];
+  namespaces: string[];
+  view: TView;
+  times: IPluginTimes;
+}
 
 // TView are the two options we have to present a list of applications to the user. This can be a gallery view, where
 // it will be possible add a single plugin to the card or the topology view, which can be used to display the

--- a/plugins/core/src/components/toolbar/Toolbar.tsx
+++ b/plugins/core/src/components/toolbar/Toolbar.tsx
@@ -231,7 +231,7 @@ export const Toolbar: React.FunctionComponent<IToolbarProps> = ({
     <PatternflyToolbar id="toolbar" style={{ paddingBottom: showSearchButton ? '0px' : undefined, zIndex: 300 }}>
       <ToolbarContent style={{ padding: showSearchButton ? '0px' : undefined }}>
         <ToolbarToggleGroup style={{ width: '100%' }} toggleIcon={<FilterIcon />} breakpoint="lg">
-          <ToolbarGroup style={{ width: '100%' }}>
+          <ToolbarGroup style={{ alignItems: 'flex-start', width: '100%' }}>
             {children}
             {showOptions && (
               <ToolbarItem alignment={{ default: 'alignRight' }}>

--- a/plugins/dashboards/src/components/page/DashboardsToolbar.tsx
+++ b/plugins/dashboards/src/components/page/DashboardsToolbar.tsx
@@ -19,7 +19,7 @@ const DashboardsToolbar: React.FunctionComponent<IDashboardsToolbarProps> = ({
   setSearchTerm,
 }: IDashboardsToolbarProps) => {
   return (
-    <Toolbar id="elasticsearch-toolbar" style={{ paddingBottom: '0px', zIndex: 300 }}>
+    <Toolbar id="dashboards-toolbar" style={{ paddingBottom: '0px', zIndex: 300 }}>
       <ToolbarContent style={{ padding: '0px' }}>
         <ToolbarToggleGroup style={{ width: '100%' }} toggleIcon={<FilterIcon />} breakpoint="lg">
           <ToolbarGroup style={{ alignItems: 'flex-start', width: '100%' }}>

--- a/plugins/flux/src/components/page/Page.tsx
+++ b/plugins/flux/src/components/page/Page.tsx
@@ -8,32 +8,29 @@ import {
   PageSectionVariants,
   Title,
 } from '@patternfly/react-core';
-import React, { useEffect, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
-import { IOptions, TType } from '../../utils/interfaces';
+import { IOptions } from '../../utils/interfaces';
 import { IPluginPageProps } from '@kobsio/plugin-core';
 import PageList from './PageList';
 import PageToolbar from './PageToolbar';
-import { getOptionsFromSearch } from '../../utils/helpers';
+import { getInitialOptions } from '../../utils/helpers';
 
 const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, description }: IPluginPageProps) => {
   const history = useHistory();
   const location = useLocation();
-  const [options, setOptions] = useState<IOptions>(getOptionsFromSearch(location.search));
+  const [options, setOptions] = useState<IOptions>(useMemo<IOptions>(() => getInitialOptions(), []));
   const [details, setDetails] = useState<React.ReactNode>(undefined);
 
-  const changeOptions = (type: TType, cluster: string): void => {
+  const changeOptions = (opts: IOptions): void => {
     history.push({
       pathname: location.pathname,
-      search: `?type=${type}&cluster=${cluster}`,
+      search: `?type=${opts.type}&cluster=${opts.cluster}`,
     });
-  };
 
-  // useEffect is used to change the resources state everytime the location.search parameter changes.
-  useEffect(() => {
-    setOptions(getOptionsFromSearch(location.search));
-  }, [location.search]);
+    setOptions(opts);
+  };
 
   return (
     <React.Fragment>
@@ -62,6 +59,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
                         cluster={options.cluster}
                         type="gitrepositories.source.toolkit.fluxcd.io/v1beta1"
                         title="Git Repos"
+                        times={options.times}
                         showDetails={setDetails}
                       />
                       <p>&nbsp;</p>
@@ -70,6 +68,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
                         cluster={options.cluster}
                         type="helmrepositories.source.toolkit.fluxcd.io/v1beta1"
                         title="Helm Repos"
+                        times={options.times}
                         showDetails={setDetails}
                       />
                       <p>&nbsp;</p>
@@ -78,6 +77,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
                         cluster={options.cluster}
                         type="buckets.source.toolkit.fluxcd.io/v1beta1"
                         title="Buckets"
+                        times={options.times}
                         showDetails={setDetails}
                       />
                     </React.Fragment>
@@ -87,6 +87,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
                       cluster={options.cluster}
                       type="kustomizations.kustomize.toolkit.fluxcd.io/v1beta1"
                       title="Kustomizations"
+                      times={options.times}
                       showDetails={setDetails}
                     />
                   ) : options.type === 'helmreleases' ? (
@@ -95,6 +96,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
                       cluster={options.cluster}
                       type="helmreleases.helm.toolkit.fluxcd.io/v2beta1"
                       title="Helm Releases"
+                      times={options.times}
                       showDetails={setDetails}
                     />
                   ) : null}

--- a/plugins/flux/src/components/page/PageList.tsx
+++ b/plugins/flux/src/components/page/PageList.tsx
@@ -3,7 +3,7 @@ import { IRow, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import React, { useContext } from 'react';
 import { useQuery } from 'react-query';
 
-import { ClustersContext, IClusterContext, emptyState } from '@kobsio/plugin-core';
+import { ClustersContext, IClusterContext, IPluginTimes, emptyState } from '@kobsio/plugin-core';
 import Details from '../panel/details/Details';
 import { TApiType } from '../../utils/interfaces';
 
@@ -12,6 +12,7 @@ interface IPageListProps {
   cluster: string;
   type: TApiType;
   title: string;
+  times: IPluginTimes;
   showDetails?: (details: React.ReactNode) => void;
 }
 
@@ -20,6 +21,7 @@ const PageList: React.FunctionComponent<IPageListProps> = ({
   cluster,
   type,
   title,
+  times,
   showDetails,
 }: IPageListProps) => {
   const clustersContext = useContext<IClusterContext>(ClustersContext);
@@ -29,7 +31,7 @@ const PageList: React.FunctionComponent<IPageListProps> = ({
       : undefined;
 
   const { isError, isLoading, error, data, refetch } = useQuery<IRow[], Error>(
-    ['flux/list', name, cluster, type],
+    ['flux/list', name, cluster, type, times],
     async () => {
       try {
         if (!resource) {

--- a/plugins/flux/src/components/page/PageToolbar.tsx
+++ b/plugins/flux/src/components/page/PageToolbar.tsx
@@ -1,24 +1,13 @@
-import {
-  Button,
-  ButtonVariant,
-  ToggleGroup,
-  ToggleGroupItem,
-  Toolbar,
-  ToolbarContent,
-  ToolbarGroup,
-  ToolbarItem,
-  ToolbarToggleGroup,
-} from '@patternfly/react-core';
-import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
 import React, { memo, useContext, useState } from 'react';
+import { ToggleGroup, ToggleGroupItem, ToolbarItem } from '@patternfly/react-core';
 
-import { ClustersContext, IClusterContext } from '@kobsio/plugin-core';
+import { ClustersContext, IClusterContext, IOptionsAdditionalFields, IPluginTimes, Toolbar } from '@kobsio/plugin-core';
 import { IOptions, TType } from '../../utils/interfaces';
 import PageToolbarItemClusters from './PageToolbarItemClusters';
 
 interface IPageToolbarProps {
   options: IOptions;
-  setOptions: (type: TType, cluster: string) => void;
+  setOptions: (options: IOptions) => void;
 }
 
 const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({ options, setOptions }: IPageToolbarProps) => {
@@ -26,51 +15,44 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({ options, setO
   const [selectedType, setSelectedType] = useState<TType>(options.type || 'sources');
   const [selectedCluster, setSelectedCluster] = useState<string>(options.cluster || clustersContext.clusters[0]);
 
+  // changeOptions changes the Prometheus option. It is used when the user clicks the search button or selects a new
+  // time range.
+  const changeOptions = (times: IPluginTimes, additionalFields: IOptionsAdditionalFields[] | undefined): void => {
+    setOptions({ cluster: selectedCluster, times: times, type: selectedType });
+  };
+
   return (
-    <Toolbar id="flux-toolbar" style={{ paddingBottom: '0px', zIndex: 300 }}>
-      <ToolbarContent style={{ padding: '0px' }}>
-        <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="lg">
-          <ToolbarGroup>
-            <ToolbarItem>
-              <PageToolbarItemClusters
-                clusters={clustersContext.clusters}
-                selectedCluster={selectedCluster}
-                selectCluster={(value: string): void => setSelectedCluster(value)}
-              />
-            </ToolbarItem>
+    <Toolbar times={options.times} showOptions={false} showSearchButton={true} setOptions={changeOptions}>
+      <ToolbarItem style={{ width: '100%' }}>
+        <PageToolbarItemClusters
+          clusters={clustersContext.clusters}
+          selectedCluster={selectedCluster}
+          selectCluster={(value: string): void => setSelectedCluster(value)}
+        />
+      </ToolbarItem>
 
-            <ToolbarItem>
-              <ToggleGroup aria-label="Type">
-                <ToggleGroupItem
-                  text="Sources"
-                  isSelected={selectedType === 'sources'}
-                  onChange={(): void => setSelectedType('sources')}
-                />
-                <ToggleGroupItem
-                  text="Kustomizations"
-                  isSelected={selectedType === 'kustomizations'}
-                  onChange={(): void => setSelectedType('kustomizations')}
-                />
-                <ToggleGroupItem
-                  text="Helm Releases"
-                  isSelected={selectedType === 'helmreleases'}
-                  onChange={(): void => setSelectedType('helmreleases')}
-                />
-              </ToggleGroup>
-            </ToolbarItem>
-
-            <ToolbarItem>
-              <Button
-                variant={ButtonVariant.primary}
-                icon={<SearchIcon />}
-                onClick={(): void => setOptions(selectedType, selectedCluster)}
-              >
-                Search
-              </Button>
-            </ToolbarItem>
-          </ToolbarGroup>
-        </ToolbarToggleGroup>
-      </ToolbarContent>
+      <ToolbarItem>
+        <ToggleGroup aria-label="Type">
+          <ToggleGroupItem
+            className="pf-u-text-nowrap"
+            text="Sources"
+            isSelected={selectedType === 'sources'}
+            onChange={(): void => setSelectedType('sources')}
+          />
+          <ToggleGroupItem
+            className="pf-u-text-nowrap"
+            text="Kustomizations"
+            isSelected={selectedType === 'kustomizations'}
+            onChange={(): void => setSelectedType('kustomizations')}
+          />
+          <ToggleGroupItem
+            className="pf-u-text-nowrap"
+            text="Helm Releases"
+            isSelected={selectedType === 'helmreleases'}
+            onChange={(): void => setSelectedType('helmreleases')}
+          />
+        </ToggleGroup>
+      </ToolbarItem>
     </Toolbar>
   );
 };

--- a/plugins/flux/src/utils/helpers.ts
+++ b/plugins/flux/src/utils/helpers.ts
@@ -1,8 +1,9 @@
 import { IOptions, TType } from './interfaces';
+import { getTimeParams } from '@kobsio/plugin-core';
 
-// getOptionsFromSearch returns the options for a given search location.
-export const getOptionsFromSearch = (search: string): IOptions => {
-  const params = new URLSearchParams(search);
+// getInitialOptions returns the initial options from the url.
+export const getInitialOptions = (): IOptions => {
+  const params = new URLSearchParams(window.location.search);
   const type = params.get('type');
   const cluster = params.get('cluster');
 
@@ -13,6 +14,7 @@ export const getOptionsFromSearch = (search: string): IOptions => {
 
   return {
     cluster: cluster || '',
+    times: getTimeParams(params),
     type: parsedType,
   };
 };

--- a/plugins/flux/src/utils/interfaces.ts
+++ b/plugins/flux/src/utils/interfaces.ts
@@ -1,5 +1,7 @@
 import { AlertVariant } from '@patternfly/react-core';
 
+import { IPluginTimes } from '@kobsio/plugin-core';
+
 export interface IPanelOptions {
   type?: string;
   cluster?: string;
@@ -11,6 +13,7 @@ export interface IPanelOptions {
 export interface IOptions {
   type: TType;
   cluster: string;
+  times: IPluginTimes;
 }
 
 export interface IArtifact {

--- a/plugins/grafana/src/components/page/Page.tsx
+++ b/plugins/grafana/src/components/page/Page.tsx
@@ -6,14 +6,14 @@ import {
   PageSectionVariants,
   Title,
 } from '@patternfly/react-core';
-import React, { useEffect, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import Dashboards from './Dashboards';
 import { IOptions } from '../../utils/interfaces';
 import { IPluginPageProps } from '@kobsio/plugin-core';
 import PageToolbar from './PageToolbar';
-import { getOptionsFromSearch } from '../../utils/helpers';
+import { getInitialOptions } from '../../utils/helpers';
 
 const Page: React.FunctionComponent<IPluginPageProps> = ({
   name,
@@ -23,7 +23,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({
 }: IPluginPageProps) => {
   const location = useLocation();
   const history = useHistory();
-  const [pageOptions, setPageOptions] = useState<IOptions>(getOptionsFromSearch(location.search));
+  const [pageOptions, setPageOptions] = useState<IOptions>(useMemo<IOptions>(() => getInitialOptions(), []));
 
   // changePageOptions is used to change the options to get a list of dashboards from Grafna. Instead of directly
   // modifying the options state we change the URL parameters.
@@ -32,13 +32,9 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({
       pathname: location.pathname,
       search: `?query=${encodeURIComponent(opts.query)}`,
     });
-  };
 
-  // useEffect is used to set the options every time the search location for the current URL changes. The URL is changed
-  // via the changePageOptions function. When the search location is changed we modify the options state.
-  useEffect(() => {
-    setPageOptions(getOptionsFromSearch(location.search));
-  }, [location.search]);
+    setPageOptions(opts);
+  };
 
   return (
     <React.Fragment>
@@ -47,7 +43,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({
           {displayName}
         </Title>
         <p>{description}</p>
-        <PageToolbar name={name} query={pageOptions.query} setOptions={changePageOptions} />
+        <PageToolbar name={name} options={pageOptions} setOptions={changePageOptions} />
       </PageSection>
 
       <Drawer isExpanded={false}>

--- a/plugins/grafana/src/components/page/PageToolbar.tsx
+++ b/plugins/grafana/src/components/page/PageToolbar.tsx
@@ -13,13 +13,14 @@ import React, { useState } from 'react';
 
 import { IOptions } from '../../utils/interfaces';
 
-interface IPageToolbarProps extends IOptions {
+interface IPageToolbarProps {
   name: string;
+  options: IOptions;
   setOptions: (data: IOptions) => void;
 }
 
-const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({ name, query, setOptions }: IPageToolbarProps) => {
-  const [data, setData] = useState<IOptions>({ query: query });
+const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({ name, options, setOptions }: IPageToolbarProps) => {
+  const [data, setData] = useState<IOptions>(options);
 
   // changeQuery changes the value of a query.
   const changeQuery = (value: string): void => {

--- a/plugins/grafana/src/utils/helpers.ts
+++ b/plugins/grafana/src/utils/helpers.ts
@@ -1,8 +1,8 @@
 import { IOptions } from './interfaces';
 
-// getOptionsFromSearch is used to get the Jaeger options from a given search location.
-export const getOptionsFromSearch = (search: string): IOptions => {
-  const params = new URLSearchParams(search);
+// getInitialOptions is used to get the initial options from the url.
+export const getInitialOptions = (): IOptions => {
+  const params = new URLSearchParams(window.location.search);
   const query = params.get('query');
 
   return {

--- a/plugins/istio/src/components/page/Application.tsx
+++ b/plugins/istio/src/components/page/Application.tsx
@@ -33,9 +33,9 @@ const Application: React.FunctionComponent<IApplicationProps> = ({ name, pluginO
   const changeOptions = (tmpOptions: IApplicationOptions): void => {
     history.push({
       pathname: location.pathname,
-      search: `?timeEnd=${tmpOptions.times.timeEnd}&timeStart=${tmpOptions.times.timeStart}&view=${
-        tmpOptions.view
-      }&filterUpstreamCluster=${encodeURIComponent(
+      search: `?time=${tmpOptions.times}&timeEnd=${tmpOptions.times.timeEnd}&timeStart=${
+        tmpOptions.times.timeStart
+      }&view=${tmpOptions.view}&filterUpstreamCluster=${encodeURIComponent(
         tmpOptions.filters.upstreamCluster,
       )}&filterMethod=${encodeURIComponent(tmpOptions.filters.method)}&filterPath=${encodeURIComponent(
         tmpOptions.filters.path,

--- a/plugins/istio/src/components/page/Applications.tsx
+++ b/plugins/istio/src/components/page/Applications.tsx
@@ -44,7 +44,7 @@ const Applications: React.FunctionComponent<IApplicationsProps> = ({
 
     history.push({
       pathname: location.pathname,
-      search: `?timeEnd=${opts.times.timeEnd}&timeStart=${opts.times.timeStart}${
+      search: `?time=${opts.times.time}&timeEnd=${opts.times.timeEnd}&timeStart=${opts.times.timeStart}${
         namespaces.length > 0 ? namespaces.join('') : ''
       }`,
     });

--- a/plugins/resources/src/components/page/Page.tsx
+++ b/plugins/resources/src/components/page/Page.tsx
@@ -8,56 +8,37 @@ import {
   PageSectionVariants,
   Title,
 } from '@patternfly/react-core';
-import React, { useEffect, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
-import { IPanelOptions } from '../../utils/interfaces';
+import { IOptions } from '../../utils/interfaces';
 import { IPluginPageProps } from '@kobsio/plugin-core';
 import PageToolbar from './PageToolbar';
 import Panel from '../panel/Panel';
-
-// getResourcesFromSearch returns the clusters, namespaces, resources and selector for the resources state from a given
-// search location.
-export const getResourcesFromSearch = (search: string): IPanelOptions => {
-  const params = new URLSearchParams(search);
-  const clusters = params.getAll('cluster');
-  const namespaces = params.getAll('namespace');
-  const resources = params.getAll('resource');
-  const selector = params.get('selector');
-
-  return {
-    clusters: clusters,
-    namespaces: namespaces,
-    resources: resources,
-    selector: selector ? selector : '',
-  };
-};
+import { getInitialOptions } from '../../utils/helpers';
 
 const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, description }: IPluginPageProps) => {
   const history = useHistory();
   const location = useLocation();
-  const [resources, setResources] = useState<IPanelOptions>(getResourcesFromSearch(location.search));
-  const [selectedResource, setSelectedResource] = useState<React.ReactNode>(undefined);
+  const [options, setOptions] = useState<IOptions>(useMemo<IOptions>(() => getInitialOptions(), []));
+  const [details, setDetails] = useState<React.ReactNode>(undefined);
 
-  // changeResources is used to set the provided resources as query parameters in the current URL. This used, so that a
-  // user can share the URL of his view with other users.
-  const changeResources = (clusters: string[], namespaces: string[], resources: string[], selector: string): void => {
-    const clusterParams = clusters.map((cluster) => `&cluster=${cluster}`);
-    const namespaceParams = namespaces.map((namespace) => `&namespace=${namespace}`);
-    const resourceParams = resources.map((resource) => `&resource=${resource}`);
+  // changeOptions is used to change the options. Besides setting a new value for the options state we also reflect the
+  // options in the current url.
+  const changeOptions = (opts: IOptions): void => {
+    const clusterParams = opts.clusters.map((cluster) => `&cluster=${cluster}`);
+    const namespaceParams = opts.namespaces.map((namespace) => `&namespace=${namespace}`);
+    const resourceParams = opts.resources.map((resource) => `&resource=${resource}`);
 
     history.push({
       pathname: location.pathname,
-      search: `?selector=${selector}${clusterParams.length > 0 ? clusterParams.join('') : ''}${
+      search: `?selector=${opts.selector}${clusterParams.length > 0 ? clusterParams.join('') : ''}${
         namespaceParams.length > 0 ? namespaceParams.join('') : ''
       }${resourceParams.length > 0 ? resourceParams.join('') : ''}`,
     });
-  };
 
-  // useEffect is used to change the resources state everytime the location.search parameter changes.
-  useEffect(() => {
-    setResources(getResourcesFromSearch(location.search));
-  }, [location.search]);
+    setOptions(opts);
+  };
 
   return (
     <React.Fragment>
@@ -66,14 +47,14 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
           {displayName}
         </Title>
         <p>{description}</p>
-        <PageToolbar resources={resources} setResources={changeResources} />
+        <PageToolbar options={options} setOptions={changeOptions} />
       </PageSection>
 
-      <Drawer isExpanded={selectedResource !== undefined}>
-        <DrawerContent panelContent={selectedResource}>
+      <Drawer isExpanded={details !== undefined}>
+        <DrawerContent panelContent={details}>
           <DrawerContentBody>
             <PageSection style={{ minHeight: '100%' }} variant={PageSectionVariants.default}>
-              {!resources ? (
+              {options.clusters.length === 0 || options.namespaces.length === 0 || options.resources.length === 0 ? (
                 <Alert variant={AlertVariant.info} title="Select clusters, resources and namespaces">
                   <p>Select a list of clusters, resources and namespaces from the toolbar.</p>
                 </Alert>
@@ -82,8 +63,9 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
                   defaults={{ cluster: '', name: '', namespace: '' }}
                   name={name}
                   title=""
-                  options={[resources]}
-                  showDetails={setSelectedResource}
+                  options={[options]}
+                  times={options.times}
+                  showDetails={setDetails}
                 />
               )}
             </PageSection>

--- a/plugins/resources/src/components/page/PageToolbar.tsx
+++ b/plugins/resources/src/components/page/PageToolbar.tsx
@@ -1,37 +1,28 @@
-import {
-  Button,
-  ButtonVariant,
-  Toolbar,
-  ToolbarContent,
-  ToolbarGroup,
-  ToolbarItem,
-  ToolbarToggleGroup,
-} from '@patternfly/react-core';
-import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
 import React, { memo, useContext, useState } from 'react';
+import { ToolbarItem } from '@patternfly/react-core';
 
-import { ClustersContext, IClusterContext } from '@kobsio/plugin-core';
-import { IPanelOptions } from '../../utils/interfaces';
+import { ClustersContext, IClusterContext, IOptionsAdditionalFields, IPluginTimes, Toolbar } from '@kobsio/plugin-core';
+import { IOptions } from '../../utils/interfaces';
 import PageToolbarItemClusters from './PageToolbarItemClusters';
 import PageToolbarItemNamespaces from './PageToolbarItemNamespaces';
 import PageToolbarItemResources from './PageToolbarItemResources';
 
 interface IPageToolbarProps {
-  resources: IPanelOptions;
-  setResources: (clusters: string[], namespaces: string[], resources: string[], selector: string) => void;
+  options: IOptions;
+  setOptions: (options: IOptions) => void;
 }
 
-const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({ resources, setResources }: IPageToolbarProps) => {
+const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({ options, setOptions }: IPageToolbarProps) => {
   const clustersContext = useContext<IClusterContext>(ClustersContext);
   const [selectedClusters, setSelectedClusters] = useState<string[]>(
-    !resources.clusters || resources.clusters.length === 0
+    options.clusters.length === 0
       ? clustersContext.clusters.length === 0
         ? []
         : [clustersContext.clusters[0]]
-      : resources.clusters,
+      : options.clusters,
   );
-  const [selectedResources, setSelectedResources] = useState<string[]>(resources.resources || []);
-  const [selectedNamespaces, setSelectedNamespaces] = useState<string[]>(resources.namespaces || []);
+  const [selectedResources, setSelectedResources] = useState<string[]>(options.resources);
+  const [selectedNamespaces, setSelectedNamespaces] = useState<string[]>(options.namespaces);
 
   // selectCluster adds/removes the given cluster to the list of selected clusters. When the cluster value is an empty
   // string the selected clusters list is cleared.
@@ -75,46 +66,45 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({ resources, se
     }
   };
 
+  // changeOptions changes the Prometheus option. It is used when the user clicks the search button or selects a new
+  // time range.
+  const changeOptions = (times: IPluginTimes, additionalFields: IOptionsAdditionalFields[] | undefined): void => {
+    setOptions({
+      clusters: selectedClusters,
+      namespaces: selectedNamespaces,
+      resources: selectedResources,
+      selector: '',
+      times: times,
+    });
+  };
+
   return (
-    <Toolbar id="resources-toolbar" style={{ paddingBottom: '0px', zIndex: 300 }}>
-      <ToolbarContent style={{ padding: '0px' }}>
-        <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="lg">
-          <ToolbarGroup>
-            <ToolbarItem>
-              <PageToolbarItemClusters
-                clusters={clustersContext.clusters}
-                selectedClusters={selectedClusters}
-                selectCluster={selectCluster}
-              />
-            </ToolbarItem>
-            {clustersContext.resources ? (
-              <ToolbarItem>
-                <PageToolbarItemResources
-                  resources={clustersContext.resources}
-                  selectedResources={selectedResources}
-                  selectResource={selectResource}
-                />
-              </ToolbarItem>
-            ) : null}
-            <ToolbarItem>
-              <PageToolbarItemNamespaces
-                selectedClusters={selectedClusters}
-                selectedNamespaces={selectedNamespaces}
-                selectNamespace={selectNamespace}
-              />
-            </ToolbarItem>
-            <ToolbarItem>
-              <Button
-                variant={ButtonVariant.primary}
-                icon={<SearchIcon />}
-                onClick={(): void => setResources(selectedClusters, selectedNamespaces, selectedResources, '')}
-              >
-                Search
-              </Button>
-            </ToolbarItem>
-          </ToolbarGroup>
-        </ToolbarToggleGroup>
-      </ToolbarContent>
+    <Toolbar times={options.times} showOptions={false} showSearchButton={true} setOptions={changeOptions}>
+      <ToolbarItem style={{ width: '100%' }}>
+        <ToolbarItem style={{ width: '100%' }}>
+          <PageToolbarItemClusters
+            clusters={clustersContext.clusters}
+            selectedClusters={selectedClusters}
+            selectCluster={selectCluster}
+          />
+        </ToolbarItem>
+        {clustersContext.resources ? (
+          <ToolbarItem style={{ width: '100%' }}>
+            <PageToolbarItemResources
+              resources={clustersContext.resources}
+              selectedResources={selectedResources}
+              selectResource={selectResource}
+            />
+          </ToolbarItem>
+        ) : null}
+        <ToolbarItem style={{ width: '100%' }}>
+          <PageToolbarItemNamespaces
+            selectedClusters={selectedClusters}
+            selectedNamespaces={selectedNamespaces}
+            selectNamespace={selectNamespace}
+          />
+        </ToolbarItem>
+      </ToolbarItem>
     </Toolbar>
   );
 };

--- a/plugins/resources/src/components/panel/Panel.tsx
+++ b/plugins/resources/src/components/panel/Panel.tsx
@@ -18,9 +18,10 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
   title,
   description,
   options,
+  times,
   showDetails,
 }: IPanelProps) => {
-  if (!options || !Array.isArray(options)) {
+  if (!options || !Array.isArray(options) || !times) {
     return (
       <PluginOptionsMissing
         title={title}
@@ -47,14 +48,14 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
   if (title) {
     return (
       <PluginCard title={title} description={description} transparent={true} actions={<PanelActions options={opts} />}>
-        <PanelList resources={opts} showDetails={showDetails} />
+        <PanelList resources={opts} times={times} showDetails={showDetails} />
       </PluginCard>
     );
   }
 
   return (
     <Card>
-      <PanelList resources={opts} showDetails={showDetails} />
+      <PanelList resources={opts} times={times} showDetails={showDetails} />
     </Card>
   );
 };

--- a/plugins/resources/src/components/panel/PanelList.tsx
+++ b/plugins/resources/src/components/panel/PanelList.tsx
@@ -1,16 +1,17 @@
 import { Accordion, AccordionContent, AccordionItem, AccordionToggle, Card } from '@patternfly/react-core';
 import React, { useContext, useState } from 'react';
 
-import { ClustersContext, IClusterContext } from '@kobsio/plugin-core';
+import { ClustersContext, IClusterContext, IPluginTimes } from '@kobsio/plugin-core';
 import { IPanelOptions } from '../../utils/interfaces';
 import PanelListItem from './PanelListItem';
 
 interface IPanelListProps {
   resources: IPanelOptions[];
+  times: IPluginTimes;
   showDetails?: (details: React.ReactNode) => void;
 }
 
-const PanelList: React.FunctionComponent<IPanelListProps> = ({ resources, showDetails }: IPanelListProps) => {
+const PanelList: React.FunctionComponent<IPanelListProps> = ({ resources, times, showDetails }: IPanelListProps) => {
   const clustersContext = useContext<IClusterContext>(ClustersContext);
   const [expanded, setExpanded] = useState<string[]>(['resources-accordion-0-0']);
 
@@ -51,6 +52,7 @@ const PanelList: React.FunctionComponent<IPanelListProps> = ({ resources, showDe
                               namespaces={resource.namespaces || []}
                               resource={clustersContext.resources[item]}
                               selector={resource.selector || ''}
+                              times={times}
                               showDetails={showDetails}
                             />
                           ) : null}

--- a/plugins/resources/src/components/panel/PanelListItem.tsx
+++ b/plugins/resources/src/components/panel/PanelListItem.tsx
@@ -2,7 +2,7 @@ import { IRow, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import React, { memo } from 'react';
 import { useQuery } from 'react-query';
 
-import { IResource, emptyState } from '@kobsio/plugin-core';
+import { IPluginTimes, IResource, emptyState } from '@kobsio/plugin-core';
 import Details from './details/Details';
 
 interface IPanelListItemProps {
@@ -10,6 +10,7 @@ interface IPanelListItemProps {
   namespaces: string[];
   resource: IResource;
   selector: string;
+  times: IPluginTimes;
   showDetails?: (details: React.ReactNode) => void;
 }
 
@@ -18,10 +19,20 @@ const PanelListItem: React.FunctionComponent<IPanelListItemProps> = ({
   namespaces,
   resource,
   selector,
+  times,
   showDetails,
 }: IPanelListItemProps) => {
   const { isError, isLoading, error, data, refetch } = useQuery<IRow[], Error>(
-    ['resources/panellistitem', clusters, namespaces, resource.scope, resource.resource, resource.path, selector],
+    [
+      'resources/panellistitem',
+      clusters,
+      namespaces,
+      resource.scope,
+      resource.resource,
+      resource.path,
+      selector,
+      times,
+    ],
     async () => {
       try {
         const clusterParams = clusters.map((cluster) => `cluster=${cluster}`).join('&');

--- a/plugins/resources/src/utils/helpers.ts
+++ b/plugins/resources/src/utils/helpers.ts
@@ -1,3 +1,23 @@
+import { IOptions } from './interfaces';
+import { getTimeParams } from '@kobsio/plugin-core';
+
+// getInitialOptions returns the initial options from the url.
+export const getInitialOptions = (): IOptions => {
+  const params = new URLSearchParams(window.location.search);
+  const clusters = params.getAll('cluster');
+  const namespaces = params.getAll('namespace');
+  const resources = params.getAll('resource');
+  const selector = params.get('selector');
+
+  return {
+    clusters: clusters || [],
+    namespaces: namespaces || [],
+    resources: resources || [],
+    selector: selector ? selector : '',
+    times: getTimeParams(params),
+  };
+};
+
 // formatResourceValue converts the given value for CPU, memory or ephemeral storage to another unit.
 export const formatResourceValue = (type: string, value: string): string => {
   if (value === '' || value === undefined) {

--- a/plugins/resources/src/utils/interfaces.ts
+++ b/plugins/resources/src/utils/interfaces.ts
@@ -1,5 +1,16 @@
 import { AlertVariant } from '@patternfly/react-core';
 
+import { IPluginTimes } from '@kobsio/plugin-core';
+
+// IOptions is the interface for the options of the page implementation of the resources.plugin.
+export interface IOptions {
+  clusters: string[];
+  namespaces: string[];
+  resources: string[];
+  selector: string;
+  times: IPluginTimes;
+}
+
 // IPanelOptions is the interface for the options property in the plugin panel implementation for the resources plugin.
 // It contains a list of clusters, namespaces, resources and a selector. Since the data is provided by a user and not
 // validated by the Kubernetes API server we have to verify that all required fields are present.

--- a/plugins/sonarqube/src/components/page/Page.tsx
+++ b/plugins/sonarqube/src/components/page/Page.tsx
@@ -6,14 +6,14 @@ import {
   PageSectionVariants,
   Title,
 } from '@patternfly/react-core';
-import React, { useEffect, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { IOptions } from '../../utils/interfaces';
 import { IPluginPageProps } from '@kobsio/plugin-core';
 import PageToolbar from './PageToolbar';
 import Projects from './Projects';
-import { getOptionsFromSearch } from '../../utils/helpers';
+import { getInitialOptions } from '../../utils/helpers';
 
 const Page: React.FunctionComponent<IPluginPageProps> = ({
   name,
@@ -23,7 +23,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({
 }: IPluginPageProps) => {
   const location = useLocation();
   const history = useHistory();
-  const [pageOptions, setPageOptions] = useState<IOptions>(getOptionsFromSearch(location.search));
+  const [pageOptions, setPageOptions] = useState<IOptions>(useMemo<IOptions>(() => getInitialOptions(), []));
 
   // changePageOptions is used to change the options to get a list of projects from SonarQube. Instead of directly
   // modifying the options state we change the URL parameters.
@@ -32,13 +32,9 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({
       pathname: location.pathname,
       search: `?query=${encodeURIComponent(opts.query)}`,
     });
-  };
 
-  // useEffect is used to set the options every time the search location for the current URL changes. The URL is changed
-  // via the changePageOptions function. When the search location is changed we modify the options state.
-  useEffect(() => {
-    setPageOptions(getOptionsFromSearch(location.search));
-  }, [location.search]);
+    setPageOptions(opts);
+  };
 
   return (
     <React.Fragment>
@@ -47,7 +43,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({
           {displayName}
         </Title>
         <p>{description}</p>
-        <PageToolbar name={name} query={pageOptions.query} setOptions={changePageOptions} />
+        <PageToolbar name={name} options={pageOptions} setOptions={changePageOptions} />
       </PageSection>
 
       <Drawer isExpanded={false}>

--- a/plugins/sonarqube/src/components/page/PageToolbar.tsx
+++ b/plugins/sonarqube/src/components/page/PageToolbar.tsx
@@ -13,13 +13,14 @@ import React, { useState } from 'react';
 
 import { IOptions } from '../../utils/interfaces';
 
-interface IPageToolbarProps extends IOptions {
+interface IPageToolbarProps {
   name: string;
+  options: IOptions;
   setOptions: (data: IOptions) => void;
 }
 
-const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({ name, query, setOptions }: IPageToolbarProps) => {
-  const [data, setData] = useState<IOptions>({ query: query });
+const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({ name, options, setOptions }: IPageToolbarProps) => {
+  const [data, setData] = useState<IOptions>(options);
 
   // changeQuery changes the value of a query.
   const changeQuery = (value: string): void => {

--- a/plugins/sonarqube/src/utils/helpers.ts
+++ b/plugins/sonarqube/src/utils/helpers.ts
@@ -1,8 +1,8 @@
 import { IOptions } from './interfaces';
 
-// getOptionsFromSearch is used to get the Jaeger options from a given search location.
-export const getOptionsFromSearch = (search: string): IOptions => {
-  const params = new URLSearchParams(search);
+// getInitialOptions is used to get the initial options from the url.
+export const getInitialOptions = (): IOptions => {
+  const params = new URLSearchParams(window.location.search);
   const query = params.get('query');
 
   return {

--- a/plugins/sql/src/components/page/Page.tsx
+++ b/plugins/sql/src/components/page/Page.tsx
@@ -6,33 +6,30 @@ import {
   PageSectionVariants,
   Title,
 } from '@patternfly/react-core';
-import React, { useEffect, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
+import { IOptions } from '../../utils/interfaces';
 import { IPluginPageProps } from '@kobsio/plugin-core';
 import PageSQL from './PageSQL';
 import PageToolbar from './PageToolbar';
-import { getQueryFromSearch } from '../../utils/helpers';
+import { getInitialOptions } from '../../utils/helpers';
 
 const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, description }: IPluginPageProps) => {
   const location = useLocation();
   const history = useHistory();
-  const [query, setQuery] = useState<string>(getQueryFromSearch(location.search));
+  const [options, setOptions] = useState<IOptions>(useMemo<IOptions>(() => getInitialOptions(), []));
 
   // changeOptions is used to change the options for an SQL query. Instead of directly modifying the options state we
   // change the URL parameters.
-  const changeOptions = (q: string): void => {
+  const changeOptions = (opts: IOptions): void => {
     history.push({
       pathname: location.pathname,
-      search: `?query=${q}`,
+      search: `?query=${opts.query}`,
     });
-  };
 
-  // useEffect is used to set the options every time the search location for the current URL changes. The URL is changed
-  // via the changeOptions function. When the search location is changed we modify the options state.
-  useEffect(() => {
-    setQuery(getQueryFromSearch(location.search));
-  }, [location.search]);
+    setOptions(opts);
+  };
 
   return (
     <React.Fragment>
@@ -41,14 +38,14 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
           {displayName}
         </Title>
         <p>{description}</p>
-        <PageToolbar query={query} setQuery={changeOptions} />
+        <PageToolbar options={options} setOptions={changeOptions} />
       </PageSection>
 
       <Drawer isExpanded={false}>
         <DrawerContent panelContent={undefined}>
           <DrawerContentBody>
             <PageSection style={{ minHeight: '100%' }} variant={PageSectionVariants.default}>
-              {query.length > 0 && <PageSQL name={name} query={query} />}
+              {options.query.length > 0 && <PageSQL name={name} query={options.query} />}
             </PageSection>
           </DrawerContentBody>
         </DrawerContent>

--- a/plugins/sql/src/components/page/PageToolbar.tsx
+++ b/plugins/sql/src/components/page/PageToolbar.tsx
@@ -11,17 +11,19 @@ import {
 import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
 import React, { useState } from 'react';
 
+import { IOptions } from '../../utils/interfaces';
+
 interface IPageToolbarProps {
-  query: string;
-  setQuery: (data: string) => void;
+  options: IOptions;
+  setOptions: (options: IOptions) => void;
 }
 
-const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({ query, setQuery }: IPageToolbarProps) => {
-  const [data, setData] = useState<string>(query);
+const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({ options, setOptions }: IPageToolbarProps) => {
+  const [data, setData] = useState<IOptions>(options);
 
   // changeQuery changes the value of a query.
   const changeQuery = (value: string): void => {
-    setData(value);
+    setData({ ...data, query: value });
   };
 
   // onEnter is used to detect if the user pressed the "ENTER" key. If this is the case we are calling the setOptions
@@ -30,7 +32,7 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({ query, setQue
   const onEnter = (e: React.KeyboardEvent<HTMLTextAreaElement> | undefined): void => {
     if (e?.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      setQuery(data);
+      setOptions(data);
     }
   };
 
@@ -45,13 +47,13 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({ query, setQue
                 resizeOrientation="vertical"
                 rows={1}
                 type="text"
-                value={data}
+                value={data.query}
                 onChange={changeQuery}
                 onKeyDown={onEnter}
               />
             </ToolbarItem>
             <ToolbarItem>
-              <Button variant={ButtonVariant.primary} icon={<SearchIcon />} onClick={(): void => setQuery(data)}>
+              <Button variant={ButtonVariant.primary} icon={<SearchIcon />} onClick={(): void => setOptions(data)}>
                 Search
               </Button>
             </ToolbarItem>

--- a/plugins/sql/src/utils/helpers.ts
+++ b/plugins/sql/src/utils/helpers.ts
@@ -1,8 +1,13 @@
-// getQueryFromSearch is used to get the sql query from a given search location.
-export const getQueryFromSearch = (search: string): string => {
-  const params = new URLSearchParams(search);
+import { IOptions } from './interfaces';
+
+// getInitialOptions is used to get the initial options from the url.
+export const getInitialOptions = (): IOptions => {
+  const params = new URLSearchParams(window.location.search);
   const query = params.get('query');
-  return query ? query : '';
+
+  return {
+    query: query ? query : '',
+  };
 };
 
 export const renderCellValue = (value: string | number | string[] | number[]): string => {


### PR DESCRIPTION
Some plugins were still not using the toolbar logic introduced in #225.
We are now using the Toolbar component and the options logic accross all
plugins.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
