### PR TITLE
[azure] Fix JSON tag in permissions struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 ### Fixed
 
 - [#227](https://github.com/kobsio/kobs/pull/227): [techdocs] Ignore comments in code blocks in table of contents.
+- [#234](https://github.com/kobsio/kobs/pull/234): [azure] Fix json tags in Azure permissions struct.
 
 ### Changed
 

--- a/plugins/azure/pkg/instance/containerinstances/containerinstances.go
+++ b/plugins/azure/pkg/instance/containerinstances/containerinstances.go
@@ -15,12 +15,6 @@ type Client struct {
 	containersClient      *armcontainerinstance.ContainersClient
 }
 
-// ContainerGroupListResult the container group list response that contains the container group properties.
-type ContainerGroupListResult struct {
-	Value    []map[string]interface{} `json:"value,omitempty"`
-	NextLink string                   `json:"nextLink,omitempty"`
-}
-
 // ListContainerGroups list all container groups in a subscription.
 //
 // We can not use the containerGroupsClient for this request, because the result is missing some important fields like

--- a/plugins/azure/pkg/instance/permissions.go
+++ b/plugins/azure/pkg/instance/permissions.go
@@ -13,9 +13,9 @@ import (
 
 // Permissions is the structure of the custom permissions field for the Azure instance.
 type Permissions struct {
-	Resources      []string `json:"resources`
-	ResourceGroups []string `json:"resourceGroups`
-	Verbs          []string `json:"resourceGroups`
+	Resources      []string `json:"resources"`
+	ResourceGroups []string `json:"resourceGroups"`
+	Verbs          []string `json:"verbs"`
 }
 
 // CheckPermissions can be used to check if a user has the permissions to access a resource. The permissions of the user


### PR DESCRIPTION
This commit fixes an typo in the JSON tag in the permissions struct of
the Azure plugin.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
