### PR TITLE
[core] Refactor frontend code of plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#233](https://github.com/kobsio/kobs/pull/233): [resources] Highlight expanded row for containers in Pod details.
 - [#235](https://github.com/kobsio/kobs/pull/235): [resources] Use `TableComposable` instead of `Table` component and unify table style across plugins.
 - [#237](https://github.com/kobsio/kobs/pull/237): [core] Adjust API paths to use the same schema as the Azure plugin.
-- [#239](https://github.com/kobsio/kobs/pull/239): [azure] Cost Management drill-down on resourceGroups.
+- [#239](https://github.com/kobsio/kobs/pull/239): [azure] Cost Management drill-down on resource groups.
+- [#238](https://github.com/kobsio/kobs/pull/238): [core] Refactor frontend code for plugins (change options handling, use `setDetails` instead of `showDetails` and rename plugins options in panels to `pluginOptions`).
 
 ## [v0.7.0](https://github.com/kobsio/kobs/releases/tag/v0.7.0) (2021-11-19)
 

--- a/docs/contributing/develop-a-plugin.md
+++ b/docs/contributing/develop-a-plugin.md
@@ -213,7 +213,7 @@ export interface IPluginPanelProps {
   description?: string;
   pluginOptions?: IPluginDataOptions;
   options?: any;
-  showDetails?: (details: React.ReactNode) => void;
+  setDetails?: (details: React.ReactNode) => void;
 }
 ```
 

--- a/plugins/applications/src/components/page/Application.tsx
+++ b/plugins/applications/src/components/page/Application.tsx
@@ -134,7 +134,7 @@ const Application: React.FunctionComponent = () => {
         <DrawerContent panelContent={details}>
           <DrawerContentBody>
             {data.dashboards ? (
-              <DashboardsWrapper defaults={data} references={data.dashboards} showDetails={setDetails} />
+              <DashboardsWrapper defaults={data} references={data.dashboards} setDetails={setDetails} />
             ) : (
               <PageSection style={{ minHeight: '100%' }} variant={PageSectionVariants.default}></PageSection>
             )}

--- a/plugins/applications/src/components/page/Applications.tsx
+++ b/plugins/applications/src/components/page/Applications.tsx
@@ -8,7 +8,7 @@ import {
   PageSectionVariants,
   Title,
 } from '@patternfly/react-core';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import ApplicationsToolbar from './ApplicationsToolbar';
@@ -32,7 +32,7 @@ const Applications: React.FunctionComponent<IApplicationsProps> = ({
 }: IApplicationsProps) => {
   const history = useHistory();
   const location = useLocation();
-  const [options, setOptions] = useState<IOptions>(useMemo<IOptions>(() => getInitialOptions(), []));
+  const [options, setOptions] = useState<IOptions>();
   const [selectedApplication, setSelectedApplication] = useState<React.ReactNode>(undefined);
 
   // changeOptions is used to change the options. Besides setting a new value for the options state we also reflect the
@@ -45,9 +45,15 @@ const Applications: React.FunctionComponent<IApplicationsProps> = ({
       pathname: location.pathname,
       search: `?view=${opts.view}${c.length > 0 ? c.join('') : ''}${n.length > 0 ? n.join('') : ''}`,
     });
-
-    setOptions(opts);
   };
+
+  useEffect(() => {
+    setOptions((prevOptions) => getInitialOptions(location.search, !prevOptions));
+  }, [location.search]);
+
+  if (!options) {
+    return null;
+  }
 
   return (
     <React.Fragment>

--- a/plugins/applications/src/components/page/Applications.tsx
+++ b/plugins/applications/src/components/page/Applications.tsx
@@ -33,7 +33,7 @@ const Applications: React.FunctionComponent<IApplicationsProps> = ({
   const history = useHistory();
   const location = useLocation();
   const [options, setOptions] = useState<IOptions>();
-  const [selectedApplication, setSelectedApplication] = useState<React.ReactNode>(undefined);
+  const [details, setDetails] = useState<React.ReactNode>(undefined);
 
   // changeOptions is used to change the options. Besides setting a new value for the options state we also reflect the
   // options in the current url.
@@ -65,8 +65,8 @@ const Applications: React.FunctionComponent<IApplicationsProps> = ({
         <ApplicationsToolbar options={options} setOptions={changeOptions} />
       </PageSection>
 
-      <Drawer isExpanded={selectedApplication !== undefined}>
-        <DrawerContent panelContent={selectedApplication}>
+      <Drawer isExpanded={details !== undefined}>
+        <DrawerContent panelContent={details}>
           <DrawerContentBody>
             <PageSection
               style={options.view === 'topology' ? { height: '100%', minHeight: '100%' } : { minHeight: '100%' }}
@@ -88,7 +88,7 @@ const Applications: React.FunctionComponent<IApplicationsProps> = ({
                     view: options.view,
                   }}
                   times={options.times}
-                  showDetails={setSelectedApplication}
+                  setDetails={setDetails}
                 />
               )}
             </PageSection>

--- a/plugins/applications/src/components/panel/ApplicationsTopology.tsx
+++ b/plugins/applications/src/components/panel/ApplicationsTopology.tsx
@@ -16,7 +16,7 @@ interface IApplicationsTopologyProps {
   clusters: string[];
   namespaces: string[];
   times: IPluginTimes;
-  showDetails?: (details: React.ReactNode) => void;
+  setDetails?: (details: React.ReactNode) => void;
 }
 
 // ApplicationsTopology is the component to display all applications inside a topology view. We need a list of clusters
@@ -26,7 +26,7 @@ const ApplicationsTopology: React.FunctionComponent<IApplicationsTopologyProps> 
   clusters,
   namespaces,
   times,
-  showDetails,
+  setDetails,
 }: IApplicationsTopologyProps) => {
   const history = useHistory();
 
@@ -93,7 +93,7 @@ const ApplicationsTopology: React.FunctionComponent<IApplicationsTopologyProps> 
 
   return (
     <div style={{ height: '100%', minHeight: '100%' }}>
-      <ApplicationsTopologyGraph edges={data.edges} nodes={data.nodes} showDetails={showDetails} />
+      <ApplicationsTopologyGraph edges={data.edges} nodes={data.nodes} setDetails={setDetails} />
     </div>
   );
 };

--- a/plugins/applications/src/components/panel/ApplicationsTopologyGraph.tsx
+++ b/plugins/applications/src/components/panel/ApplicationsTopologyGraph.tsx
@@ -92,14 +92,14 @@ const nodeLabel = (node: INodeData): string => {
 interface IApplicationsTopologyGraphProps {
   edges: IEdge[];
   nodes: INode[];
-  showDetails?: (details: React.ReactNode) => void;
+  setDetails?: (details: React.ReactNode) => void;
 }
 
 // ApplicationsTopologyGraph is the component, which renders the topology graph.
 const ApplicationsTopologyGraph: React.FunctionComponent<IApplicationsTopologyGraphProps> = ({
   edges,
   nodes,
-  showDetails,
+  setDetails,
 }: IApplicationsTopologyGraphProps) => {
   const [width, setWidth] = useState<number>(0);
   const [height, setHeight] = useState<number>(0);
@@ -115,11 +115,11 @@ const ApplicationsTopologyGraph: React.FunctionComponent<IApplicationsTopologyGr
       const node = event.target;
       const data: INodeData = node.data();
 
-      if (data.type === 'application' && showDetails) {
-        showDetails(<Details application={data} close={(): void => showDetails(undefined)} />);
+      if (data.type === 'application' && setDetails) {
+        setDetails(<Details application={data} close={(): void => setDetails(undefined)} />);
       }
     },
-    [showDetails],
+    [setDetails],
   );
 
   const cyCallback = useCallback(

--- a/plugins/applications/src/components/panel/Panel.tsx
+++ b/plugins/applications/src/components/panel/Panel.tsx
@@ -19,7 +19,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
   description,
   options,
   times,
-  showDetails,
+  setDetails,
 }: IPanelProps) => {
   // We have to validate that the required options object was provided in the Application CR by a user. This is
   // important so that the React UI doesn't crash, when the user didn't use the plugin correctly.
@@ -44,7 +44,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
         clusters={options.clusters || [defaults.cluster]}
         namespaces={options.namespaces || [defaults.namespace]}
         times={times}
-        showDetails={showDetails}
+        setDetails={setDetails}
       />
     );
 

--- a/plugins/applications/src/utils/helpers.ts
+++ b/plugins/applications/src/utils/helpers.ts
@@ -2,8 +2,8 @@ import { IOptions, TView } from './interfaces';
 import { getTimeParams } from '@kobsio/plugin-core';
 
 // getInitialOptions returns the initial options for the applications page from the url.
-export const getInitialOptions = (): IOptions => {
-  const params = new URLSearchParams(window.location.search);
+export const getInitialOptions = (search: string, isInitial: boolean): IOptions => {
+  const params = new URLSearchParams(search);
   const clusters = params.getAll('cluster');
   const namespaces = params.getAll('namespace');
   const view = params.get('view');
@@ -11,7 +11,7 @@ export const getInitialOptions = (): IOptions => {
   return {
     clusters: clusters,
     namespaces: namespaces,
-    times: getTimeParams(params),
+    times: getTimeParams(params, isInitial),
     view: view ? (view as TView) : 'gallery',
   };
 };

--- a/plugins/azure/src/components/panel/Panel.tsx
+++ b/plugins/azure/src/components/panel/Panel.tsx
@@ -33,7 +33,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
   description,
   times,
   options,
-  showDetails,
+  setDetails,
 }: IPanelProps) => {
   // Panels for container services.
   if (
@@ -48,7 +48,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
         <CIContainerGroups
           name={name}
           resourceGroups={options.containerinstances.resourceGroups}
-          setDetails={showDetails}
+          setDetails={setDetails}
         />
       </PluginCard>
     );
@@ -143,7 +143,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
         <KSKubernetesServices
           name={name}
           resourceGroups={options.kubernetesservices.resourceGroups}
-          setDetails={showDetails}
+          setDetails={setDetails}
         />
       </PluginCard>
     );
@@ -225,7 +225,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
         <VMSSVirtualMachineScaleSets
           name={name}
           resourceGroups={options.virtualmachinescalesets.resourceGroups}
-          setDetails={showDetails}
+          setDetails={setDetails}
         />
       </PluginCard>
     );

--- a/plugins/core/src/components/app/Home.tsx
+++ b/plugins/core/src/components/app/Home.tsx
@@ -102,7 +102,7 @@ const HomePage: React.FunctionComponent = () => {
               name={pluginDetails.name}
               displayName={pluginDetails.displayName}
               description={pluginDetails.description}
-              options={pluginDetails.options}
+              pluginOptions={pluginDetails.options}
             />
           ) : activePage === 'account' ? (
             <Account />

--- a/plugins/core/src/components/plugin/PluginPage.tsx
+++ b/plugins/core/src/components/plugin/PluginPage.tsx
@@ -73,7 +73,7 @@ export const PluginPage: React.FunctionComponent = () => {
       name={pluginDetails.name}
       displayName={pluginDetails.displayName}
       description={pluginDetails.description}
-      options={pluginDetails.options}
+      pluginOptions={pluginDetails.options}
     />
   );
 };

--- a/plugins/core/src/components/plugin/PluginPanel.tsx
+++ b/plugins/core/src/components/plugin/PluginPanel.tsx
@@ -17,7 +17,7 @@ export const PluginPanel: React.FunctionComponent<IPluginPanelProps> = ({
   title,
   description,
   options,
-  showDetails,
+  setDetails,
 }: IPluginPanelProps) => {
   const authContext = useContext<IAuthContext>(AuthContext);
 
@@ -56,7 +56,7 @@ export const PluginPanel: React.FunctionComponent<IPluginPanelProps> = ({
       description={description}
       pluginOptions={pluginDetails.options}
       options={options}
-      showDetails={showDetails}
+      setDetails={setDetails}
     />
   );
 };

--- a/plugins/core/src/context/PluginsContext.tsx
+++ b/plugins/core/src/context/PluginsContext.tsx
@@ -62,7 +62,7 @@ export interface IPluginPageProps {
   name: string;
   displayName: string;
   description: string;
-  options?: IPluginDataOptions;
+  pluginOptions?: IPluginDataOptions;
 }
 
 // IPluginPanelProps is the interface for the properties of the panel component of each plugin. It contains the already

--- a/plugins/core/src/context/PluginsContext.tsx
+++ b/plugins/core/src/context/PluginsContext.tsx
@@ -77,7 +77,7 @@ export interface IPluginPanelProps {
   pluginOptions?: IPluginDataOptions;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   options?: any;
-  showDetails?: (details: React.ReactNode) => void;
+  setDetails?: (details: React.ReactNode) => void;
 }
 
 // IPluginPreviewProps is the interface for the properties of the preview component of each plugin. It contains the

--- a/plugins/core/src/utils/time.ts
+++ b/plugins/core/src/utils/time.ts
@@ -33,16 +33,24 @@ export const formatTime = (timestamp: number): string => {
 };
 
 // getTimeParams returns a times object for the parsed time parameters from a URL.
-export const getTimeParams = (params: URLSearchParams): IPluginTimes => {
+export const getTimeParams = (params: URLSearchParams, isInitial: boolean): IPluginTimes => {
   const time = params.get('time');
   const timeEnd = params.get('timeEnd');
   const timeStart = params.get('timeStart');
 
   if (time && TTimeOptions.includes(time) && time !== 'custom') {
+    if (isInitial) {
+      return {
+        time: time as TTime,
+        timeEnd: Math.floor(Date.now() / 1000),
+        timeStart: Math.floor(Date.now() / 1000) - timeOptions[time].seconds,
+      };
+    }
+
     return {
       time: time as TTime,
-      timeEnd: Math.floor(Date.now() / 1000),
-      timeStart: Math.floor(Date.now() / 1000) - timeOptions[time].seconds,
+      timeEnd: timeEnd ? parseInt(timeEnd) : Math.floor(Date.now() / 1000),
+      timeStart: timeStart ? parseInt(timeStart) : Math.floor(Date.now() / 1000) - timeOptions[time].seconds,
     };
   }
 

--- a/plugins/dashboards/src/components/dashboards/Dashboard.tsx
+++ b/plugins/dashboards/src/components/dashboards/Dashboard.tsx
@@ -24,7 +24,7 @@ interface IDashboardProps {
   defaults: IPluginDefaults;
   dashboard: IDashboard;
   forceDefaultSpan: boolean;
-  showDetails?: (details: React.ReactNode) => void;
+  setDetails?: (details: React.ReactNode) => void;
 }
 
 // The Dashboard component renders the rows and panels for a single dashboard, by including a plugin via the PluginPanel
@@ -37,7 +37,7 @@ const Dashboard: React.FunctionComponent<IDashboardProps> = ({
   defaults,
   dashboard,
   forceDefaultSpan,
-  showDetails,
+  setDetails,
 }: IDashboardProps) => {
   const clustersContext = useContext<IClusterContext>(ClustersContext);
   const pluginsContext = useContext<IPluginsContext>(PluginsContext);
@@ -218,7 +218,7 @@ const Dashboard: React.FunctionComponent<IDashboardProps> = ({
                             description={panel.description}
                             name={panel.plugin.name}
                             options={panel.plugin.options}
-                            showDetails={showDetails}
+                            setDetails={setDetails}
                           />
                         </div>
                       ) : (

--- a/plugins/dashboards/src/components/dashboards/DashboardWrapper.tsx
+++ b/plugins/dashboards/src/components/dashboards/DashboardWrapper.tsx
@@ -6,13 +6,13 @@ import Dashboard from './Dashboard';
 interface IDashboardWrapperProps {
   defaults: IPluginDefaults;
   dashboard: IDashboard;
-  showDetails?: (details: React.ReactNode) => void;
+  setDetails?: (details: React.ReactNode) => void;
 }
 
 const DashboardWrapper: React.FunctionComponent<IDashboardWrapperProps> = ({
   defaults,
   dashboard,
-  showDetails,
+  setDetails,
 }: IDashboardWrapperProps) => {
   const refWrapper = useRef<HTMLDivElement>(null);
   const tabsSize = useDimensions(refWrapper);
@@ -25,7 +25,7 @@ const DashboardWrapper: React.FunctionComponent<IDashboardWrapperProps> = ({
         defaults={defaults}
         dashboard={dashboard}
         forceDefaultSpan={tabsSize.width < 1200}
-        showDetails={showDetails}
+        setDetails={setDetails}
       />
     </div>
   );

--- a/plugins/dashboards/src/components/dashboards/Dashboards.tsx
+++ b/plugins/dashboards/src/components/dashboards/Dashboards.tsx
@@ -21,7 +21,7 @@ import { getInitialOptions } from '../../utils/dashboard';
 interface IDashboardsProps {
   defaults: IPluginDefaults;
   references: IReference[];
-  showDetails?: (details: React.ReactNode) => void;
+  setDetails?: (details: React.ReactNode) => void;
   forceDefaultSpan: boolean;
 }
 
@@ -31,7 +31,7 @@ interface IDashboardsProps {
 const Dashboards: React.FunctionComponent<IDashboardsProps> = ({
   defaults,
   references,
-  showDetails,
+  setDetails,
   forceDefaultSpan,
 }: IDashboardsProps) => {
   const location = useLocation();
@@ -53,10 +53,10 @@ const Dashboards: React.FunctionComponent<IDashboardsProps> = ({
   // a drawer it can happen that we already show some dashboards in the main view and so we can not rely on the query
   // parameters.
   useEffect(() => {
-    if (showDetails !== undefined) {
-      setOptions(getInitialOptions(location.search, references, showDetails !== undefined));
+    if (setDetails !== undefined) {
+      setOptions(getInitialOptions(location.search, references, setDetails !== undefined));
     }
-  }, [location.search, references, showDetails]);
+  }, [location.search, references, setDetails]);
 
   // Fetch all dashboards. The dashboards are available via the data variable. To fetch the dashboards we have to pass
   // the defaults and the references to the API. The defaults are required so that a user can omit the cluster and
@@ -132,7 +132,7 @@ const Dashboards: React.FunctionComponent<IDashboardsProps> = ({
     <Tabs
       activeKey={options.dashboard}
       onSelect={(event, tabIndex): void =>
-        showDetails
+        setDetails
           ? changeOptions({ ...options, dashboard: tabIndex.toString() })
           : setOptions({ ...options, dashboard: tabIndex.toString() })
       }
@@ -148,7 +148,7 @@ const Dashboards: React.FunctionComponent<IDashboardsProps> = ({
               defaults={defaults}
               dashboard={dashboard}
               forceDefaultSpan={forceDefaultSpan}
-              showDetails={showDetails}
+              setDetails={setDetails}
             />
           </PageSection>
         </Tab>

--- a/plugins/dashboards/src/components/dashboards/Dashboards.tsx
+++ b/plugins/dashboards/src/components/dashboards/Dashboards.tsx
@@ -16,7 +16,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { IDashboard, IPluginDefaults, IReference } from '@kobsio/plugin-core';
 import Dashboard from './Dashboard';
 import { IDashboardsOptions } from '../../utils/interfaces';
-import { getOptionsFromSearch } from '../../utils/dashboard';
+import { getInitialOptions } from '../../utils/dashboard';
 
 interface IDashboardsProps {
   defaults: IPluginDefaults;
@@ -36,9 +36,7 @@ const Dashboards: React.FunctionComponent<IDashboardsProps> = ({
 }: IDashboardsProps) => {
   const location = useLocation();
   const history = useHistory();
-  const [options, setOptions] = useState<IDashboardsOptions>(
-    getOptionsFromSearch(location.search, references, showDetails !== undefined),
-  );
+  const [options, setOptions] = useState<IDashboardsOptions>();
 
   // changeOptions adjusts the search location (query paramters). We do not set the options directly (except when the
   // Dashboards component is rendered inside a drawer), so that a user can share the url and a other users gets the same
@@ -56,7 +54,7 @@ const Dashboards: React.FunctionComponent<IDashboardsProps> = ({
   // parameters.
   useEffect(() => {
     if (showDetails !== undefined) {
-      setOptions(getOptionsFromSearch(location.search, references, showDetails !== undefined));
+      setOptions(getInitialOptions(location.search, references, showDetails !== undefined));
     }
   }, [location.search, references, showDetails]);
 
@@ -90,6 +88,10 @@ const Dashboards: React.FunctionComponent<IDashboardsProps> = ({
       }
     },
   );
+
+  if (!options) {
+    return null;
+  }
 
   // When the isLoading parameter is true we show a Spinner, so the user sees that the dashboards are currently fetched.
   if (isLoading) {

--- a/plugins/dashboards/src/components/dashboards/DashboardsWrapper.tsx
+++ b/plugins/dashboards/src/components/dashboards/DashboardsWrapper.tsx
@@ -6,7 +6,7 @@ import Dashboards from './Dashboards';
 interface IDashboardsWrapperProps {
   defaults: IPluginDefaults;
   references: IReference[];
-  showDetails?: (details: React.ReactNode) => void;
+  setDetails?: (details: React.ReactNode) => void;
 }
 
 // The DashboardsWrapper component is a wrapper for the Dashboards component. It is used to determine the dimensions for
@@ -17,7 +17,7 @@ interface IDashboardsWrapperProps {
 export const DashboardsWrapper: React.FunctionComponent<IDashboardsWrapperProps> = ({
   defaults,
   references,
-  showDetails,
+  setDetails,
 }: IDashboardsWrapperProps) => {
   const refTabs = useRef<HTMLDivElement>(null);
   const tabsSize = useDimensions(refTabs);
@@ -27,7 +27,7 @@ export const DashboardsWrapper: React.FunctionComponent<IDashboardsWrapperProps>
       <Dashboards
         defaults={defaults}
         references={references}
-        showDetails={showDetails}
+        setDetails={setDetails}
         forceDefaultSpan={tabsSize.width < 1200}
       />
     </div>

--- a/plugins/dashboards/src/components/page/Dashboard.tsx
+++ b/plugins/dashboards/src/components/page/Dashboard.tsx
@@ -14,7 +14,7 @@ import React, { useState } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 
 import { IDashboard, Title } from '@kobsio/plugin-core';
-import { getDefaultsFromSearch, getPlaceholdersFromSearch } from '../../utils/dashboard';
+import { getInitialDefaults, getPlaceholdersFromSearch } from '../../utils/dashboard';
 import DashboardWrapper from '../dashboards/DashboardWrapper';
 
 interface IDashboardParams {
@@ -27,7 +27,7 @@ const Dashboard: React.FunctionComponent = () => {
   const history = useHistory();
   const location = useLocation();
   const params = useParams<IDashboardParams>();
-  const defaults = getDefaultsFromSearch(location.search);
+  const defaults = getInitialDefaults(location.search);
   const placeholders = getPlaceholdersFromSearch(location.search);
   const [details, setDetails] = useState<React.ReactNode>(undefined);
 

--- a/plugins/dashboards/src/components/page/Dashboard.tsx
+++ b/plugins/dashboards/src/components/page/Dashboard.tsx
@@ -105,7 +105,7 @@ const Dashboard: React.FunctionComponent = () => {
           <DrawerContent panelContent={details}>
             <DrawerContentBody>
               <PageSection variant={PageSectionVariants.default} style={{ minHeight: '100%' }}>
-                <DashboardWrapper defaults={defaults} dashboard={data} showDetails={setDetails} />
+                <DashboardWrapper defaults={defaults} dashboard={data} setDetails={setDetails} />
               </PageSection>
             </DrawerContentBody>
           </DrawerContent>

--- a/plugins/dashboards/src/utils/dashboard.ts
+++ b/plugins/dashboards/src/utils/dashboard.ts
@@ -85,11 +85,7 @@ export const interpolate = (
 // getOptionsFromSearch is used to parse the given search location and return is as options for Prometheus. This is
 // needed, so that a user can explore his Prometheus data from a chart. When the user selects the explore action, we
 // pass him to this page and pass the data via the URL parameters.
-export const getOptionsFromSearch = (
-  search: string,
-  references: IReference[],
-  useDrawer: boolean,
-): IDashboardsOptions => {
+export const getInitialOptions = (search: string, references: IReference[], useDrawer: boolean): IDashboardsOptions => {
   const params = new URLSearchParams(search);
   const dashboard = params.get('dashboard');
 
@@ -151,8 +147,8 @@ export const getPlaceholdersFromSearch = (search: string): IPlaceholders | undef
   return placeholders;
 };
 
-// getDefaultsFromSearch returns the plugins defaults from a given search string.
-export const getDefaultsFromSearch = (search: string): IPluginDefaults => {
+// getInitialDefaults returns the plugins defaults from a given search string.
+export const getInitialDefaults = (search: string): IPluginDefaults => {
   const params = new URLSearchParams(search);
   const cluster = params.get('defaultCluster');
   const namespace = params.get('defaultNamespace');

--- a/plugins/elasticsearch/src/components/page/Page.tsx
+++ b/plugins/elasticsearch/src/components/page/Page.tsx
@@ -6,7 +6,7 @@ import {
   PageSectionVariants,
   Title,
 } from '@patternfly/react-core';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { IPluginPageProps, IPluginTimes } from '@kobsio/plugin-core';
@@ -18,7 +18,7 @@ import { getInitialOptions } from '../../utils/helpers';
 const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, description }: IPluginPageProps) => {
   const location = useLocation();
   const history = useHistory();
-  const [options, setOptions] = useState<IOptions>(useMemo<IOptions>(() => getInitialOptions(), []));
+  const [options, setOptions] = useState<IOptions>();
 
   // changeOptions is used to change the options. Besides setting a new value for the options state we also reflect the
   // options in the current url.
@@ -31,34 +31,46 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
         opts.times.timeStart
       }${fields.length > 0 ? fields.join('') : ''}`,
     });
-
-    setOptions(opts);
   };
 
   // selectField is used to add a field as parameter, when it isn't present and to remove a fields from as parameter,
   // when it is already present via the changeOptions function.
   const selectField = (field: string): void => {
-    let tmpFields: string[] = [];
-    if (options.fields) {
-      tmpFields = [...options.fields];
-    }
+    if (options) {
+      let tmpFields: string[] = [];
+      if (options.fields) {
+        tmpFields = [...options.fields];
+      }
 
-    if (tmpFields.includes(field)) {
-      tmpFields = tmpFields.filter((f) => f !== field);
-    } else {
-      tmpFields.push(field);
-    }
+      if (tmpFields.includes(field)) {
+        tmpFields = tmpFields.filter((f) => f !== field);
+      } else {
+        tmpFields.push(field);
+      }
 
-    changeOptions({ ...options, fields: tmpFields });
+      changeOptions({ ...options, fields: tmpFields });
+    }
   };
 
   const addFilter = (filter: string): void => {
-    changeOptions({ ...options, query: `${options.query} ${filter}` });
+    if (options) {
+      changeOptions({ ...options, query: `${options.query} ${filter}` });
+    }
   };
 
   const changeTime = (times: IPluginTimes): void => {
-    changeOptions({ ...options, times: times });
+    if (options) {
+      changeOptions({ ...options, times: times });
+    }
   };
+
+  useEffect(() => {
+    setOptions((prevOptions) => getInitialOptions(location.search, !prevOptions));
+  }, [location.search]);
+
+  if (!options) {
+    return null;
+  }
 
   return (
     <React.Fragment>

--- a/plugins/elasticsearch/src/utils/helpers.ts
+++ b/plugins/elasticsearch/src/utils/helpers.ts
@@ -2,15 +2,15 @@ import { IDocument, IKeyValue, IOptions } from './interfaces';
 import { getTimeParams } from '@kobsio/plugin-core';
 
 // getInitialOptions is used to get the initial options for Elasticsearch from the url.
-export const getInitialOptions = (): IOptions => {
-  const params = new URLSearchParams(window.location.search);
+export const getInitialOptions = (search: string, isInitial: boolean): IOptions => {
+  const params = new URLSearchParams(search);
   const fields = params.getAll('field');
   const query = params.get('query');
 
   return {
     fields: fields.length > 0 ? fields : undefined,
     query: query ? query : '',
-    times: getTimeParams(params),
+    times: getTimeParams(params, isInitial),
   };
 };
 

--- a/plugins/flux/src/components/page/Page.tsx
+++ b/plugins/flux/src/components/page/Page.tsx
@@ -66,7 +66,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
                         type="gitrepositories.source.toolkit.fluxcd.io/v1beta1"
                         title="Git Repos"
                         times={options.times}
-                        showDetails={setDetails}
+                        setDetails={setDetails}
                       />
                       <p>&nbsp;</p>
                       <PageList
@@ -75,7 +75,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
                         type="helmrepositories.source.toolkit.fluxcd.io/v1beta1"
                         title="Helm Repos"
                         times={options.times}
-                        showDetails={setDetails}
+                        setDetails={setDetails}
                       />
                       <p>&nbsp;</p>
                       <PageList
@@ -84,7 +84,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
                         type="buckets.source.toolkit.fluxcd.io/v1beta1"
                         title="Buckets"
                         times={options.times}
-                        showDetails={setDetails}
+                        setDetails={setDetails}
                       />
                     </React.Fragment>
                   ) : options.type === 'kustomizations' ? (
@@ -94,7 +94,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
                       type="kustomizations.kustomize.toolkit.fluxcd.io/v1beta1"
                       title="Kustomizations"
                       times={options.times}
-                      showDetails={setDetails}
+                      setDetails={setDetails}
                     />
                   ) : options.type === 'helmreleases' ? (
                     <PageList
@@ -103,7 +103,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
                       type="helmreleases.helm.toolkit.fluxcd.io/v2beta1"
                       title="Helm Releases"
                       times={options.times}
-                      showDetails={setDetails}
+                      setDetails={setDetails}
                     />
                   ) : null}
                 </React.Fragment>

--- a/plugins/flux/src/components/page/Page.tsx
+++ b/plugins/flux/src/components/page/Page.tsx
@@ -8,7 +8,7 @@ import {
   PageSectionVariants,
   Title,
 } from '@patternfly/react-core';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { IOptions } from '../../utils/interfaces';
@@ -20,7 +20,7 @@ import { getInitialOptions } from '../../utils/helpers';
 const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, description }: IPluginPageProps) => {
   const history = useHistory();
   const location = useLocation();
-  const [options, setOptions] = useState<IOptions>(useMemo<IOptions>(() => getInitialOptions(), []));
+  const [options, setOptions] = useState<IOptions>();
   const [details, setDetails] = useState<React.ReactNode>(undefined);
 
   const changeOptions = (opts: IOptions): void => {
@@ -28,9 +28,15 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
       pathname: location.pathname,
       search: `?type=${opts.type}&cluster=${opts.cluster}`,
     });
-
-    setOptions(opts);
   };
+
+  useEffect(() => {
+    setOptions((prevOptions) => getInitialOptions(location.search, !prevOptions));
+  }, [location.search]);
+
+  if (!options) {
+    return null;
+  }
 
   return (
     <React.Fragment>

--- a/plugins/flux/src/components/page/PageList.tsx
+++ b/plugins/flux/src/components/page/PageList.tsx
@@ -87,8 +87,6 @@ const PageList: React.FunctionComponent<IPageListProps> = ({
     }
   };
 
-  console.log(selectedRow);
-
   return (
     <Card isCompact={true}>
       <CardTitle>{title}</CardTitle>

--- a/plugins/flux/src/components/page/PageList.tsx
+++ b/plugins/flux/src/components/page/PageList.tsx
@@ -13,7 +13,7 @@ interface IPageListProps {
   type: TApiType;
   title: string;
   times: IPluginTimes;
-  showDetails?: (details: React.ReactNode) => void;
+  setDetails?: (details: React.ReactNode) => void;
 }
 
 const PageList: React.FunctionComponent<IPageListProps> = ({
@@ -22,7 +22,7 @@ const PageList: React.FunctionComponent<IPageListProps> = ({
   type,
   title,
   times,
-  showDetails,
+  setDetails,
 }: IPageListProps) => {
   const clustersContext = useContext<IClusterContext>(ClustersContext);
   const resource =
@@ -69,15 +69,15 @@ const PageList: React.FunctionComponent<IPageListProps> = ({
   };
 
   const handleRowClick = (rowIndex: number, row: IResourceRow): void => {
-    if (showDetails && resource) {
-      showDetails(
+    if (setDetails && resource) {
+      setDetails(
         <Details
           name={name}
           type={type}
           request={resource}
           resource={row}
           close={(): void => {
-            showDetails(undefined);
+            setDetails(undefined);
             setSelectedRow(-1);
           }}
           refetch={refetchhWithDelay}
@@ -104,10 +104,10 @@ const PageList: React.FunctionComponent<IPageListProps> = ({
               ? data.map((row, rowIndex) => (
                   <Tr
                     key={rowIndex}
-                    isHoverable={showDetails ? true : false}
+                    isHoverable={setDetails ? true : false}
                     isRowSelected={selectedRow === rowIndex}
                     onClick={(): void =>
-                      showDetails &&
+                      setDetails &&
                       resource &&
                       data &&
                       data.length > 0 &&

--- a/plugins/flux/src/components/panel/Panel.tsx
+++ b/plugins/flux/src/components/panel/Panel.tsx
@@ -17,7 +17,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
   title,
   description,
   options,
-  showDetails,
+  setDetails,
 }: IPanelProps) => {
   if (
     !options ||
@@ -47,7 +47,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
         cluster={options.cluster || defaults.cluster}
         namespace={options.namespace || ''}
         selector={options.selector}
-        showDetails={showDetails}
+        setDetails={setDetails}
       />
     </PluginCard>
   );

--- a/plugins/flux/src/components/panel/PanelList.tsx
+++ b/plugins/flux/src/components/panel/PanelList.tsx
@@ -13,7 +13,7 @@ interface IPanelListProps {
   namespace: string;
   selector?: string;
   type: TApiType;
-  showDetails?: (details: React.ReactNode) => void;
+  setDetails?: (details: React.ReactNode) => void;
 }
 
 const PanelList: React.FunctionComponent<IPanelListProps> = ({
@@ -23,7 +23,7 @@ const PanelList: React.FunctionComponent<IPanelListProps> = ({
   cluster,
   namespace,
   selector,
-  showDetails,
+  setDetails,
 }: IPanelListProps) => {
   const clustersContext = useContext<IClusterContext>(ClustersContext);
   const resource =
@@ -72,15 +72,15 @@ const PanelList: React.FunctionComponent<IPanelListProps> = ({
   };
 
   const handleRowClick = (rowIndex: number, row: IResourceRow): void => {
-    if (showDetails && resource) {
-      showDetails(
+    if (setDetails && resource) {
+      setDetails(
         <Details
           name={name}
           type={type}
           request={resource}
           resource={row}
           close={(): void => {
-            showDetails(undefined);
+            setDetails(undefined);
             setSelectedRow(-1);
           }}
           refetch={refetchhWithDelay}
@@ -104,14 +104,10 @@ const PanelList: React.FunctionComponent<IPanelListProps> = ({
           ? data.map((row, rowIndex) => (
               <Tr
                 key={rowIndex}
-                isHoverable={showDetails ? true : false}
+                isHoverable={setDetails ? true : false}
                 isRowSelected={selectedRow === rowIndex}
                 onClick={(): void =>
-                  showDetails &&
-                  resource &&
-                  data &&
-                  data.length > 0 &&
-                  data[0].cells?.length === resource.columns.length
+                  setDetails && resource && data && data.length > 0 && data[0].cells?.length === resource.columns.length
                     ? handleRowClick(rowIndex, row)
                     : undefined
                 }

--- a/plugins/flux/src/utils/helpers.ts
+++ b/plugins/flux/src/utils/helpers.ts
@@ -2,8 +2,8 @@ import { IOptions, TType } from './interfaces';
 import { getTimeParams } from '@kobsio/plugin-core';
 
 // getInitialOptions returns the initial options from the url.
-export const getInitialOptions = (): IOptions => {
-  const params = new URLSearchParams(window.location.search);
+export const getInitialOptions = (search: string, isInitial: boolean): IOptions => {
+  const params = new URLSearchParams(search);
   const type = params.get('type');
   const cluster = params.get('cluster');
 
@@ -14,7 +14,7 @@ export const getInitialOptions = (): IOptions => {
 
   return {
     cluster: cluster || '',
-    times: getTimeParams(params),
+    times: getTimeParams(params, isInitial),
     type: parsedType,
   };
 };

--- a/plugins/grafana/src/components/page/Page.tsx
+++ b/plugins/grafana/src/components/page/Page.tsx
@@ -19,28 +19,26 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({
   name,
   displayName,
   description,
-  options,
+  pluginOptions,
 }: IPluginPageProps) => {
   const location = useLocation();
   const history = useHistory();
-  const [pageOptions, setPageOptions] = useState<IOptions>();
+  const [options, setOptions] = useState<IOptions>();
 
-  // changePageOptions is used to change the options to get a list of dashboards from Grafna. Instead of directly
-  // modifying the options state we change the URL parameters.
-  const changePageOptions = (opts: IOptions): void => {
+  // changeOptions is used to change the options to get a list of dashboards from Grafna. Instead of directly modifying
+  // the options state we change the URL parameters.
+  const changeOptions = (opts: IOptions): void => {
     history.push({
       pathname: location.pathname,
       search: `?query=${encodeURIComponent(opts.query)}`,
     });
-
-    setPageOptions(opts);
   };
 
   useEffect(() => {
-    setPageOptions(getInitialOptions(location.search));
+    setOptions(getInitialOptions(location.search));
   }, [location.search]);
 
-  if (!pageOptions) {
+  if (!options) {
     return null;
   }
 
@@ -51,7 +49,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({
           {displayName}
         </Title>
         <p>{description}</p>
-        <PageToolbar name={name} options={pageOptions} setOptions={changePageOptions} />
+        <PageToolbar name={name} options={options} setOptions={changeOptions} />
       </PageSection>
 
       <Drawer isExpanded={false}>
@@ -60,8 +58,8 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({
             <PageSection style={{ minHeight: '100%' }} variant={PageSectionVariants.default}>
               <Dashboards
                 name={name}
-                query={pageOptions.query}
-                publicAddress={options && options.publicAddress ? options.publicAddress : ''}
+                query={options.query}
+                publicAddress={pluginOptions && pluginOptions.publicAddress ? pluginOptions.publicAddress : ''}
               />
             </PageSection>
           </DrawerContentBody>

--- a/plugins/grafana/src/components/page/Page.tsx
+++ b/plugins/grafana/src/components/page/Page.tsx
@@ -6,7 +6,7 @@ import {
   PageSectionVariants,
   Title,
 } from '@patternfly/react-core';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import Dashboards from './Dashboards';
@@ -23,7 +23,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({
 }: IPluginPageProps) => {
   const location = useLocation();
   const history = useHistory();
-  const [pageOptions, setPageOptions] = useState<IOptions>(useMemo<IOptions>(() => getInitialOptions(), []));
+  const [pageOptions, setPageOptions] = useState<IOptions>();
 
   // changePageOptions is used to change the options to get a list of dashboards from Grafna. Instead of directly
   // modifying the options state we change the URL parameters.
@@ -35,6 +35,14 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({
 
     setPageOptions(opts);
   };
+
+  useEffect(() => {
+    setPageOptions(getInitialOptions(location.search));
+  }, [location.search]);
+
+  if (!pageOptions) {
+    return null;
+  }
 
   return (
     <React.Fragment>

--- a/plugins/grafana/src/utils/helpers.ts
+++ b/plugins/grafana/src/utils/helpers.ts
@@ -1,8 +1,8 @@
 import { IOptions } from './interfaces';
 
 // getInitialOptions is used to get the initial options from the url.
-export const getInitialOptions = (): IOptions => {
-  const params = new URLSearchParams(window.location.search);
+export const getInitialOptions = (search: string): IOptions => {
+  const params = new URLSearchParams(search);
   const query = params.get('query');
 
   return {

--- a/plugins/harbor/src/components/page/Page.tsx
+++ b/plugins/harbor/src/components/page/Page.tsx
@@ -10,7 +10,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({
   name,
   displayName,
   description,
-  options,
+  pluginOptions,
 }: IPluginPageProps) => {
   return (
     <Switch>
@@ -21,7 +21,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({
         <RepositoriesPage name={name} />
       </Route>
       <Route exact={true} path={`/${name}/artifacts/:projectName/:repositoryName`}>
-        <ArtifactsPage name={name} address={options && options.address ? options.address : ''} />
+        <ArtifactsPage name={name} address={pluginOptions && pluginOptions.address ? pluginOptions.address : ''} />
       </Route>
     </Switch>
   );

--- a/plugins/harbor/src/components/panel/Panel.tsx
+++ b/plugins/harbor/src/components/panel/Panel.tsx
@@ -18,7 +18,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
   times,
   options,
   pluginOptions,
-  showDetails,
+  setDetails,
 }: IPanelProps) => {
   if (options && options.type === 'projects') {
     return (
@@ -55,7 +55,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
           projectName={options.artifacts.projectName}
           repositoryName={options.artifacts.repositoryName}
           query={options.artifacts.query || ''}
-          setDetails={showDetails}
+          setDetails={setDetails}
         />
       </PluginCard>
     );

--- a/plugins/istio/src/components/page/Application.tsx
+++ b/plugins/istio/src/components/page/Application.tsx
@@ -1,5 +1,5 @@
 import { Drawer, DrawerColorVariant, DrawerContent, PageSection, PageSectionVariants } from '@patternfly/react-core';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 
 import { IApplicationOptions, IFilters, IPluginOptions } from '../../utils/interfaces';
@@ -25,10 +25,7 @@ const Application: React.FunctionComponent<IApplicationProps> = ({ name, pluginO
   const location = useLocation();
   const history = useHistory();
   const [details, setDetails] = useState<React.ReactNode>(undefined);
-
-  const [options, setOptions] = useState<IApplicationOptions>(
-    useMemo<IApplicationOptions>(() => getInitialApplicationOptions(), []),
-  );
+  const [options, setOptions] = useState<IApplicationOptions>();
 
   const changeOptions = (tmpOptions: IApplicationOptions): void => {
     history.push({
@@ -41,22 +38,28 @@ const Application: React.FunctionComponent<IApplicationProps> = ({ name, pluginO
         tmpOptions.filters.path,
       )}`,
     });
-
-    setOptions(tmpOptions);
   };
 
   const setFilters = (filters: IFilters): void => {
-    history.push({
-      pathname: location.pathname,
-      search: `?timeEnd=${options.times.timeEnd}&timeStart=${options.times.timeStart}&view=${
-        options.view
-      }&filterUpstreamCluster=${encodeURIComponent(filters.upstreamCluster)}&filterMethod=${encodeURIComponent(
-        filters.method,
-      )}&filterPath=${encodeURIComponent(filters.path)}`,
-    });
-
-    setOptions({ ...options, filters: filters });
+    if (options) {
+      history.push({
+        pathname: location.pathname,
+        search: `?timeEnd=${options.times.timeEnd}&timeStart=${options.times.timeStart}&view=${
+          options.view
+        }&filterUpstreamCluster=${encodeURIComponent(filters.upstreamCluster)}&filterMethod=${encodeURIComponent(
+          filters.method,
+        )}&filterPath=${encodeURIComponent(filters.path)}`,
+      });
+    }
   };
+
+  useEffect(() => {
+    setOptions((prevOptions) => getInitialApplicationOptions(location.search, !prevOptions));
+  }, [location.search]);
+
+  if (!options) {
+    return null;
+  }
 
   return (
     <React.Fragment>

--- a/plugins/istio/src/components/page/Applications.tsx
+++ b/plugins/istio/src/components/page/Applications.tsx
@@ -11,7 +11,7 @@ import {
   PageSectionVariants,
   Title,
 } from '@patternfly/react-core';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { IApplicationsOptions, IPluginOptions } from '../../utils/interfaces';
@@ -35,9 +35,7 @@ const Applications: React.FunctionComponent<IApplicationsProps> = ({
 }: IApplicationsProps) => {
   const location = useLocation();
   const history = useHistory();
-  const [options, setOptions] = useState<IApplicationsOptions>(
-    useMemo<IApplicationsOptions>(() => getInitialApplicationsOptions(), []),
-  );
+  const [options, setOptions] = useState<IApplicationsOptions>();
 
   const changeOptions = (opts: IApplicationsOptions): void => {
     const namespaces = opts.namespaces ? opts.namespaces.map((namespace) => `&namespace=${namespace}`) : [];
@@ -48,9 +46,15 @@ const Applications: React.FunctionComponent<IApplicationsProps> = ({
         namespaces.length > 0 ? namespaces.join('') : ''
       }`,
     });
-
-    setOptions(opts);
   };
+
+  useEffect(() => {
+    setOptions((prevOptions) => getInitialApplicationsOptions(location.search, !prevOptions));
+  }, [location.search]);
+
+  if (!options) {
+    return null;
+  }
 
   return (
     <React.Fragment>

--- a/plugins/istio/src/components/page/Page.tsx
+++ b/plugins/istio/src/components/page/Page.tsx
@@ -10,24 +10,29 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({
   name,
   displayName,
   description,
-  options,
+  pluginOptions,
 }: IPluginPageProps) => {
-  if (!options || !options.hasOwnProperty('prometheus')) {
+  if (!pluginOptions || !pluginOptions.hasOwnProperty('prometheus')) {
     return null;
   }
 
-  const pluginOptions: IPluginOptions = {
-    klogs: options['klogs'],
-    prometheus: options['prometheus'],
+  const tmpPluginOptions: IPluginOptions = {
+    klogs: pluginOptions['klogs'],
+    prometheus: pluginOptions['prometheus'],
   };
 
   return (
     <Switch>
       <Route exact={true} path={`/${name}`}>
-        <Applications name={name} displayName={displayName} description={description} pluginOptions={pluginOptions} />
+        <Applications
+          name={name}
+          displayName={displayName}
+          description={description}
+          pluginOptions={tmpPluginOptions}
+        />
       </Route>
       <Route exact={true} path={`/${name}/:namespace/:application`}>
-        <Application name={name} pluginOptions={pluginOptions} />
+        <Application name={name} pluginOptions={tmpPluginOptions} />
       </Route>
     </Switch>
   );

--- a/plugins/istio/src/components/panel/Panel.tsx
+++ b/plugins/istio/src/components/panel/Panel.tsx
@@ -20,7 +20,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
   description,
   times,
   options,
-  showDetails,
+  setDetails,
 }: IPanelProps) => {
   const history = useHistory();
 
@@ -91,7 +91,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
           reporter="destination"
           additionalColumns={[{ label: 'pod', title: 'Pod' }]}
           times={times}
-          setDetails={showDetails}
+          setDetails={setDetails}
         />
       </PluginCard>
     );
@@ -126,7 +126,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
           reporter="destination"
           times={times}
           additionalColumns={[{ label: 'destination_version', title: 'Version' }]}
-          setDetails={showDetails}
+          setDetails={setDetails}
         />
       </PluginCard>
     );
@@ -157,7 +157,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
           namespace={options.namespaces[0]}
           application={options.application}
           times={times}
-          setDetails={showDetails}
+          setDetails={setDetails}
         />
       </PluginCard>
     );
@@ -200,7 +200,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
           times={times}
           liveUpdate={false}
           filters={filters}
-          setDetails={showDetails}
+          setDetails={setDetails}
         />
       </PluginCard>
     );
@@ -243,7 +243,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
           times={times}
           liveUpdate={false}
           filters={filters}
-          setDetails={showDetails}
+          setDetails={setDetails}
         />
       </PluginCard>
     );

--- a/plugins/istio/src/utils/helpers.ts
+++ b/plugins/istio/src/utils/helpers.ts
@@ -4,19 +4,19 @@ import { IApplicationOptions, IApplicationsOptions, ITopDetailsMetrics } from '.
 import { getTimeParams } from '@kobsio/plugin-core';
 
 // getInitialApplicationsOptions is used to get the initial Istio options from the url.
-export const getInitialApplicationsOptions = (): IApplicationsOptions => {
-  const params = new URLSearchParams(window.location.search);
+export const getInitialApplicationsOptions = (search: string, isInitial: boolean): IApplicationsOptions => {
+  const params = new URLSearchParams(search);
   const namespaces = params.getAll('namespace');
 
   return {
     namespaces: namespaces.length > 0 ? namespaces : [],
-    times: getTimeParams(params),
+    times: getTimeParams(params, isInitial),
   };
 };
 
 // getInitialApplicationOptions is used to get the initial Istio options from the url.
-export const getInitialApplicationOptions = (): IApplicationOptions => {
-  const params = new URLSearchParams(window.location.search);
+export const getInitialApplicationOptions = (search: string, isInitial: boolean): IApplicationOptions => {
+  const params = new URLSearchParams(search);
   const view = params.get('view');
   const filterUpstreamCluster = params.get('filterUpstreamCluster');
   const filterMethod = params.get('filterMethod');
@@ -28,7 +28,7 @@ export const getInitialApplicationOptions = (): IApplicationOptions => {
       path: filterPath ? filterPath : '',
       upstreamCluster: filterUpstreamCluster ? filterUpstreamCluster : '',
     },
-    times: getTimeParams(params),
+    times: getTimeParams(params, isInitial),
     view: view ? view : 'metrics',
   };
 };

--- a/plugins/jaeger/src/components/page/Traces.tsx
+++ b/plugins/jaeger/src/components/page/Traces.tsx
@@ -24,7 +24,7 @@ const Traces: React.FunctionComponent<ITracesProps> = ({ name, displayName, desc
   const location = useLocation();
   const history = useHistory();
   const [options, setOptions] = useState<IOptions>();
-  const [selectedTrace, setSelectedTrace] = useState<React.ReactNode>(undefined);
+  const [details, setDetails] = useState<React.ReactNode>(undefined);
 
   // changeOptions is used to change the options. Besides setting a new value for the options state we also reflect the
   // options in the current url.
@@ -60,15 +60,15 @@ const Traces: React.FunctionComponent<ITracesProps> = ({ name, displayName, desc
         <TracesToolbar name={name} options={options} setOptions={changeOptions} />
       </PageSection>
 
-      <Drawer isExpanded={selectedTrace !== undefined}>
-        <DrawerContent panelContent={selectedTrace}>
+      <Drawer isExpanded={details !== undefined}>
+        <DrawerContent panelContent={details}>
           <DrawerContentBody>
             <PageSection style={{ minHeight: '100%' }} variant={PageSectionVariants.default}>
               {options.service ? (
                 <TracesPanel
                   name={name}
                   title=""
-                  showDetails={setSelectedTrace}
+                  setDetails={setDetails}
                   queries={[
                     {
                       limit: options.limit,

--- a/plugins/jaeger/src/components/page/Traces.tsx
+++ b/plugins/jaeger/src/components/page/Traces.tsx
@@ -7,7 +7,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { Link, useHistory, useLocation } from 'react-router-dom';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { IOptions } from '../../utils/interfaces';
 import TracesPanel from '../panel/Traces';
@@ -23,7 +23,7 @@ interface ITracesProps {
 const Traces: React.FunctionComponent<ITracesProps> = ({ name, displayName, description }: ITracesProps) => {
   const location = useLocation();
   const history = useHistory();
-  const [options, setOptions] = useState<IOptions>(useMemo<IOptions>(() => getInitialOptions(), []));
+  const [options, setOptions] = useState<IOptions>();
   const [selectedTrace, setSelectedTrace] = useState<React.ReactNode>(undefined);
 
   // changeOptions is used to change the options. Besides setting a new value for the options state we also reflect the
@@ -37,9 +37,15 @@ const Traces: React.FunctionComponent<ITracesProps> = ({ name, displayName, desc
         opts.times.timeStart
       }`,
     });
-
-    setOptions({ ...opts, operation: 'All Operations' ? '' : opts.operation });
   };
+
+  useEffect(() => {
+    setOptions((prevOptions) => getInitialOptions(location.search, !prevOptions));
+  }, [location.search]);
+
+  if (!options) {
+    return null;
+  }
 
   return (
     <React.Fragment>

--- a/plugins/jaeger/src/components/panel/Panel.tsx
+++ b/plugins/jaeger/src/components/panel/Panel.tsx
@@ -14,7 +14,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
   description,
   times,
   options,
-  showDetails,
+  setDetails,
 }: IPanelProps) => {
   if (!options || !options.queries || !Array.isArray(options.queries) || options.queries.length === 0 || !times) {
     return (
@@ -32,7 +32,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
       name={name}
       title={title}
       description={description}
-      showDetails={showDetails}
+      setDetails={setDetails}
       showChart={options.showChart || false}
       queries={options.queries}
       times={times}

--- a/plugins/jaeger/src/components/panel/Traces.tsx
+++ b/plugins/jaeger/src/components/panel/Traces.tsx
@@ -26,7 +26,7 @@ interface ITracesProps {
   showChart: boolean;
   queries: IQuery[];
   times: IPluginTimes;
-  showDetails?: (details: React.ReactNode) => void;
+  setDetails?: (details: React.ReactNode) => void;
 }
 
 const Traces: React.FunctionComponent<ITracesProps> = ({
@@ -34,7 +34,7 @@ const Traces: React.FunctionComponent<ITracesProps> = ({
   title,
   description,
   times,
-  showDetails,
+  setDetails,
   showChart,
   queries,
 }: ITracesProps) => {
@@ -154,14 +154,14 @@ const Traces: React.FunctionComponent<ITracesProps> = ({
           <React.Fragment>
             {showChart ? (
               <React.Fragment>
-                <TracesChart name={name} traces={data} showDetails={showDetails} />
+                <TracesChart name={name} traces={data} setDetails={setDetails} />
                 <p>&nbsp;</p>
                 <p>&nbsp;</p>
                 <p>&nbsp;</p>
               </React.Fragment>
             ) : null}
 
-            <TracesList name={name} traces={data} showDetails={showDetails} />
+            <TracesList name={name} traces={data} setDetails={setDetails} />
           </React.Fragment>
         ) : null}
       </div>

--- a/plugins/jaeger/src/components/panel/TracesChart.tsx
+++ b/plugins/jaeger/src/components/panel/TracesChart.tsx
@@ -21,14 +21,14 @@ interface IDatum extends ScatterPlotDatum {
 interface ITracesChartProps {
   name: string;
   traces: ITrace[];
-  showDetails?: (details: React.ReactNode) => void;
+  setDetails?: (details: React.ReactNode) => void;
 }
 
 function isIDatum(object: ScatterPlotDatum): object is IDatum {
   return (object as IDatum).trace !== undefined;
 }
 
-const TracesChart: React.FunctionComponent<ITracesChartProps> = ({ name, traces, showDetails }: ITracesChartProps) => {
+const TracesChart: React.FunctionComponent<ITracesChartProps> = ({ name, traces, setDetails }: ITracesChartProps) => {
   const { series, min, max, first, last } = useMemo<{
     series: ScatterPlotRawSerie<ScatterPlotDatum>[];
     min: number;
@@ -99,8 +99,8 @@ const TracesChart: React.FunctionComponent<ITracesChartProps> = ({ name, traces,
             margin={{ bottom: 25, left: 0, right: 0, top: 0 }}
             nodeSize={{ key: 'data.spans', sizes: [15, 75], values: [min, max] }}
             onClick={(node: ScatterPlotNodeData<ScatterPlotDatum>): void => {
-              if (showDetails && isIDatum(node.data)) {
-                showDetails(<Trace name={name} trace={node.data.trace} close={(): void => showDetails(undefined)} />);
+              if (setDetails && isIDatum(node.data)) {
+                setDetails(<Trace name={name} trace={node.data.trace} close={(): void => setDetails(undefined)} />);
               }
             }}
             renderNode={(ctx: CanvasRenderingContext2D, props: ScatterPlotNodeData<ScatterPlotDatum>): void => {

--- a/plugins/jaeger/src/components/panel/TracesList.tsx
+++ b/plugins/jaeger/src/components/panel/TracesList.tsx
@@ -7,16 +7,16 @@ import TracesListItem from './TracesListItem';
 interface ITracesListProps {
   name: string;
   traces: ITrace[];
-  showDetails?: (details: React.ReactNode) => void;
+  setDetails?: (details: React.ReactNode) => void;
 }
 
-const TracesList: React.FunctionComponent<ITracesListProps> = ({ name, traces, showDetails }: ITracesListProps) => {
+const TracesList: React.FunctionComponent<ITracesListProps> = ({ name, traces, setDetails }: ITracesListProps) => {
   return (
     <Menu>
       <MenuContent>
         <MenuList>
           {traces.map((trace, index) => (
-            <TracesListItem key={trace.traceID} name={name} trace={trace} showDetails={showDetails} />
+            <TracesListItem key={trace.traceID} name={name} trace={trace} setDetails={setDetails} />
           ))}
         </MenuList>
       </MenuContent>

--- a/plugins/jaeger/src/components/panel/TracesListItem.tsx
+++ b/plugins/jaeger/src/components/panel/TracesListItem.tsx
@@ -12,13 +12,13 @@ import { getColorForService } from '../../utils/colors';
 interface ITracesListItemProps {
   name: string;
   trace: ITrace;
-  showDetails?: (details: React.ReactNode) => void;
+  setDetails?: (details: React.ReactNode) => void;
 }
 
 const TracesListItem: React.FunctionComponent<ITracesListItemProps> = ({
   name,
   trace,
-  showDetails,
+  setDetails,
 }: ITracesListItemProps) => {
   const item = (
     <MenuItem
@@ -45,8 +45,8 @@ const TracesListItem: React.FunctionComponent<ITracesListItemProps> = ({
         </span>
       }
       onClick={
-        showDetails
-          ? (): void => showDetails(<Trace name={name} trace={trace} close={(): void => showDetails(undefined)} />)
+        setDetails
+          ? (): void => setDetails(<Trace name={name} trace={trace} close={(): void => setDetails(undefined)} />)
           : undefined
       }
     >
@@ -64,7 +64,7 @@ const TracesListItem: React.FunctionComponent<ITracesListItemProps> = ({
     </MenuItem>
   );
 
-  if (!showDetails) {
+  if (!setDetails) {
     return <LinkWrapper link={`/${name}/trace/${trace.traceID}`}>{item}</LinkWrapper>;
   }
 

--- a/plugins/jaeger/src/utils/helpers.ts
+++ b/plugins/jaeger/src/utils/helpers.ts
@@ -3,8 +3,8 @@ import { IPluginTimes, formatTime, getTimeParams } from '@kobsio/plugin-core';
 import TreeNode from './TreeNode';
 
 // getInitialOptions is used to get the initial Jaeger options from the url.
-export const getInitialOptions = (): IOptions => {
-  const params = new URLSearchParams(window.location.search);
+export const getInitialOptions = (search: string, isInitial: boolean): IOptions => {
+  const params = new URLSearchParams(search);
   const limit = params.get('limit');
   const maxDuration = params.get('maxDuration');
   const minDuration = params.get('minDuration');
@@ -19,7 +19,7 @@ export const getInitialOptions = (): IOptions => {
     operation: operation ? operation : '',
     service: service ? service : '',
     tags: tags ? tags : '',
-    times: getTimeParams(params),
+    times: getTimeParams(params, isInitial),
   };
 };
 

--- a/plugins/kiali/src/components/page/Page.tsx
+++ b/plugins/kiali/src/components/page/Page.tsx
@@ -6,7 +6,7 @@ import {
   PageSectionVariants,
   Title,
 } from '@patternfly/react-core';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import GraphWrapper from '../panel/GraphWrapper';
@@ -18,7 +18,7 @@ import { getInitialOptions } from '../../utils/helpers';
 const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, description }: IPluginPageProps) => {
   const location = useLocation();
   const history = useHistory();
-  const [options, setOptions] = useState<IOptions>(useMemo<IOptions>(() => getInitialOptions(), []));
+  const [options, setOptions] = useState<IOptions>();
   const [details, setDetails] = useState<React.ReactNode>(undefined);
 
   // changeOptions is used to change the options. Besides setting a new value for the options state we also reflect the
@@ -32,9 +32,15 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
         namespaces.length > 0 ? namespaces.join('') : ''
       }`,
     });
-
-    setOptions(opts);
   };
+
+  useEffect(() => {
+    setOptions((prevOptions) => getInitialOptions(location.search, !prevOptions));
+  }, [location.search]);
+
+  if (!options) {
+    return null;
+  }
 
   return (
     <React.Fragment>

--- a/plugins/kiali/src/components/panel/Panel.tsx
+++ b/plugins/kiali/src/components/panel/Panel.tsx
@@ -15,7 +15,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
   description,
   times,
   options,
-  showDetails,
+  setDetails,
 }: IPanelProps) => {
   if (!options || !options.namespaces || !Array.isArray(options.namespaces) || !times) {
     return (
@@ -35,7 +35,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
       transparent={true}
       actions={<GraphActions name={name} namespaces={options.namespaces} times={times} />}
     >
-      <GraphWrapper name={name} namespaces={options.namespaces} times={times} setDetails={showDetails} />
+      <GraphWrapper name={name} namespaces={options.namespaces} times={times} setDetails={setDetails} />
     </PluginCard>
   );
 };

--- a/plugins/kiali/src/utils/helpers.ts
+++ b/plugins/kiali/src/utils/helpers.ts
@@ -2,13 +2,13 @@ import { IMetric, INodeData, IOptions, ISerie } from './interfaces';
 import { getTimeParams } from '@kobsio/plugin-core';
 
 // getInitialOptions is used to get the initial Kiali options from a url.
-export const getInitialOptions = (): IOptions => {
-  const params = new URLSearchParams(window.location.search);
+export const getInitialOptions = (search: string, isInitial: boolean): IOptions => {
+  const params = new URLSearchParams(search);
   const namespaces = params.getAll('namespace');
 
   return {
     namespaces: namespaces.length > 0 ? namespaces : undefined,
-    times: getTimeParams(params),
+    times: getTimeParams(params, isInitial),
   };
 };
 

--- a/plugins/klogs/src/components/page/AggregationPage.tsx
+++ b/plugins/klogs/src/components/page/AggregationPage.tsx
@@ -12,7 +12,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { Link, useHistory, useLocation } from 'react-router-dom';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import Aggregation from './Aggregation';
 import AggregationOptions from './AggregationOptions';
@@ -33,27 +33,34 @@ const AggregationPage: React.FunctionComponent<IAggregationPageProps> = ({
 }: IAggregationPageProps) => {
   const location = useLocation();
   const history = useHistory();
-  const [tmpOptions, setTmpOptions] = useState<IAggregationOptions>(
-    useMemo<IAggregationOptions>(() => getInitialAggregationOptions(), []),
-  );
-  const [options, setOptions] = useState<IAggregationOptions>(
-    useMemo<IAggregationOptions>(() => getInitialAggregationOptions(), []),
-  );
+  const [options, setOptions] = useState<IAggregationOptions>();
+  const [tmpOptions, setTmpOptions] = useState<IAggregationOptions>();
 
   // changeOptions is used to change the options. Besides setting a new value for the options state we also reflect the
   // options in the current url.
   const changeOptions = (): void => {
-    history.push({
-      pathname: location.pathname,
-      search: `?query=${encodeURIComponent(tmpOptions.query)}&time=${tmpOptions.times.time}&timeEnd=${
-        tmpOptions.times.timeEnd
-      }&timeStart=${tmpOptions.times.timeStart}&chart=${tmpOptions.chart}&aggregation=${encodeURIComponent(
-        JSON.stringify(tmpOptions.options),
-      )}`,
-    });
-
-    setOptions(tmpOptions);
+    if (tmpOptions) {
+      history.push({
+        pathname: location.pathname,
+        search: `?query=${encodeURIComponent(tmpOptions.query)}&time=${tmpOptions.times.time}&timeEnd=${
+          tmpOptions.times.timeEnd
+        }&timeStart=${tmpOptions.times.timeStart}&chart=${tmpOptions.chart}&aggregation=${encodeURIComponent(
+          JSON.stringify(tmpOptions.options),
+        )}`,
+      });
+    }
   };
+
+  useEffect(() => {
+    setOptions((prevOptions) => getInitialAggregationOptions(location.search, !prevOptions));
+    setTmpOptions((prevOptions) =>
+      !prevOptions ? getInitialAggregationOptions(location.search, !prevOptions) : prevOptions,
+    );
+  }, [location.search]);
+
+  if (!options || !tmpOptions) {
+    return null;
+  }
 
   return (
     <React.Fragment>

--- a/plugins/klogs/src/components/page/LogsPage.tsx
+++ b/plugins/klogs/src/components/page/LogsPage.tsx
@@ -10,7 +10,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { Link, useHistory, useLocation } from 'react-router-dom';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { IOptions } from '../../utils/interfaces';
 import { IPluginTimes } from '@kobsio/plugin-core';
@@ -27,7 +27,7 @@ interface ILogsPageProps {
 const LogsPage: React.FunctionComponent<ILogsPageProps> = ({ name, displayName, description }: ILogsPageProps) => {
   const location = useLocation();
   const history = useHistory();
-  const [options, setOptions] = useState<IOptions>(useMemo<IOptions>(() => getInitialOptions(), []));
+  const [options, setOptions] = useState<IOptions>();
 
   // changeOptions is used to change the options. Besides setting a new value for the options state we also reflect the
   // options in the current url.
@@ -40,29 +40,29 @@ const LogsPage: React.FunctionComponent<ILogsPageProps> = ({ name, displayName, 
         opts.times.time
       }&timeEnd=${opts.times.timeEnd}&timeStart=${opts.times.timeStart}${fields.length > 0 ? fields.join('') : ''}`,
     });
-
-    setOptions(opts);
   };
 
   // selectField is used to add a field as parameter, when it isn't present and to remove a fields from as parameter,
   // when it is already present via the changeOptions function.
   const selectField = (field: string): void => {
-    let tmpFields: string[] = [];
-    if (options.fields) {
-      tmpFields = [...options.fields];
-    }
+    if (options) {
+      let tmpFields: string[] = [];
+      if (options.fields) {
+        tmpFields = [...options.fields];
+      }
 
-    if (tmpFields.includes(field)) {
-      tmpFields = tmpFields.filter((f) => f !== field);
-    } else {
-      tmpFields.push(field);
-    }
+      if (tmpFields.includes(field)) {
+        tmpFields = tmpFields.filter((f) => f !== field);
+      } else {
+        tmpFields.push(field);
+      }
 
-    changeOptions({ ...options, fields: tmpFields });
+      changeOptions({ ...options, fields: tmpFields });
+    }
   };
 
   const changeFieldOrder = (oldIndex: number, newIndex: number): void => {
-    if (options.fields) {
+    if (options && options.fields) {
       const tmpFields = [...options.fields];
       const tmpField = tmpFields[oldIndex];
 
@@ -75,19 +75,33 @@ const LogsPage: React.FunctionComponent<ILogsPageProps> = ({ name, displayName, 
 
   // addFilter adds the given filter as string to the query, so that it can be used to filter down an existing query.
   const addFilter = (filter: string): void => {
-    changeOptions({ ...options, query: `${options.query} ${filter}` });
+    if (options) {
+      changeOptions({ ...options, query: `${options.query} ${filter}` });
+    }
   };
 
   // changeTime changes the selected time range. This can be used to change the time outside of the toolbar, e.g. by
   // selecting a time range in the chart.
   const changeTime = (times: IPluginTimes): void => {
-    changeOptions({ ...options, times: times });
+    if (options) {
+      changeOptions({ ...options, times: times });
+    }
   };
 
   // changeOrder changes the order parameters for a query.
   const changeOrder = (order: string, orderBy: string): void => {
-    changeOptions({ ...options, order: order, orderBy: orderBy });
+    if (options) {
+      changeOptions({ ...options, order: order, orderBy: orderBy });
+    }
   };
+
+  useEffect(() => {
+    setOptions((prevOptions) => getInitialOptions(location.search, !prevOptions));
+  }, [location.search]);
+
+  if (!options) {
+    return null;
+  }
 
   return (
     <React.Fragment>

--- a/plugins/klogs/src/utils/helpers.ts
+++ b/plugins/klogs/src/utils/helpers.ts
@@ -2,8 +2,8 @@ import { IAggregationOptions, IAggregationOptionsAggregation, IOptions } from '.
 import { getTimeParams } from '@kobsio/plugin-core';
 
 // getInitialOptions is used to get the initial klogs options from the url.
-export const getInitialOptions = (): IOptions => {
-  const params = new URLSearchParams(window.location.search);
+export const getInitialOptions = (search: string, isInitial: boolean): IOptions => {
+  const params = new URLSearchParams(search);
   const fields = params.getAll('field');
   const order = params.get('order');
   const orderBy = params.get('orderBy');
@@ -14,13 +14,13 @@ export const getInitialOptions = (): IOptions => {
     order: order ? order : 'descending',
     orderBy: orderBy ? orderBy : '',
     query: query ? query : '',
-    times: getTimeParams(params),
+    times: getTimeParams(params, isInitial),
   };
 };
 
 // getInitialAggregationOptions is used to get the initial options for an aggregation from the url.
-export const getInitialAggregationOptions = (): IAggregationOptions => {
-  const params = new URLSearchParams(window.location.search);
+export const getInitialAggregationOptions = (search: string, isInitial: boolean): IAggregationOptions => {
+  const params = new URLSearchParams(search);
 
   const chart = params.get('chart');
   const query = params.get('query');
@@ -36,14 +36,14 @@ export const getInitialAggregationOptions = (): IAggregationOptions => {
       chart: chart ? chart : 'pie',
       options: aggregationOptions,
       query: query ? query : '',
-      times: getTimeParams(params),
+      times: getTimeParams(params, isInitial),
     };
   } catch (err) {
     return {
       chart: chart ? chart : 'pie',
       options: aggregationOptionDefaults,
       query: query ? query : '',
-      times: getTimeParams(params),
+      times: getTimeParams(params, isInitial),
     };
   }
 };

--- a/plugins/opsgenie/src/components/page/Page.tsx
+++ b/plugins/opsgenie/src/components/page/Page.tsx
@@ -6,7 +6,7 @@ import {
   PageSectionVariants,
   Title,
 } from '@patternfly/react-core';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import Alerts from '../panel/Alerts';
@@ -19,7 +19,7 @@ import { getInitialOptions } from '../../utils/helpers';
 const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, description }: IPluginPageProps) => {
   const location = useLocation();
   const history = useHistory();
-  const [options, setOptions] = useState<IOptions>(useMemo<IOptions>(() => getInitialOptions(), []));
+  const [options, setOptions] = useState<IOptions>();
   const [details, setDetails] = useState<React.ReactNode>(undefined);
 
   // changeOptions is used to change the options to get a list of traces from Jaeger. Instead of directly modifying the
@@ -31,9 +31,15 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
         opts.times.timeEnd
       }&timeStart=${opts.times.timeStart}`,
     });
-
-    setOptions(opts);
   };
+
+  useEffect(() => {
+    setOptions((prevOptions) => getInitialOptions(location.search, !prevOptions));
+  }, [location.search]);
+
+  if (!options) {
+    return null;
+  }
 
   return (
     <React.Fragment>

--- a/plugins/opsgenie/src/components/panel/Panel.tsx
+++ b/plugins/opsgenie/src/components/panel/Panel.tsx
@@ -17,7 +17,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
   description,
   times,
   options,
-  showDetails,
+  setDetails,
 }: IPanelProps) => {
   if (!options || !times) {
     return (
@@ -43,7 +43,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
           query={options.query || ''}
           interval={options.interval}
           times={times}
-          setDetails={showDetails}
+          setDetails={setDetails}
         />
       </PluginCard>
     );
@@ -61,7 +61,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
         query={options.query || ''}
         interval={options.interval}
         times={times}
-        setDetails={showDetails}
+        setDetails={setDetails}
       />
     </PluginCard>
   );

--- a/plugins/opsgenie/src/utils/helpers.ts
+++ b/plugins/opsgenie/src/utils/helpers.ts
@@ -2,14 +2,14 @@ import { IPluginTimes, formatTime, getTimeParams } from '@kobsio/plugin-core';
 import { IOptions } from './interfaces';
 
 // getInitialOptions is used to get the initial Opsgenie options from a the url.
-export const getInitialOptions = (): IOptions => {
-  const params = new URLSearchParams(window.location.search);
+export const getInitialOptions = (search: string, isInitial: boolean): IOptions => {
+  const params = new URLSearchParams(search);
   const query = params.get('query');
   const type = params.get('type');
 
   return {
     query: query === null ? 'status: open' : query,
-    times: getTimeParams(params),
+    times: getTimeParams(params, isInitial),
     type: type ? type : 'alerts',
   };
 };

--- a/plugins/prometheus/src/components/page/Page.tsx
+++ b/plugins/prometheus/src/components/page/Page.tsx
@@ -1,5 +1,5 @@
 import { PageSection, PageSectionVariants, Title } from '@patternfly/react-core';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { IOptions } from '../../utils/interfaces';
@@ -11,7 +11,7 @@ import { getInitialOptions } from '../../utils/helpers';
 const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, description }: IPluginPageProps) => {
   const location = useLocation();
   const history = useHistory();
-  const [options, setOptions] = useState<IOptions>(useMemo<IOptions>(() => getInitialOptions(), []));
+  const [options, setOptions] = useState<IOptions>();
 
   // changeOptions is used to change the options. Besides setting a new value for the options state we also reflect the
   // options in the current url.
@@ -24,9 +24,15 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
         opts.resolution
       }${queries.length > 0 ? queries.join('') : ''}`,
     });
-
-    setOptions(opts);
   };
+
+  useEffect(() => {
+    setOptions((prevOptions) => getInitialOptions(location.search, !prevOptions));
+  }, [location.search]);
+
+  if (!options) {
+    return null;
+  }
 
   return (
     <React.Fragment>

--- a/plugins/prometheus/src/utils/helpers.ts
+++ b/plugins/prometheus/src/utils/helpers.ts
@@ -6,15 +6,15 @@ import { getTimeParams } from '@kobsio/plugin-core';
 // getInitialOptions is used to parse the given search location and return is as options for Prometheus. This is
 // needed, so that a user can explore his Prometheus data from a chart. When the user selects the explore action, we
 // pass him to this page and pass the data via the URL parameters.
-export const getInitialOptions = (): IOptions => {
-  const params = new URLSearchParams(window.location.search);
+export const getInitialOptions = (search: string, isInitial: boolean): IOptions => {
+  const params = new URLSearchParams(search);
   const queries = params.getAll('query');
   const resolution = params.get('resolution');
 
   return {
     queries: queries.length > 0 ? queries : [''],
     resolution: resolution ? resolution : '',
-    times: getTimeParams(params),
+    times: getTimeParams(params, isInitial),
   };
 };
 

--- a/plugins/resources/src/components/page/Page.tsx
+++ b/plugins/resources/src/components/page/Page.tsx
@@ -71,7 +71,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
                   title=""
                   options={[options]}
                   times={options.times}
-                  showDetails={setDetails}
+                  setDetails={setDetails}
                 />
               )}
             </PageSection>

--- a/plugins/resources/src/components/page/Page.tsx
+++ b/plugins/resources/src/components/page/Page.tsx
@@ -8,7 +8,7 @@ import {
   PageSectionVariants,
   Title,
 } from '@patternfly/react-core';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { IOptions } from '../../utils/interfaces';
@@ -20,7 +20,7 @@ import { getInitialOptions } from '../../utils/helpers';
 const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, description }: IPluginPageProps) => {
   const history = useHistory();
   const location = useLocation();
-  const [options, setOptions] = useState<IOptions>(useMemo<IOptions>(() => getInitialOptions(), []));
+  const [options, setOptions] = useState<IOptions>();
   const [details, setDetails] = useState<React.ReactNode>(undefined);
 
   // changeOptions is used to change the options. Besides setting a new value for the options state we also reflect the
@@ -36,9 +36,15 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
         namespaceParams.length > 0 ? namespaceParams.join('') : ''
       }${resourceParams.length > 0 ? resourceParams.join('') : ''}`,
     });
-
-    setOptions(opts);
   };
+
+  useEffect(() => {
+    setOptions((prevOptions) => getInitialOptions(location.search, !prevOptions));
+  }, [location.search]);
+
+  if (!options) {
+    return null;
+  }
 
   return (
     <React.Fragment>

--- a/plugins/resources/src/components/panel/Panel.tsx
+++ b/plugins/resources/src/components/panel/Panel.tsx
@@ -19,7 +19,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
   description,
   options,
   times,
-  showDetails,
+  setDetails,
 }: IPanelProps) => {
   if (!options || !Array.isArray(options) || !times) {
     return (
@@ -48,14 +48,14 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
   if (title) {
     return (
       <PluginCard title={title} description={description} transparent={true} actions={<PanelActions options={opts} />}>
-        <PanelList resources={opts} times={times} showDetails={showDetails} />
+        <PanelList resources={opts} times={times} setDetails={setDetails} />
       </PluginCard>
     );
   }
 
   return (
     <Card>
-      <PanelList resources={opts} times={times} showDetails={showDetails} />
+      <PanelList resources={opts} times={times} setDetails={setDetails} />
     </Card>
   );
 };

--- a/plugins/resources/src/components/panel/PanelList.tsx
+++ b/plugins/resources/src/components/panel/PanelList.tsx
@@ -8,10 +8,10 @@ import PanelListItem from './PanelListItem';
 interface IPanelListProps {
   resources: IPanelOptions[];
   times: IPluginTimes;
-  showDetails?: (details: React.ReactNode) => void;
+  setDetails?: (details: React.ReactNode) => void;
 }
 
-const PanelList: React.FunctionComponent<IPanelListProps> = ({ resources, times, showDetails }: IPanelListProps) => {
+const PanelList: React.FunctionComponent<IPanelListProps> = ({ resources, times, setDetails }: IPanelListProps) => {
   const clustersContext = useContext<IClusterContext>(ClustersContext);
   const [expanded, setExpanded] = useState<string[]>(['resources-accordion-0-0']);
 
@@ -53,7 +53,7 @@ const PanelList: React.FunctionComponent<IPanelListProps> = ({ resources, times,
                               resource={clustersContext.resources[item]}
                               selector={resource.selector || ''}
                               times={times}
-                              showDetails={showDetails}
+                              setDetails={setDetails}
                             />
                           ) : null}
                         </AccordionContent>

--- a/plugins/resources/src/components/panel/PanelListItem.tsx
+++ b/plugins/resources/src/components/panel/PanelListItem.tsx
@@ -11,7 +11,7 @@ interface IPanelListItemProps {
   resource: IResource;
   selector: string;
   times: IPluginTimes;
-  showDetails?: (details: React.ReactNode) => void;
+  setDetails?: (details: React.ReactNode) => void;
 }
 
 const PanelListItem: React.FunctionComponent<IPanelListItemProps> = ({
@@ -20,7 +20,7 @@ const PanelListItem: React.FunctionComponent<IPanelListItemProps> = ({
   resource,
   selector,
   times,
-  showDetails,
+  setDetails,
 }: IPanelListItemProps) => {
   const [selectedRow, setSelectedRow] = useState<number>(-1);
 
@@ -73,13 +73,13 @@ const PanelListItem: React.FunctionComponent<IPanelListItemProps> = ({
   };
 
   const handleRowClick = (rowIndex: number, row: IResourceRow): void => {
-    if (showDetails && resource) {
-      showDetails(
+    if (setDetails && resource) {
+      setDetails(
         <Details
           request={resource}
           resource={row}
           close={(): void => {
-            showDetails(undefined);
+            setDetails(undefined);
             setSelectedRow(-1);
           }}
           refetch={refetchhWithDelay}
@@ -103,10 +103,10 @@ const PanelListItem: React.FunctionComponent<IPanelListItemProps> = ({
           ? data.map((row, rowIndex) => (
               <Tr
                 key={rowIndex}
-                isHoverable={showDetails ? true : false}
+                isHoverable={setDetails ? true : false}
                 isRowSelected={selectedRow === rowIndex}
                 onClick={(): void =>
-                  showDetails && data && data.length > 0 && data[0].cells?.length === resource.columns.length
+                  setDetails && data && data.length > 0 && data[0].cells?.length === resource.columns.length
                     ? handleRowClick(rowIndex, row)
                     : undefined
                 }

--- a/plugins/resources/src/utils/helpers.ts
+++ b/plugins/resources/src/utils/helpers.ts
@@ -2,8 +2,8 @@ import { IOptions } from './interfaces';
 import { getTimeParams } from '@kobsio/plugin-core';
 
 // getInitialOptions returns the initial options from the url.
-export const getInitialOptions = (): IOptions => {
-  const params = new URLSearchParams(window.location.search);
+export const getInitialOptions = (search: string, isInitial: boolean): IOptions => {
+  const params = new URLSearchParams(search);
   const clusters = params.getAll('cluster');
   const namespaces = params.getAll('namespace');
   const resources = params.getAll('resource');
@@ -14,7 +14,7 @@ export const getInitialOptions = (): IOptions => {
     namespaces: namespaces || [],
     resources: resources || [],
     selector: selector ? selector : '',
-    times: getTimeParams(params),
+    times: getTimeParams(params, isInitial),
   };
 };
 

--- a/plugins/rss/src/components/panel/Panel.tsx
+++ b/plugins/rss/src/components/panel/Panel.tsx
@@ -12,7 +12,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
   title,
   description,
   options,
-  showDetails,
+  setDetails,
 }: IPanelProps) => {
   if (!options || !options.urls || !Array.isArray(options.urls) || options.urls.length === 0) {
     return (
@@ -27,7 +27,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
 
   return (
     <PluginCard title={title} description={description} transparent={true}>
-      <Feed urls={options.urls} sortBy={options.sortBy || 'published'} setDetails={showDetails} />
+      <Feed urls={options.urls} sortBy={options.sortBy || 'published'} setDetails={setDetails} />
     </PluginCard>
   );
 };

--- a/plugins/sonarqube/src/components/page/Page.tsx
+++ b/plugins/sonarqube/src/components/page/Page.tsx
@@ -19,15 +19,15 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({
   name,
   displayName,
   description,
-  options,
+  pluginOptions,
 }: IPluginPageProps) => {
   const location = useLocation();
   const history = useHistory();
-  const [pageOptions, setPageOptions] = useState<IOptions>();
+  const [options, setOptions] = useState<IOptions>();
 
-  // changePageOptions is used to change the options to get a list of projects from SonarQube. Instead of directly
+  // changeOptions is used to change the options to get a list of projects from SonarQube. Instead of directly
   // modifying the options state we change the URL parameters.
-  const changePageOptions = (opts: IOptions): void => {
+  const changeOptions = (opts: IOptions): void => {
     history.push({
       pathname: location.pathname,
       search: `?query=${encodeURIComponent(opts.query)}`,
@@ -35,10 +35,10 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({
   };
 
   useEffect(() => {
-    setPageOptions(getInitialOptions(location.search));
+    setOptions(getInitialOptions(location.search));
   }, [location.search]);
 
-  if (!pageOptions) {
+  if (!options) {
     return null;
   }
 
@@ -49,14 +49,18 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({
           {displayName}
         </Title>
         <p>{description}</p>
-        <PageToolbar name={name} options={pageOptions} setOptions={changePageOptions} />
+        <PageToolbar name={name} options={options} setOptions={changeOptions} />
       </PageSection>
 
       <Drawer isExpanded={false}>
         <DrawerContent panelContent={undefined}>
           <DrawerContentBody>
             <PageSection style={{ minHeight: '100%' }} variant={PageSectionVariants.default}>
-              <Projects name={name} query={pageOptions.query} url={options && options.url ? options.url : ''} />
+              <Projects
+                name={name}
+                query={options.query}
+                url={pluginOptions && pluginOptions.url ? pluginOptions.url : ''}
+              />
             </PageSection>
           </DrawerContentBody>
         </DrawerContent>

--- a/plugins/sonarqube/src/components/page/Page.tsx
+++ b/plugins/sonarqube/src/components/page/Page.tsx
@@ -6,7 +6,7 @@ import {
   PageSectionVariants,
   Title,
 } from '@patternfly/react-core';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { IOptions } from '../../utils/interfaces';
@@ -23,7 +23,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({
 }: IPluginPageProps) => {
   const location = useLocation();
   const history = useHistory();
-  const [pageOptions, setPageOptions] = useState<IOptions>(useMemo<IOptions>(() => getInitialOptions(), []));
+  const [pageOptions, setPageOptions] = useState<IOptions>();
 
   // changePageOptions is used to change the options to get a list of projects from SonarQube. Instead of directly
   // modifying the options state we change the URL parameters.
@@ -32,9 +32,15 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({
       pathname: location.pathname,
       search: `?query=${encodeURIComponent(opts.query)}`,
     });
-
-    setPageOptions(opts);
   };
+
+  useEffect(() => {
+    setPageOptions(getInitialOptions(location.search));
+  }, [location.search]);
+
+  if (!pageOptions) {
+    return null;
+  }
 
   return (
     <React.Fragment>

--- a/plugins/sonarqube/src/utils/helpers.ts
+++ b/plugins/sonarqube/src/utils/helpers.ts
@@ -1,8 +1,8 @@
 import { IOptions } from './interfaces';
 
 // getInitialOptions is used to get the initial options from the url.
-export const getInitialOptions = (): IOptions => {
-  const params = new URLSearchParams(window.location.search);
+export const getInitialOptions = (search: string): IOptions => {
+  const params = new URLSearchParams(search);
   const query = params.get('query');
 
   return {

--- a/plugins/sql/src/components/page/Page.tsx
+++ b/plugins/sql/src/components/page/Page.tsx
@@ -6,7 +6,7 @@ import {
   PageSectionVariants,
   Title,
 } from '@patternfly/react-core';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { IOptions } from '../../utils/interfaces';
@@ -18,7 +18,7 @@ import { getInitialOptions } from '../../utils/helpers';
 const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, description }: IPluginPageProps) => {
   const location = useLocation();
   const history = useHistory();
-  const [options, setOptions] = useState<IOptions>(useMemo<IOptions>(() => getInitialOptions(), []));
+  const [options, setOptions] = useState<IOptions>();
 
   // changeOptions is used to change the options for an SQL query. Instead of directly modifying the options state we
   // change the URL parameters.
@@ -27,9 +27,15 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
       pathname: location.pathname,
       search: `?query=${opts.query}`,
     });
-
-    setOptions(opts);
   };
+
+  useEffect(() => {
+    setOptions(getInitialOptions(location.search));
+  }, [location.search]);
+
+  if (!options) {
+    return null;
+  }
 
   return (
     <React.Fragment>

--- a/plugins/sql/src/utils/helpers.ts
+++ b/plugins/sql/src/utils/helpers.ts
@@ -1,8 +1,8 @@
 import { IOptions } from './interfaces';
 
 // getInitialOptions is used to get the initial options from the url.
-export const getInitialOptions = (): IOptions => {
-  const params = new URLSearchParams(window.location.search);
+export const getInitialOptions = (search: string): IOptions => {
+  const params = new URLSearchParams(search);
   const query = params.get('query');
 
   return {

--- a/plugins/teams/src/components/page/Team.tsx
+++ b/plugins/teams/src/components/page/Team.tsx
@@ -113,7 +113,7 @@ const Team: React.FunctionComponent = () => {
         <DrawerContent panelContent={details}>
           <DrawerContentBody>
             {data.dashboards ? (
-              <DashboardsWrapper defaults={data} references={data.dashboards} showDetails={setDetails} />
+              <DashboardsWrapper defaults={data} references={data.dashboards} setDetails={setDetails} />
             ) : (
               <PageSection style={{ minHeight: '100%' }} variant={PageSectionVariants.default}></PageSection>
             )}

--- a/plugins/techdocs/src/components/KobsCode.tsx
+++ b/plugins/techdocs/src/components/KobsCode.tsx
@@ -23,7 +23,7 @@ const KobsCode: React.FunctionComponent<IKobsCodeProps> = ({ panel, setDetails }
         description={panel.description}
         name={panel.plugin.name}
         options={panel.plugin.options}
-        showDetails={setDetails}
+        setDetails={setDetails}
       />
     </div>
   );

--- a/plugins/techdocs/src/components/panel/Panel.tsx
+++ b/plugins/techdocs/src/components/panel/Panel.tsx
@@ -14,7 +14,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
   title,
   description,
   options,
-  showDetails,
+  setDetails,
 }: IPanelProps) => {
   if (options && options.type && options.type === 'list') {
     return (


### PR DESCRIPTION
- We are going back to the implementation based on "useEffect" for the
options handling, instead of the "useMemo" handling, introduced in #232.
- We had a mixed usage of "setDetails" and "showDetails" across plugins.
To clean this up we are now only using "setDetails".
- To have the same nameing as for the panel implementation we renamed
options to pluginOptions for the page implementation of a plugin.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
