### PR TITLE
[core] Adjust API paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#232](https://github.com/kobsio/kobs/pull/232): [core] Change options handling for various plugins.
 - [#233](https://github.com/kobsio/kobs/pull/233): [resources] Highlight expanded row for containers in Pod details.
 - [#235](https://github.com/kobsio/kobs/pull/235): [resources] Use `TableComposable` instead of `Table` component and unify table style across plugins.
+- [#237](https://github.com/kobsio/kobs/pull/237): [core] Adjust API paths to use the same schema as the Azure plugin.
 
 ## [v0.7.0](https://github.com/kobsio/kobs/releases/tag/v0.7.0) (2021-11-19)
 

--- a/plugins/dashboards/src/components/dashboards/Dashboard.tsx
+++ b/plugins/dashboards/src/components/dashboards/Dashboard.tsx
@@ -105,7 +105,7 @@ const Dashboard: React.FunctionComponent<IDashboardProps> = ({
             const pluginDetails = pluginsContext.getPluginDetails(tmpVariables[i].plugin.name);
 
             if (pluginDetails?.type === 'prometheus') {
-              const response = await fetch(`/api/plugins/prometheus/variable/${tmpVariables[i].plugin.name}`, {
+              const response = await fetch(`/api/plugins/prometheus/${tmpVariables[i].plugin.name}/variable`, {
                 body: JSON.stringify({
                   label: tmpVariables[i].plugin.options.label,
                   query: interpolate(tmpVariables[i].plugin.options.query, tmpVariables, times),

--- a/plugins/elasticsearch/elasticsearch.go
+++ b/plugins/elasticsearch/elasticsearch.go
@@ -107,7 +107,9 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 		instances,
 	}
 
-	router.Get("/logs/{name}", router.getLogs)
+	router.Route("/{name}", func(r chi.Router) {
+		r.Get("/logs", router.getLogs)
+	})
 
 	return router
 }

--- a/plugins/elasticsearch/src/components/page/PageLogs.tsx
+++ b/plugins/elasticsearch/src/components/page/PageLogs.tsx
@@ -49,7 +49,7 @@ const PageLogs: React.FunctionComponent<IPageLogsProps> = ({
     async () => {
       try {
         const response = await fetch(
-          `/api/plugins/elasticsearch/logs/${name}?query=${query}&timeStart=${times.timeStart}&timeEnd=${times.timeEnd}`,
+          `/api/plugins/elasticsearch/${name}/logs?query=${query}&timeStart=${times.timeStart}&timeEnd=${times.timeEnd}`,
           {
             method: 'get',
           },

--- a/plugins/elasticsearch/src/components/panel/Logs.tsx
+++ b/plugins/elasticsearch/src/components/panel/Logs.tsx
@@ -42,7 +42,7 @@ const Logs: React.FunctionComponent<ILogsProps> = ({
     async () => {
       try {
         const response = await fetch(
-          `/api/plugins/elasticsearch/logs/${name}?query=${selectedQuery.query}&timeStart=${times.timeStart}&timeEnd=${times.timeEnd}`,
+          `/api/plugins/elasticsearch/${name}/logs?query=${selectedQuery.query}&timeStart=${times.timeStart}&timeEnd=${times.timeEnd}`,
           {
             method: 'get',
           },

--- a/plugins/elasticsearch/src/components/preview/Chart.tsx
+++ b/plugins/elasticsearch/src/components/preview/Chart.tsx
@@ -29,7 +29,7 @@ export const Chart: React.FunctionComponent<IChartProps> = ({ name, times, title
         }
 
         const response = await fetch(
-          `/api/plugins/elasticsearch/logs/${name}?query=${options.queries[0].query}&timeStart=${times.timeStart}&timeEnd=${times.timeEnd}`,
+          `/api/plugins/elasticsearch/${name}/logs?query=${options.queries[0].query}&timeStart=${times.timeStart}&timeEnd=${times.timeEnd}`,
           {
             method: 'get',
           },

--- a/plugins/grafana/grafana.go
+++ b/plugins/grafana/grafana.go
@@ -112,7 +112,9 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 		instances,
 	}
 
-	router.Get("/dashboards/{name}", router.getDashboards)
+	router.Route("/{name}", func(r chi.Router) {
+		r.Get("/dashboards", router.getDashboards)
+	})
 
 	return router
 }

--- a/plugins/grafana/src/components/page/Dashboards.tsx
+++ b/plugins/grafana/src/components/page/Dashboards.tsx
@@ -16,7 +16,7 @@ const Dashboards: React.FunctionComponent<IDashboardsProps> = ({ name, query, pu
     ['grafana/dashboards', name, query],
     async () => {
       try {
-        const response = await fetch(`/api/plugins/grafana/dashboards/${name}?query=${encodeURIComponent(query)}`, {
+        const response = await fetch(`/api/plugins/grafana/${name}/dashboards?query=${encodeURIComponent(query)}`, {
           method: 'get',
         });
         const json = await response.json();

--- a/plugins/grafana/src/components/panel/Dashboards.tsx
+++ b/plugins/grafana/src/components/panel/Dashboards.tsx
@@ -22,7 +22,7 @@ const Dashboards: React.FunctionComponent<IDashboardsProps> = ({
       try {
         const uidParams = dashboardIDs.map((dashboardID) => `uid=${dashboardID}`).join('&');
 
-        const response = await fetch(`/api/plugins/grafana/dashboards/${name}?${uidParams}`, {
+        const response = await fetch(`/api/plugins/grafana/${name}/dashboards?${uidParams}`, {
           method: 'get',
         });
         const json = await response.json();

--- a/plugins/harbor/harbor.go
+++ b/plugins/harbor/harbor.go
@@ -213,12 +213,14 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 		instances,
 	}
 
-	router.Get("/projects/{name}", router.getProjects)
-	router.Get("/repositories/{name}", router.getRepositories)
-	router.Get("/artifacts/{name}", router.getArtifacts)
-	router.Get("/artifact/{name}", router.getArtifact)
-	router.Get("/vulnerabilities/{name}", router.getVulnerabilities)
-	router.Get("/buildhistory/{name}", router.getBuildHistory)
+	router.Route("/{name}", func(r chi.Router) {
+		r.Get("/projects", router.getProjects)
+		r.Get("/repositories", router.getRepositories)
+		r.Get("/artifacts", router.getArtifacts)
+		r.Get("/artifact", router.getArtifact)
+		r.Get("/vulnerabilities", router.getVulnerabilities)
+		r.Get("/buildhistory", router.getBuildHistory)
+	})
 
 	return router
 }

--- a/plugins/harbor/src/components/panel/Artifacts.tsx
+++ b/plugins/harbor/src/components/panel/Artifacts.tsx
@@ -39,7 +39,7 @@ const Artifacts: React.FunctionComponent<IArtifactsProps> = ({
     async () => {
       try {
         const response = await fetch(
-          `/api/plugins/harbor/artifacts/${name}?projectName=${projectName}&repositoryName=${repositoryName}&query=${query}&page=${page.page}&pageSize=${page.pageSize}`,
+          `/api/plugins/harbor/${name}/artifacts?projectName=${projectName}&repositoryName=${repositoryName}&query=${query}&page=${page.page}&pageSize=${page.pageSize}`,
           {
             method: 'get',
           },

--- a/plugins/harbor/src/components/panel/Projects.tsx
+++ b/plugins/harbor/src/components/panel/Projects.tsx
@@ -27,7 +27,7 @@ const Projects: React.FunctionComponent<IProjectsProps> = ({ name }: IProjectsPr
     async () => {
       try {
         const response = await fetch(
-          `/api/plugins/harbor/projects/${name}?page=${page.page}&pageSize=${page.pageSize}`,
+          `/api/plugins/harbor/${name}/projects?page=${page.page}&pageSize=${page.pageSize}`,
           {
             method: 'get',
           },

--- a/plugins/harbor/src/components/panel/Repositories.tsx
+++ b/plugins/harbor/src/components/panel/Repositories.tsx
@@ -33,7 +33,7 @@ const Repositories: React.FunctionComponent<IRepositoriesProps> = ({
     async () => {
       try {
         const response = await fetch(
-          `/api/plugins/harbor/repositories/${name}?projectName=${projectName}&query=${query}&page=${page.page}&pageSize=${page.pageSize}`,
+          `/api/plugins/harbor/${name}/repositories?projectName=${projectName}&query=${query}&page=${page.page}&pageSize=${page.pageSize}`,
           {
             method: 'get',
           },

--- a/plugins/harbor/src/components/panel/details/BuildHistory.tsx
+++ b/plugins/harbor/src/components/panel/details/BuildHistory.tsx
@@ -24,7 +24,7 @@ const BuildHistory: React.FunctionComponent<IBuildHistoryProps> = ({
     async () => {
       try {
         const response = await fetch(
-          `/api/plugins/harbor/buildhistory/${name}?projectName=${projectName}&repositoryName=${repositoryName}&artifactReference=${artifactReference}`,
+          `/api/plugins/harbor/${name}/buildhistory?projectName=${projectName}&repositoryName=${repositoryName}&artifactReference=${artifactReference}`,
           {
             method: 'get',
           },

--- a/plugins/harbor/src/components/panel/details/Reference.tsx
+++ b/plugins/harbor/src/components/panel/details/Reference.tsx
@@ -25,7 +25,7 @@ const Reference: React.FunctionComponent<IReferenceProps> = ({
     async () => {
       try {
         const response = await fetch(
-          `/api/plugins/harbor/artifact/${name}?projectName=${projectName}&repositoryName=${repositoryName}&artifactReference=${artifactReference}`,
+          `/api/plugins/harbor/${name}/artifact?projectName=${projectName}&repositoryName=${repositoryName}&artifactReference=${artifactReference}`,
           {
             method: 'get',
           },

--- a/plugins/harbor/src/components/panel/details/Vulnerabilities.tsx
+++ b/plugins/harbor/src/components/panel/details/Vulnerabilities.tsx
@@ -24,7 +24,7 @@ const Vulnerabilities: React.FunctionComponent<IVulnerabilitiesProps> = ({
     async () => {
       try {
         const response = await fetch(
-          `/api/plugins/harbor/vulnerabilities/${name}?projectName=${projectName}&repositoryName=${repositoryName}&artifactReference=${artifactReference}`,
+          `/api/plugins/harbor/${name}/vulnerabilities?projectName=${projectName}&repositoryName=${repositoryName}&artifactReference=${artifactReference}`,
           {
             method: 'get',
           },

--- a/plugins/istio/istio.go
+++ b/plugins/istio/istio.go
@@ -401,14 +401,16 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 		instances,
 	}
 
-	router.Get("/namespaces/{name}", router.getNamespaces)
-	router.Get("/metrics/{name}", router.getMetrics)
-	router.Get("/metricsdetails/{name}", router.getMetricsDetails)
-	router.Get("/metricspod/{name}", router.getMetricsPod)
-	router.Get("/topology/{name}", router.getTopology)
-	router.Get("/tap/{name}", router.getTap)
-	router.Get("/top/{name}", router.getTop)
-	router.Get("/topdetails/{name}", router.getTopDetails)
+	router.Route("/{name}", func(r chi.Router) {
+		r.Get("/namespaces", router.getNamespaces)
+		r.Get("/metrics", router.getMetrics)
+		r.Get("/metricsdetails", router.getMetricsDetails)
+		r.Get("/metricspod", router.getMetricsPod)
+		r.Get("/topology", router.getTopology)
+		r.Get("/tap", router.getTap)
+		r.Get("/top", router.getTop)
+		r.Get("/topdetails", router.getTopDetails)
+	})
 
 	return router
 }

--- a/plugins/istio/src/components/page/ApplicationsToolbar.tsx
+++ b/plugins/istio/src/components/page/ApplicationsToolbar.tsx
@@ -18,7 +18,7 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({ name, options
   const { isLoading, isError, error, data } = useQuery<string[], Error>(['istio/namespaces', name], async () => {
     try {
       const response = await fetch(
-        `/api/plugins/istio/namespaces/${name}?timeStart=${options.times.timeStart}&timeEnd=${options.times.timeEnd}`,
+        `/api/plugins/istio/${name}/namespaces?timeStart=${options.times.timeStart}&timeEnd=${options.times.timeEnd}`,
         {
           method: 'get',
         },

--- a/plugins/istio/src/components/panel/MetricsTable.tsx
+++ b/plugins/istio/src/components/panel/MetricsTable.tsx
@@ -47,7 +47,7 @@ const MetricsTable: React.FunctionComponent<IMetricsTableProps> = ({
         const namespaceParams = namespaces ? namespaces.map((namespace) => `&namespace=${namespace}`) : [];
 
         const response = await fetch(
-          `/api/plugins/istio/metrics/${name}?timeStart=${times.timeStart}&timeEnd=${times.timeEnd}&application=${
+          `/api/plugins/istio/${name}/metrics?timeStart=${times.timeStart}&timeEnd=${times.timeEnd}&application=${
             application ? application : ''
           }&label=${label}&groupBy=${groupBy}&reporter=${reporter}${
             namespaceParams.length > 0 ? namespaceParams.join('') : ''

--- a/plugins/istio/src/components/panel/Tap.tsx
+++ b/plugins/istio/src/components/panel/Tap.tsx
@@ -46,7 +46,7 @@ const Tap: React.FunctionComponent<ITapProps> = ({
           : times.timeStart;
 
         const response = await fetch(
-          `/api/plugins/istio/tap/${name}?timeStart=${timeStart}&timeEnd=${timeEnd}&application=${application}&namespace=${namespace}&filterUpstreamCluster=${encodeURIComponent(
+          `/api/plugins/istio/${name}/tap?timeStart=${timeStart}&timeEnd=${timeEnd}&application=${application}&namespace=${namespace}&filterUpstreamCluster=${encodeURIComponent(
             filters.upstreamCluster,
           )}&filterMethod=${encodeURIComponent(filters.method)}&filterPath=${encodeURIComponent(filters.path)}`,
           {

--- a/plugins/istio/src/components/panel/Top.tsx
+++ b/plugins/istio/src/components/panel/Top.tsx
@@ -78,7 +78,7 @@ const Top: React.FunctionComponent<ITopProps> = ({
         const [sortBy, sortDirection] = getSortParameters(sort);
 
         const response = await fetch(
-          `/api/plugins/istio/top/${name}?timeStart=${
+          `/api/plugins/istio/${name}/top?timeStart=${
             times.timeStart
           }&timeEnd=${timeEnd}&application=${application}&namespace=${namespace}&filterUpstreamCluster=${encodeURIComponent(
             filters.upstreamCluster,

--- a/plugins/istio/src/components/panel/Topology.tsx
+++ b/plugins/istio/src/components/panel/Topology.tsx
@@ -31,7 +31,7 @@ const Topology: React.FunctionComponent<ITopologyProps> = ({
     async () => {
       try {
         const response = await fetch(
-          `/api/plugins/istio/topology/${name}?timeStart=${times.timeStart}&timeEnd=${times.timeEnd}&application=${application}&namespace=${namespace}`,
+          `/api/plugins/istio/${name}/topology?timeStart=${times.timeStart}&timeEnd=${times.timeEnd}&application=${application}&namespace=${namespace}`,
           {
             method: 'get',
           },

--- a/plugins/istio/src/components/panel/details/DetailsMetricsMetric.tsx
+++ b/plugins/istio/src/components/panel/details/DetailsMetricsMetric.tsx
@@ -54,7 +54,7 @@ const DetailsMetricsMetric: React.FunctionComponent<IDetailsMetricsMetricProps> 
     async () => {
       try {
         const response = await fetch(
-          `/api/plugins/istio/metricsdetails/${name}?timeStart=${times.timeStart}&timeEnd=${times.timeEnd}&metric=${metric}&reporter=${reporter}&destinationWorkload=${destinationWorkload}&destinationWorkloadNamespace=${destinationWorkloadNamespace}&destinationVersion=${destinationVersion}&destinationService=${destinationService}&sourceWorkload=${sourceWorkload}&sourceWorkloadNamespace=${sourceWorkloadNamespace}&pod=${pod}`,
+          `/api/plugins/istio/${name}/metricsdetails?timeStart=${times.timeStart}&timeEnd=${times.timeEnd}&metric=${metric}&reporter=${reporter}&destinationWorkload=${destinationWorkload}&destinationWorkloadNamespace=${destinationWorkloadNamespace}&destinationVersion=${destinationVersion}&destinationService=${destinationService}&sourceWorkload=${sourceWorkload}&sourceWorkloadNamespace=${sourceWorkloadNamespace}&pod=${pod}`,
           {
             method: 'get',
           },

--- a/plugins/istio/src/components/panel/details/DetailsMetricsPod.tsx
+++ b/plugins/istio/src/components/panel/details/DetailsMetricsPod.tsx
@@ -29,7 +29,7 @@ const DetailsMetricsPod: React.FunctionComponent<IDetailsMetricsPodProps> = ({
     async () => {
       try {
         const response = await fetch(
-          `/api/plugins/istio/metricspod/${name}?timeStart=${times.timeStart}&timeEnd=${times.timeEnd}&metric=${metric}&namespace=${namespace}&pod=${pod}`,
+          `/api/plugins/istio/${name}/metricspod?timeStart=${times.timeStart}&timeEnd=${times.timeEnd}&metric=${metric}&namespace=${namespace}&pod=${pod}`,
           {
             method: 'get',
           },

--- a/plugins/istio/src/components/panel/details/DetailsTop.tsx
+++ b/plugins/istio/src/components/panel/details/DetailsTop.tsx
@@ -39,7 +39,7 @@ const DetailsTop: React.FunctionComponent<IDetailsTopProps> = ({
     async () => {
       try {
         const response = await fetch(
-          `/api/plugins/istio/topdetails/${name}?timeStart=${times.timeStart}&timeEnd=${
+          `/api/plugins/istio/${name}/topdetails?timeStart=${times.timeStart}&timeEnd=${
             times.timeEnd
           }&application=${application}&namespace=${namespace}&upstreamCluster=${encodeURIComponent(
             row[0],

--- a/plugins/jaeger/jaeger.go
+++ b/plugins/jaeger/jaeger.go
@@ -169,10 +169,12 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 		instances,
 	}
 
-	router.Get("/services/{name}", router.getServices)
-	router.Get("/operations/{name}", router.getOperations)
-	router.Get("/traces/{name}", router.getTraces)
-	router.Get("/trace/{name}", router.getTrace)
+	router.Route("/{name}", func(r chi.Router) {
+		r.Get("/services", router.getServices)
+		r.Get("/operations", router.getOperations)
+		r.Get("/traces", router.getTraces)
+		r.Get("/trace", router.getTrace)
+	})
 
 	return router
 }

--- a/plugins/jaeger/src/components/page/TraceCompareID.tsx
+++ b/plugins/jaeger/src/components/page/TraceCompareID.tsx
@@ -27,7 +27,7 @@ const TraceCompareID: React.FunctionComponent<ITraceCompareIDProps> = ({ name, t
     ['jaeger/trace', name, traceID],
     async () => {
       try {
-        const response = await fetch(`/api/plugins/jaeger/trace/${name}?traceID=${traceID}`, {
+        const response = await fetch(`/api/plugins/jaeger/${name}/trace?traceID=${traceID}`, {
           method: 'get',
         });
         const json = await response.json();

--- a/plugins/jaeger/src/components/page/TracesToolbarOperations.tsx
+++ b/plugins/jaeger/src/components/page/TracesToolbarOperations.tsx
@@ -23,7 +23,7 @@ const TracesToolbarOperations: React.FunctionComponent<ITracesToolbarOperationsP
     ['jaeger/operations', name, service],
     async () => {
       try {
-        const response = await fetch(`/api/plugins/jaeger/operations/${name}?service=${service}`, {
+        const response = await fetch(`/api/plugins/jaeger/${name}/operations?service=${service}`, {
           method: 'get',
         });
         const json = await response.json();

--- a/plugins/jaeger/src/components/page/TracesToolbarServices.tsx
+++ b/plugins/jaeger/src/components/page/TracesToolbarServices.tsx
@@ -17,7 +17,7 @@ const TracesToolbarServices: React.FunctionComponent<ITracesToolbarServicesProps
 
   const { isError, isLoading, error, data } = useQuery<string[], Error>(['jaeger/services', name], async () => {
     try {
-      const response = await fetch(`/api/plugins/jaeger/services/${name}`, {
+      const response = await fetch(`/api/plugins/jaeger/${name}/services`, {
         method: 'get',
       });
       const json = await response.json();

--- a/plugins/jaeger/src/components/panel/Traces.tsx
+++ b/plugins/jaeger/src/components/panel/Traces.tsx
@@ -46,7 +46,7 @@ const Traces: React.FunctionComponent<ITracesProps> = ({
     async () => {
       try {
         const response = await fetch(
-          `/api/plugins/jaeger/traces/${name}?limit=${selectedQuery.limit || '20'}&maxDuration=${
+          `/api/plugins/jaeger/${name}/traces?limit=${selectedQuery.limit || '20'}&maxDuration=${
             selectedQuery.maxDuration || ''
           }&minDuration=${selectedQuery.minDuration || ''}&operation=${selectedQuery.operation || ''}&service=${
             selectedQuery.service || ''

--- a/plugins/kiali/kiali.go
+++ b/plugins/kiali/kiali.go
@@ -151,9 +151,11 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 		instances,
 	}
 
-	router.Get("/namespaces/{name}", router.getNamespaces)
-	router.Get("/graph/{name}", router.getGraph)
-	router.Get("/metrics/{name}", router.getMetrics)
+	router.Route("/{name}", func(r chi.Router) {
+		r.Get("/namespaces", router.getNamespaces)
+		r.Get("/graph", router.getGraph)
+		r.Get("/metrics", router.getMetrics)
+	})
 
 	return router
 }

--- a/plugins/kiali/src/components/page/PageToolbarNamespaces.tsx
+++ b/plugins/kiali/src/components/page/PageToolbarNamespaces.tsx
@@ -17,7 +17,7 @@ const PageToolbarNamespaces: React.FunctionComponent<IPageToolbarNamespacesProps
 
   const { isError, isLoading, error, data } = useQuery<string[], Error>(['kiali/namespaces', name], async () => {
     try {
-      const response = await fetch(`/api/plugins/kiali/namespaces/${name}`, {
+      const response = await fetch(`/api/plugins/kiali/${name}/namespaces`, {
         method: 'get',
       });
       const json = await response.json();

--- a/plugins/kiali/src/components/panel/GraphWrapper.tsx
+++ b/plugins/kiali/src/components/panel/GraphWrapper.tsx
@@ -27,7 +27,7 @@ const GraphWrapper: React.FunctionComponent<IGraphWrapperProps> = ({
         const namespaceParams = namespaces.map((namespace) => `namespace=${namespace}`).join('&');
 
         const response = await fetch(
-          `/api/plugins/kiali/graph/${name}?duration=${
+          `/api/plugins/kiali/${name}/graph?duration=${
             times.timeEnd - times.timeStart
           }&graphType=versionedApp&injectServiceNodes=true&groupBy=app${[
             'deadNode',

--- a/plugins/kiali/src/components/panel/details/EdgeMetricsHTTP.tsx
+++ b/plugins/kiali/src/components/panel/details/EdgeMetricsHTTP.tsx
@@ -52,7 +52,7 @@ const EdgeMetricsHTTP: React.FunctionComponent<IEdgeMetricsHTTPProps> = ({
         }
 
         const response = await fetch(
-          `/api/plugins/kiali/metrics/${name}?url=${encodeURIComponent(
+          `/api/plugins/kiali/${name}/metrics?url=${encodeURIComponent(
             `/kiali/api/namespaces/${targetNode.data?.namespace}/${nodeType}/${nodeName}/metrics?queryTime=${
               times.timeEnd
             }&duration=${times.timeEnd - times.timeStart}${getSteps(

--- a/plugins/kiali/src/components/panel/details/EdgeMetricsTCP.tsx
+++ b/plugins/kiali/src/components/panel/details/EdgeMetricsTCP.tsx
@@ -57,7 +57,7 @@ const EdgeMetricsTCP: React.FunctionComponent<IEdgeMetricsTCPProps> = ({
         }
 
         const response = await fetch(
-          `/api/plugins/kiali/metrics/${name}?url=${encodeURIComponent(
+          `/api/plugins/kiali/${name}/metrics?url=${encodeURIComponent(
             `/kiali/api/namespaces/${targetNode.data?.namespace}/${nodeType}/${nodeName}/metrics?queryTime=${
               times.timeEnd
             }&duration=${times.timeEnd - times.timeStart}${getSteps(

--- a/plugins/kiali/src/components/panel/details/EdgeMetricsgRPC.tsx
+++ b/plugins/kiali/src/components/panel/details/EdgeMetricsgRPC.tsx
@@ -52,7 +52,7 @@ const EdgeMetricsgRPC: React.FunctionComponent<IEdgeMetricsgRPCProps> = ({
         }
 
         const response = await fetch(
-          `/api/plugins/kiali/metrics/${name}?url=${encodeURIComponent(
+          `/api/plugins/kiali/${name}/metrics?url=${encodeURIComponent(
             `/kiali/api/namespaces/${targetNode.data?.namespace}/${nodeType}/${nodeName}/metrics?queryTime=${
               times.timeEnd
             }&duration=${times.timeEnd - times.timeStart}${getSteps(

--- a/plugins/kiali/src/components/panel/details/NodeMetrics.tsx
+++ b/plugins/kiali/src/components/panel/details/NodeMetrics.tsx
@@ -106,7 +106,7 @@ const NodeMetrics: React.FunctionComponent<INodeMetricsProps> = ({
     async () => {
       try {
         const response = await fetch(
-          `/api/plugins/kiali/metrics/${name}?url=${encodeURIComponent(
+          `/api/plugins/kiali/${name}/metrics?url=${encodeURIComponent(
             `/kiali/api/namespaces/${nodeNamespace}/${nodeType}/${nodeName}/metrics?queryTime=${
               times.timeEnd
             }&duration=${times.timeEnd - times.timeStart}${getSteps(

--- a/plugins/klogs/klogs.go
+++ b/plugins/klogs/klogs.go
@@ -236,9 +236,11 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 		instances,
 	}
 
-	router.Get("/fields/{name}", router.getFields)
-	router.Get("/logs/{name}", router.getLogs)
-	router.Post("/aggregation/{name}", router.getAggregation)
+	router.Route("/{name}", func(r chi.Router) {
+		r.Get("/fields", router.getFields)
+		r.Get("/logs", router.getLogs)
+		r.Post("/aggregation", router.getAggregation)
+	})
 
 	return router, instances
 }

--- a/plugins/klogs/src/components/page/Aggregation.tsx
+++ b/plugins/klogs/src/components/page/Aggregation.tsx
@@ -19,7 +19,7 @@ const Aggregation: React.FunctionComponent<IAggregationProps> = ({ name, options
     ['klogs/aggregation', name, options],
     async () => {
       try {
-        const response = await fetch(`/api/plugins/klogs/aggregation/${name}`, {
+        const response = await fetch(`/api/plugins/klogs/${name}/aggregation`, {
           body: JSON.stringify(options),
           method: 'post',
         });

--- a/plugins/klogs/src/components/page/Logs.tsx
+++ b/plugins/klogs/src/components/page/Logs.tsx
@@ -56,7 +56,7 @@ const Logs: React.FunctionComponent<ILogsProps> = ({
     async () => {
       try {
         const response = await fetch(
-          `/api/plugins/klogs/logs/${name}?query=${encodeURIComponent(
+          `/api/plugins/klogs/${name}/logs?query=${encodeURIComponent(
             query,
           )}&order=${order}&orderBy=${encodeURIComponent(orderBy)}&timeStart=${times.timeStart}&timeEnd=${
             times.timeEnd

--- a/plugins/klogs/src/components/panel/Aggregation.tsx
+++ b/plugins/klogs/src/components/panel/Aggregation.tsx
@@ -24,7 +24,7 @@ const Aggregation: React.FunctionComponent<IAggregationProps> = ({
     ['klogs/aggregation', name, options],
     async () => {
       try {
-        const response = await fetch(`/api/plugins/klogs/aggregation/${name}`, {
+        const response = await fetch(`/api/plugins/klogs/${name}/aggregation`, {
           body: JSON.stringify(options),
           method: 'post',
         });

--- a/plugins/klogs/src/components/panel/Logs.tsx
+++ b/plugins/klogs/src/components/panel/Logs.tsx
@@ -38,7 +38,7 @@ const Logs: React.FunctionComponent<ILogsProps> = ({ name, title, description, q
         }
 
         const response = await fetch(
-          `/api/plugins/klogs/logs/${name}?query=${encodeURIComponent(selectedQuery.query)}&order=${
+          `/api/plugins/klogs/${name}/logs?query=${encodeURIComponent(selectedQuery.query)}&order=${
             selectedQuery.order || ''
           }&orderBy=${encodeURIComponent(selectedQuery.orderBy || '')}&timeStart=${times.timeStart}&timeEnd=${
             times.timeEnd

--- a/plugins/opsgenie/opsgenie.go
+++ b/plugins/opsgenie/opsgenie.go
@@ -347,17 +347,19 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 		instances,
 	}
 
-	router.Get("/alerts/{name}", router.getAlerts)
-	router.Get("/alert/details/{name}", router.getAlertDetails)
-	router.Get("/alert/logs/{name}", router.getAlertLogs)
-	router.Get("/alert/notes/{name}", router.getAlertNotes)
-	router.Get("/alert/acknowledge/{name}", router.acknowledgeAlert)
-	router.Get("/alert/snooze/{name}", router.snoozeAlert)
-	router.Get("/alert/close/{name}", router.closeAlert)
-	router.Get("/incidents/{name}", router.getIncidents)
-	router.Get("/incident/logs/{name}", router.getIncidentLogs)
-	router.Get("/incident/notes/{name}", router.getIncidentNotes)
-	router.Get("/incident/timeline/{name}", router.getIncidentTimeline)
+	router.Route("/{name}", func(r chi.Router) {
+		r.Get("/alerts", router.getAlerts)
+		r.Get("/alert/details", router.getAlertDetails)
+		r.Get("/alert/logs", router.getAlertLogs)
+		r.Get("/alert/notes", router.getAlertNotes)
+		r.Get("/alert/acknowledge", router.acknowledgeAlert)
+		r.Get("/alert/snooze", router.snoozeAlert)
+		r.Get("/alert/close", router.closeAlert)
+		r.Get("/incidents", router.getIncidents)
+		r.Get("/incident/logs", router.getIncidentLogs)
+		r.Get("/incident/notes", router.getIncidentNotes)
+		r.Get("/incident/timeline", router.getIncidentTimeline)
+	})
 
 	return router
 }

--- a/plugins/opsgenie/src/components/panel/Alerts.tsx
+++ b/plugins/opsgenie/src/components/panel/Alerts.tsx
@@ -21,7 +21,7 @@ const Alerts: React.FunctionComponent<IAlertsProps> = ({ name, query, interval, 
     async () => {
       try {
         const response = await fetch(
-          `/api/plugins/opsgenie/alerts/${name}?query=${queryWithTime(query, times, interval)}`,
+          `/api/plugins/opsgenie/${name}/alerts?query=${queryWithTime(query, times, interval)}`,
           {
             method: 'get',
           },

--- a/plugins/opsgenie/src/components/panel/Incidents.tsx
+++ b/plugins/opsgenie/src/components/panel/Incidents.tsx
@@ -27,7 +27,7 @@ const Incidents: React.FunctionComponent<IIncidentsProps> = ({
     async () => {
       try {
         const response = await fetch(
-          `/api/plugins/opsgenie/incidents/${name}?query=${queryWithTime(query, times, interval)}`,
+          `/api/plugins/opsgenie/${name}/incidents?query=${queryWithTime(query, times, interval)}`,
           {
             method: 'get',
           },

--- a/plugins/opsgenie/src/components/panel/details/Logs.tsx
+++ b/plugins/opsgenie/src/components/panel/details/Logs.tsx
@@ -25,7 +25,7 @@ const Logs: React.FunctionComponent<ILogsProps> = ({ name, id, type }: ILogsProp
     ['opsgenie/alerts/logs', name, id, type],
     async () => {
       try {
-        const response = await fetch(`/api/plugins/opsgenie/${type}/logs/${name}?id=${id}`, {
+        const response = await fetch(`/api/plugins/opsgenie/${name}/${type}/logs?id=${id}`, {
           method: 'get',
         });
         const json = await response.json();

--- a/plugins/opsgenie/src/components/panel/details/alert/Details.tsx
+++ b/plugins/opsgenie/src/components/panel/details/alert/Details.tsx
@@ -25,7 +25,7 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ name, id }: IDetailsP
     ['opsgenie/alerts/details', name, id],
     async () => {
       try {
-        const response = await fetch(`/api/plugins/opsgenie/alert/details/${name}?id=${id}`, {
+        const response = await fetch(`/api/plugins/opsgenie/${name}/alert/details?id=${id}`, {
           method: 'get',
         });
         const json = await response.json();

--- a/plugins/opsgenie/src/components/panel/details/alert/actions/Acknowledge.tsx
+++ b/plugins/opsgenie/src/components/panel/details/alert/actions/Acknowledge.tsx
@@ -20,7 +20,7 @@ const Acknowledge: React.FunctionComponent<IAcknowledgeProps> = ({
     hideDropdown();
 
     try {
-      const response = await fetch(`/api/plugins/opsgenie/alert/acknowledge/${name}?id=${alert.id}`, {
+      const response = await fetch(`/api/plugins/opsgenie/${name}/alert/acknowledge?id=${alert.id}`, {
         method: 'get',
       });
       const json = await response.json();

--- a/plugins/opsgenie/src/components/panel/details/alert/actions/Close.tsx
+++ b/plugins/opsgenie/src/components/panel/details/alert/actions/Close.tsx
@@ -15,7 +15,7 @@ const Close: React.FunctionComponent<ICloseProps> = ({ name, alert, hideDropdown
     hideDropdown();
 
     try {
-      const response = await fetch(`/api/plugins/opsgenie/alert/close/${name}?id=${alert.id}`, {
+      const response = await fetch(`/api/plugins/opsgenie/${name}/alert/close?id=${alert.id}`, {
         method: 'get',
       });
       const json = await response.json();

--- a/plugins/opsgenie/src/components/panel/details/alert/actions/Snooze.tsx
+++ b/plugins/opsgenie/src/components/panel/details/alert/actions/Snooze.tsx
@@ -29,7 +29,7 @@ const Snooze: React.FunctionComponent<ISnoozeProps> = ({ name, alert, hideDropdo
     hideDropdown();
 
     try {
-      const response = await fetch(`/api/plugins/opsgenie/alert/snooze/${name}?id=${alert.id}&snooze=${duration}`, {
+      const response = await fetch(`/api/plugins/opsgenie/${name}/alert/snooze?id=${alert.id}&snooze=${duration}`, {
         method: 'get',
       });
       const json = await response.json();

--- a/plugins/opsgenie/src/components/panel/details/incident/Timeline.tsx
+++ b/plugins/opsgenie/src/components/panel/details/incident/Timeline.tsx
@@ -24,7 +24,7 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ name, id }: IDetailsP
     ['opsgenie/incident/timeline', name, id],
     async () => {
       try {
-        const response = await fetch(`/api/plugins/opsgenie/incident/timeline/${name}?id=${id}`, {
+        const response = await fetch(`/api/plugins/opsgenie/${name}/incident/timeline?id=${id}`, {
           method: 'get',
         });
         const json = await response.json();

--- a/plugins/prometheus/prometheus.go
+++ b/plugins/prometheus/prometheus.go
@@ -207,10 +207,12 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 		instances,
 	}
 
-	router.Post("/variable/{name}", router.getVariable)
-	router.Post("/metrics/{name}", router.getMetrics)
-	router.Post("/table/{name}", router.getTable)
-	router.Get("/labels/{name}", router.getLabels)
+	router.Route("/{name}", func(r chi.Router) {
+		r.Post("/variable", router.getVariable)
+		r.Post("/metrics", router.getMetrics)
+		r.Post("/table", router.getTable)
+		r.Get("/labels", router.getLabels)
+	})
 
 	return router, instances
 }

--- a/plugins/prometheus/src/components/page/PageChartWrapper.tsx
+++ b/plugins/prometheus/src/components/page/PageChartWrapper.tsx
@@ -26,7 +26,7 @@ const PageChartWrapper: React.FunctionComponent<IPageChartWrapperProps> = ({
     ['prometheus/metrics', name, queries, resolution, times],
     async () => {
       try {
-        const response = await fetch(`/api/plugins/prometheus/metrics/${name}`, {
+        const response = await fetch(`/api/plugins/prometheus/${name}/metrics`, {
           body: JSON.stringify({
             queries: queries.map((query) => {
               return { label: '', query: query };

--- a/plugins/prometheus/src/components/page/PageToolbarAutocomplete.tsx
+++ b/plugins/prometheus/src/components/page/PageToolbarAutocomplete.tsx
@@ -32,7 +32,7 @@ export const PageToolbarAutocomplete: React.FunctionComponent<IPageToolbarAutoco
         return undefined;
       }
 
-      const response = await fetch(`/api/plugins/prometheus/labels/${name}?searchTerm=${debouncedQuery}`, {
+      const response = await fetch(`/api/plugins/prometheus/${name}/labels?searchTerm=${debouncedQuery}`, {
         method: 'get',
       });
       const json = await response.json();

--- a/plugins/prometheus/src/components/panel/ChartWrapper.tsx
+++ b/plugins/prometheus/src/components/panel/ChartWrapper.tsx
@@ -43,7 +43,7 @@ export const ChartWrapper: React.FunctionComponent<IChartWrapperProps> = ({
           throw new Error('Queries are missing');
         }
 
-        const response = await fetch(`/api/plugins/prometheus/metrics/${name}`, {
+        const response = await fetch(`/api/plugins/prometheus/${name}/metrics`, {
           body: JSON.stringify({
             queries: options.queries,
             resolution: '',

--- a/plugins/prometheus/src/components/panel/Sparkline.tsx
+++ b/plugins/prometheus/src/components/panel/Sparkline.tsx
@@ -35,7 +35,7 @@ export const Spakrline: React.FunctionComponent<ISpakrlineProps> = ({
           throw new Error('Queries are missing');
         }
 
-        const response = await fetch(`/api/plugins/prometheus/metrics/${name}`, {
+        const response = await fetch(`/api/plugins/prometheus/${name}/metrics`, {
           body: JSON.stringify({
             queries: options.queries,
             resolution: '',

--- a/plugins/prometheus/src/components/panel/Table.tsx
+++ b/plugins/prometheus/src/components/panel/Table.tsx
@@ -50,7 +50,7 @@ export const Table: React.FunctionComponent<ITableProps> = ({
           throw new Error('Queries are missing');
         }
 
-        const response = await fetch(`/api/plugins/prometheus/table/${name}`, {
+        const response = await fetch(`/api/plugins/prometheus/${name}/table`, {
           body: JSON.stringify({
             queries: options.queries,
             resolution: '',

--- a/plugins/prometheus/src/components/preview/Sparkline.tsx
+++ b/plugins/prometheus/src/components/preview/Sparkline.tsx
@@ -28,7 +28,7 @@ export const Spakrline: React.FunctionComponent<ISpakrlineProps> = ({
           throw new Error('Queries are missing');
         }
 
-        const response = await fetch(`/api/plugins/prometheus/metrics/${name}`, {
+        const response = await fetch(`/api/plugins/prometheus/${name}/metrics`, {
           body: JSON.stringify({
             queries: options.queries,
             resolution: '',

--- a/plugins/sonarqube/sonarqube.go
+++ b/plugins/sonarqube/sonarqube.go
@@ -118,8 +118,10 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 		instances,
 	}
 
-	router.Get("/projects/{name}", router.getProjects)
-	router.Get("/projectmeasures/{name}", router.getProjectMeasures)
+	router.Route("/{name}", func(r chi.Router) {
+		r.Get("/projects", router.getProjects)
+		r.Get("/projectmeasures", router.getProjectMeasures)
+	})
 
 	return router
 }

--- a/plugins/sonarqube/src/components/page/Projects.tsx
+++ b/plugins/sonarqube/src/components/page/Projects.tsx
@@ -32,7 +32,7 @@ const Projects: React.FunctionComponent<IProjectsProps> = ({ name, query, url }:
     async () => {
       try {
         const response = await fetch(
-          `/api/plugins/sonarqube/projects/${name}?query=${encodeURIComponent(query)}&pageNumber=${
+          `/api/plugins/sonarqube/${name}/projects?query=${encodeURIComponent(query)}&pageNumber=${
             page.page
           }&pageSize=${page.perPage}`,
           {

--- a/plugins/sonarqube/src/components/panel/Measures.tsx
+++ b/plugins/sonarqube/src/components/panel/Measures.tsx
@@ -20,7 +20,7 @@ const Measures: React.FunctionComponent<IMeasuresProps> = ({ name, project, metr
         const metricKeyParams = metricKeys ? metricKeys.map((key) => `metricKey=${key}`).join('&') : '';
 
         const response = await fetch(
-          `/api/plugins/sonarqube/projectmeasures/${name}?project=${project}&${metricKeyParams}`,
+          `/api/plugins/sonarqube/${name}/projectmeasures?project=${project}&${metricKeyParams}`,
           {
             method: 'get',
           },

--- a/plugins/sql/sql.go
+++ b/plugins/sql/sql.go
@@ -95,7 +95,9 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 		instances,
 	}
 
-	router.Get("/query/{name}", router.getQueryResults)
+	router.Route("/{name}", func(r chi.Router) {
+		r.Get("/query", router.getQueryResults)
+	})
 
 	return router
 }

--- a/plugins/sql/src/components/page/PageSQL.tsx
+++ b/plugins/sql/src/components/page/PageSQL.tsx
@@ -16,7 +16,7 @@ const PageSQL: React.FunctionComponent<IPageSQLProps> = ({ name, query }: IPageS
 
   const { isError, isFetching, error, data, refetch } = useQuery<ISQLData, Error>(['sql/query', query], async () => {
     try {
-      const response = await fetch(`/api/plugins/sql/query/${name}?query=${encodeURIComponent(query)}`, {
+      const response = await fetch(`/api/plugins/sql/${name}/query?query=${encodeURIComponent(query)}`, {
         method: 'get',
       });
       const json = await response.json();

--- a/plugins/sql/src/components/panel/SQL.tsx
+++ b/plugins/sql/src/components/panel/SQL.tsx
@@ -36,7 +36,7 @@ const SQL: React.FunctionComponent<ISQLProps> = ({ name, title, description, que
         }
 
         const response = await fetch(
-          `/api/plugins/sql/query/${name}?query=${encodeURIComponent(selectedQuery.query)}`,
+          `/api/plugins/sql/${name}/query?query=${encodeURIComponent(selectedQuery.query)}`,
           {
             method: 'get',
           },

--- a/plugins/techdocs/src/components/page/ServicePage.tsx
+++ b/plugins/techdocs/src/components/page/ServicePage.tsx
@@ -35,7 +35,7 @@ const ServicePage: React.FunctionComponent<IServicePageProps> = ({ name }: IServ
     ['techdocs/index', name, params.service],
     async () => {
       try {
-        const response = await fetch(`/api/plugins/techdocs/index/${name}?service=${params.service}`, {
+        const response = await fetch(`/api/plugins/techdocs/${name}/index?service=${params.service}`, {
           method: 'get',
         });
         const json = await response.json();

--- a/plugins/techdocs/src/components/page/ServicePageWrapper.tsx
+++ b/plugins/techdocs/src/components/page/ServicePageWrapper.tsx
@@ -35,7 +35,7 @@ const ServicePageWrapper: React.FunctionComponent<IServicePageWrapperProps> = ({
     ['techdocs/markdown', name, index, path],
     async () => {
       try {
-        const response = await fetch(`/api/plugins/techdocs/markdown/${name}?service=${index.key}&path=${path}`, {
+        const response = await fetch(`/api/plugins/techdocs/${name}/markdown?service=${index.key}&path=${path}`, {
           method: 'get',
         });
         const json = await response.json();

--- a/plugins/techdocs/src/components/panel/TableOfContentsWrapper.tsx
+++ b/plugins/techdocs/src/components/panel/TableOfContentsWrapper.tsx
@@ -23,7 +23,7 @@ const TableOfContentsWrapper: React.FunctionComponent<ITableOfContentsWrapperPro
     ['techdocs/index', name, service],
     async () => {
       try {
-        const response = await fetch(`/api/plugins/techdocs/index/${name}?service=${service}`, {
+        const response = await fetch(`/api/plugins/techdocs/${name}/index?service=${service}`, {
           method: 'get',
         });
         const json = await response.json();

--- a/plugins/techdocs/src/components/panel/TechDocsList.tsx
+++ b/plugins/techdocs/src/components/panel/TechDocsList.tsx
@@ -14,7 +14,7 @@ const TechDocsList: React.FunctionComponent<ITechDocsListProps> = ({ name }: ITe
     ['techdocs/indexes', name],
     async () => {
       try {
-        const response = await fetch(`/api/plugins/techdocs/indexes/${name}`, {
+        const response = await fetch(`/api/plugins/techdocs/${name}/indexes`, {
           method: 'get',
         });
         const json = await response.json();

--- a/plugins/techdocs/src/utils/helpers.ts
+++ b/plugins/techdocs/src/utils/helpers.ts
@@ -31,5 +31,5 @@ export const imageTransformer = (uri: string, name: string, service: string, pat
   const normalizedPath = normalizePath(`${getPathWithoutFile(path)}/${uri}`);
   const host = process.env.NODE_ENV === 'development' ? `http://localhost:15220` : `https://${window.location.host}`;
 
-  return `${host}/api/plugins/techdocs/file/${name}?service=${service}&path=${normalizedPath}`;
+  return `${host}/api/plugins/techdocs/${name}/file?service=${service}&path=${normalizedPath}`;
 };

--- a/plugins/techdocs/techdocs.go
+++ b/plugins/techdocs/techdocs.go
@@ -158,10 +158,12 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 		instances,
 	}
 
-	router.Get("/indexes/{name}", router.getIndexes)
-	router.Get("/index/{name}", router.getIndex)
-	router.Get("/markdown/{name}", router.getMarkdown)
-	router.Get("/file/{name}", router.getFile)
+	router.Route("/{name}", func(r chi.Router) {
+		r.Get("/indexes", router.getIndexes)
+		r.Get("/index", router.getIndex)
+		r.Get("/markdown", router.getMarkdown)
+		r.Get("/file", router.getFile)
+	})
 
 	return router
 }


### PR DESCRIPTION
Adjust the API paths to use the same schema as the Azure plugin. With
the new schema the "name" of the plugin (for multi instance plugins) now
comes after the plugin type and not at the end of the path.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
