### PR TITLE
[azure] Cost Management drill-down on resourceGroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#233](https://github.com/kobsio/kobs/pull/233): [resources] Highlight expanded row for containers in Pod details.
 - [#235](https://github.com/kobsio/kobs/pull/235): [resources] Use `TableComposable` instead of `Table` component and unify table style across plugins.
 - [#237](https://github.com/kobsio/kobs/pull/237): [core] Adjust API paths to use the same schema as the Azure plugin.
+- [#239](https://github.com/kobsio/kobs/pull/239): [azure] Cost Management drill-down on resourceGroups.
 
 ## [v0.7.0](https://github.com/kobsio/kobs/releases/tag/v0.7.0) (2021-11-19)
 

--- a/plugins/azure/costmanagement.go
+++ b/plugins/azure/costmanagement.go
@@ -20,6 +20,7 @@ func (router *Router) getActualCost(w http.ResponseWriter, r *http.Request) {
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Invalid timeframe parameter")
 		return
 	}
+	scope := r.URL.Query().Get("scope")
 
 	i := router.getInstance(name)
 	if i == nil {
@@ -27,7 +28,7 @@ func (router *Router) getActualCost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	costUsage, err := i.CostManagement.GetActualCost(r.Context(), timeframe)
+	costUsage, err := i.CostManagement.GetActualCost(r.Context(), timeframe, scope)
 	if err != nil {
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not query cost usage")
 		return

--- a/plugins/azure/src/components/costmanagement/ActualCosts.tsx
+++ b/plugins/azure/src/components/costmanagement/ActualCosts.tsx
@@ -8,18 +8,23 @@ import { IQueryResult } from './interfaces';
 interface IActualCostsProps {
   name: string;
   timeframe: number;
+  scope: string;
 }
 
-const ActualCosts: React.FunctionComponent<IActualCostsProps> = ({ name, timeframe }: IActualCostsProps) => {
+const ActualCosts: React.FunctionComponent<IActualCostsProps> = ({ name, timeframe, scope }: IActualCostsProps) => {
   const { isError, isLoading, error, data, refetch } = useQuery<IQueryResult, Error>(
-    ['azure/costmanagement/actualcost', name, timeframe],
+    ['azure/costmanagement/actualcost', name, timeframe, scope],
     async () => {
       try {
         const timeframeParam = `timeframe=${timeframe}`;
+        const scopeParam = `scope=${scope}`;
 
-        const response = await fetch(`/api/plugins/azure/${name}/costmanagement/actualcost?${timeframeParam}`, {
-          method: 'get',
-        });
+        const response = await fetch(
+          `/api/plugins/azure/${name}/costmanagement/actualcost?${timeframeParam}&${scopeParam}`,
+          {
+            method: 'get',
+          },
+        );
 
         const json = await response.json();
 

--- a/plugins/azure/src/components/costmanagement/CostManagementToolbar.tsx
+++ b/plugins/azure/src/components/costmanagement/CostManagementToolbar.tsx
@@ -2,21 +2,32 @@ import { Toolbar, ToolbarContent, ToolbarItem, ToolbarToggleGroup } from '@patte
 import { FilterIcon } from '@patternfly/react-icons';
 import React from 'react';
 
+import CostManagementToolbarItemScope from './CostManagementToolbarItemScope';
 import CostManagementToolbarItemTimeframe from './CostManagementToolbarItemTimeframe';
 
 export interface ICostManagementToolbarProps {
   timeframe: number;
   setTimeframe: (timeframe: number) => void;
+  scope: string;
+  setScope: (scope: string) => void;
+  resourceGroups: string[];
 }
 
 const CostManagementToolbar: React.FunctionComponent<ICostManagementToolbarProps> = ({
   timeframe,
   setTimeframe,
+  scope,
+  setScope,
+  resourceGroups,
 }: ICostManagementToolbarProps) => {
   return (
     <Toolbar id="cost-management-toolbar" style={{ paddingBottom: '0px', zIndex: 300 }}>
       <ToolbarContent style={{ padding: '0px' }}>
         <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="lg">
+          <ToolbarItem variant="label">Scope</ToolbarItem>
+          <ToolbarItem>
+            <CostManagementToolbarItemScope scope={scope} setScope={setScope} resourceGroups={resourceGroups} />
+          </ToolbarItem>
           <ToolbarItem variant="label">Timeframe</ToolbarItem>
           <ToolbarItem>
             <CostManagementToolbarItemTimeframe timeframe={timeframe} setTimeframe={setTimeframe} />

--- a/plugins/azure/src/components/costmanagement/CostManagementToolbarItemScope.tsx
+++ b/plugins/azure/src/components/costmanagement/CostManagementToolbarItemScope.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+
+export interface ICostManagementToolbarItemScopeProps {
+  scope: string;
+  setScope: (scope: string) => void;
+  resourceGroups: string[];
+}
+
+// CostManagementToolbarItemScope lets the user select the scope
+const CostManagementToolbarItemScope: React.FunctionComponent<ICostManagementToolbarItemScopeProps> = ({
+  scope,
+  setScope,
+  resourceGroups,
+}: ICostManagementToolbarItemScopeProps) => {
+  const [showSelect, setShowSelect] = useState<boolean>(false);
+  const options = resourceGroups;
+  if (options.indexOf('All') === -1) {
+    options.push('All');
+  }
+
+  return (
+    <Select
+      variant={SelectVariant.single}
+      typeAheadAriaLabel="Select scope"
+      placeholderText="Select scope"
+      onToggle={(): void => setShowSelect(!showSelect)}
+      onSelect={(e, value): void => setScope(value as string)}
+      selections={scope}
+      isOpen={showSelect}
+    >
+      {options.map((scope, index) => (
+        <SelectOption key={index} value={scope} />
+      ))}
+    </Select>
+  );
+};
+
+export default CostManagementToolbarItemScope;

--- a/plugins/azure/src/components/costmanagement/CostPieChart.tsx
+++ b/plugins/azure/src/components/costmanagement/CostPieChart.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ResponsivePieCanvas } from '@nivo/pie';
+import { ResponsivePie } from '@nivo/pie';
 
 import { IQueryResult } from './interfaces';
 import { convertQueryResult } from '../../utils/helpers';
@@ -10,7 +10,7 @@ interface ICostPieChartProps {
 
 export const CostPieChart: React.FunctionComponent<ICostPieChartProps> = ({ data }: ICostPieChartProps) => {
   return (
-    <ResponsivePieCanvas
+    <ResponsivePie
       data={convertQueryResult(data)}
       margin={{ bottom: 80, left: 80, right: 80, top: 40 }}
       valueFormat=" >-.2f"
@@ -27,17 +27,18 @@ export const CostPieChart: React.FunctionComponent<ICostPieChartProps> = ({ data
       arcLinkLabelsColor={{ from: 'color' }}
       arcLabelsSkipAngle={10}
       arcLabelsTextColor={{ from: 'color', modifiers: [['darker', 2]] }}
+      motionConfig="gentle"
       legends={[
         {
           anchor: 'right',
           direction: 'column',
           itemDirection: 'left-to-right',
           itemHeight: 20,
-          itemWidth: 100,
+          itemWidth: 250,
           itemsSpacing: 5,
           justify: false,
           symbolSize: 20,
-          translateX: 0,
+          translateX: -200,
           translateY: 0,
         },
       ]}

--- a/plugins/azure/src/components/costmanagement/Page.tsx
+++ b/plugins/azure/src/components/costmanagement/Page.tsx
@@ -11,24 +11,33 @@ const service = 'costmanagement';
 interface ICostManagementPageProps {
   name: string;
   displayName: string;
+  resourceGroups: string[];
 }
 
 const CostManagementPage: React.FunctionComponent<ICostManagementPageProps> = ({
   name,
   displayName,
+  resourceGroups,
 }: ICostManagementPageProps) => {
   const [timeframe, setTimeframe] = useState<number>(7);
+  const [scope, setScope] = useState<string>('All');
 
   return (
     <React.Fragment>
       <PageSection variant={PageSectionVariants.light}>
         <Title title={services[service].name} subtitle={displayName} size="xl" />
         <p>{services[service].description}</p>
-        <CostManagementToolbar timeframe={timeframe} setTimeframe={setTimeframe} />
+        <CostManagementToolbar
+          timeframe={timeframe}
+          setTimeframe={setTimeframe}
+          scope={scope}
+          setScope={setScope}
+          resourceGroups={resourceGroups}
+        />
       </PageSection>
 
       <PageSection style={{ minHeight: '100%' }} variant={PageSectionVariants.default}>
-        <ActualCosts name={name} timeframe={timeframe} />
+        <ActualCosts name={name} timeframe={timeframe} scope={scope} />
       </PageSection>
     </React.Fragment>
   );

--- a/plugins/azure/src/components/page/Page.tsx
+++ b/plugins/azure/src/components/page/Page.tsx
@@ -79,7 +79,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
         <ContainerInstancesPage name={name} displayName={displayName} resourceGroups={data} />
       </Route>
       <Route exact={true} path={`/${name}/costmanagement`}>
-        <CostManagementPage name={name} displayName={displayName} />
+        <CostManagementPage name={name} displayName={displayName} resourceGroups={data} />
       </Route>
       <Route exact={true} path={`/${name}/kubernetesservices`}>
         <KubernetesServicesPage name={name} displayName={displayName} resourceGroups={data} />


### PR DESCRIPTION
Small rework for CostManagament which adds the possibility to view costs on `resourceGroup` level.

### Selecting `All`

When selecting scope `All` the visualized costs are grouped by `ResourceGroups` (same as current behavior).

### Selecting a `resourceGroup`

If a `resourceGroup` is selected the costs are grouped by `ServiceName`

![image](https://user-images.githubusercontent.com/9337156/146527252-5575a6ed-27df-47f6-ac00-b0497fca7c4e.png)

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
