### PR TITLE
[resources] Use TableComposable instead of Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,13 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 ### Changed
 
 - [#217](https://github.com/kobsio/kobs/pull/217): [azure] Use resource groups to get a list of container instances.
-- [#225](https://github.com/kobsio/kobs/pull/225): [core] :warning: _Breaking change:_ :warning: Change options handling accross all plugins and re-add `time` property.
+- [#225](https://github.com/kobsio/kobs/pull/225): [core] :warning: _Breaking change:_ :warning: Change options handling across all plugins and re-add `time` property.
 - [#229](https://github.com/kobsio/kobs/pull/229): [opsgenie] Allow users to overwrite the selected time range in a dashboard for an Opsgenie panel via the new `interval` property.
 - [#230](https://github.com/kobsio/kobs/pull/230): [dashboards] Add special variables `__timeStart` and `__timeEnd` for dashboards.
 - [#231](https://github.com/kobsio/kobs/pull/231): [klogs] Highlight expanded row and do not use index as key. The same changes were also applied for the Elasticsearch plugin.
 - [#232](https://github.com/kobsio/kobs/pull/232): [core] Change options handling for various plugins.
 - [#233](https://github.com/kobsio/kobs/pull/233): [resources] Highlight expanded row for containers in Pod details.
+- [#235](https://github.com/kobsio/kobs/pull/235): [resources] Use `TableComposable` instead of `Table` component and unify table style across plugins.
 
 ## [v0.7.0](https://github.com/kobsio/kobs/releases/tag/v0.7.0) (2021-11-19)
 
@@ -209,7 +210,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#52](https://github.com/kobsio/kobs/pull/52): Add option to enter a single trace id in the Jaeger plugin.
 - [#56](https://github.com/kobsio/kobs/pull/56): Add actions for Elasticsearch plugin to include/exclude and toggle values in the logs view.
 - [#58](https://github.com/kobsio/kobs/pull/58): Add plugin support for Teams. It is now possible to define plugins within a Team CR, which are then added to the teams page in the React UI.
-- [#59](https://github.com/kobsio/kobs/pull/59): Add support for Templates via the new Templates CRD. Templates allows a user to reuse plugin definitions accross Applications, Teams and Kubernetes resources.
+- [#59](https://github.com/kobsio/kobs/pull/59): Add support for Templates via the new Templates CRD. Templates allows a user to reuse plugin definitions across Applications, Teams and Kubernetes resources.
 - [#60](https://github.com/kobsio/kobs/pull/60): Add support for additional Pod annotations and labels in the Helm chart via the new `podAnnotations` and `podLabels` values.
 - [#63](https://github.com/kobsio/kobs/pull/63): Add Kiali plugin (in the current version the Kiali plugin only supports the graph feature from Kiali).
 - [#66](https://github.com/kobsio/kobs/pull/66): Add edge metrics for Kiali plugin.

--- a/plugins/core/src/utils/resources.tsx
+++ b/plugins/core/src/utils/resources.tsx
@@ -37,7 +37,7 @@ import {
   V2beta1HorizontalPodAutoscalerList,
 } from '@kubernetes/client-node';
 import { SearchIcon, SquareIcon } from '@patternfly/react-icons';
-import { IRow } from '@patternfly/react-table';
+import { Td, Tr } from '@patternfly/react-table';
 import { JSONPath } from 'jsonpath-plus';
 import React from 'react';
 
@@ -76,7 +76,7 @@ export interface IResource {
   isCRD: boolean;
   path: string;
   resource: string;
-  rows: (items: IResourceItems[]) => IRow[];
+  rows: (items: IResourceItems[]) => IResourceRow[];
   scope: TScope;
   title: string;
 }
@@ -100,6 +100,15 @@ export interface ICRDColumn {
   type: string;
 }
 
+export interface IResourceRow {
+  cells: React.ReactNode[];
+  cluster: string;
+  name: string;
+  namespace: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  props: any;
+}
+
 // resources is the list of Kubernetes standard resources. To generate the rows for a resource, we have to pass the
 // item from the API call to the rows function. The returned rows are mostly the same as they are also retunred by
 // kubectl.
@@ -111,8 +120,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/apis/batch/v1beta1',
     resource: 'cronjobs',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const cronJobsList: V1beta1CronJobList = item.resources;
@@ -132,7 +141,7 @@ export const resources: IResources = {
           rows.push({
             cells: [
               cronJob.metadata?.name,
-              item.namespace || cronJob.metadata?.namespace,
+              item.namespace || cronJob.metadata?.namespace || '',
               item.cluster,
               schedule,
               suspend,
@@ -140,6 +149,9 @@ export const resources: IResources = {
               lastSchedule,
               age,
             ],
+            cluster: item.cluster,
+            name: cronJob.metadata?.name || '',
+            namespace: item.namespace || cronJob.metadata?.namespace || '',
             props: cronJob,
           });
         }
@@ -168,8 +180,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/apis/apps/v1',
     resource: 'daemonsets',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const daemonSetList: V1DaemonSetList = item.resources;
@@ -204,7 +216,7 @@ export const resources: IResources = {
           rows.push({
             cells: [
               daemonSet.metadata?.name,
-              item.namespace || daemonSet.metadata?.namespace,
+              item.namespace || daemonSet.metadata?.namespace || '',
               item.cluster,
               desired,
               current,
@@ -217,6 +229,9 @@ export const resources: IResources = {
                 <SquareIcon color={status} />
               </span>,
             ],
+            cluster: item.cluster,
+            name: daemonSet.metadata?.name || '',
+            namespace: item.namespace || daemonSet.metadata?.namespace || '',
             props: daemonSet,
           });
         }
@@ -233,8 +248,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/apis/apps/v1',
     resource: 'deployments',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const deploymentList: V1DeploymentList = item.resources;
@@ -261,7 +276,7 @@ export const resources: IResources = {
           rows.push({
             cells: [
               deployment.metadata?.name,
-              item.namespace || deployment.metadata?.namespace,
+              item.namespace || deployment.metadata?.namespace || '',
               item.cluster,
               `${ready}/${shouldReady}`,
               upToDate,
@@ -271,6 +286,9 @@ export const resources: IResources = {
                 <SquareIcon color={status} />
               </span>,
             ],
+            cluster: item.cluster,
+            name: deployment.metadata?.name || '',
+            namespace: item.namespace || deployment.metadata?.namespace || '',
             props: deployment,
           });
         }
@@ -288,8 +306,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/apis/batch/v1',
     resource: 'jobs',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const jobList: V1JobList = item.resources;
@@ -316,7 +334,7 @@ export const resources: IResources = {
           rows.push({
             cells: [
               job.metadata?.name,
-              item.namespace || job.metadata?.namespace,
+              item.namespace || job.metadata?.namespace || '',
               item.cluster,
               `${completions}/${completionsShould}`,
               duration,
@@ -325,6 +343,9 @@ export const resources: IResources = {
                 <SquareIcon color={status} />
               </span>,
             ],
+            cluster: item.cluster,
+            name: job.metadata?.name || '',
+            namespace: item.namespace || job.metadata?.namespace || '',
             props: job,
           });
         }
@@ -341,8 +362,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/api/v1',
     resource: 'pods',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const podList: V1PodList = item.resources;
@@ -381,7 +402,7 @@ export const resources: IResources = {
           rows.push({
             cells: [
               pod.metadata?.name,
-              item.namespace || pod.metadata?.namespace,
+              item.namespace || pod.metadata?.namespace || '',
               item.cluster,
               `${isReady}/${shouldReady}`,
               reason ? reason : phase,
@@ -399,6 +420,9 @@ export const resources: IResources = {
                 />
               </span>,
             ],
+            cluster: item.cluster,
+            name: pod.metadata?.name || '',
+            namespace: item.namespace || pod.metadata?.namespace || '',
             props: pod,
           });
         }
@@ -415,8 +439,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/apis/apps/v1',
     resource: 'replicasets',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const replicaSetList: V1ReplicaSetList = item.resources;
@@ -440,7 +464,7 @@ export const resources: IResources = {
           rows.push({
             cells: [
               replicaSet.metadata?.name,
-              item.namespace || replicaSet.metadata?.namespace,
+              item.namespace || replicaSet.metadata?.namespace || '',
               item.cluster,
               desired,
               current,
@@ -450,6 +474,9 @@ export const resources: IResources = {
                 <SquareIcon color={status} />
               </span>,
             ],
+            cluster: item.cluster,
+            name: replicaSet.metadata?.name || '',
+            namespace: item.namespace || replicaSet.metadata?.namespace || '',
             props: replicaSet,
           });
         }
@@ -466,8 +493,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/apis/apps/v1',
     resource: 'statefulsets',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const statefulSetList: V1StatefulSetList = item.resources;
@@ -493,7 +520,7 @@ export const resources: IResources = {
           rows.push({
             cells: [
               statefulSet.metadata?.name,
-              item.namespace || statefulSet.metadata?.namespace,
+              item.namespace || statefulSet.metadata?.namespace || '',
               item.cluster,
               `${ready}/${shouldReady}`,
               upToDate,
@@ -502,6 +529,9 @@ export const resources: IResources = {
                 <SquareIcon color={status} />
               </span>,
             ],
+            cluster: item.cluster,
+            name: statefulSet.metadata?.name || '',
+            namespace: item.namespace || statefulSet.metadata?.namespace || '',
             props: statefulSet,
           });
         }
@@ -519,8 +549,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/api/v1',
     resource: 'endpoints',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const enpointList: V1EndpointsList = item.resources;
@@ -542,11 +572,14 @@ export const resources: IResources = {
           rows.push({
             cells: [
               endpoint.metadata?.name,
-              item.namespace || endpoint.metadata?.namespace,
+              item.namespace || endpoint.metadata?.namespace || '',
               item.cluster,
               ep.join(', '),
               age,
             ],
+            cluster: item.cluster,
+            name: endpoint.metadata?.name || '',
+            namespace: item.namespace || endpoint.metadata?.namespace || '',
             props: endpoint,
           });
         }
@@ -563,8 +596,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/apis/autoscaling/v2beta1',
     resource: 'horizontalpodautoscalers',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const hpaList: V2beta1HorizontalPodAutoscalerList = item.resources;
@@ -587,7 +620,7 @@ export const resources: IResources = {
           rows.push({
             cells: [
               hpa.metadata?.name,
-              item.namespace || hpa.metadata?.namespace,
+              item.namespace || hpa.metadata?.namespace || '',
               item.cluster,
               reference,
               minPods,
@@ -595,6 +628,9 @@ export const resources: IResources = {
               replicas,
               age,
             ],
+            cluster: item.cluster,
+            name: hpa.metadata?.name || '',
+            namespace: item.namespace || hpa.metadata?.namespace || '',
             props: hpa,
           });
         }
@@ -611,8 +647,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/apis/extensions/v1beta1',
     resource: 'ingresses',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const ingressList: V1IngressList = item.resources;
@@ -634,12 +670,15 @@ export const resources: IResources = {
           rows.push({
             cells: [
               ingress.metadata?.name,
-              item.namespace || ingress.metadata?.namespace,
+              item.namespace || ingress.metadata?.namespace || '',
               item.cluster,
               hosts ? hosts.join(', ') : '',
               address,
               age,
             ],
+            cluster: item.cluster,
+            name: ingress.metadata?.name || '',
+            namespace: item.namespace || ingress.metadata?.namespace || '',
             props: ingress,
           });
         }
@@ -656,8 +695,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/apis/networking.k8s.io/v1',
     resource: 'networkpolicies',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const networkPolicyList: V1NetworkPolicyList = item.resources;
@@ -674,11 +713,14 @@ export const resources: IResources = {
           rows.push({
             cells: [
               networkPolicy.metadata?.name,
-              item.namespace || networkPolicy.metadata?.namespace,
+              item.namespace || networkPolicy.metadata?.namespace || '',
               item.cluster,
               podSelector,
               age,
             ],
+            cluster: item.cluster,
+            name: networkPolicy.metadata?.name || '',
+            namespace: item.namespace || networkPolicy.metadata?.namespace || '',
             props: networkPolicy,
           });
         }
@@ -695,8 +737,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/api/v1',
     resource: 'services',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const serviceList: V1ServiceList = item.resources;
@@ -726,7 +768,7 @@ export const resources: IResources = {
           rows.push({
             cells: [
               service.metadata?.name,
-              item.namespace || service.metadata?.namespace,
+              item.namespace || service.metadata?.namespace || '',
               item.cluster,
               type,
               clusterIP,
@@ -734,6 +776,9 @@ export const resources: IResources = {
               ports,
               age,
             ],
+            cluster: item.cluster,
+            name: service.metadata?.name || '',
+            namespace: item.namespace || service.metadata?.namespace || '',
             props: service,
           });
         }
@@ -751,8 +796,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/api/v1',
     resource: 'configmaps',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const configMapList: V1ConfigMapList = item.resources;
@@ -768,11 +813,14 @@ export const resources: IResources = {
           rows.push({
             cells: [
               configMap.metadata?.name,
-              item.namespace || configMap.metadata?.namespace,
+              item.namespace || configMap.metadata?.namespace || '',
               item.cluster,
               configMap.data ? Object.keys(configMap.data).length : 0,
               age,
             ],
+            cluster: item.cluster,
+            name: configMap.metadata?.name || '',
+            namespace: item.namespace || configMap.metadata?.namespace || '',
             props: configMap,
           });
         }
@@ -789,8 +837,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/api/v1',
     resource: 'persistentvolumeclaims',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const pvcList: V1PersistentVolumeClaimList = item.resources;
@@ -809,7 +857,7 @@ export const resources: IResources = {
           rows.push({
             cells: [
               pvc.metadata?.name,
-              item.namespace || pvc.metadata?.namespace,
+              item.namespace || pvc.metadata?.namespace || '',
               item.cluster,
               status,
               volume,
@@ -818,6 +866,9 @@ export const resources: IResources = {
               storageClass,
               age,
             ],
+            cluster: item.cluster,
+            name: pvc.metadata?.name || '',
+            namespace: item.namespace || pvc.metadata?.namespace || '',
             props: pvc,
           });
         }
@@ -845,8 +896,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/api/v1',
     resource: 'persistentvolumes',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const persistentVolumeList: V1PersistentVolumeList = item.resources;
@@ -893,6 +944,9 @@ export const resources: IResources = {
               reason,
               age,
             ],
+            cluster: item.cluster,
+            name: persistentVolume.metadata?.name || '',
+            namespace: '',
             props: persistentVolume,
           });
         }
@@ -909,8 +963,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/apis/policy/v1beta1',
     resource: 'poddisruptionbudgets',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const pdbList: V1beta1PodDisruptionBudgetList = item.resources;
@@ -946,6 +1000,9 @@ export const resources: IResources = {
                 <SquareIcon color={status} />
               </span>,
             ],
+            cluster: item.cluster,
+            name: pdb.metadata?.name || '',
+            namespace: item.namespace || pdb.metadata?.namespace || '',
             props: pdb,
           });
         }
@@ -962,8 +1019,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/api/v1',
     resource: 'secrets',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const secretList: V1SecretList = item.resources;
@@ -976,7 +1033,17 @@ export const resources: IResources = {
               : '-';
 
           rows.push({
-            cells: [secret.metadata?.name, item.namespace || secret.metadata?.namespace, item.cluster, type, data, age],
+            cells: [
+              secret.metadata?.name,
+              item.namespace || secret.metadata?.namespace || '',
+              item.cluster,
+              type,
+              data,
+              age,
+            ],
+            cluster: item.cluster,
+            name: secret.metadata?.name || '',
+            namespace: item.namespace || secret.metadata?.namespace || '',
             props: secret,
           });
         }
@@ -993,8 +1060,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/api/v1',
     resource: 'serviceaccounts',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const serviceAccountList: V1ServiceAccountList = item.resources;
@@ -1011,11 +1078,14 @@ export const resources: IResources = {
           rows.push({
             cells: [
               serviceAccount.metadata?.name,
-              item.namespace || serviceAccount.metadata?.namespace,
+              item.namespace || serviceAccount.metadata?.namespace || '',
               item.cluster,
               secrets,
               age,
             ],
+            cluster: item.cluster,
+            name: serviceAccount.metadata?.name || '',
+            namespace: item.namespace || serviceAccount.metadata?.namespace || '',
             props: serviceAccount,
           });
         }
@@ -1040,8 +1110,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/apis/storage.k8s.io/v1',
     resource: 'storageclasses',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const storageClassList: V1StorageClassList = item.resources;
@@ -1068,6 +1138,9 @@ export const resources: IResources = {
               allowVolumeExpansion,
               age,
             ],
+            cluster: item.cluster,
+            name: storageClass.metadata?.name || '',
+            namespace: '',
             props: storageClass,
           });
         }
@@ -1085,8 +1158,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/apis/rbac.authorization.k8s.io/v1',
     resource: 'clusterrolebindings',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const clusterRoleBindingsList: V1ClusterRoleBindingList = item.resources;
@@ -1101,6 +1174,9 @@ export const resources: IResources = {
 
           rows.push({
             cells: [clusterRoleBindings.metadata?.name, item.cluster, age],
+            cluster: item.cluster,
+            name: clusterRoleBindings.metadata?.name || '',
+            namespace: '',
             props: clusterRoleBindings,
           });
         }
@@ -1117,8 +1193,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/apis/rbac.authorization.k8s.io/v1',
     resource: 'clusterroles',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const clusterRoleList: V1ClusterRoleList = item.resources;
@@ -1133,6 +1209,9 @@ export const resources: IResources = {
 
           rows.push({
             cells: [clusterRole.metadata?.name, item.cluster, age],
+            cluster: item.cluster,
+            name: clusterRole.metadata?.name || '',
+            namespace: '',
             props: clusterRole,
           });
         }
@@ -1149,8 +1228,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/apis/rbac.authorization.k8s.io/v1',
     resource: 'rolebindings',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const roleBindingList: V1RoleBindingList = item.resources;
@@ -1164,7 +1243,15 @@ export const resources: IResources = {
               : '-';
 
           rows.push({
-            cells: [roleBinding.metadata?.name, item.namespace || roleBinding.metadata?.namespace, item.cluster, age],
+            cells: [
+              roleBinding.metadata?.name,
+              item.namespace || roleBinding.metadata?.namespace || '',
+              item.cluster,
+              age,
+            ],
+            cluster: item.cluster,
+            name: roleBinding.metadata?.name || '',
+            namespace: item.namespace || roleBinding.metadata?.namespace || '',
             props: roleBinding,
           });
         }
@@ -1181,8 +1268,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/apis/rbac.authorization.k8s.io/v1',
     resource: 'roles',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const roleList: V1RoleList = item.resources;
@@ -1193,7 +1280,10 @@ export const resources: IResources = {
               : '-';
 
           rows.push({
-            cells: [role.metadata?.name, item.namespace || role.metadata?.namespace, item.cluster, age],
+            cells: [role.metadata?.name, item.namespace || role.metadata?.namespace || '', item.cluster, age],
+            cluster: item.cluster,
+            name: role.metadata?.name || '',
+            namespace: item.namespace || role.metadata?.namespace || '',
             props: role,
           });
         }
@@ -1211,8 +1301,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/api/v1',
     resource: 'events',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const eventList: CoreV1EventList = item.resources;
@@ -1220,7 +1310,7 @@ export const resources: IResources = {
           rows.push({
             cells: [
               event.metadata?.name,
-              item.namespace || event.metadata.namespace,
+              item.namespace || event.metadata.namespace || '',
               item.cluster,
               event.lastTimestamp
                 ? timeDifference(new Date().getTime(), new Date(event.lastTimestamp.toString()).getTime())
@@ -1230,6 +1320,9 @@ export const resources: IResources = {
               `${event.involvedObject.kind}/${event.involvedObject.name}`,
               event.message,
             ],
+            cluster: item.cluster,
+            name: event.metadata?.name || '',
+            namespace: item.namespace || event.metadata?.namespace || '',
             props: event,
           });
         }
@@ -1246,8 +1339,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/api/v1',
     resource: 'namespaces',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const namespaceList: V1NamespaceList = item.resources;
@@ -1263,6 +1356,9 @@ export const resources: IResources = {
 
           rows.push({
             cells: [namespace.metadata?.name, item.cluster, status, age],
+            cluster: item.cluster,
+            name: namespace.metadata?.name || '',
+            namespace: '',
             props: namespace,
           });
         }
@@ -1279,8 +1375,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/api/v1',
     resource: 'nodes',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const nodeList: V1NodeList = item.resources;
@@ -1305,6 +1401,9 @@ export const resources: IResources = {
 
           rows.push({
             cells: [node.metadata?.name, item.cluster, status.join(', '), version, age],
+            cluster: item.cluster,
+            name: node.metadata?.name || '',
+            namespace: '',
             props: node,
           });
         }
@@ -1333,8 +1432,8 @@ export const resources: IResources = {
     isCRD: false,
     path: '/apis/policy/v1beta1',
     resource: 'podsecuritypolicies',
-    rows: (items: IResourceItems[]): IRow[] => {
-      const rows: IRow[] = [];
+    rows: (items: IResourceItems[]): IResourceRow[] => {
+      const rows: IResourceRow[] = [];
 
       for (const item of items) {
         const pspList: V1beta1PodSecurityPolicyList = item.resources;
@@ -1369,6 +1468,9 @@ export const resources: IResources = {
               volumes,
               age,
             ],
+            cluster: item.cluster,
+            name: psp.metadata?.name || '',
+            namespace: '',
             props: psp,
           });
         }
@@ -1397,8 +1499,8 @@ export const customResourceDefinition = (crds: ICRD[]): IResources => {
       isCRD: true,
       path: crd.path,
       resource: crd.resource,
-      rows: (items: IResourceItems[]): IRow[] => {
-        const rows: IRow[] = [];
+      rows: (items: IResourceItems[]): IResourceRow[] => {
+        const rows: IResourceRow[] = [];
 
         for (const item of items) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1423,6 +1525,9 @@ export const customResourceDefinition = (crds: ICRD[]): IResources => {
 
             rows.push({
               cells: [...defaultCells, ...crdCells],
+              cluster: item.cluster,
+              name: cr.metadata?.name,
+              namespace: item.namespace || cr.metadata?.namespace || '',
               props: cr,
             });
           }
@@ -1440,36 +1545,35 @@ export const customResourceDefinition = (crds: ICRD[]): IResources => {
 
 // emptyState is used to display an empty state in the table for a resource, when the API call returned an error or no
 // items.
-export const emptyState = (cols: number, isLoading: boolean, isError: boolean, error: Error | null): IRow[] => {
-  return [
-    {
-      cells: [
-        {
-          props: { colSpan: cols },
-          title: (
-            <Bullseye>
-              <EmptyState variant={EmptyStateVariant.small}>
-                {isLoading ? (
-                  <EmptyStateIcon variant="container" component={Spinner} />
-                ) : (
-                  <React.Fragment>
-                    <EmptyStateIcon icon={SearchIcon} />
-                    <Title headingLevel="h2" size="lg">
-                      {isError ? 'An error occured' : 'No items found'}
-                    </Title>
-                    <EmptyStateBody>
-                      {isError
-                        ? error?.message
-                        : 'No items match the filter criteria. Select another cluster or namespace.'}
-                    </EmptyStateBody>
-                  </React.Fragment>
-                )}
-              </EmptyState>
-            </Bullseye>
-          ),
-        },
-      ],
-      heightAuto: true,
-    },
-  ];
+export const emptyState = (
+  cols: number,
+  isLoading: boolean,
+  isError: boolean,
+  error: Error | null,
+): React.ReactElement => {
+  return (
+    <Tr>
+      <Td colSpan={cols}>
+        <Bullseye>
+          <EmptyState variant={EmptyStateVariant.small}>
+            {isLoading ? (
+              <EmptyStateIcon variant="container" component={Spinner} />
+            ) : (
+              <React.Fragment>
+                <EmptyStateIcon icon={SearchIcon} />
+                <Title headingLevel="h2" size="lg">
+                  {isError ? 'An error occured' : 'No items found'}
+                </Title>
+                <EmptyStateBody>
+                  {isError
+                    ? error?.message
+                    : 'No items match the filter criteria. Select another cluster or namespace.'}
+                </EmptyStateBody>
+              </React.Fragment>
+            )}
+          </EmptyState>
+        </Bullseye>
+      </Td>
+    </Tr>
+  );
 };

--- a/plugins/flux/src/components/panel/details/Conditions.tsx
+++ b/plugins/flux/src/components/panel/details/Conditions.tsx
@@ -12,7 +12,7 @@ const Conditions: React.FunctionComponent<IConditionsProps> = ({ conditions }: I
     <Card className="pf-u-mb-lg" isCompact={true}>
       <CardTitle>Conditions</CardTitle>
       <CardBody>
-        <TableComposable aria-label="Conditions" variant={TableVariant.compact} borders={true}>
+        <TableComposable aria-label="Conditions" variant={TableVariant.compact} borders={false}>
           <Thead>
             <Tr>
               <Th>Type</Th>

--- a/plugins/flux/src/components/panel/details/Details.tsx
+++ b/plugins/flux/src/components/panel/details/Details.tsx
@@ -40,10 +40,8 @@ const Details: React.FunctionComponent<IDetailsProps> = ({
     <DrawerPanelContent minSize="50%">
       <DrawerHead>
         <Title
-          title={resource.name.title}
-          subtitle={
-            resource.namespace ? `${resource.namespace.title} (${resource.cluster.title})` : resource.cluster.title
-          }
+          title={resource.name}
+          subtitle={resource.namespace ? `${resource.namespace} (${resource.cluster})` : resource.cluster}
           size="lg"
         />
         <DrawerActions style={{ padding: 0 }}>
@@ -64,9 +62,9 @@ const Details: React.FunctionComponent<IDetailsProps> = ({
         {type === 'kustomizations.kustomize.toolkit.fluxcd.io/v1beta1' ? (
           <KustomizationInfo
             name={name}
-            cluster={resource.cluster.title}
+            cluster={resource.cluster}
             source={resource.props?.spec?.sourceRef?.name}
-            namespace={resource.namespace.title}
+            namespace={resource.namespace}
             path={resource.props?.spec?.path}
             interval={resource.props?.spec?.interval}
             prune={resource.props?.spec?.prune}
@@ -86,11 +84,7 @@ const Details: React.FunctionComponent<IDetailsProps> = ({
         resource.props.spec.chart &&
         resource.props.spec.chart.spec &&
         resource.props.spec.chart.spec.sourceRef ? (
-          <HelmSource
-            name={name}
-            cluster={resource.cluster.title}
-            source={resource.props?.spec?.chart?.spec?.sourceRef}
-          />
+          <HelmSource name={name} cluster={resource.cluster} source={resource.props?.spec?.chart?.spec?.sourceRef} />
         ) : null}
         {type === 'gitrepositories.source.toolkit.fluxcd.io/v1beta1' ? (
           <GitReference

--- a/plugins/istio/src/components/page/Application.tsx
+++ b/plugins/istio/src/components/page/Application.tsx
@@ -33,7 +33,7 @@ const Application: React.FunctionComponent<IApplicationProps> = ({ name, pluginO
   const changeOptions = (tmpOptions: IApplicationOptions): void => {
     history.push({
       pathname: location.pathname,
-      search: `?time=${tmpOptions.times}&timeEnd=${tmpOptions.times.timeEnd}&timeStart=${
+      search: `?time=${tmpOptions.times.time}&timeEnd=${tmpOptions.times.timeEnd}&timeStart=${
         tmpOptions.times.timeStart
       }&view=${tmpOptions.view}&filterUpstreamCluster=${encodeURIComponent(
         tmpOptions.filters.upstreamCluster,

--- a/plugins/istio/src/components/panel/Top.tsx
+++ b/plugins/istio/src/components/panel/Top.tsx
@@ -65,6 +65,7 @@ const Top: React.FunctionComponent<ITopProps> = ({
   filters,
   setDetails,
 }: ITopProps) => {
+  const [selectedRow, setSelectedRow] = useState<number>(-1);
   const [sort, setSort] = useState<ISort>({ direction: SortByDirection.desc, index: 0 });
 
   const { isError, isLoading, error, data, refetch } = useQuery<string[][], Error>(
@@ -108,7 +109,7 @@ const Top: React.FunctionComponent<ITopProps> = ({
     },
   );
 
-  const onTdClick = (row: string[]): void => {
+  const onTdClick = (rowIndex: number, row: string[]): void => {
     if (setDetails) {
       setDetails(
         <DetailsTop
@@ -117,9 +118,13 @@ const Top: React.FunctionComponent<ITopProps> = ({
           application={application}
           row={row}
           times={times}
-          close={(): void => setDetails(undefined)}
+          close={(): void => {
+            setDetails(undefined);
+            setSelectedRow(-1);
+          }}
         />,
       );
+      setSelectedRow(rowIndex);
     }
   };
 
@@ -155,7 +160,7 @@ const Top: React.FunctionComponent<ITopProps> = ({
   }
 
   return (
-    <TableComposable aria-label="Tap" variant={TableVariant.compact} borders={false}>
+    <TableComposable aria-label="Tap" variant={TableVariant.compact} borders={true}>
       <Thead>
         <Tr>
           <Th>Direction</Th>
@@ -186,35 +191,39 @@ const Top: React.FunctionComponent<ITopProps> = ({
       </Thead>
       <Tbody>
         {data.map((row, index) => (
-          <Tr key={index} isHoverable={setDetails ? true : false}>
-            <Td dataLabel="Direction" onClick={(): void => onTdClick(row)}>
+          <Tr key={index} isHoverable={setDetails ? true : false} isRowSelected={selectedRow === index}>
+            <Td dataLabel="Direction" onClick={(): void => onTdClick(index, row)}>
               {getDirection(row[0]) || '-'}
             </Td>
-            <Td dataLabel="Upstream Cluster" onClick={(): void => onTdClick(row)}>
+            <Td dataLabel="Upstream Cluster" onClick={(): void => onTdClick(index, row)}>
               {row[0] || '-'}
             </Td>
-            <Td dataLabel="Method" onClick={(): void => onTdClick(row)}>
+            <Td dataLabel="Method" onClick={(): void => onTdClick(index, row)}>
               {row[1] || '-'}
             </Td>
-            <Td className="pf-u-text-wrap pf-u-text-break-word" dataLabel="Path" onClick={(): void => onTdClick(row)}>
+            <Td
+              className="pf-u-text-wrap pf-u-text-break-word"
+              dataLabel="Path"
+              onClick={(): void => onTdClick(index, row)}
+            >
               {row[2] || '-'}
             </Td>
-            <Td className="pf-u-text-nowrap" dataLabel="Count" onClick={(): void => onTdClick(row)}>
+            <Td className="pf-u-text-nowrap" dataLabel="Count" onClick={(): void => onTdClick(index, row)}>
               {formatNumber(row[3])}
             </Td>
-            <Td className="pf-u-text-nowrap" dataLabel="Best" onClick={(): void => onTdClick(row)}>
+            <Td className="pf-u-text-nowrap" dataLabel="Best" onClick={(): void => onTdClick(index, row)}>
               {formatNumber(row[4], 'ms', 0)}
             </Td>
-            <Td className="pf-u-text-nowrap" dataLabel="Worst" onClick={(): void => onTdClick(row)}>
+            <Td className="pf-u-text-nowrap" dataLabel="Worst" onClick={(): void => onTdClick(index, row)}>
               {formatNumber(row[5], 'ms', 0)}
             </Td>
-            <Td className="pf-u-text-nowrap" dataLabel="Avg" onClick={(): void => onTdClick(row)}>
+            <Td className="pf-u-text-nowrap" dataLabel="Avg" onClick={(): void => onTdClick(index, row)}>
               {formatNumber(row[6], 'ms', 0)}
             </Td>
-            <Td className="pf-u-text-nowrap" dataLabel="Last" onClick={(): void => onTdClick(row)}>
+            <Td className="pf-u-text-nowrap" dataLabel="Last" onClick={(): void => onTdClick(index, row)}>
               {formatNumber(row[7], 'ms', 0)}
             </Td>
-            <Td className="pf-u-text-nowrap" dataLabel="SR" onClick={(): void => onTdClick(row)}>
+            <Td className="pf-u-text-nowrap" dataLabel="SR" onClick={(): void => onTdClick(index, row)}>
               {formatNumber(row[8], '%', 2)}
             </Td>
             <Td noPadding={true} style={{ padding: 0 }}>

--- a/plugins/resources/src/components/panel/PanelListItem.tsx
+++ b/plugins/resources/src/components/panel/PanelListItem.tsx
@@ -1,8 +1,8 @@
-import { IRow, Table, TableBody, TableHeader } from '@patternfly/react-table';
-import React, { memo } from 'react';
+import React, { memo, useState } from 'react';
+import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { useQuery } from 'react-query';
 
-import { IPluginTimes, IResource, emptyState } from '@kobsio/plugin-core';
+import { IPluginTimes, IResource, IResourceRow, emptyState } from '@kobsio/plugin-core';
 import Details from './details/Details';
 
 interface IPanelListItemProps {
@@ -22,7 +22,9 @@ const PanelListItem: React.FunctionComponent<IPanelListItemProps> = ({
   times,
   showDetails,
 }: IPanelListItemProps) => {
-  const { isError, isLoading, error, data, refetch } = useQuery<IRow[], Error>(
+  const [selectedRow, setSelectedRow] = useState<number>(-1);
+
+  const { isError, isLoading, error, data, refetch } = useQuery<IResourceRow[], Error>(
     [
       'resources/panellistitem',
       clusters,
@@ -70,35 +72,53 @@ const PanelListItem: React.FunctionComponent<IPanelListItemProps> = ({
     }, 3000);
   };
 
+  const handleRowClick = (rowIndex: number, row: IResourceRow): void => {
+    if (showDetails && resource) {
+      showDetails(
+        <Details
+          request={resource}
+          resource={row}
+          close={(): void => {
+            showDetails(undefined);
+            setSelectedRow(-1);
+          }}
+          refetch={refetchhWithDelay}
+        />,
+      );
+      setSelectedRow(rowIndex);
+    }
+  };
+
   return (
-    <Table
-      aria-label={resource.title}
-      variant="compact"
-      borders={false}
-      cells={resource.columns}
-      rows={
-        data && data.length > 0 && data[0].cells?.length === resource.columns.length
-          ? data
-          : emptyState(resource.columns.length, isLoading, isError, error)
-      }
-    >
-      <TableHeader />
-      <TableBody
-        onRowClick={
-          showDetails && data && data.length > 0 && data[0].cells?.length === resource.columns.length
-            ? (e, row, props, data): void =>
-                showDetails(
-                  <Details
-                    request={resource}
-                    resource={row}
-                    close={(): void => showDetails(undefined)}
-                    refetch={refetchhWithDelay}
-                  />,
-                )
-            : undefined
-        }
-      />
-    </Table>
+    <TableComposable aria-label={resource.title} variant={TableVariant.compact} borders={true}>
+      <Thead>
+        <Tr>
+          {resource.columns.map((column) => (
+            <Th key={column}>{column}</Th>
+          ))}
+        </Tr>
+      </Thead>
+      <Tbody>
+        {data && data.length > 0 && data[0].cells?.length === resource.columns.length
+          ? data.map((row, rowIndex) => (
+              <Tr
+                key={rowIndex}
+                isHoverable={showDetails ? true : false}
+                isRowSelected={selectedRow === rowIndex}
+                onClick={(): void =>
+                  showDetails && data && data.length > 0 && data[0].cells?.length === resource.columns.length
+                    ? handleRowClick(rowIndex, row)
+                    : undefined
+                }
+              >
+                {row.cells.map((cell, cellIndex) => (
+                  <Td key={cellIndex}>{cell}</Td>
+                ))}
+              </Tr>
+            ))
+          : emptyState(resource.columns.length, isLoading, isError, error)}
+      </Tbody>
+    </TableComposable>
   );
 };
 

--- a/plugins/resources/src/components/panel/details/Actions.tsx
+++ b/plugins/resources/src/components/panel/details/Actions.tsx
@@ -1,6 +1,5 @@
 import { Alert, AlertActionCloseButton, AlertGroup, Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
 import React, { useState } from 'react';
-import { IRow } from '@patternfly/react-table';
 
 import CreateEphemeralContainer from './actions/CreateEphemeralContainer';
 import CreateJob from './actions/CreateJob';
@@ -9,6 +8,7 @@ import DownloadFile from './actions/DownloadFile';
 import Edit from './actions/Edit';
 import { IAlert } from '../../../utils/interfaces';
 import { IResource } from '@kobsio/plugin-core';
+import { IResourceRow } from '@kobsio/plugin-core';
 import Logs from './actions/Logs';
 import Restart from './actions/Restart';
 import Scale from './actions/Scale';
@@ -17,7 +17,7 @@ import UploadFile from './actions/UploadFile';
 
 interface IActionProps {
   request: IResource;
-  resource: IRow;
+  resource: IResourceRow;
   refetch: () => void;
 }
 

--- a/plugins/resources/src/components/panel/details/Dashboards.tsx
+++ b/plugins/resources/src/components/panel/details/Dashboards.tsx
@@ -1,15 +1,14 @@
 import { Alert, AlertVariant } from '@patternfly/react-core';
-import { IRow } from '@patternfly/react-table';
 import { JSONPath } from 'jsonpath-plus';
 import React from 'react';
 
+import { IReference, IResourceRow } from '@kobsio/plugin-core';
 import { DashboardsWrapper } from '@kobsio/plugin-dashboards';
-import { IReference } from '@kobsio/plugin-core';
 
 // getDashboards parses the kobs.io/dashboards annotation of a Kubernetes resources and returns all provided dashboards.
 // Before we are returning the dashboards we are checking all the provided placeholder and if one of the placeholders
 // uses an JSONPath we are replacing it with the correct value.
-const getDashboards = (resource: IRow): IReference[] | undefined => {
+const getDashboards = (resource: IResourceRow): IReference[] | undefined => {
   try {
     if (
       resource.props &&
@@ -50,7 +49,7 @@ const getDashboards = (resource: IRow): IReference[] | undefined => {
 };
 
 interface IDashboardsProps {
-  resource: IRow;
+  resource: IResourceRow;
 }
 
 const Dashboards: React.FunctionComponent<IDashboardsProps> = ({ resource }: IDashboardsProps) => {
@@ -69,9 +68,9 @@ const Dashboards: React.FunctionComponent<IDashboardsProps> = ({ resource }: IDa
   return (
     <DashboardsWrapper
       defaults={{
-        cluster: resource.cluster.title,
-        name: resource.name.title,
-        namespace: resource.namespace.title,
+        cluster: resource.cluster,
+        name: resource.name,
+        namespace: resource.namespace,
       }}
       references={dashboards}
     />

--- a/plugins/resources/src/components/panel/details/Details.tsx
+++ b/plugins/resources/src/components/panel/details/Details.tsx
@@ -10,10 +10,9 @@ import {
   Tabs,
 } from '@patternfly/react-core';
 import React, { useState } from 'react';
-import { IRow } from '@patternfly/react-table';
 import yaml from 'js-yaml';
 
-import { Editor, IResource, Title } from '@kobsio/plugin-core';
+import { Editor, IResource, IResourceRow, Title } from '@kobsio/plugin-core';
 import Actions from './Actions';
 import Dashboards from './Dashboards';
 import Events from './Events';
@@ -23,7 +22,7 @@ import Pods from './Pods';
 
 // getSelector is used to get the label selector for various resources as string. The returned string can be used in
 // a Kubernetes API request to get the all pods, which are matching the label selector.
-const getSelector = (request: IResource, resource: IRow): string => {
+const getSelector = (request: IResource, resource: IResourceRow): string => {
   if (
     request.resource === 'deployments' ||
     request.resource === 'daemonsets' ||
@@ -42,7 +41,7 @@ const getSelector = (request: IResource, resource: IRow): string => {
 
 interface IDetailsProps {
   request: IResource;
-  resource: IRow;
+  resource: IResourceRow;
   close: () => void;
   refetch: () => void;
 }
@@ -56,10 +55,8 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ request, resource, cl
     <DrawerPanelContent minSize="50%">
       <DrawerHead>
         <Title
-          title={resource.name.title}
-          subtitle={
-            resource.namespace ? `${resource.namespace.title} (${resource.cluster.title})` : resource.cluster.title
-          }
+          title={resource.name}
+          subtitle={resource.namespace ? `${resource.namespace} (${resource.cluster})` : resource.cluster}
           size="lg"
         />
         <DrawerActions style={{ padding: 0 }}>
@@ -95,9 +92,9 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ request, resource, cl
           <Tab eventKey="events" title={<TabTitleText>Events</TabTitleText>}>
             <div style={{ maxWidth: '100%', overflowX: 'scroll', padding: '24px 24px' }}>
               <Events
-                cluster={resource.cluster.title}
-                namespace={resource.namespace ? resource.namespace.title : ''}
-                name={resource.name.title}
+                cluster={resource.cluster}
+                namespace={resource.namespace ? resource.namespace : ''}
+                name={resource.name}
               />
             </div>
           </Tab>
@@ -106,8 +103,8 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ request, resource, cl
             <Tab eventKey="pods" title={<TabTitleText>Pods</TabTitleText>}>
               <div style={{ maxWidth: '100%', overflowX: 'scroll', padding: '24px 24px' }}>
                 <Pods
-                  cluster={resource.cluster.title}
-                  namespace={resource.namespace ? resource.namespace.title : ''}
+                  cluster={resource.cluster}
+                  namespace={resource.namespace ? resource.namespace : ''}
                   paramName={podSelector ? 'labelSelector' : 'fieldSelector'}
                   param={podSelector ? podSelector : `spec.nodeName=${resource.props.metadata.name}`}
                 />

--- a/plugins/resources/src/components/panel/details/Events.tsx
+++ b/plugins/resources/src/components/panel/details/Events.tsx
@@ -1,9 +1,9 @@
 import { Card, Flex, FlexItem } from '@patternfly/react-core';
-import { IRow, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import React, { useContext } from 'react';
+import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { useQuery } from 'react-query';
 
-import { ClustersContext, IClusterContext, emptyState } from '@kobsio/plugin-core';
+import { ClustersContext, IClusterContext, IResourceRow, emptyState } from '@kobsio/plugin-core';
 
 interface IEventsProps {
   cluster: string;
@@ -16,7 +16,7 @@ interface IEventsProps {
 const Events: React.FunctionComponent<IEventsProps> = ({ cluster, namespace, name }: IEventsProps) => {
   const clustersContext = useContext<IClusterContext>(ClustersContext);
 
-  const { isError, isLoading, error, data } = useQuery<IRow[], Error>(
+  const { isError, isLoading, error, data } = useQuery<IResourceRow[], Error>(
     ['resources/events', cluster, namespace, name],
     async () => {
       try {
@@ -47,21 +47,26 @@ const Events: React.FunctionComponent<IEventsProps> = ({ cluster, namespace, nam
     <Card>
       <Flex direction={{ default: 'column' }}>
         <FlexItem>
-          <Table
-            aria-label="events"
-            variant="compact"
-            borders={false}
-            isStickyHeader={false}
-            cells={clustersContext.resources?.events.columns}
-            rows={
-              data && data.length > 0
-                ? data
-                : emptyState(clustersContext.resources?.pods.columns.length || 3, isLoading, isError, error)
-            }
-          >
-            <TableHeader />
-            <TableBody />
-          </Table>
+          <TableComposable aria-label="events" variant={TableVariant.compact} borders={false}>
+            <Thead>
+              <Tr>
+                {clustersContext.resources?.events.columns.map((column) => (
+                  <Th key={column}>{column}</Th>
+                ))}
+              </Tr>
+            </Thead>
+            <Tbody>
+              {data && data.length > 0
+                ? data.map((row, rowIndex) => (
+                    <Tr key={rowIndex}>
+                      {row.cells.map((cell, cellIndex) => (
+                        <Td key={cellIndex}>{cell}</Td>
+                      ))}
+                    </Tr>
+                  ))
+                : emptyState(clustersContext.resources?.events.columns.length || 3, isLoading, isError, error)}
+            </Tbody>
+          </TableComposable>
         </FlexItem>
       </Flex>
     </Card>

--- a/plugins/resources/src/components/panel/details/Links.tsx
+++ b/plugins/resources/src/components/panel/details/Links.tsx
@@ -7,14 +7,13 @@ import {
   DescriptionListTerm,
 } from '@patternfly/react-core';
 import { TopologyIcon, UsersIcon } from '@patternfly/react-icons';
-import { IRow } from '@patternfly/react-table';
 import { Link } from 'react-router-dom';
 import React from 'react';
 
-import { IPluginDefaults } from '@kobsio/plugin-core';
+import { IPluginDefaults, IResourceRow } from '@kobsio/plugin-core';
 
 // getTeams parses the kobs.io/teams annotation of a Kubernetes resources and returns all provided teams.
-const getTeams = (resource: IRow): IPluginDefaults[] | undefined => {
+const getTeams = (resource: IResourceRow): IPluginDefaults[] | undefined => {
   try {
     if (
       resource.props &&
@@ -30,7 +29,7 @@ const getTeams = (resource: IRow): IPluginDefaults[] | undefined => {
 };
 
 // getApplications parses the kobs.io/teams annotation of a Kubernetes resources and returns all provided teams.
-const getApplications = (resource: IRow): IPluginDefaults[] | undefined => {
+const getApplications = (resource: IResourceRow): IPluginDefaults[] | undefined => {
   try {
     if (
       resource.props &&
@@ -46,7 +45,7 @@ const getApplications = (resource: IRow): IPluginDefaults[] | undefined => {
 };
 
 interface ILinksProps {
-  resource: IRow;
+  resource: IResourceRow;
 }
 
 const Links: React.FunctionComponent<ILinksProps> = ({ resource }: ILinksProps) => {
@@ -64,8 +63,8 @@ const Links: React.FunctionComponent<ILinksProps> = ({ resource }: ILinksProps) 
                 {applications.map((application, index) => (
                   <Link
                     key={index}
-                    to={`/applications/${application.cluster || resource.cluster.title}/${
-                      application.namespace || resource.namespace.title
+                    to={`/applications/${application.cluster || resource.cluster}/${
+                      application.namespace || resource.namespace
                     }/${application.name}`}
                   >
                     <Button variant={ButtonVariant.link} isInline={true} icon={<TopologyIcon />}>
@@ -84,9 +83,9 @@ const Links: React.FunctionComponent<ILinksProps> = ({ resource }: ILinksProps) 
                 {teams.map((team, index) => (
                   <Link
                     key={index}
-                    to={`/teams/${team.cluster || resource.cluster.title}/${
-                      team.namespace || resource.namespace.title
-                    }/${team.name}`}
+                    to={`/teams/${team.cluster || resource.cluster}/${team.namespace || resource.namespace}/${
+                      team.name
+                    }`}
                   >
                     <Button variant={ButtonVariant.link} isInline={true} icon={<UsersIcon />}>
                       {team.name}

--- a/plugins/resources/src/components/panel/details/Overview.tsx
+++ b/plugins/resources/src/components/panel/details/Overview.tsx
@@ -6,15 +6,14 @@ import {
   DescriptionListGroup,
   DescriptionListTerm,
 } from '@patternfly/react-core';
-import { IRow } from '@patternfly/react-table';
 import React from 'react';
 import { V1OwnerReference } from '@kubernetes/client-node';
 
+import { IResource, IResourceRow } from '@kobsio/plugin-core';
 import Conditions from './overview/Conditions';
 import CronJob from './overview/CronJob';
 import DaemonSet from './overview/DaemonSet';
 import Deployment from './overview/Deployment';
-import { IResource } from '@kobsio/plugin-core';
 import Job from './overview/Job';
 import Node from './overview/Node';
 import Pod from './overview/Pod';
@@ -23,7 +22,7 @@ import { timeDifference } from '@kobsio/plugin-core';
 
 interface IOverviewProps {
   request: IResource;
-  resource: IRow;
+  resource: IResourceRow;
 }
 
 // Overview is the overview tab for a resource. It shows the metadata of a resource in a clear way. We can also
@@ -39,41 +38,21 @@ const Overview: React.FunctionComponent<IOverviewProps> = ({ request, resource }
   // Overwrite the additions for several resources.
   if (request.resource === 'pods') {
     additions = (
-      <Pod
-        cluster={resource.cluster?.title}
-        namespace={resource.namespace?.title}
-        name={resource.name?.title}
-        pod={resource.props}
-      />
+      <Pod cluster={resource.cluster} namespace={resource.namespace} name={resource.name} pod={resource.props} />
     );
   } else if (request.resource === 'deployments') {
-    additions = (
-      <Deployment cluster={resource.cluster?.title} namespace={resource.namespace?.title} deployment={resource.props} />
-    );
+    additions = <Deployment cluster={resource.cluster} namespace={resource.namespace} deployment={resource.props} />;
   } else if (request.resource === 'daemonsets') {
-    additions = (
-      <DaemonSet cluster={resource.cluster?.title} namespace={resource.namespace?.title} daemonSet={resource.props} />
-    );
+    additions = <DaemonSet cluster={resource.cluster} namespace={resource.namespace} daemonSet={resource.props} />;
   } else if (request.resource === 'statefulsets') {
-    additions = (
-      <StatefulSet
-        cluster={resource.cluster?.title}
-        namespace={resource.namespace?.title}
-        statefulSet={resource.props}
-      />
-    );
+    additions = <StatefulSet cluster={resource.cluster} namespace={resource.namespace} statefulSet={resource.props} />;
   } else if (request.resource === 'cronjobs') {
     additions = <CronJob cronJob={resource.props} />;
   } else if (request.resource === 'jobs') {
-    additions = <Job cluster={resource.cluster?.title} namespace={resource.namespace?.title} job={resource.props} />;
+    additions = <Job cluster={resource.cluster} namespace={resource.namespace} job={resource.props} />;
   } else if (request.resource === 'nodes') {
     additions = (
-      <Node
-        cluster={resource.cluster?.title}
-        namespace={resource.namespace?.title}
-        name={resource.name?.title}
-        node={resource.props}
-      />
+      <Node cluster={resource.cluster} namespace={resource.namespace} name={resource.name} node={resource.props} />
     );
   }
 
@@ -81,22 +60,22 @@ const Overview: React.FunctionComponent<IOverviewProps> = ({ request, resource }
     <Card isCompact={true}>
       <CardBody>
         <DescriptionList className="pf-u-text-break-word" isHorizontal={true}>
-          {resource.name?.title && (
+          {resource.name && (
             <DescriptionListGroup>
               <DescriptionListTerm>Name</DescriptionListTerm>
-              <DescriptionListDescription>{resource.name?.title}</DescriptionListDescription>
+              <DescriptionListDescription>{resource.name}</DescriptionListDescription>
             </DescriptionListGroup>
           )}
-          {resource.namespace?.title && (
+          {resource.namespace && (
             <DescriptionListGroup>
               <DescriptionListTerm>Namespace</DescriptionListTerm>
-              <DescriptionListDescription>{resource.namespace?.title}</DescriptionListDescription>
+              <DescriptionListDescription>{resource.namespace}</DescriptionListDescription>
             </DescriptionListGroup>
           )}
-          {resource.cluster?.title && (
+          {resource.cluster && (
             <DescriptionListGroup>
               <DescriptionListTerm>Cluster</DescriptionListTerm>
-              <DescriptionListDescription>{resource.cluster?.title}</DescriptionListDescription>
+              <DescriptionListDescription>{resource.cluster}</DescriptionListDescription>
             </DescriptionListGroup>
           )}
           {resource.props?.metadata?.labels && (

--- a/plugins/resources/src/components/panel/details/Pods.tsx
+++ b/plugins/resources/src/components/panel/details/Pods.tsx
@@ -1,9 +1,9 @@
 import { Card, Flex, FlexItem } from '@patternfly/react-core';
-import { IRow, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import React, { useContext } from 'react';
+import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { useQuery } from 'react-query';
 
-import { ClustersContext, IClusterContext, emptyState } from '@kobsio/plugin-core';
+import { ClustersContext, IClusterContext, IResourceRow, emptyState } from '@kobsio/plugin-core';
 
 interface IPodsProps {
   cluster: string;
@@ -17,7 +17,7 @@ interface IPodsProps {
 const Pods: React.FunctionComponent<IPodsProps> = ({ cluster, namespace, paramName, param }: IPodsProps) => {
   const clustersContext = useContext<IClusterContext>(ClustersContext);
 
-  const { isError, isLoading, error, data } = useQuery<IRow[], Error>(
+  const { isError, isLoading, error, data } = useQuery<IResourceRow[], Error>(
     ['resources/pods', cluster, namespace, paramName, param],
     async () => {
       try {
@@ -48,21 +48,26 @@ const Pods: React.FunctionComponent<IPodsProps> = ({ cluster, namespace, paramNa
     <Card>
       <Flex direction={{ default: 'column' }}>
         <FlexItem>
-          <Table
-            aria-label="pods"
-            variant="compact"
-            borders={false}
-            isStickyHeader={false}
-            cells={clustersContext.resources?.pods.columns}
-            rows={
-              data && data.length > 0
-                ? data
-                : emptyState(clustersContext.resources?.pods.columns.length || 3, isLoading, isError, error)
-            }
-          >
-            <TableHeader />
-            <TableBody />
-          </Table>
+          <TableComposable aria-label="pods" variant={TableVariant.compact} borders={false}>
+            <Thead>
+              <Tr>
+                {clustersContext.resources?.pods.columns.map((column) => (
+                  <Th key={column}>{column}</Th>
+                ))}
+              </Tr>
+            </Thead>
+            <Tbody>
+              {data && data.length > 0
+                ? data.map((row, rowIndex) => (
+                    <Tr key={rowIndex}>
+                      {row.cells.map((cell, cellIndex) => (
+                        <Td key={cellIndex}>{cell}</Td>
+                      ))}
+                    </Tr>
+                  ))
+                : emptyState(clustersContext.resources?.pods.columns.length || 3, isLoading, isError, error)}
+            </Tbody>
+          </TableComposable>
         </FlexItem>
       </Flex>
     </Card>

--- a/plugins/resources/src/components/panel/details/actions/CreateEphemeralContainer.tsx
+++ b/plugins/resources/src/components/panel/details/actions/CreateEphemeralContainer.tsx
@@ -10,16 +10,15 @@ import {
   ModalVariant,
 } from '@patternfly/react-core';
 import React, { useContext, useState } from 'react';
-import { IRow } from '@patternfly/react-table';
 import { V1EphemeralContainer } from '@kubernetes/client-node';
 import yaml from 'js-yaml';
 
-import { Editor, IPluginsContext, IResource, PluginsContext } from '@kobsio/plugin-core';
+import { Editor, IPluginsContext, IResource, IResourceRow, PluginsContext } from '@kobsio/plugin-core';
 import { IAlert } from '../../../../utils/interfaces';
 
 interface ICreateEphemeralContainerProps {
   request: IResource;
-  resource: IRow;
+  resource: IResourceRow;
   show: boolean;
   setShow: (value: boolean) => void;
   setAlert: (alert: IAlert) => void;
@@ -52,15 +51,15 @@ const CreateEphemeralContainer: React.FunctionComponent<ICreateEphemeralContaine
         ephemeralContainers: [parsedEphemeralContainer],
         kind: 'EphemeralContainers',
         metadata: {
-          name: resource.name.title,
-          namespace: resource.namespace.title,
+          name: resource.name,
+          namespace: resource.namespace,
         },
       };
 
       const response = await fetch(
-        `/api/plugins/resources/resources?cluster=${resource.cluster.title}${
-          resource.namespace ? `&namespace=${resource.namespace.title}` : ''
-        }&name=${resource.name.title}&resource=pods&path=/api/v1&subResource=ephemeralcontainers`,
+        `/api/plugins/resources/resources?cluster=${resource.cluster}${
+          resource.namespace ? `&namespace=${resource.namespace}` : ''
+        }&name=${resource.name}&resource=pods&path=/api/v1&subResource=ephemeralcontainers`,
         {
           body: JSON.stringify(manifest),
           method: 'post',

--- a/plugins/resources/src/components/panel/details/actions/CreateJob.tsx
+++ b/plugins/resources/src/components/panel/details/actions/CreateJob.tsx
@@ -1,10 +1,9 @@
 import { AlertVariant, Button, ButtonVariant, Modal, ModalVariant } from '@patternfly/react-core';
-import { IRow } from '@patternfly/react-table';
 import React from 'react';
 import { V1Job } from '@kubernetes/client-node';
 
+import { IResource, IResourceRow } from '@kobsio/plugin-core';
 import { IAlert } from '../../../../utils/interfaces';
-import { IResource } from '@kobsio/plugin-core';
 
 export const randomString = (length: number): string => {
   let result = '';
@@ -20,7 +19,7 @@ export const randomString = (length: number): string => {
 
 interface ICreateJobProps {
   request: IResource;
-  resource: IRow;
+  resource: IResourceRow;
   show: boolean;
   setShow: (value: boolean) => void;
   setAlert: (alert: IAlert) => void;
@@ -74,8 +73,8 @@ const CreateJob: React.FunctionComponent<ICreateJobProps> = ({
       };
 
       const response = await fetch(
-        `/api/plugins/resources/resources?cluster=${resource.cluster.title}${
-          resource.namespace ? `&namespace=${resource.namespace.title}` : ''
+        `/api/plugins/resources/resources?cluster=${resource.cluster}${
+          resource.namespace ? `&namespace=${resource.namespace}` : ''
         }&resource=jobs&path=/apis/batch/v1`,
         {
           body: JSON.stringify(job),
@@ -117,9 +116,8 @@ const CreateJob: React.FunctionComponent<ICreateJobProps> = ({
       ]}
     >
       <p>
-        Do you really want to trigger the CronJob <b>{resource.name.title}</b> (
-        {resource.namespace ? `${resource.namespace.title} ${resource.cluster.title}` : resource.cluster.title})
-        manually?
+        Do you really want to trigger the CronJob <b>{resource.name}</b> (
+        {resource.namespace ? `${resource.namespace} ${resource.cluster}` : resource.cluster}) manually?
       </p>
     </Modal>
   );

--- a/plugins/resources/src/components/panel/details/actions/Delete.tsx
+++ b/plugins/resources/src/components/panel/details/actions/Delete.tsx
@@ -1,13 +1,12 @@
 import { AlertVariant, Button, ButtonVariant, Checkbox, Modal, ModalVariant } from '@patternfly/react-core';
 import React, { useState } from 'react';
-import { IRow } from '@patternfly/react-table';
 
+import { IResource, IResourceRow } from '@kobsio/plugin-core';
 import { IAlert } from '../../../../utils/interfaces';
-import { IResource } from '@kobsio/plugin-core';
 
 interface IDeleteProps {
   request: IResource;
-  resource: IRow;
+  resource: IResourceRow;
   show: boolean;
   setShow: (value: boolean) => void;
   setAlert: (alert: IAlert) => void;
@@ -27,16 +26,16 @@ const Delete: React.FunctionComponent<IDeleteProps> = ({
   const handleDelete = async (): Promise<void> => {
     try {
       const response = await fetch(
-        `/api/plugins/resources/resources?cluster=${resource.cluster.title}${
-          resource.namespace ? `&namespace=${resource.namespace.title}` : ''
-        }&name=${resource.name.title}&resource=${request.resource}&path=${request.path}&force=${force}`,
+        `/api/plugins/resources/resources?cluster=${resource.cluster}${
+          resource.namespace ? `&namespace=${resource.namespace}` : ''
+        }&name=${resource.name}&resource=${request.resource}&path=${request.path}&force=${force}`,
         { method: 'delete' },
       );
       const json = await response.json();
 
       if (response.status >= 200 && response.status < 300) {
         setShow(false);
-        setAlert({ title: `${resource.name.title} was deleted`, variant: AlertVariant.success });
+        setAlert({ title: `${resource.name} was deleted`, variant: AlertVariant.success });
         refetch();
       } else {
         if (json.error) {
@@ -54,7 +53,7 @@ const Delete: React.FunctionComponent<IDeleteProps> = ({
   return (
     <Modal
       variant={ModalVariant.small}
-      title={`Delete ${resource.name.title}`}
+      title={`Delete ${resource.name}`}
       isOpen={show}
       onClose={(): void => setShow(false)}
       actions={[
@@ -67,8 +66,8 @@ const Delete: React.FunctionComponent<IDeleteProps> = ({
       ]}
     >
       <p>
-        Do you really want to delete <b>{resource.name.title}</b> (
-        {resource.namespace ? `${resource.namespace.title} ${resource.cluster.title}` : resource.cluster.title})?
+        Do you really want to delete <b>{resource.name}</b> (
+        {resource.namespace ? `${resource.namespace} ${resource.cluster}` : resource.cluster})?
       </p>
       <p>&nbsp;</p>
       <Checkbox

--- a/plugins/resources/src/components/panel/details/actions/DownloadFile.tsx
+++ b/plugins/resources/src/components/panel/details/actions/DownloadFile.tsx
@@ -11,11 +11,10 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import React, { useState } from 'react';
-import { IRow } from '@patternfly/react-table';
 import { V1Pod } from '@kubernetes/client-node';
 
+import { IResourceRow, blobDownload } from '@kobsio/plugin-core';
 import { IAlert } from '../../../../utils/interfaces';
-import { blobDownload } from '@kobsio/plugin-core';
 
 // getContainers returns a list with all container names for the given Pod. It contains all specified init containers
 // and the "normal" containers.
@@ -44,7 +43,7 @@ const getContainers = (pod: V1Pod): string[] => {
 };
 
 interface IDownloadFileProps {
-  resource: IRow;
+  resource: IResourceRow;
   show: boolean;
   setShow: (value: boolean) => void;
   setAlert: (alert: IAlert) => void;
@@ -67,15 +66,15 @@ const DownloadFile: React.FunctionComponent<IDownloadFileProps> = ({
 
     try {
       const response = await fetch(
-        `/api/plugins/resources/file?cluster=${resource.cluster.title}${
-          resource.namespace ? `&namespace=${resource.namespace.title}` : ''
-        }&name=${resource.name.title}&container=${container}&srcPath=${sourcePath}`,
+        `/api/plugins/resources/file?cluster=${resource.cluster}${
+          resource.namespace ? `&namespace=${resource.namespace}` : ''
+        }&name=${resource.name}&container=${container}&srcPath=${sourcePath}`,
         { method: 'get' },
       );
 
       if (response.status >= 200 && response.status < 300) {
         const data = await response.blob();
-        blobDownload(data, `${resource.name.title}__${container}.tar`);
+        blobDownload(data, `${resource.name}__${container}.tar`);
 
         setIsLoading(false);
         setShow(false);

--- a/plugins/resources/src/components/panel/details/actions/Edit.tsx
+++ b/plugins/resources/src/components/panel/details/actions/Edit.tsx
@@ -1,15 +1,14 @@
 import { AlertVariant, Button, ButtonVariant, Modal, ModalVariant } from '@patternfly/react-core';
 import React, { useEffect, useState } from 'react';
-import { IRow } from '@patternfly/react-table';
 import { compare } from 'fast-json-patch';
 import yaml from 'js-yaml';
 
-import { Editor, IResource } from '@kobsio/plugin-core';
+import { Editor, IResource, IResourceRow } from '@kobsio/plugin-core';
 import { IAlert } from '../../../../utils/interfaces';
 
 interface IEditProps {
   request: IResource;
-  resource: IRow;
+  resource: IResourceRow;
   show: boolean;
   setShow: (value: boolean) => void;
   setAlert: (alert: IAlert) => void;
@@ -33,9 +32,9 @@ const Edit: React.FunctionComponent<IEditProps> = ({
       const diff = compare(resource.props, parsedValue as any);
 
       const response = await fetch(
-        `/api/plugins/resources/resources?cluster=${resource.cluster.title}${
-          resource.namespace ? `&namespace=${resource.namespace.title}` : ''
-        }&name=${resource.name.title}&resource=${request.resource}&path=${request.path}`,
+        `/api/plugins/resources/resources?cluster=${resource.cluster}${
+          resource.namespace ? `&namespace=${resource.namespace}` : ''
+        }&name=${resource.name}&resource=${request.resource}&path=${request.path}`,
         {
           body: JSON.stringify(diff),
           method: 'put',
@@ -45,7 +44,7 @@ const Edit: React.FunctionComponent<IEditProps> = ({
 
       if (response.status >= 200 && response.status < 300) {
         setShow(false);
-        setAlert({ title: `${resource.name.title} was saved`, variant: AlertVariant.success });
+        setAlert({ title: `${resource.name} was saved`, variant: AlertVariant.success });
         refetch();
       } else {
         if (json.error) {
@@ -67,7 +66,7 @@ const Edit: React.FunctionComponent<IEditProps> = ({
   return (
     <Modal
       variant={ModalVariant.large}
-      title={`Edit ${resource.name.title}`}
+      title={`Edit ${resource.name}`}
       isOpen={show}
       onClose={(): void => setShow(false)}
       actions={[

--- a/plugins/resources/src/components/panel/details/actions/Logs.tsx
+++ b/plugins/resources/src/components/panel/details/actions/Logs.tsx
@@ -11,13 +11,13 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import React, { useContext, useState } from 'react';
-import { IRow } from '@patternfly/react-table';
 import { V1Pod } from '@kubernetes/client-node';
 import { Terminal as xTerm } from 'xterm';
 
 import {
   IPluginsContext,
   IResource,
+  IResourceRow,
   ITerminalContext,
   PluginsContext,
   TERMINAL_OPTIONS,
@@ -52,7 +52,7 @@ const getContainers = (pod: V1Pod): string[] => {
 
 interface ILogsProps {
   request: IResource;
-  resource: IRow;
+  resource: IResourceRow;
   show: boolean;
   setShow: (value: boolean) => void;
 }
@@ -83,9 +83,9 @@ const Logs: React.FunctionComponent<ILogsProps> = ({ request, resource, show, se
       const host = configuredWebSocketAddress || `wss://${window.location.host}`;
 
       const ws = new WebSocket(
-        `${host}/api/plugins/resources/logs?cluster=${resource.cluster.title}${
-          resource.namespace ? `&namespace=${resource.namespace.title}` : ''
-        }&name=${resource.name.title}&container=${container}&since=${since}&tail=${
+        `${host}/api/plugins/resources/logs?cluster=${resource.cluster}${
+          resource.namespace ? `&namespace=${resource.namespace}` : ''
+        }&name=${resource.name}&container=${container}&since=${since}&tail=${
           TERMINAL_OPTIONS.scrollback
         }&previous=false&follow=true`,
       );
@@ -105,7 +105,7 @@ const Logs: React.FunctionComponent<ILogsProps> = ({ request, resource, show, se
       };
 
       terminalsContext.addTerminal({
-        name: `${resource.name.title}: ${container}`,
+        name: `${resource.name}: ${container}`,
         terminal: term,
         webSocket: ws,
       });
@@ -113,7 +113,7 @@ const Logs: React.FunctionComponent<ILogsProps> = ({ request, resource, show, se
       if (err.message) {
         term.write(`${err.message}\n\r`);
         terminalsContext.addTerminal({
-          name: `${resource.name.title}: ${container}`,
+          name: `${resource.name}: ${container}`,
           terminal: term,
         });
       }
@@ -126,9 +126,9 @@ const Logs: React.FunctionComponent<ILogsProps> = ({ request, resource, show, se
 
     try {
       const response = await fetch(
-        `/api/plugins/resources/logs?cluster=${resource.cluster.title}${
-          resource.namespace ? `&namespace=${resource.namespace.title}` : ''
-        }&name=${resource.name.title}&container=${container}&regex=${encodeURIComponent(regex)}&since=${since}&tail=${
+        `/api/plugins/resources/logs?cluster=${resource.cluster}${
+          resource.namespace ? `&namespace=${resource.namespace}` : ''
+        }&name=${resource.name}&container=${container}&regex=${encodeURIComponent(regex)}&since=${since}&tail=${
           TERMINAL_OPTIONS.scrollback
         }&previous=${previous}&follow=false`,
         { method: 'get' },
@@ -138,7 +138,7 @@ const Logs: React.FunctionComponent<ILogsProps> = ({ request, resource, show, se
       if (response.status >= 200 && response.status < 300) {
         term.write(`${json.logs}`);
         terminalsContext.addTerminal({
-          name: `${resource.namespace.title}: ${container} (logs)`,
+          name: `${resource.namespace}: ${container} (logs)`,
           terminal: term,
         });
         setIsLoading(false);
@@ -154,7 +154,7 @@ const Logs: React.FunctionComponent<ILogsProps> = ({ request, resource, show, se
       if (err.message) {
         term.write(`${err.message}\n\r`);
         terminalsContext.addTerminal({
-          name: `${resource.namespace.title}: ${container} (logs)`,
+          name: `${resource.namespace}: ${container} (logs)`,
           terminal: term,
         });
       }

--- a/plugins/resources/src/components/panel/details/actions/Restart.tsx
+++ b/plugins/resources/src/components/panel/details/actions/Restart.tsx
@@ -1,14 +1,13 @@
 import { AlertVariant, Button, ButtonVariant, Modal, ModalVariant } from '@patternfly/react-core';
-import { IRow } from '@patternfly/react-table';
 import React from 'react';
 import { compare } from 'fast-json-patch';
 
+import { IResource, IResourceRow } from '@kobsio/plugin-core';
 import { IAlert } from '../../../../utils/interfaces';
-import { IResource } from '@kobsio/plugin-core';
 
 interface IRestartProps {
   request: IResource;
-  resource: IRow;
+  resource: IResourceRow;
   show: boolean;
   setShow: (value: boolean) => void;
   setAlert: (alert: IAlert) => void;
@@ -39,9 +38,9 @@ const Restart: React.FunctionComponent<IRestartProps> = ({
       const diff = compare(resource.props, copy);
 
       const response = await fetch(
-        `/api/plugins/resources/resources?cluster=${resource.cluster.title}${
-          resource.namespace ? `&namespace=${resource.namespace.title}` : ''
-        }&name=${resource.name.title}&resource=${request.resource}&path=${request.path}`,
+        `/api/plugins/resources/resources?cluster=${resource.cluster}${
+          resource.namespace ? `&namespace=${resource.namespace}` : ''
+        }&name=${resource.name}&resource=${request.resource}&path=${request.path}`,
         {
           body: JSON.stringify(diff),
           method: 'put',
@@ -51,7 +50,7 @@ const Restart: React.FunctionComponent<IRestartProps> = ({
 
       if (response.status >= 200 && response.status < 300) {
         setShow(false);
-        setAlert({ title: `${resource.name.title} was restarted`, variant: AlertVariant.success });
+        setAlert({ title: `${resource.name} was restarted`, variant: AlertVariant.success });
         refetch();
       } else {
         if (json.error) {
@@ -69,7 +68,7 @@ const Restart: React.FunctionComponent<IRestartProps> = ({
   return (
     <Modal
       variant={ModalVariant.small}
-      title={`Restart ${resource.name.title}`}
+      title={`Restart ${resource.name}`}
       isOpen={show}
       onClose={(): void => setShow(false)}
       actions={[
@@ -82,8 +81,8 @@ const Restart: React.FunctionComponent<IRestartProps> = ({
       ]}
     >
       <p>
-        Do you really want to restart <b>{resource.name.title}</b> (
-        {resource.namespace ? `${resource.namespace.title}/${resource.cluster.title}` : resource.cluster.title})?
+        Do you really want to restart <b>{resource.name}</b> (
+        {resource.namespace ? `${resource.namespace}/${resource.cluster}` : resource.cluster})?
       </p>
     </Modal>
   );

--- a/plugins/resources/src/components/panel/details/actions/Scale.tsx
+++ b/plugins/resources/src/components/panel/details/actions/Scale.tsx
@@ -1,13 +1,12 @@
 import { AlertVariant, Button, ButtonVariant, Modal, ModalVariant, NumberInput } from '@patternfly/react-core';
 import React, { useEffect, useState } from 'react';
-import { IRow } from '@patternfly/react-table';
 
+import { IResource, IResourceRow } from '@kobsio/plugin-core';
 import { IAlert } from '../../../../utils/interfaces';
-import { IResource } from '@kobsio/plugin-core';
 
 interface IScaleProps {
   request: IResource;
-  resource: IRow;
+  resource: IResourceRow;
   show: boolean;
   setShow: (value: boolean) => void;
   setAlert: (alert: IAlert) => void;
@@ -27,9 +26,9 @@ const Scale: React.FunctionComponent<IScaleProps> = ({
   const handleScale = async (): Promise<void> => {
     try {
       const response = await fetch(
-        `/api/plugins/resources/resources?cluster=${resource.cluster.title}${
-          resource.namespace ? `&namespace=${resource.namespace.title}` : ''
-        }&name=${resource.name.title}&resource=${request.resource}&path=${request.path}`,
+        `/api/plugins/resources/resources?cluster=${resource.cluster}${
+          resource.namespace ? `&namespace=${resource.namespace}` : ''
+        }&name=${resource.name}&resource=${request.resource}&path=${request.path}`,
         {
           body: JSON.stringify([{ op: 'replace', path: '/spec/replicas', value: replicas }]),
           method: 'put',
@@ -39,7 +38,7 @@ const Scale: React.FunctionComponent<IScaleProps> = ({
 
       if (response.status >= 200 && response.status < 300) {
         setShow(false);
-        setAlert({ title: `Scale replicas for ${resource.name.title} to ${replicas}`, variant: AlertVariant.success });
+        setAlert({ title: `Scale replicas for ${resource.name} to ${replicas}`, variant: AlertVariant.success });
         refetch();
       } else {
         if (json.error) {
@@ -61,7 +60,7 @@ const Scale: React.FunctionComponent<IScaleProps> = ({
   return (
     <Modal
       variant={ModalVariant.small}
-      title={`Scale ${resource.name.title}`}
+      title={`Scale ${resource.name}`}
       isOpen={show}
       onClose={(): void => setShow(false)}
       actions={[
@@ -78,8 +77,8 @@ const Scale: React.FunctionComponent<IScaleProps> = ({
       ]}
     >
       <p>
-        Set new replica count for <b>{resource.name.title}</b> (
-        {resource.namespace ? `${resource.namespace.title} ${resource.cluster.title}` : resource.cluster.title}):
+        Set new replica count for <b>{resource.name}</b> (
+        {resource.namespace ? `${resource.namespace} ${resource.cluster}` : resource.cluster}):
       </p>
       <NumberInput
         value={replicas}

--- a/plugins/resources/src/components/panel/details/actions/Terminal.tsx
+++ b/plugins/resources/src/components/panel/details/actions/Terminal.tsx
@@ -9,13 +9,13 @@ import {
   ModalVariant,
 } from '@patternfly/react-core';
 import React, { useContext, useState } from 'react';
-import { IRow } from '@patternfly/react-table';
 import { V1Pod } from '@kubernetes/client-node';
 import { Terminal as xTerm } from 'xterm';
 
 import {
   IPluginsContext,
   IResource,
+  IResourceRow,
   ITerminalContext,
   PluginsContext,
   TERMINAL_OPTIONS,
@@ -50,7 +50,7 @@ const getContainers = (pod: V1Pod): string[] => {
 
 interface ITerminalProps {
   request: IResource;
-  resource: IRow;
+  resource: IResourceRow;
   show: boolean;
   setShow: (value: boolean) => void;
 }
@@ -78,9 +78,9 @@ const Terminal: React.FunctionComponent<ITerminalProps> = ({ request, resource, 
       const host = configuredWebSocketAddress || `wss://${window.location.host}`;
 
       const ws = new WebSocket(
-        `${host}/api/plugins/resources/terminal?cluster=${resource.cluster.title}${
-          resource.namespace ? `&namespace=${resource.namespace.title}` : ''
-        }&name=${resource.name.title}&container=${container}&shell=${shell}`,
+        `${host}/api/plugins/resources/terminal?cluster=${resource.cluster}${
+          resource.namespace ? `&namespace=${resource.namespace}` : ''
+        }&name=${resource.name}&container=${container}&shell=${shell}`,
       );
 
       term.reset();
@@ -114,7 +114,7 @@ const Terminal: React.FunctionComponent<ITerminalProps> = ({ request, resource, 
       };
 
       terminalsContext.addTerminal({
-        name: `${resource.name.title}: ${container} (${shell})`,
+        name: `${resource.name}: ${container} (${shell})`,
         terminal: term,
         webSocket: ws,
       });
@@ -122,7 +122,7 @@ const Terminal: React.FunctionComponent<ITerminalProps> = ({ request, resource, 
       if (err.message) {
         term.write(`${err.message}\n\r`);
         terminalsContext.addTerminal({
-          name: `${resource.name.title}: ${container} (${shell})`,
+          name: `${resource.name}: ${container} (${shell})`,
           terminal: term,
         });
       }

--- a/plugins/resources/src/components/panel/details/actions/UploadFile.tsx
+++ b/plugins/resources/src/components/panel/details/actions/UploadFile.tsx
@@ -12,10 +12,10 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import React, { useState } from 'react';
-import { IRow } from '@patternfly/react-table';
 import { V1Pod } from '@kubernetes/client-node';
 
 import { IAlert } from '../../../../utils/interfaces';
+import { IResourceRow } from '@kobsio/plugin-core';
 
 interface ISourceFile {
   filename: string;
@@ -49,7 +49,7 @@ const getContainers = (pod: V1Pod): string[] => {
 };
 
 interface IUploadFileProps {
-  resource: IRow;
+  resource: IResourceRow;
   show: boolean;
   setShow: (value: boolean) => void;
   setAlert: (alert: IAlert) => void;
@@ -80,9 +80,9 @@ const UploadFile: React.FunctionComponent<IUploadFileProps> = ({
       formData.append('file', sourceFile.value);
 
       const response = await fetch(
-        `/api/plugins/resources/file?cluster=${resource.cluster.title}${
-          resource.namespace ? `&namespace=${resource.namespace.title}` : ''
-        }&name=${resource.name.title}&container=${container}&destPath=${destinationPath}`,
+        `/api/plugins/resources/file?cluster=${resource.cluster}${
+          resource.namespace ? `&namespace=${resource.namespace}` : ''
+        }&name=${resource.name}&container=${container}&destPath=${destinationPath}`,
         {
           body: formData,
           method: 'post',


### PR DESCRIPTION
We are now using the TableComposable component instead of the Table
component to display Kubernetes resources, so that we are finally
removed the Table component from all places were it was used.

We also adjusted the style of hoverable / selectable tables across
several plugins, so that the selected row (the row which is shown in the
details) is now correctly highlighted.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
