### PR TITLE
[core] Switch to zap for logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#237](https://github.com/kobsio/kobs/pull/237): [core] Adjust API paths to use the same schema as the Azure plugin.
 - [#239](https://github.com/kobsio/kobs/pull/239): [azure] Cost Management drill-down on resource groups.
 - [#238](https://github.com/kobsio/kobs/pull/238): [core] Refactor frontend code for plugins (change options handling, use `setDetails` instead of `showDetails` and rename plugins options in panels to `pluginOptions`).
+- [#240](https://github.com/kobsio/kobs/pull/240): [core] Switch from `github.com/sirupsen/logrus` to `go.uber.org/zap` for logging and enrich log lines via `context.Context`.
 
 ## [v0.7.0](https://github.com/kobsio/kobs/releases/tag/v0.7.0) (2021-11-19)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,13 +117,7 @@ When you run the kobs binary, it will use the following ports:
 
 When you are using [VS Code](https://code.visualstudio.com) you can also use the `launch.json` file from the `.vscode` folder for debugging the kobs server. You can also adjust the log level to `trace` via the `--log.level` flag, for more useful output during development.
 
-When you add a new package and want to output some log lines make sure that you are not using `logrus` directly. Instead you should add a new `log` variable, which contains the package name:
-
-```go
-var (
-    log = logrus.WithFields(logrus.Fields{"package": "<PACKAGE-NAME>"})
-)
-```
+When you are adding a new package and want to output some log line your can use the `github.com/kobsio/kobs/pkg/log` package. The package is a wrapper around `go.uber.org/zap`, which we are using for logging and adds an option to add additional fields to a log line via a `context.Context`.
 
 The Go code is formatted using [`gofmt`](https://golang.org/cmd/gofmt/).
 

--- a/deploy/helm/kobs/Chart.yaml
+++ b/deploy/helm/kobs/Chart.yaml
@@ -4,5 +4,5 @@ description: Kubernetes Observability Platform
 type: application
 home: https://kobs.io
 icon: https://kobs.io/assets/images/logo.svg
-version: 0.8.2
+version: 0.8.3
 appVersion: v0.7.0

--- a/deploy/helm/kobs/values.yaml
+++ b/deploy/helm/kobs/values.yaml
@@ -110,7 +110,7 @@ kobs:
       header: X-Auth-Request-Email
       interval: 1h0m0s
     clustersCacheDurationNamespaces: 5m
-    logFormat: plain
+    logFormat: console
     logLevel: info
 
   ## Set the content of the config.yaml file, which is used by kobs. The configuration file is used to specify the

--- a/docs/contributing/develop-a-plugin.md
+++ b/docs/contributing/develop-a-plugin.md
@@ -96,17 +96,14 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
         "github.com/kobsio/kobs/pkg/api/clusters"
         "github.com/kobsio/kobs/pkg/api/middleware/errresponse"
         "github.com/kobsio/kobs/pkg/api/plugins/plugin"
+        "github.com/kobsio/kobs/pkg/log"
 
         "github.com/go-chi/chi/v5"
         "github.com/go-chi/render"
-        "github.com/sirupsen/logrus"
+        "go.uber.org/zap"
     )
 
     const Route = "/helloworld"
-
-    var (
-        log = logrus.WithFields(logrus.Fields{"package": "helloworld"})
-    )
 
     type Config struct {
         Name           string `json:"name"`
@@ -124,6 +121,7 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
     // getName returns the name form the configuration.
     func (router *Router) getName(w http.ResponseWriter, r *http.Request) {
         if router.config.HelloWorldName == "" {
+            log.Error(r.Context(), "Name is missing")
             errresponse.Render(w, r, nil, http.StatusInternalServerError, "Name is missing")
             return
         }
@@ -134,7 +132,7 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
             router.config.HelloWorldName,
         }
 
-        log.WithFields(logrus.Fields{"name": data.Name}).Tracef("getName")
+        log.Debug(r.Context(), "Get name result.", zap.String("name", data.Name))
         render.JSON(w, r, data)
     }
 

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -72,8 +72,8 @@ helm upgrade --install kobs kobs/kobs
 | `kobs.settings.auth.header` | The header, which contains the details about the authenticated user. | `X-Auth-Request-Email` |
 | `kobs.settings.auth.interval` | The interval to refresh the internal users list and there permissions. | `1h0m0s` |
 | `kobs.settings.clustersCacheDurationNamespaces` | The duration for how long the list of namespaces for each cluster should be cached. | `5m` |
-| `kobs.settings.logFormat` | Set the output format of the logs. Must be `plain` or `json`. | `plain` |
-| `kobs.settings.logLevel` | Set the log level. Must be `trace`, `debug`, `info`, `warn`, `error`, `fatal` or `panic`. | `info` |
+| `kobs.settings.logFormat` | Set the output format of the logs. Must be `console` or `json`. | `console` |
+| `kobs.settings.logLevel` | Set the log level. Must be `debug`, `info`, `warn`, `error`, `fatal` or `panic`. | `info` |
 | `kobs.config` | Content of the `config.yaml` file, which is loaded during the start of kobs and contains the configuration. | |
 | `istio.virtualService.create` | Specifies whether a VirtualService should be created. | `false` |
 | `istio.virtualService.gateways` | A list of gateways for the VirtualService. | `[]` |

--- a/go.mod
+++ b/go.mod
@@ -30,9 +30,9 @@ require (
 	github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.8
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/common v0.32.1
-	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
+	go.uber.org/zap v1.19.0
 	k8s.io/api v0.22.4
 	k8s.io/apiextensions-apiserver v0.22.4
 	k8s.io/apimachinery v0.22.4
@@ -101,8 +101,11 @@ require (
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/rs/zerolog v1.20.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/vjeantet/grok v1.0.0 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/net v0.0.0-20210610132358-84b48f89b13b // indirect
 	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c // indirect

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,7 @@ github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQ
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
+github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -729,6 +730,7 @@ go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
@@ -778,6 +780,7 @@ golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
@@ -1002,6 +1005,7 @@ golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
+golang.org/x/tools v0.1.2 h1:kRBLX7v7Af8W7Gdbbc908OJcdgtK8bOz9Uaj8/F1ACA=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/api/clusters/cluster/copy/copy.go
+++ b/pkg/api/clusters/cluster/copy/copy.go
@@ -7,13 +7,10 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/sirupsen/logrus"
+	"github.com/kobsio/kobs/pkg/log"
+
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
-)
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "clusters"})
 )
 
 // FileFromPod let a user download a file from a container.
@@ -34,7 +31,7 @@ func FileFromPod(w http.ResponseWriter, config *rest.Config, reqURL *url.URL) er
 			Tty:    false,
 		})
 		if err != nil {
-			log.WithError(err).Errorf("could not copy file from pod")
+			log.Error(nil, "Could not copy file from pod.")
 		}
 	}()
 

--- a/pkg/api/clusters/cluster/terminal/terminal.go
+++ b/pkg/api/clusters/cluster/terminal/terminal.go
@@ -11,13 +11,8 @@ import (
 	"net/url"
 
 	"github.com/gorilla/websocket"
-	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
-)
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "clusters"})
 )
 
 const END_OF_TRANSMISSION = "\u0004"

--- a/pkg/api/clusters/clusters.go
+++ b/pkg/api/clusters/clusters.go
@@ -7,12 +7,10 @@ import (
 	"github.com/kobsio/kobs/pkg/api/clusters/cluster"
 	"github.com/kobsio/kobs/pkg/api/clusters/provider"
 
-	"github.com/sirupsen/logrus"
 	flag "github.com/spf13/pflag"
 )
 
 var (
-	log                     = logrus.WithFields(logrus.Fields{"package": "clusters"})
 	cacheDurationNamespaces time.Duration
 	forbiddenResources      []string
 )

--- a/pkg/api/clusters/provider/incluster/incluster.go
+++ b/pkg/api/clusters/provider/incluster/incluster.go
@@ -2,13 +2,10 @@ package incluster
 
 import (
 	"github.com/kobsio/kobs/pkg/api/clusters/cluster"
+	"github.com/kobsio/kobs/pkg/log"
 
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 	"k8s.io/client-go/rest"
-)
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "clusters"})
 )
 
 // Config is the configuration for the InCluster provider.
@@ -19,11 +16,11 @@ type Config struct {
 // GetCluster returns the cluster, where kobs is running in via the incluster configuration. For the selection of the
 // cluster via a name, the user has to provide this name.
 func GetCluster(config *Config) ([]*cluster.Cluster, error) {
-	log.WithFields(logrus.Fields{"name": config.Name}).Tracef("Load incluster config.")
+	log.Debug(nil, "Load incluster config.", zap.String("name", config.Name))
 
 	restConfig, err := rest.InClusterConfig()
 	if err != nil {
-		log.WithError(err).Debugf("Could not create rest config.")
+		log.Error(nil, "Could not create rest config.", zap.Error(err))
 		return nil, err
 	}
 

--- a/pkg/api/clusters/provider/provider.go
+++ b/pkg/api/clusters/provider/provider.go
@@ -4,12 +4,9 @@ import (
 	"github.com/kobsio/kobs/pkg/api/clusters/cluster"
 	"github.com/kobsio/kobs/pkg/api/clusters/provider/incluster"
 	"github.com/kobsio/kobs/pkg/api/clusters/provider/kubeconfig"
+	"github.com/kobsio/kobs/pkg/log"
 
-	"github.com/sirupsen/logrus"
-)
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "clusters"})
+	"go.uber.org/zap"
 )
 
 // Type is the type of the cluster provider. At the moment it is only possible to load clusters via the
@@ -43,7 +40,7 @@ func GetClusters(config *Config) ([]*cluster.Cluster, error) {
 	case KUBECONFIG:
 		return kubeconfig.GetClusters(&config.Kubeconfig)
 	default:
-		log.WithFields(logrus.Fields{"provider": config.Provider}).Warnf("Invalid provider.")
+		log.Warn(nil, "Invalid provider.", zap.String("provider", string(config.Provider)))
 		return nil, nil
 	}
 }

--- a/pkg/api/middleware/auth/handler.go
+++ b/pkg/api/middleware/auth/handler.go
@@ -10,13 +10,10 @@ import (
 	authContext "github.com/kobsio/kobs/pkg/api/middleware/auth/context"
 	"github.com/kobsio/kobs/pkg/api/middleware/errresponse"
 
-	"github.com/sirupsen/logrus"
 	flag "github.com/spf13/pflag"
 )
 
 var (
-	log = logrus.WithFields(logrus.Fields{"package": "authentication"})
-
 	flagEnabled     bool
 	flagUserHeader  string
 	flagInterval    time.Duration

--- a/pkg/api/middleware/errresponse/errresponse.go
+++ b/pkg/api/middleware/errresponse/errresponse.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/kobsio/kobs/pkg/api/middleware/httplog"
-
 	"github.com/go-chi/render"
 )
 
@@ -25,8 +23,6 @@ func Render(w http.ResponseWriter, r *http.Request, err error, status int, msg s
 	errResponse := &ErrResponse{
 		Error: msg,
 	}
-
-	httplog.LogEntrySetField(r, "error", msg)
 
 	render.Status(r, status)
 	render.JSON(w, r, errResponse)

--- a/pkg/api/middleware/httplog/httplog.go
+++ b/pkg/api/middleware/httplog/httplog.go
@@ -1,5 +1,4 @@
-// Package httplog implements our custom http logger for kobs based on logrus. It is based on the chi logging example
-// from https://github.com/go-chi/chi/blob/master/_examples/logging/main.go
+// Package httplog implements our custom http logger middleware for kobs based on zap.
 package httplog
 
 import (
@@ -7,106 +6,39 @@ import (
 	"net/http"
 	"time"
 
-	authContext "github.com/kobsio/kobs/pkg/api/middleware/auth/context"
+	"github.com/kobsio/kobs/pkg/log"
 
 	"github.com/go-chi/chi/v5/middleware"
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
-// StructuredLogger is a simple, but powerful implementation of a custom structured
-// logger backed on logrus. I encourage users to copy it, adapt it and make it their
-// own. Also take a look at https://github.com/pressly/lg for a dedicated pkg based
-// on this work, designed for context-based http routers.
+// Logger is a middleware that handles the request logging for chi via zap.
+func Logger(next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		wrw := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+		next.ServeHTTP(wrw, r)
 
-func NewStructuredLogger(logger *logrus.Logger) func(next http.Handler) http.Handler {
-	return middleware.RequestLogger(&StructuredLogger{logger})
-}
+		scheme := "http"
+		if r.TLS != nil {
+			scheme = "https"
+		}
 
-type StructuredLogger struct {
-	Logger *logrus.Logger
-}
+		fields := []zapcore.Field{
+			zap.String("requestScheme", scheme),
+			zap.String("requestProto", r.Proto),
+			zap.String("requestMethod", r.Method),
+			zap.String("requestAddr", r.RemoteAddr),
+			zap.String("requestUserAgent", r.UserAgent()),
+			zap.String("requestURI", fmt.Sprintf("%s://%s%s", scheme, r.Host, r.RequestURI)),
+			zap.Int("responseStatus", wrw.Status()),
+			zap.Int("responseBytes", wrw.BytesWritten()),
+			zap.Float64("requestLatency", float64(time.Since(start).Nanoseconds())/1000000),
+		}
 
-func (l *StructuredLogger) NewLogEntry(r *http.Request) middleware.LogEntry {
-	entry := &StructuredLoggerEntry{Logger: logrus.NewEntry(l.Logger)}
-	logFields := logrus.Fields{}
-
-	logFields["ts"] = time.Now().UTC().Format(time.RFC1123)
-
-	if reqID := middleware.GetReqID(r.Context()); reqID != "" {
-		logFields["req_id"] = reqID
+		log.Info(r.Context(), "Request completed.", fields...)
 	}
 
-	if user, _ := authContext.GetUser(r.Context()); user != nil {
-		logFields["user"] = user.ID
-	}
-
-	scheme := "http"
-	if r.TLS != nil {
-		scheme = "https"
-	}
-	logFields["http_scheme"] = scheme
-	logFields["http_proto"] = r.Proto
-	logFields["http_method"] = r.Method
-
-	logFields["remote_addr"] = r.RemoteAddr
-	logFields["user_agent"] = r.UserAgent()
-
-	logFields["uri"] = fmt.Sprintf("%s://%s%s", scheme, r.Host, r.RequestURI)
-
-	entry.Logger = entry.Logger.WithFields(logFields)
-
-	entry.Logger.Infoln("request started")
-
-	return entry
-}
-
-type StructuredLoggerEntry struct {
-	Logger logrus.FieldLogger
-}
-
-func (l *StructuredLoggerEntry) Write(status, bytes int, header http.Header, elapsed time.Duration, extra interface{}) {
-	l.Logger = l.Logger.WithFields(logrus.Fields{
-		"resp_status":       status,
-		"resp_bytes_length": bytes,
-		"resp_elapsed_ms":   float64(elapsed.Nanoseconds()) / 1000000.0,
-	})
-
-	if status >= 500 {
-		l.Logger.Errorf("request complete")
-	} else if status >= 400 {
-		l.Logger.Warnf("request complete")
-	} else {
-		l.Logger.Infof("request complete")
-	}
-}
-
-func (l *StructuredLoggerEntry) Panic(v interface{}, stack []byte) {
-	l.Logger = l.Logger.WithFields(logrus.Fields{
-		"stack": string(stack),
-		"panic": fmt.Sprintf("%+v", v),
-	})
-}
-
-// Helper methods used by the application to get the request-scoped
-// logger entry and set additional fields between handlers.
-//
-// This is a useful pattern to use to set state on the entry as it
-// passes through the handler chain, which at any point can be logged
-// with a call to .Print(), .Info(), etc.
-
-func GetLogEntry(r *http.Request) logrus.FieldLogger {
-	entry := middleware.GetLogEntry(r).(*StructuredLoggerEntry)
-	return entry.Logger
-}
-
-func LogEntrySetField(r *http.Request, key string, value interface{}) {
-	if entry, ok := r.Context().Value(middleware.LogEntryCtxKey).(*StructuredLoggerEntry); ok {
-		entry.Logger = entry.Logger.WithField(key, value)
-	}
-}
-
-func LogEntrySetFields(r *http.Request, fields map[string]interface{}) {
-	if entry, ok := r.Context().Value(middleware.LogEntryCtxKey).(*StructuredLoggerEntry); ok {
-		entry.Logger = entry.Logger.WithFields(fields)
-	}
+	return http.HandlerFunc(fn)
 }

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -9,14 +9,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kobsio/kobs/pkg/log"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
-	"github.com/sirupsen/logrus"
 	flag "github.com/spf13/pflag"
+	"go.uber.org/zap"
 )
 
 var (
-	log       = logrus.WithFields(logrus.Fields{"package": "app"})
 	address   string
 	assetsDir string
 )
@@ -47,27 +48,27 @@ type Server struct {
 
 // Start starts serving the application server.
 func (s *Server) Start() {
-	log.Infof("Application server listen on %s.", s.server.Addr)
+	log.Info(nil, "Application server started.", zap.String("address", s.server.Addr))
 
 	if err := s.server.ListenAndServe(); err != nil {
 		if err != http.ErrServerClosed {
-			log.WithError(err).Error("Application server died unexpected.")
+			log.Error(nil, "Application server died unexpected.", zap.Error(err))
 		} else {
-			log.Info("Application server was stopped.")
+			log.Info(nil, "Application server was stopped.")
 		}
 	}
 }
 
 // Stop terminates the application server gracefully.
 func (s *Server) Stop() {
-	log.Debugf("Start shutdown of the Application server.")
+	log.Debug(nil, "Start shutdown of the Application server.")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	err := s.server.Shutdown(ctx)
 	if err != nil {
-		log.WithError(err).Error("Graceful shutdown of the Application server failed.")
+		log.Error(nil, "Graceful shutdown of the Application server failed.", zap.Error(err))
 	}
 }
 

--- a/pkg/log/level.go
+++ b/pkg/log/level.go
@@ -1,0 +1,26 @@
+package log
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// ParseLevel parses the give string for the log level and returns the corresponding log level for zap.
+func ParseLevel(level string) zap.AtomicLevel {
+	switch level {
+	case "debug":
+		return zap.NewAtomicLevelAt(zapcore.DebugLevel)
+	case "info":
+		return zap.NewAtomicLevelAt(zapcore.InfoLevel)
+	case "warn":
+		return zap.NewAtomicLevelAt(zapcore.WarnLevel)
+	case "error":
+		return zap.NewAtomicLevelAt(zapcore.ErrorLevel)
+	case "fatal":
+		return zap.NewAtomicLevelAt(zapcore.FatalLevel)
+	case "panic":
+		return zap.NewAtomicLevelAt(zapcore.PanicLevel)
+	default:
+		return zap.NewAtomicLevelAt(zapcore.InfoLevel)
+	}
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,96 @@
+// Package log implements some utilities for our logging. E.g. it provides an utility for parsing the specified log
+// level and a context aware logging function, which can be used to extend the list of fields for a log line, with the
+// fields from the passed in context.
+package log
+
+import (
+	"context"
+
+	authContext "github.com/kobsio/kobs/pkg/api/middleware/auth/context"
+
+	"github.com/go-chi/chi/v5/middleware"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// Key to use when setting additional log fields.
+type ctxKeyLog int
+
+// LogKey is the key that holds the log fields in a context.
+const LogKey ctxKeyLog = 0
+
+// ContextWithValue takes an existing context and adds all the provided fields to the context so that they will then be
+// logged for each line where the returned context is used.
+// In the first step we have to check if the context already contains some log fields. If this is the case, we append
+// the provided fields, so that the new context contains all fields.
+func ContextWithValue(ctx context.Context, fields ...zapcore.Field) context.Context {
+	if ctxFields, ok := ctx.Value(LogKey).([]zapcore.Field); ok {
+		fields = append(fields, ctxFields...)
+	}
+
+	return context.WithValue(ctx, LogKey, fields)
+}
+
+// getFields appends all fields from the provided context like the request id, the user id and the fields set via the
+// ContextWithValue() function.
+func getFields(ctx context.Context, fields ...zapcore.Field) []zapcore.Field {
+	if ctx == nil {
+		return fields
+	}
+
+	if requestID := middleware.GetReqID(ctx); requestID != "" {
+		fields = append(fields, zap.String("requestID", requestID))
+	}
+
+	if user, _ := authContext.GetUser(ctx); user != nil {
+		fields = append(fields, zap.String("userID", user.ID))
+	}
+
+	if ctxFields, ok := ctx.Value(LogKey).([]zapcore.Field); ok {
+		fields = append(fields, ctxFields...)
+	}
+
+	return fields
+}
+
+// Debug is a wrapper around the zap.L().Debug() function, which adds all fields from the passed context to the log
+// message.
+func Debug(ctx context.Context, msg string, fields ...zapcore.Field) {
+	fields = getFields(ctx, fields...)
+	zap.L().Debug(msg, fields...)
+}
+
+// Info is a wrapper around the zap.L().Info() function, which adds all fields from the passed context to the log
+// message.
+func Info(ctx context.Context, msg string, fields ...zapcore.Field) {
+	fields = getFields(ctx, fields...)
+	zap.L().Info(msg, fields...)
+}
+
+// Warn is a wrapper around the zap.L().Warn() function, which adds all fields from the passed context to the log
+// message.
+func Warn(ctx context.Context, msg string, fields ...zapcore.Field) {
+	fields = getFields(ctx, fields...)
+	zap.L().Warn(msg, fields...)
+}
+
+// Error is a wrapper around the zap.L().Error() function, which adds all fields from the passed context to the log
+// message.
+func Error(ctx context.Context, msg string, fields ...zapcore.Field) {
+	fields = getFields(ctx, fields...)
+	zap.L().Error(msg, fields...)
+}
+
+// Fatal is a wrapper around the zap.L().Fatal() function, which adds all fields from the passed context to the log
+// message.
+func Fatal(ctx context.Context, msg string, fields ...zapcore.Field) {
+	fields = getFields(ctx, fields...)
+	zap.L().Fatal(msg, fields...)
+}
+
+// Panic is a wrapper around the zap.L().Panic() function, which adds all fields from the passed context to the log
+// message.
+func Panic(ctx context.Context, msg string, fields ...zapcore.Field) {
+	fields = getFields(ctx, fields...)
+	zap.L().Panic(msg, fields...)
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -6,14 +6,15 @@ import (
 	"os"
 	"time"
 
+	"github.com/kobsio/kobs/pkg/log"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/sirupsen/logrus"
 	flag "github.com/spf13/pflag"
+	"go.uber.org/zap"
 )
 
 var (
-	log     = logrus.WithFields(logrus.Fields{"package": "metrics"})
 	address string
 )
 
@@ -35,22 +36,23 @@ type Server struct {
 
 // Start starts serving the metrics server.
 func (s *Server) Start() {
-	log.Infof("Metrics server listen on %s.", s.Addr)
+	log.Info(nil, "Metrics server started.", zap.String("address", s.Addr))
 
 	if err := s.ListenAndServe(); err != http.ErrServerClosed {
-		log.WithError(err).Fatalf("Metrics server died unexpected.")
+		log.Error(nil, "Metrics server died unexpected.", zap.Error(err))
 	}
 }
 
 // Stop terminates the metrics server gracefully.
 func (s *Server) Stop() {
-	log.Debugf("Start shutdown of the metrics server.")
+	log.Debug(nil, "Start shutdown of the metrics server.")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if err := s.Shutdown(ctx); err != nil {
-		log.WithError(err).Errorf("Gracefull shutdown of the metrics server failed.")
+	err := s.Shutdown(ctx)
+	if err != nil {
+		log.Error(nil, "Graceful shutdown of the metrics server failed.", zap.Error(err))
 	}
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // Build information. Populated at build-time.
@@ -51,11 +52,11 @@ func Print(program string) (string, error) {
 }
 
 // Info returns version, branch and revision information.
-func Info() logrus.Fields {
-	return logrus.Fields{"version": Version, "branch": Branch, "revision": Revision}
+func Info() []zapcore.Field {
+	return []zapcore.Field{zap.String("version", Version), zap.String("branch", Branch), zap.String("revision", Revision)}
 }
 
 // BuildContext returns goVersion, buildUser and buildDate information.
-func BuildContext() logrus.Fields {
-	return logrus.Fields{"go": GoVersion, "user": BuildUser, "date": BuildDate}
+func BuildContext() []zapcore.Field {
+	return []zapcore.Field{zap.String("go", GoVersion), zap.String("user", BuildUser), zap.String("date", BuildDate)}
 }

--- a/plugins/azure/azure.go
+++ b/plugins/azure/azure.go
@@ -3,19 +3,16 @@ package azure
 import (
 	"github.com/kobsio/kobs/pkg/api/clusters"
 	"github.com/kobsio/kobs/pkg/api/plugins/plugin"
+	"github.com/kobsio/kobs/pkg/log"
 	"github.com/kobsio/kobs/plugins/azure/pkg/instance"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 )
 
 // Route is the route under which the plugin should be registered in our router for the rest api.
 const (
 	Route = "/azure"
-)
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "azure"})
 )
 
 // Config is the structure of the configuration for the Azure plugin.
@@ -45,7 +42,7 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 	for _, cfg := range config {
 		inst, err := instance.New(cfg)
 		if err != nil {
-			log.WithError(err).WithFields(logrus.Fields{"name": cfg.Name}).Fatalf("Could not create Azure instance")
+			log.Fatal(nil, "Could not create Azure instance.", zap.Error(err), zap.String("name", cfg.Name))
 		}
 
 		instances = append(instances, inst)

--- a/plugins/azure/containerinstances.go
+++ b/plugins/azure/containerinstances.go
@@ -4,21 +4,23 @@ import (
 	"net/http"
 
 	"github.com/kobsio/kobs/pkg/api/middleware/errresponse"
+	"github.com/kobsio/kobs/pkg/log"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerinstance/armcontainerinstance"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 )
 
 func (router *Router) getContainerGroups(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	resourceGroups := r.URL.Query()["resourceGroup"]
 
-	log.WithFields(logrus.Fields{"name": name, "resourceGroups": resourceGroups}).Tracef("getContainerGroups")
+	log.Debug(r.Context(), "Get container groups parameters.", zap.String("name", name), zap.Strings("resourceGroups", resourceGroups))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
@@ -30,6 +32,7 @@ func (router *Router) getContainerGroups(w http.ResponseWriter, r *http.Request)
 		if err == nil {
 			cgs, err := i.ContainerInstances.ListContainerGroups(r.Context(), resourceGroup)
 			if err != nil {
+				log.Error(r.Context(), "Could not list container groups.", zap.Error(err))
 				errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not list container groups")
 				return
 			}
@@ -46,22 +49,25 @@ func (router *Router) getContainerGroup(w http.ResponseWriter, r *http.Request) 
 	resourceGroup := r.URL.Query().Get("resourceGroup")
 	containerGroup := r.URL.Query().Get("containerGroup")
 
-	log.WithFields(logrus.Fields{"name": name, "resourceGroup": resourceGroup, "containerGroup": containerGroup}).Tracef("getContainerGroup")
+	log.Debug(r.Context(), "Get container group parameters.", zap.String("name", name), zap.String("resourceGroup", resourceGroup), zap.String("containerGroup", containerGroup))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	err := i.CheckPermissions(r, "containerinstances", resourceGroup)
 	if err != nil {
+		log.Warn(r.Context(), "User is not allowed to get the container instance.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusForbidden, "You are not allowed to get the container instance")
 		return
 	}
 
 	cg, err := i.ContainerInstances.GetContainerGroup(r.Context(), resourceGroup, containerGroup)
 	if err != nil {
+		log.Error(r.Context(), "Could not get container instances.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get container instances")
 		return
 	}
@@ -74,22 +80,25 @@ func (router *Router) restartContainerGroup(w http.ResponseWriter, r *http.Reque
 	resourceGroup := r.URL.Query().Get("resourceGroup")
 	containerGroup := r.URL.Query().Get("containerGroup")
 
-	log.WithFields(logrus.Fields{"name": name, "resourceGroup": resourceGroup, "containerGroup": containerGroup}).Tracef("restartContainerGroup")
+	log.Debug(r.Context(), "Restart container group parameters.", zap.String("name", name), zap.String("resourceGroup", resourceGroup), zap.String("containerGroup", containerGroup))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	err := i.CheckPermissions(r, "containerinstances", resourceGroup)
 	if err != nil {
+		log.Warn(r.Context(), "User is not allowed to get the container instance.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusForbidden, "You are not allowed to restart the container instance")
 		return
 	}
 
 	err = i.ContainerInstances.RestartContainerGroup(r.Context(), resourceGroup, containerGroup)
 	if err != nil {
+		log.Error(r.Context(), "Could not restart container group.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get restart container group")
 		return
 	}
@@ -103,16 +112,18 @@ func (router *Router) getContainerLogs(w http.ResponseWriter, r *http.Request) {
 	containerGroup := r.URL.Query().Get("containerGroup")
 	container := r.URL.Query().Get("container")
 
-	log.WithFields(logrus.Fields{"name": name, "resourceGroup": resourceGroup, "containerGroup": containerGroup, "container": container}).Tracef("getContainerLogs")
+	log.Debug(r.Context(), "Get container logs.", zap.String("name", name), zap.String("resourceGroup", resourceGroup), zap.String("containerGroup", containerGroup), zap.String("container", container))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	err := i.CheckPermissions(r, "containerinstances", resourceGroup)
 	if err != nil {
+		log.Warn(r.Context(), "User is not allowed to get the container instance.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusForbidden, "You are not allowed to get the logs of the container instance")
 		return
 	}
@@ -122,6 +133,7 @@ func (router *Router) getContainerLogs(w http.ResponseWriter, r *http.Request) {
 
 	logs, err := i.ContainerInstances.GetContainerLogs(r.Context(), resourceGroup, containerGroup, container, &tail, &timestamps)
 	if err != nil {
+		log.Error(r.Context(), "Could not get container logs.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get container logs")
 		return
 	}

--- a/plugins/azure/costmanagement.go
+++ b/plugins/azure/costmanagement.go
@@ -5,35 +5,40 @@ import (
 	"strconv"
 
 	"github.com/kobsio/kobs/pkg/api/middleware/errresponse"
+	"github.com/kobsio/kobs/pkg/log"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 )
 
 func (router *Router) getActualCost(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
-	log.WithFields(logrus.Fields{"name": name}).Tracef("getActualCost")
+	timeframe := r.URL.Query().Get("timeframe")
+	scope := r.URL.Query().Get("scope")
 
-	timeframe, err := strconv.Atoi(r.URL.Query().Get("timeframe"))
+	log.Debug(r.Context(), "Get actual costs parameters.", zap.String("name", name), zap.String("timeframe", timeframe), zap.String("scope", scope))
+
+	timeframeParsed, err := strconv.Atoi(timeframe)
 	if err != nil {
+		log.Error(r.Context(), "Invalid timeframe parameter.", zap.Error(err))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Invalid timeframe parameter")
 		return
 	}
-	scope := r.URL.Query().Get("scope")
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
-	costUsage, err := i.CostManagement.GetActualCost(r.Context(), timeframe, scope)
+	costUsage, err := i.CostManagement.GetActualCost(r.Context(), timeframeParsed, scope)
 	if err != nil {
+		log.Error(r.Context(), "Could not query cost usage.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not query cost usage")
 		return
 	}
 
 	render.JSON(w, r, costUsage)
-
 }

--- a/plugins/azure/monitor.go
+++ b/plugins/azure/monitor.go
@@ -5,10 +5,11 @@ import (
 	"strconv"
 
 	"github.com/kobsio/kobs/pkg/api/middleware/errresponse"
+	"github.com/kobsio/kobs/pkg/log"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 )
 
 func (router *Router) getMetrics(w http.ResponseWriter, r *http.Request) {
@@ -20,34 +21,39 @@ func (router *Router) getMetrics(w http.ResponseWriter, r *http.Request) {
 	timeStart := r.URL.Query().Get("timeStart")
 	timeEnd := r.URL.Query().Get("timeEnd")
 
-	log.WithFields(logrus.Fields{"name": name, "resourceGroup": resourceGroup, "provider": provider, "metricNames": metricNames, "aggregationType": aggregationType, "timeStart": timeStart, "timeEnd": timeEnd}).Tracef("getMetrics")
+	log.Debug(r.Context(), "Get metrics parameters.", zap.String("name", name), zap.String("resourceGroup", resourceGroup), zap.String("provider", provider), zap.String("metricNames", metricNames), zap.String("aggregationType", aggregationType), zap.String("timeStart", timeStart), zap.String("timeEnd", timeEnd))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	err := i.CheckPermissions(r, "monitor", resourceGroup)
 	if err != nil {
+		log.Warn(r.Context(), "User is not allowed to get the metrics.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusForbidden, "You are not allowed to view metrics")
 		return
 	}
 
 	parsedTimeStart, err := strconv.ParseInt(timeStart, 10, 64)
 	if err != nil {
+		log.Error(r.Context(), "Could not parse start time.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusBadRequest, "Could not parse start time")
 		return
 	}
 
 	parsedTimeEnd, err := strconv.ParseInt(timeEnd, 10, 64)
 	if err != nil {
+		log.Error(r.Context(), "Could not parse end time.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusBadRequest, "Could not parse end time")
 		return
 	}
 
 	metrics, err := i.Monitor.GetMetrics(r.Context(), resourceGroup, provider, metricNames, aggregationType, parsedTimeStart, parsedTimeEnd)
 	if err != nil {
+		log.Error(r.Context(), "Could not get metrics.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get metrics")
 		return
 	}

--- a/plugins/azure/pkg/instance/instance.go
+++ b/plugins/azure/pkg/instance/instance.go
@@ -10,11 +10,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
-	"github.com/sirupsen/logrus"
-)
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "azure"})
 )
 
 // Config is the structure of the configuration for a single Azure instance.

--- a/plugins/azure/resourcegroups.go
+++ b/plugins/azure/resourcegroups.go
@@ -4,25 +4,28 @@ import (
 	"net/http"
 
 	"github.com/kobsio/kobs/pkg/api/middleware/errresponse"
+	"github.com/kobsio/kobs/pkg/log"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 )
 
 func (router *Router) getResourceGroups(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 
-	log.WithFields(logrus.Fields{"name": name}).Tracef("getResourceGroups")
+	log.Debug(r.Context(), "Get resource groups parameters.", zap.String("name", name))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	resourceGroups, err := i.ResourceGroups.ListResourceGroups(r.Context())
 	if err != nil {
+		log.Error(r.Context(), "Could not list resource groups.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not list resource groups")
 		return
 	}

--- a/plugins/azure/virtualmachinescalesets.go
+++ b/plugins/azure/virtualmachinescalesets.go
@@ -4,21 +4,23 @@ import (
 	"net/http"
 
 	"github.com/kobsio/kobs/pkg/api/middleware/errresponse"
+	"github.com/kobsio/kobs/pkg/log"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 )
 
 func (router *Router) getVirtualMachineScaleSets(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	resourceGroups := r.URL.Query()["resourceGroup"]
 
-	log.WithFields(logrus.Fields{"name": name, "resourceGroups": resourceGroups}).Tracef("getVirtualMachineScaleSets")
+	log.Debug(r.Context(), "Get virtual machine scale sets parameters.", zap.String("name", name), zap.Strings("resourceGroups", resourceGroups))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
@@ -30,6 +32,7 @@ func (router *Router) getVirtualMachineScaleSets(w http.ResponseWriter, r *http.
 		if err == nil {
 			vsss, err := i.VirtualMachineScaleSets.ListVirtualMachineScaleSets(r.Context(), resourceGroup)
 			if err != nil {
+				log.Error(r.Context(), "Could not list virtual machine scale sets.", zap.Error(err))
 				errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not list virtual machine scale sets")
 				return
 			}
@@ -46,22 +49,25 @@ func (router *Router) getVirtualMachineScaleSetDetails(w http.ResponseWriter, r 
 	resourceGroup := r.URL.Query().Get("resourceGroup")
 	virtualMachineScaleSet := r.URL.Query().Get("virtualMachineScaleSet")
 
-	log.WithFields(logrus.Fields{"name": name, "resourceGroup": resourceGroup, "virtualMachineScaleSet": virtualMachineScaleSet}).Tracef("getVirtualMachineScaleSetDetails")
+	log.Debug(r.Context(), "Get virtual machine scale set details parameters.", zap.String("name", name), zap.String("resourceGroup", resourceGroup), zap.String("virtualMachineScaleSet", virtualMachineScaleSet))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	err := i.CheckPermissions(r, "virtualmachinescalesets", resourceGroup)
 	if err != nil {
+		log.Warn(r.Context(), "User is not allowed to get the virtual machine scale set.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusForbidden, "You are not allowed to get the virtual machine scale set")
 		return
 	}
 
 	vmss, err := i.VirtualMachineScaleSets.GetVirtualMachineScaleSet(r.Context(), resourceGroup, virtualMachineScaleSet)
 	if err != nil {
+		log.Error(r.Context(), "Could not get virtual machine scale set", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get virtual machine scale set")
 		return
 	}
@@ -74,22 +80,25 @@ func (router *Router) getVirtualMachines(w http.ResponseWriter, r *http.Request)
 	resourceGroup := r.URL.Query().Get("resourceGroup")
 	virtualMachineScaleSet := r.URL.Query().Get("virtualMachineScaleSet")
 
-	log.WithFields(logrus.Fields{"name": name, "resourceGroup": resourceGroup, "virtualMachineScaleSet": virtualMachineScaleSet}).Tracef("getVirtualMachines")
+	log.Debug(r.Context(), "Get virtual machines parameters.", zap.String("name", name), zap.String("resourceGroup", resourceGroup), zap.String("virtualMachineScaleSet", virtualMachineScaleSet))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	err := i.CheckPermissions(r, "virtualmachinescalesets", resourceGroup)
 	if err != nil {
+		log.Warn(r.Context(), "User is not allowed to get the virtual machines.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusForbidden, "You are not allowed to list the virtual machines")
 		return
 	}
 
 	vms, err := i.VirtualMachineScaleSets.ListVirtualMachines(r.Context(), resourceGroup, virtualMachineScaleSet)
 	if err != nil {
+		log.Error(r.Context(), "Could not get virtual machines.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get virtual machines")
 		return
 	}

--- a/plugins/dashboards/dashboards.go
+++ b/plugins/dashboards/dashboards.go
@@ -8,19 +8,16 @@ import (
 	"github.com/kobsio/kobs/pkg/api/clusters"
 	"github.com/kobsio/kobs/pkg/api/middleware/errresponse"
 	"github.com/kobsio/kobs/pkg/api/plugins/plugin"
+	"github.com/kobsio/kobs/pkg/log"
 	"github.com/kobsio/kobs/plugins/dashboards/pkg/placeholders"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 )
 
 // Route is the route under which the plugin should be registered in our router for the rest api.
 const Route = "/dashboards"
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "dashboards"})
-)
 
 // Config is the structure of the configuration for the dashboards plugin.
 type Config struct{}
@@ -51,21 +48,21 @@ type getDashboardRequest struct {
 // through all the clusters and retrieving all dashboards via the GetDashboards function. Finally we return an array of
 // dashboards.
 func (router *Router) getAllDashboards(w http.ResponseWriter, r *http.Request) {
-	log.Tracef("getAllDashboards")
+	log.Debug(r.Context(), "Get all dashboards.")
 
 	var dashboards []dashboard.DashboardSpec
 
 	for _, cluster := range router.clusters.Clusters {
 		dashboard, err := cluster.GetDashboards(r.Context(), "")
 		if err != nil {
-			errresponse.Render(w, r, err, http.StatusBadRequest, "Could not get dashboards")
+			log.Error(r.Context(), "Could not get dashboards.", zap.Error(err))
 			return
 		}
 
 		dashboards = append(dashboards, dashboard...)
 	}
 
-	log.WithFields(logrus.Fields{"count": len(dashboards)}).Tracef("getAllDashboards")
+	log.Debug(r.Context(), "Get all dashboards result.", zap.Int("dashboardsCount", len(dashboards)))
 	render.JSON(w, r, dashboards)
 }
 
@@ -73,12 +70,13 @@ func (router *Router) getAllDashboards(w http.ResponseWriter, r *http.Request) {
 // list of references and some defaults, which are used to set the cluster/namespace in the reference when they are not
 // provided.
 func (router *Router) getDashboards(w http.ResponseWriter, r *http.Request) {
-	log.Tracef("getDashboards")
+	log.Debug(r.Context(), "Get dashboards.")
 
 	var data getDashboardsRequest
 
 	err := json.NewDecoder(r.Body).Decode(&data)
 	if err != nil {
+		log.Error(r.Context(), "Could not decode request body.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusBadRequest, "Could not decode request body")
 		return
 	}
@@ -111,12 +109,14 @@ func (router *Router) getDashboards(w http.ResponseWriter, r *http.Request) {
 		} else {
 			cluster := router.clusters.GetCluster(reference.Cluster)
 			if cluster == nil {
+				log.Error(r.Context(), "Invalid cluster name.", zap.String("cluster", reference.Cluster))
 				errresponse.Render(w, r, nil, http.StatusBadRequest, "Invalid cluster name")
 				return
 			}
 
 			dashboard, err := cluster.GetDashboard(r.Context(), reference.Namespace, reference.Name)
 			if err != nil {
+				log.Error(r.Context(), "Could not get dashboard.", zap.Error(err))
 				errresponse.Render(w, r, err, http.StatusBadRequest, "Could not get dashboard")
 				return
 			}
@@ -124,6 +124,7 @@ func (router *Router) getDashboards(w http.ResponseWriter, r *http.Request) {
 			if reference.Placeholders != nil {
 				dashboard, err = placeholders.Replace(reference.Placeholders, *dashboard)
 				if err != nil {
+					log.Error(r.Context(), "Could not replace placeholders.", zap.Error(err))
 					errresponse.Render(w, r, err, http.StatusBadRequest, "Could not replace placeholders")
 					return
 				}
@@ -134,7 +135,7 @@ func (router *Router) getDashboards(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	log.WithFields(logrus.Fields{"count": len(dashboards)}).Tracef("getDashboards")
+	log.Debug(r.Context(), "Get dashboards result.", zap.Int("dashboardsCount", len(dashboards)))
 	render.JSON(w, r, dashboards)
 }
 
@@ -142,8 +143,6 @@ func (router *Router) getDashboards(w http.ResponseWriter, r *http.Request) {
 // which is set via the request body. To get the dashboard we have to get the cluster and then using the GetDashboard
 // function to return the dashboard.
 func (router *Router) getDashboard(w http.ResponseWriter, r *http.Request) {
-	log.Tracef("getDashboard")
-
 	var data getDashboardRequest
 
 	err := json.NewDecoder(r.Body).Decode(&data)
@@ -152,33 +151,36 @@ func (router *Router) getDashboard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.WithFields(logrus.Fields{"cluster": data.Cluster, "namespace": data.Namespace, "name": data.Name, "placeholders": data.Placeholders}).Tracef("getDashboard")
+	log.Debug(r.Context(), "Get dashboard request data.", zap.String("cluster", data.Cluster), zap.String("namespace", data.Namespace), zap.String("name", data.Name), zap.Any("placeholders", data.Placeholders))
 
 	cluster := router.clusters.GetCluster(data.Cluster)
 	if cluster == nil {
+		log.Error(r.Context(), "Invalid cluster name.", zap.String("cluster", data.Cluster))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Invalid cluster name")
 		return
 	}
 
 	dashboard, err := cluster.GetDashboard(r.Context(), data.Namespace, data.Name)
 	if err != nil {
+		log.Error(r.Context(), "Could not get dashboard.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusBadRequest, "Could not get dashboard")
 		return
 	}
 
 	if data.Placeholders == nil {
-		log.WithFields(logrus.Fields{"cluster": data.Cluster, "namespace": data.Namespace, "name": data.Name}).Tracef("return dashboard without replacing placeholders")
+		log.Debug(r.Context(), "Return dashboard without replacing placeholders.", zap.String("cluster", data.Cluster), zap.String("namespace", data.Namespace), zap.String("name", data.Name))
 		render.JSON(w, r, dashboard)
 		return
 	}
 
 	dashboardReplacedPlaceholders, err := placeholders.Replace(data.Placeholders, *dashboard)
 	if err != nil {
+		log.Error(r.Context(), "Could not replace placeholders.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusBadRequest, "Could not replace placeholders")
 		return
 	}
 
-	log.WithFields(logrus.Fields{"cluster": data.Cluster, "namespace": data.Namespace, "name": data.Name}).Tracef("return dashboard with replaced placeholders")
+	log.Debug(r.Context(), "Return dashboard with replaced placeholders.", zap.String("cluster", data.Cluster), zap.String("namespace", data.Namespace), zap.String("name", data.Name))
 	render.JSON(w, r, dashboardReplacedPlaceholders)
 	return
 }

--- a/plugins/elasticsearch/elasticsearch.go
+++ b/plugins/elasticsearch/elasticsearch.go
@@ -7,19 +7,16 @@ import (
 	"github.com/kobsio/kobs/pkg/api/clusters"
 	"github.com/kobsio/kobs/pkg/api/middleware/errresponse"
 	"github.com/kobsio/kobs/pkg/api/plugins/plugin"
+	"github.com/kobsio/kobs/pkg/log"
 	"github.com/kobsio/kobs/plugins/elasticsearch/pkg/instance"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 )
 
 // Route is the route under which the plugin should be registered in our router for the rest api.
 const Route = "/elasticsearch"
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "elasticsearch"})
-)
 
 // Config is the structure of the configuration for the elasticsearch plugin.
 type Config []instance.Config
@@ -52,28 +49,32 @@ func (router *Router) getLogs(w http.ResponseWriter, r *http.Request) {
 	timeStart := r.URL.Query().Get("timeStart")
 	timeEnd := r.URL.Query().Get("timeEnd")
 
-	log.WithFields(logrus.Fields{"name": name, "query": query, "timeStart": timeStart, "timeEnd": timeEnd}).Tracef("getLogs")
+	log.Debug(r.Context(), "Get logs parameters.", zap.String("name", name), zap.String("query", query), zap.String("timeStart", timeStart), zap.String("timeEnd", timeEnd))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	parsedTimeStart, err := strconv.ParseInt(timeStart, 10, 64)
 	if err != nil {
+		log.Error(r.Context(), "Could not parse start time.", zap.Error(err))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not parse start time")
 		return
 	}
 
 	parsedTimeEnd, err := strconv.ParseInt(timeEnd, 10, 64)
 	if err != nil {
+		log.Error(r.Context(), "Could not parse end time.", zap.Error(err))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not parse end time")
 		return
 	}
 
 	data, err := i.GetLogs(r.Context(), query, parsedTimeStart, parsedTimeEnd)
 	if err != nil {
+		log.Error(r.Context(), "Could not get logs.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get logs")
 		return
 	}
@@ -88,7 +89,7 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 	for _, cfg := range config {
 		instance, err := instance.New(cfg)
 		if err != nil {
-			log.WithError(err).WithFields(logrus.Fields{"name": cfg.Name}).Fatalf("Could not create Elasticsearch instance")
+			log.Fatal(nil, "Could not create Elasticsearch instance.", zap.Error(err), zap.String("name", cfg.Name))
 		}
 
 		instances = append(instances, instance)

--- a/plugins/grafana/pkg/instance/instance.go
+++ b/plugins/grafana/pkg/instance/instance.go
@@ -8,12 +8,9 @@ import (
 	"net/http"
 
 	"github.com/kobsio/kobs/pkg/api/middleware/roundtripper"
+	"github.com/kobsio/kobs/pkg/log"
 
-	"github.com/sirupsen/logrus"
-)
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "grafana"})
+	"go.uber.org/zap"
 )
 
 // Config is the structure of the configuration for a single Grafana instance.
@@ -38,7 +35,7 @@ type Instance struct {
 // doRequest is a helper function to run a request against a Grafana instance for the given path. It returns the body
 // or if the request failed the error message.
 func (i *Instance) doRequest(ctx context.Context, url string) ([]byte, error) {
-	log.WithFields(logrus.Fields{"url": i.address + url}).Tracef("request url")
+	log.Debug(ctx, "Request URL.", zap.String("url", i.address+url))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s%s", i.address, url), nil)
 	if err != nil {

--- a/plugins/harbor/harbor.go
+++ b/plugins/harbor/harbor.go
@@ -6,20 +6,17 @@ import (
 	"github.com/kobsio/kobs/pkg/api/clusters"
 	"github.com/kobsio/kobs/pkg/api/middleware/errresponse"
 	"github.com/kobsio/kobs/pkg/api/plugins/plugin"
+	"github.com/kobsio/kobs/pkg/log"
 	"github.com/kobsio/kobs/plugins/harbor/pkg/instance"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 )
 
 // Route is the route under which the plugin should be registered in our router for the rest api.
 const (
 	Route = "/harbor"
-)
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "harbor"})
 )
 
 // Config is the structure of the configuration for the Harbor plugin.
@@ -47,16 +44,18 @@ func (router *Router) getProjects(w http.ResponseWriter, r *http.Request) {
 	page := r.URL.Query().Get("page")
 	pageSize := r.URL.Query().Get("pageSize")
 
-	log.WithFields(logrus.Fields{"name": name, "page": page, "pageSize": pageSize}).Tracef("getProjects")
+	log.Debug(r.Context(), "Get projects parameters.", zap.String("name", name), zap.String("page", page), zap.String("pageSize", pageSize))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	projectsData, err := i.GetProjects(r.Context(), page, pageSize)
 	if err != nil {
+		log.Error(r.Context(), "Could not get projects.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get projects")
 		return
 	}
@@ -71,16 +70,18 @@ func (router *Router) getRepositories(w http.ResponseWriter, r *http.Request) {
 	page := r.URL.Query().Get("page")
 	pageSize := r.URL.Query().Get("pageSize")
 
-	log.WithFields(logrus.Fields{"name": name, "projectName": projectName, "query": query, "page": page, "pageSize": pageSize}).Tracef("getRepositories")
+	log.Debug(r.Context(), "Get repositories parameters.", zap.String("name", name), zap.String("projectName", projectName), zap.String("query", query), zap.String("page", page), zap.String("pageSize", pageSize))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	repositoriesData, err := i.GetRepositories(r.Context(), projectName, query, page, pageSize)
 	if err != nil {
+		log.Error(r.Context(), "Could not get repositories.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get repositories")
 		return
 	}
@@ -96,16 +97,18 @@ func (router *Router) getArtifacts(w http.ResponseWriter, r *http.Request) {
 	page := r.URL.Query().Get("page")
 	pageSize := r.URL.Query().Get("pageSize")
 
-	log.WithFields(logrus.Fields{"name": name, "projectName": projectName, "repositoryName": repositoryName, "query": query, "page": page, "pageSize": pageSize}).Tracef("getArtifacts")
+	log.Debug(r.Context(), "Get repositories parameters.", zap.String("name", name), zap.String("projectName", projectName), zap.String("repositoryName", repositoryName), zap.String("query", query), zap.String("page", page), zap.String("pageSize", pageSize))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	artifactsData, err := i.GetArtifacts(r.Context(), projectName, repositoryName, query, page, pageSize)
 	if err != nil {
+		log.Error(r.Context(), "Could not get artifacts.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get artifacts")
 		return
 	}
@@ -119,16 +122,18 @@ func (router *Router) getArtifact(w http.ResponseWriter, r *http.Request) {
 	repositoryName := r.URL.Query().Get("repositoryName")
 	artifactReference := r.URL.Query().Get("artifactReference")
 
-	log.WithFields(logrus.Fields{"name": name, "projectName": projectName, "repositoryName": repositoryName, "artifactReference": artifactReference}).Tracef("getArtifact")
+	log.Debug(r.Context(), "Get artifact parameters.", zap.String("name", name), zap.String("projectName", projectName), zap.String("repositoryName", repositoryName), zap.String("artifactReference", artifactReference))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	artifact, err := i.GetArtifact(r.Context(), projectName, repositoryName, artifactReference)
 	if err != nil {
+		log.Error(r.Context(), "Could not get artifact.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get artifact")
 		return
 	}
@@ -142,16 +147,18 @@ func (router *Router) getVulnerabilities(w http.ResponseWriter, r *http.Request)
 	repositoryName := r.URL.Query().Get("repositoryName")
 	artifactReference := r.URL.Query().Get("artifactReference")
 
-	log.WithFields(logrus.Fields{"name": name, "projectName": projectName, "repositoryName": repositoryName, "artifactReference": artifactReference}).Tracef("getVulnerabilities")
+	log.Debug(r.Context(), "Get vulnerabilities parameters.", zap.String("name", name), zap.String("projectName", projectName), zap.String("repositoryName", repositoryName), zap.String("artifactReference", artifactReference))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	vulnerabilities, err := i.GetVulnerabilities(r.Context(), projectName, repositoryName, artifactReference)
 	if err != nil {
+		log.Error(r.Context(), "Could not get vulnerabilities", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get vulnerabilities")
 		return
 	}
@@ -165,16 +172,18 @@ func (router *Router) getBuildHistory(w http.ResponseWriter, r *http.Request) {
 	repositoryName := r.URL.Query().Get("repositoryName")
 	artifactReference := r.URL.Query().Get("artifactReference")
 
-	log.WithFields(logrus.Fields{"name": name, "projectName": projectName, "repositoryName": repositoryName, "artifactReference": artifactReference}).Tracef("getBuildHistory")
+	log.Debug(r.Context(), "Get build history parameters.", zap.String("name", name), zap.String("projectName", projectName), zap.String("repositoryName", repositoryName), zap.String("artifactReference", artifactReference))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	buildHistory, err := i.GetBuildHistory(r.Context(), projectName, repositoryName, artifactReference)
 	if err != nil {
+		log.Error(r.Context(), "Could not get build history.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get build history")
 		return
 	}
@@ -189,7 +198,7 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 	for _, cfg := range config {
 		instance, err := instance.New(cfg)
 		if err != nil {
-			log.WithError(err).WithFields(logrus.Fields{"name": cfg.Name}).Fatalf("Could not create Harbor instance")
+			log.Fatal(nil, "Could not create Harbor instance.", zap.Error(err), zap.String("name", cfg.Name))
 		}
 
 		instances = append(instances, instance)

--- a/plugins/harbor/pkg/instance/instance.go
+++ b/plugins/harbor/pkg/instance/instance.go
@@ -10,12 +10,6 @@ import (
 	"strconv"
 
 	"github.com/kobsio/kobs/pkg/api/middleware/roundtripper"
-
-	"github.com/sirupsen/logrus"
-)
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "harbor"})
 )
 
 // Config is the structure of the configuration for a single Harbor instance.

--- a/plugins/istio/pkg/instance/instance.go
+++ b/plugins/istio/pkg/instance/instance.go
@@ -7,12 +7,6 @@ import (
 
 	klogsInstance "github.com/kobsio/kobs/plugins/klogs/pkg/instance"
 	prometheusInstance "github.com/kobsio/kobs/plugins/prometheus/pkg/instance"
-
-	"github.com/sirupsen/logrus"
-)
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "istio"})
 )
 
 // Config is the structure of the configuration for a single Opsgenie instance.

--- a/plugins/jaeger/pkg/instance/instance.go
+++ b/plugins/jaeger/pkg/instance/instance.go
@@ -7,12 +7,6 @@ import (
 	"net/http"
 
 	"github.com/kobsio/kobs/pkg/api/middleware/roundtripper"
-
-	"github.com/sirupsen/logrus"
-)
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "jaeger"})
 )
 
 // Config is the structure of the configuration for a single Jaeger instance.

--- a/plugins/kiali/kiali.go
+++ b/plugins/kiali/kiali.go
@@ -7,19 +7,16 @@ import (
 	"github.com/kobsio/kobs/pkg/api/clusters"
 	"github.com/kobsio/kobs/pkg/api/middleware/errresponse"
 	"github.com/kobsio/kobs/pkg/api/plugins/plugin"
+	"github.com/kobsio/kobs/pkg/log"
 	"github.com/kobsio/kobs/plugins/kiali/pkg/instance"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 )
 
 // Route is the route under which the plugin should be registered in our router for the rest api.
 const Route = "/kiali"
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "kiali"})
-)
 
 // Config is the structure of the configuration for the kiali plugin.
 type Config []instance.Config
@@ -44,16 +41,18 @@ func (router *Router) getInstance(name string) *instance.Instance {
 func (router *Router) getNamespaces(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 
-	log.WithFields(logrus.Fields{"name": name}).Tracef("getNamespaces")
+	log.Debug(r.Context(), "Get namespaces parameters.", zap.String("name", name))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	namespaces, err := i.GetNamespaces(r.Context())
 	if err != nil {
+		log.Error(r.Context(), "Could not get namespaces.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get namespaces")
 		return
 	}
@@ -75,28 +74,32 @@ func (router *Router) getGraph(w http.ResponseWriter, r *http.Request) {
 	appenders := r.URL.Query()["appender"]
 	namespaces := r.URL.Query()["namespace"]
 
-	log.WithFields(logrus.Fields{"name": name}).Tracef("getGraph")
+	log.Debug(r.Context(), "Get graph parameters.", zap.String("name", name), zap.String("duration", duration), zap.String("graphType", graphType), zap.String("groupBy", groupBy), zap.String("injecteServiceNodes", injectServiceNodes), zap.Strings("appenders", appenders), zap.Strings("namespaces", namespaces))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	parsedDuration, err := strconv.ParseInt(duration, 10, 64)
 	if err != nil {
+		log.Error(r.Context(), "Could not parse duration parameter.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusBadRequest, "Could not parse duration parameter")
 		return
 	}
 
 	parsedInjectServiceNodes, err := strconv.ParseBool(injectServiceNodes)
 	if err != nil {
+		log.Error(r.Context(), "Could not parse inject service nodes parameter.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusBadRequest, "Could not parse inject service nodes parameter")
 		return
 	}
 
 	graph, err := i.GetGraph(r.Context(), parsedDuration, graphType, groupBy, parsedInjectServiceNodes, appenders, namespaces)
 	if err != nil {
+		log.Error(r.Context(), "Could not get topology graph.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get topology graph")
 		return
 	}
@@ -108,16 +111,18 @@ func (router *Router) getMetrics(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	url := r.URL.Query().Get("url")
 
-	log.WithFields(logrus.Fields{"name": name, "url": url}).Tracef("getMetrics")
+	log.Debug(r.Context(), "Get metrics parameters.", zap.String("name", name), zap.String("url", url))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	metrics, err := i.GetMetrics(r.Context(), url)
 	if err != nil {
+		log.Error(r.Context(), "Could not get metrics.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get metrics")
 		return
 	}
@@ -132,7 +137,7 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 	for _, cfg := range config {
 		instance, err := instance.New(cfg)
 		if err != nil {
-			log.WithError(err).WithFields(logrus.Fields{"name": cfg.Name}).Fatalf("Could not create Kiali instance")
+			log.Fatal(nil, "Could not create Kiali instance.", zap.Error(err), zap.String("name", cfg.Name))
 		}
 
 		instances = append(instances, instance)

--- a/plugins/kiali/pkg/instance/instance.go
+++ b/plugins/kiali/pkg/instance/instance.go
@@ -13,11 +13,6 @@ import (
 
 	"github.com/kiali/kiali/graph/config/cytoscape"
 	"github.com/kiali/kiali/models"
-	"github.com/sirupsen/logrus"
-)
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "kiali"})
 )
 
 // Config is the structure of the configuration for a single Kiali instance.

--- a/plugins/markdown/markdown.go
+++ b/plugins/markdown/markdown.go
@@ -5,15 +5,10 @@ import (
 	"github.com/kobsio/kobs/pkg/api/plugins/plugin"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/sirupsen/logrus"
 )
 
 // Route is the route under which the plugin should be registered in our router for the rest api.
 const Route = "/markdown"
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "markdown"})
-)
 
 // Config is the structure of the configuration for the markdown plugin.
 type Config struct{}

--- a/plugins/opsgenie/opsgenie.go
+++ b/plugins/opsgenie/opsgenie.go
@@ -8,20 +8,17 @@ import (
 	authContext "github.com/kobsio/kobs/pkg/api/middleware/auth/context"
 	"github.com/kobsio/kobs/pkg/api/middleware/errresponse"
 	"github.com/kobsio/kobs/pkg/api/plugins/plugin"
+	"github.com/kobsio/kobs/pkg/log"
 	"github.com/kobsio/kobs/plugins/opsgenie/pkg/instance"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 )
 
 // Route is the route under which the plugin should be registered in our router for the rest api.
 const (
 	Route = "/opsgenie"
-)
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "opsgenie"})
 )
 
 // Config is the structure of the configuration for the opsgenie plugin.
@@ -48,16 +45,18 @@ func (router *Router) getAlerts(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	query := r.URL.Query().Get("query")
 
-	log.WithFields(logrus.Fields{"name": name, "query": query}).Tracef("getAlerts")
+	log.Debug(r.Context(), "Get alerts parameters.", zap.String("name", name), zap.String("query", query))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	alerts, err := i.GetAlerts(r.Context(), query)
 	if err != nil {
+		log.Error(r.Context(), "Could not get alerts.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get alerts")
 		return
 	}
@@ -69,16 +68,18 @@ func (router *Router) getAlertDetails(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	id := r.URL.Query().Get("id")
 
-	log.WithFields(logrus.Fields{"name": name, "id": id}).Tracef("getAlertDetails")
+	log.Debug(r.Context(), "Get alert details parameters.", zap.String("name", name), zap.String("id", id))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	details, err := i.GetAlertDetails(r.Context(), id)
 	if err != nil {
+		log.Error(r.Context(), "Could not get alert details.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get alert details")
 		return
 	}
@@ -90,16 +91,18 @@ func (router *Router) getAlertLogs(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	id := r.URL.Query().Get("id")
 
-	log.WithFields(logrus.Fields{"name": name, "id": id}).Tracef("getAlertLogs")
+	log.Debug(r.Context(), "Get alert logs parameters.", zap.String("name", name), zap.String("id", id))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	logs, err := i.GetAlertLogs(r.Context(), id)
 	if err != nil {
+		log.Error(r.Context(), "Could not get alert logs.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get alert logs")
 		return
 	}
@@ -111,16 +114,18 @@ func (router *Router) getAlertNotes(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	id := r.URL.Query().Get("id")
 
-	log.WithFields(logrus.Fields{"name": name, "id": id}).Tracef("getAlertNotes")
+	log.Debug(r.Context(), "Get alert notes parameters.", zap.String("name", name), zap.String("id", id))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	notes, err := i.GetAlertNotes(r.Context(), id)
 	if err != nil {
+		log.Error(r.Context(), "Could not get alert notes.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get alert notes")
 		return
 	}
@@ -132,16 +137,18 @@ func (router *Router) getIncidents(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	query := r.URL.Query().Get("query")
 
-	log.WithFields(logrus.Fields{"name": name, "query": query}).Tracef("getIncidents")
+	log.Debug(r.Context(), "Get incidents parameters.", zap.String("name", name), zap.String("query", query))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	incidents, err := i.GetIncidents(r.Context(), query)
 	if err != nil {
+		log.Error(r.Context(), "Could not get incidents.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get incidents")
 		return
 	}
@@ -153,16 +160,18 @@ func (router *Router) getIncidentLogs(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	id := r.URL.Query().Get("id")
 
-	log.WithFields(logrus.Fields{"name": name, "id": id}).Tracef("getIncidentLogs")
+	log.Debug(r.Context(), "Get incident logs parameters.", zap.String("name", name), zap.String("id", id))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	logs, err := i.GetIncidentLogs(r.Context(), id)
 	if err != nil {
+		log.Error(r.Context(), "Could not get incident logs.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get incident logs")
 		return
 	}
@@ -174,16 +183,18 @@ func (router *Router) getIncidentNotes(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	id := r.URL.Query().Get("id")
 
-	log.WithFields(logrus.Fields{"name": name, "id": id}).Tracef("getIncidentNotes")
+	log.Debug(r.Context(), "Get incident notes parameters.", zap.String("name", name), zap.String("id", id))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	notes, err := i.GetIncidentNotes(r.Context(), id)
 	if err != nil {
+		log.Error(r.Context(), "Could not get incident notes.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get incident notes")
 		return
 	}
@@ -195,16 +206,18 @@ func (router *Router) getIncidentTimeline(w http.ResponseWriter, r *http.Request
 	name := chi.URLParam(r, "name")
 	id := r.URL.Query().Get("id")
 
-	log.WithFields(logrus.Fields{"name": name, "id": id}).Tracef("getIncidentTimeline")
+	log.Debug(r.Context(), "Get incident timeline parameters.", zap.String("name", name), zap.String("id", id))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	timeline, err := i.GetIncidentTimeline(r.Context(), id)
 	if err != nil {
+		log.Error(r.Context(), "Could not get incident timeline.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get incident timeline")
 		return
 	}
@@ -215,6 +228,7 @@ func (router *Router) getIncidentTimeline(w http.ResponseWriter, r *http.Request
 func (router *Router) acknowledgeAlert(w http.ResponseWriter, r *http.Request) {
 	user, err := authContext.GetUser(r.Context())
 	if err != nil {
+		log.Warn(r.Context(), "User is not authorized to acknowledge the alert.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusUnauthorized, "You are not authorized to acknowledge the alert")
 		return
 	}
@@ -222,21 +236,24 @@ func (router *Router) acknowledgeAlert(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	id := r.URL.Query().Get("id")
 
-	log.WithFields(logrus.Fields{"name": name, "id": id}).Tracef("acknowledgeAlert")
+	log.Debug(r.Context(), "Acknowlege alert parameters.", zap.String("name", name), zap.String("id", id))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	if !i.Actions.Acknowledge {
+		log.Warn(r.Context(), "It is not allowed to acknowledge alerts.")
 		errresponse.Render(w, r, nil, http.StatusForbidden, "It is not allowed to acknowledge alerts")
 		return
 	}
 
 	err = i.AcknowledgeAlert(r.Context(), id, user.ID)
 	if err != nil {
+		log.Error(r.Context(), "Could not acknowledge alert.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not acknowledge alert")
 		return
 	}
@@ -247,6 +264,7 @@ func (router *Router) acknowledgeAlert(w http.ResponseWriter, r *http.Request) {
 func (router *Router) snoozeAlert(w http.ResponseWriter, r *http.Request) {
 	user, err := authContext.GetUser(r.Context())
 	if err != nil {
+		log.Warn(r.Context(), "User is not authorized to snooze the alert.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusUnauthorized, "You are not authorized to snooze the alert")
 		return
 	}
@@ -255,21 +273,24 @@ func (router *Router) snoozeAlert(w http.ResponseWriter, r *http.Request) {
 	id := r.URL.Query().Get("id")
 	snooze := r.URL.Query().Get("snooze")
 
-	log.WithFields(logrus.Fields{"name": name, "id": id}).Tracef("snoozeAlert")
+	log.Debug(r.Context(), "Snooze alert parameters.", zap.String("name", name), zap.String("id", id))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	if !i.Actions.Snooze {
+		log.Warn(r.Context(), "It is not allowed to snooze alerts.")
 		errresponse.Render(w, r, nil, http.StatusForbidden, "It is not allowed to snooze alerts")
 		return
 	}
 
 	snoozeParsed, err := time.ParseDuration(snooze)
 	if err != nil {
+		log.Error(r.Context(), "Could not snooze alert.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not parse snooze parameter")
 		return
 	}
@@ -286,6 +307,7 @@ func (router *Router) snoozeAlert(w http.ResponseWriter, r *http.Request) {
 func (router *Router) closeAlert(w http.ResponseWriter, r *http.Request) {
 	user, err := authContext.GetUser(r.Context())
 	if err != nil {
+		log.Warn(r.Context(), "User is not authorized to close the alert.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusUnauthorized, "You are not authorized to close the alert")
 		return
 	}
@@ -293,21 +315,24 @@ func (router *Router) closeAlert(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	id := r.URL.Query().Get("id")
 
-	log.WithFields(logrus.Fields{"name": name, "id": id}).Tracef("closeAlert")
+	log.Debug(r.Context(), "Close alert parameters.", zap.String("name", name), zap.String("id", id))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	if !i.Actions.Close {
+		log.Warn(r.Context(), "It is not allowed to close alerts.")
 		errresponse.Render(w, r, nil, http.StatusForbidden, "It is not allowed to close alerts")
 		return
 	}
 
 	err = i.CloseAlert(r.Context(), id, user.ID)
 	if err != nil {
+		log.Error(r.Context(), "Could not close alert.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not close alert")
 		return
 	}
@@ -322,7 +347,7 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 	for _, cfg := range config {
 		instance, err := instance.New(cfg)
 		if err != nil {
-			log.WithError(err).WithFields(logrus.Fields{"name": cfg.Name}).Fatalf("Could not create Opsgenie instance")
+			log.Fatal(nil, "Could not create Opsgenie instance.", zap.Error(err), zap.String("name", cfg.Name))
 		}
 
 		instances = append(instances, instance)

--- a/plugins/opsgenie/pkg/instance/instance.go
+++ b/plugins/opsgenie/pkg/instance/instance.go
@@ -9,11 +9,6 @@ import (
 	"github.com/opsgenie/opsgenie-go-sdk-v2/alert"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/incident"
-	"github.com/sirupsen/logrus"
-)
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "opsgenie"})
 )
 
 // Config is the structure of the configuration for a single Opsgenie instance.
@@ -184,29 +179,23 @@ func (i *Instance) CloseAlert(ctx context.Context, id, user string) error {
 
 // New returns a new Elasticsearch instance for the given configuration.
 func New(config Config) (*Instance, error) {
-	alertClient, err := alert.NewClient(&client.Config{
+	opsgenieConfig := &client.Config{
 		ApiKey:         config.APIKey,
 		OpsGenieAPIURL: client.ApiUrl(config.APIUrl),
-		Logger:         log.Logger,
-	})
+	}
+	opsgenieConfig.ConfigureLogLevel("error")
+
+	alertClient, err := alert.NewClient(opsgenieConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	incidentClient, err := incident.NewClient(&client.Config{
-		ApiKey:         config.APIKey,
-		OpsGenieAPIURL: client.ApiUrl(config.APIUrl),
-		Logger:         log.Logger,
-	})
+	incidentClient, err := incident.NewClient(opsgenieConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	timelineClient, err := timeline.NewClient(&client.Config{
-		ApiKey:         config.APIKey,
-		OpsGenieAPIURL: client.ApiUrl(config.APIUrl),
-		Logger:         log.Logger,
-	})
+	timelineClient, err := timeline.NewClient(opsgenieConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/prometheus/pkg/instance/instance.go
+++ b/plugins/prometheus/pkg/instance/instance.go
@@ -9,15 +9,12 @@ import (
 	"time"
 
 	"github.com/kobsio/kobs/pkg/api/middleware/roundtripper"
+	"github.com/kobsio/kobs/pkg/log"
 
 	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-	"github.com/sirupsen/logrus"
-)
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "prometheus"})
+	"go.uber.org/zap"
 )
 
 // Config is the structure of the configuration for a single Prometheus instance.
@@ -42,7 +39,7 @@ type Instance struct {
 // GetVariable returns all values for a label from the given query. For that we have to retrive the label sets from the
 // Prometheus instance and so that we can add the values for the specified label to the values slice.
 func (i *Instance) GetVariable(ctx context.Context, label, query, queryType string, timeStart, timeEnd int64) ([]string, error) {
-	log.WithFields(logrus.Fields{"query": query}).Tracef("Query variable values")
+	log.Debug(ctx, "Query variable values.", zap.String("query", query))
 
 	labelSets, _, err := i.v1api.Series(ctx, []string{query}, time.Unix(timeStart, 0), time.Unix(timeEnd, 0))
 	if err != nil {
@@ -87,7 +84,7 @@ func (i *Instance) GetMetrics(ctx context.Context, queries []Query, resolution s
 	var metrics []Metric
 
 	for queryIndex, query := range queries {
-		log.WithFields(logrus.Fields{"query": query.Query, "label": query.Label, "resolution": resolution, "start": r.Start, "end": r.End}).Tracef("Query time series")
+		log.Debug(ctx, "Query time series.", zap.String("query", query.Query), zap.String("label", query.Label), zap.String("resolution", resolution), zap.Time("start", r.Start), zap.Time("end", r.End))
 
 		result, _, err := i.v1api.QueryRange(ctx, query.Query, r)
 		if err != nil {
@@ -214,7 +211,7 @@ func (i *Instance) GetTableData(ctx context.Context, queries []Query, timeEnd in
 	rows = make(map[string]map[string]string)
 
 	for queryIndex, query := range queries {
-		log.WithFields(logrus.Fields{"query": query, "time": queryTime}).Tracef("Query table data")
+		log.Debug(ctx, "Query table data.", zap.String("query", query.Query), zap.String("label", query.Label), zap.Time("time", queryTime))
 
 		result, _, err := i.v1api.Query(ctx, query.Query, queryTime)
 		if err != nil {
@@ -272,9 +269,9 @@ func (i *Instance) GetLabelValues(ctx context.Context, searchTerm string) ([]str
 
 		i.labelValues = labelValues
 		i.labelValuesLastFetch = now
-		log.WithFields(logrus.Fields{"instance": i.Name}).Tracef("Get metric names.")
+		log.Debug(ctx, "Get metric names.", zap.String("name", i.Name))
 	} else {
-		log.WithFields(logrus.Fields{"instance": i.Name}).Tracef("Use cached metric names.")
+		log.Debug(ctx, "Use cached metric names.", zap.String("name", i.Name))
 	}
 
 	var names []string

--- a/plugins/prometheus/prometheus.go
+++ b/plugins/prometheus/prometheus.go
@@ -7,19 +7,16 @@ import (
 	"github.com/kobsio/kobs/pkg/api/clusters"
 	"github.com/kobsio/kobs/pkg/api/middleware/errresponse"
 	"github.com/kobsio/kobs/pkg/api/plugins/plugin"
+	"github.com/kobsio/kobs/pkg/log"
 	"github.com/kobsio/kobs/plugins/prometheus/pkg/instance"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 )
 
 // Route is the route under which the plugin should be registered in our router for the rest api.
 const Route = "/prometheus"
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "prometheus"})
-)
 
 // Config is the structure of the configuration for the prometheus plugin.
 type Config []instance.Config
@@ -67,10 +64,11 @@ func (router *Router) getInstance(name string) *instance.Instance {
 func (router *Router) getVariable(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 
-	log.WithFields(logrus.Fields{"name": name}).Tracef("getVariables")
+	log.Debug(r.Context(), "Get variables parameters.", zap.String("name", name))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
@@ -79,17 +77,19 @@ func (router *Router) getVariable(w http.ResponseWriter, r *http.Request) {
 
 	err := json.NewDecoder(r.Body).Decode(&data)
 	if err != nil {
+		log.Error(r.Context(), "Could not decode request body.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusBadRequest, "Could not decode request body")
 		return
 	}
 
 	values, err := i.GetVariable(r.Context(), data.Label, data.Query, data.Type, data.TimeStart, data.TimeEnd)
 	if err != nil {
+		log.Error(r.Context(), "Could not get variable.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusBadRequest, "Could not get variable")
 		return
 	}
 
-	log.WithFields(logrus.Fields{"values": len(values)}).Tracef("getVariables")
+	log.Debug(r.Context(), "Get variables result.", zap.Int("valuesCount", len(values)))
 	render.JSON(w, r, values)
 }
 
@@ -99,10 +99,11 @@ func (router *Router) getVariable(w http.ResponseWriter, r *http.Request) {
 func (router *Router) getMetrics(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 
-	log.WithFields(logrus.Fields{"name": name}).Tracef("getMetrics")
+	log.Debug(r.Context(), "Get metrics parameters.", zap.String("name", name))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
@@ -111,17 +112,19 @@ func (router *Router) getMetrics(w http.ResponseWriter, r *http.Request) {
 
 	err := json.NewDecoder(r.Body).Decode(&data)
 	if err != nil {
+		log.Error(r.Context(), "Could not decode request body.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusBadRequest, "Could not decode request body")
 		return
 	}
 
 	metrics, err := i.GetMetrics(r.Context(), data.Queries, data.Resolution, data.TimeStart, data.TimeEnd)
 	if err != nil {
+		log.Error(r.Context(), "Could not get metrics.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusBadRequest, "Could not get metrics")
 		return
 	}
 
-	log.WithFields(logrus.Fields{"metrics": len(metrics.Metrics)}).Tracef("getMetrics")
+	log.Debug(r.Context(), "Get metrics result.", zap.Int("metricsCount", len(metrics.Metrics)))
 	render.JSON(w, r, metrics)
 }
 
@@ -131,10 +134,11 @@ func (router *Router) getMetrics(w http.ResponseWriter, r *http.Request) {
 func (router *Router) getTable(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 
-	log.WithFields(logrus.Fields{"name": name}).Tracef("getTable")
+	log.Debug(r.Context(), "Get table parameters.", zap.String("name", name))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
@@ -143,17 +147,19 @@ func (router *Router) getTable(w http.ResponseWriter, r *http.Request) {
 
 	err := json.NewDecoder(r.Body).Decode(&data)
 	if err != nil {
+		log.Error(r.Context(), "Could not decode request body.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusBadRequest, "Could not decode request body")
 		return
 	}
 
 	rows, err := i.GetTableData(r.Context(), data.Queries, data.TimeEnd)
 	if err != nil {
+		log.Error(r.Context(), "Could not get metrics.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusBadRequest, "Could not get metrics")
 		return
 	}
 
-	log.WithFields(logrus.Fields{"rows": len(rows)}).Tracef("getTable")
+	log.Debug(r.Context(), "Get table results.", zap.Int("rowsCount", len(rows)))
 	render.JSON(w, r, rows)
 }
 
@@ -163,21 +169,23 @@ func (router *Router) getLabels(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	searchTerm := r.URL.Query().Get("searchTerm")
 
-	log.WithFields(logrus.Fields{"name": name, "searchTerm": searchTerm}).Tracef("getLabels")
+	log.Debug(r.Context(), "Get labels parameters.", zap.String("name", name), zap.String("searchTerm", searchTerm))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	labelValues, err := i.GetLabelValues(r.Context(), searchTerm)
 	if err != nil {
+		log.Error(r.Context(), "Could not get label values.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get label values")
 		return
 	}
 
-	log.WithFields(logrus.Fields{"labelValues": len(labelValues)}).Tracef("getLabels")
+	log.Debug(r.Context(), "Get labels result.", zap.Int("labelValuesCount", len(labelValues)))
 	render.JSON(w, r, labelValues)
 }
 
@@ -188,7 +196,7 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 	for _, cfg := range config {
 		instance, err := instance.New(cfg)
 		if err != nil {
-			log.WithError(err).WithFields(logrus.Fields{"name": cfg.Name}).Fatalf("Could not create Prometheus instance")
+			log.Fatal(nil, "Could not create Prometheus instance.", zap.Error(err), zap.String("name", cfg.Name))
 		}
 
 		instances = append(instances, instance)

--- a/plugins/sonarqube/pkg/instance/instance.go
+++ b/plugins/sonarqube/pkg/instance/instance.go
@@ -9,12 +9,6 @@ import (
 	"strings"
 
 	"github.com/kobsio/kobs/pkg/api/middleware/roundtripper"
-
-	"github.com/sirupsen/logrus"
-)
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "sonarqube"})
 )
 
 // Config is the structure of the configuration for a single Opsgenie instance.

--- a/plugins/sql/pkg/instance/instance.go
+++ b/plugins/sql/pkg/instance/instance.go
@@ -6,14 +6,12 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/kobsio/kobs/pkg/log"
+
 	_ "github.com/ClickHouse/clickhouse-go"
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
-	"github.com/sirupsen/logrus"
-)
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "sql"})
+	"go.uber.org/zap"
 )
 
 // Config is the structure of the configuration for a single SQL database instance.
@@ -90,7 +88,7 @@ func New(config Config) (*Instance, error) {
 
 	client, err := sql.Open(config.Driver, config.Connection)
 	if err != nil {
-		log.WithError(err).Errorf("could not initialize database connection")
+		log.Error(nil, "could not initialize database connection", zap.Error(err))
 		return nil, err
 	}
 

--- a/plugins/sql/sql.go
+++ b/plugins/sql/sql.go
@@ -6,19 +6,16 @@ import (
 	"github.com/kobsio/kobs/pkg/api/clusters"
 	"github.com/kobsio/kobs/pkg/api/middleware/errresponse"
 	"github.com/kobsio/kobs/pkg/api/plugins/plugin"
+	"github.com/kobsio/kobs/pkg/log"
 	"github.com/kobsio/kobs/plugins/sql/pkg/instance"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 )
 
 // Route is the route under which the plugin should be registered in our router for the rest api.
 const Route = "/sql"
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "sql"})
-)
 
 // Config is the structure of the configuration for the sql plugin.
 type Config []instance.Config
@@ -44,16 +41,18 @@ func (router *Router) getQueryResults(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	query := r.URL.Query().Get("query")
 
-	log.WithFields(logrus.Fields{"name": name, "query": query}).Tracef("getSQL")
+	log.Debug(r.Context(), "Get SQL parameters.", zap.String("name", name), zap.String("query", query))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	rows, columns, err := i.GetQueryResults(r.Context(), query)
 	if err != nil {
+		log.Error(r.Context(), "Could not get result for SQL query.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusBadRequest, "Could not get result for SQL query")
 		return
 	}
@@ -76,7 +75,7 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 	for _, cfg := range config {
 		instance, err := instance.New(cfg)
 		if err != nil {
-			log.WithError(err).WithFields(logrus.Fields{"name": cfg.Name}).Fatalf("Could not create sql instance")
+			log.Fatal(nil, "Could not create sql instance.", zap.Error(err), zap.String("name", cfg.Name))
 		}
 
 		instances = append(instances, instance)

--- a/plugins/techdocs/pkg/instance/instance.go
+++ b/plugins/techdocs/pkg/instance/instance.go
@@ -5,12 +5,6 @@ import (
 
 	"github.com/kobsio/kobs/plugins/techdocs/pkg/providers"
 	"github.com/kobsio/kobs/plugins/techdocs/pkg/shared"
-
-	"github.com/sirupsen/logrus"
-)
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "techdocs"})
 )
 
 // Config is the structure of the configuration for a single TechDocs instance.

--- a/plugins/techdocs/pkg/providers/local/local.go
+++ b/plugins/techdocs/pkg/providers/local/local.go
@@ -5,13 +5,10 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/kobsio/kobs/pkg/log"
 	"github.com/kobsio/kobs/plugins/techdocs/pkg/shared"
 
-	"github.com/sirupsen/logrus"
-)
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "techdocs", "provider": "local"})
+	"go.uber.org/zap"
 )
 
 // Config is the structure of the configuration for the local file system provider.
@@ -38,11 +35,11 @@ func (p *Provider) GetIndexes(ctx context.Context) ([]shared.Index, error) {
 			indexPath := fmt.Sprintf("%s/%s/index.yaml", p.config.RootDirectory, file.Name())
 			content, err := ioutil.ReadFile(indexPath)
 			if err != nil {
-				log.WithError(err).WithFields(logrus.Fields{"file": indexPath}).Errorf("could not read file")
+				log.Error(ctx, "Could not read file.", zap.Error(err), zap.String("file", indexPath))
 			} else {
 				index, err := shared.ParseIndex(content)
 				if err != nil {
-					log.WithError(err).WithFields(logrus.Fields{"file": indexPath}).Errorf("could not parse index file")
+					log.Error(ctx, "Could not parse index file.", zap.Error(err), zap.String("file", indexPath))
 				} else {
 					indexes = append(indexes, index)
 				}

--- a/plugins/techdocs/pkg/providers/providers.go
+++ b/plugins/techdocs/pkg/providers/providers.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/kobsio/kobs/pkg/log"
 	"github.com/kobsio/kobs/plugins/techdocs/pkg/providers/local"
 	"github.com/kobsio/kobs/plugins/techdocs/pkg/providers/s3"
 	"github.com/kobsio/kobs/plugins/techdocs/pkg/shared"
 
-	"github.com/sirupsen/logrus"
-)
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "techdocs"})
+	"go.uber.org/zap"
 )
 
 // Type is the type for the different providers.
@@ -48,7 +45,7 @@ func New(config Config) (Provider, error) {
 	case S3:
 		return s3.New(config.S3)
 	default:
-		log.WithFields(logrus.Fields{"provider": config.Type}).Warnf("Invalid provider.")
+		log.Error(nil, "Invalid provider.", zap.String("provider", string(config.Type)))
 		return nil, fmt.Errorf("invalid provider type")
 	}
 }

--- a/plugins/techdocs/techdocs.go
+++ b/plugins/techdocs/techdocs.go
@@ -8,20 +8,17 @@ import (
 	"github.com/kobsio/kobs/pkg/api/clusters"
 	"github.com/kobsio/kobs/pkg/api/middleware/errresponse"
 	"github.com/kobsio/kobs/pkg/api/plugins/plugin"
+	"github.com/kobsio/kobs/pkg/log"
 	"github.com/kobsio/kobs/plugins/techdocs/pkg/instance"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 )
 
 // Route is the route under which the plugin should be registered in our router for the rest api.
 const (
 	Route = "/techdocs"
-)
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "techdocs"})
 )
 
 // Config is the structure of the configuration for the techdocs plugin.
@@ -47,16 +44,18 @@ func (router *Router) getInstance(name string) *instance.Instance {
 func (router *Router) getIndexes(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 
-	log.WithFields(logrus.Fields{"name": name}).Tracef("getTechDocs")
+	log.Debug(r.Context(), "Get TechDocs parameters.", zap.String("name", name))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	indexes, err := i.GetIndexes(r.Context())
 	if err != nil {
+		log.Error(r.Context(), "Could not get indexes.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get indexes")
 		return
 	}
@@ -68,16 +67,18 @@ func (router *Router) getIndex(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	service := r.URL.Query().Get("service")
 
-	log.WithFields(logrus.Fields{"name": name, "service": service}).Tracef("getTechDoc")
+	log.Debug(r.Context(), "Get TechDoc parameters.", zap.String("name", name), zap.String("service", service))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	index, err := i.GetIndex(r.Context(), service)
 	if err != nil {
+		log.Error(r.Context(), "Could not get index.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get index")
 		return
 	}
@@ -90,16 +91,18 @@ func (router *Router) getMarkdown(w http.ResponseWriter, r *http.Request) {
 	service := r.URL.Query().Get("service")
 	path := r.URL.Query().Get("path")
 
-	log.WithFields(logrus.Fields{"name": name, "service": service, "path": path}).Tracef("getMarkdown")
+	log.Debug(r.Context(), "Get markdown parameters.", zap.String("name", name), zap.String("service", service), zap.String("path", path))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Could not find instance name")
 		return
 	}
 
 	markdown, err := i.GetMarkdown(r.Context(), service, path)
 	if err != nil {
+		log.Error(r.Context(), "Could not get markdown.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get markdown")
 		return
 	}
@@ -112,10 +115,11 @@ func (router *Router) getFile(w http.ResponseWriter, r *http.Request) {
 	service := r.URL.Query().Get("service")
 	path := r.URL.Query().Get("path")
 
-	log.WithFields(logrus.Fields{"name": name, "service": service, "path": path}).Tracef("getFile")
+	log.Debug(r.Context(), "Get file parameters.", zap.String("name", name), zap.String("service", service), zap.String("path", path))
 
 	i := router.getInstance(name)
 	if i == nil {
+		log.Error(r.Context(), "Could not find instance name.", zap.String("name", name))
 		render.Status(r, http.StatusBadRequest)
 		render.Data(w, r, []byte(`Could not find instance name`))
 		return
@@ -123,6 +127,7 @@ func (router *Router) getFile(w http.ResponseWriter, r *http.Request) {
 
 	bytes, err := i.GetFile(r.Context(), service, path)
 	if err != nil {
+		log.Error(r.Context(), "Could not get file.", zap.Error(err))
 		render.Status(r, http.StatusBadRequest)
 		render.Data(w, r, []byte(`Could not get file`))
 		return
@@ -139,7 +144,7 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 	for _, cfg := range config {
 		instance, err := instance.New(cfg)
 		if err != nil {
-			log.WithError(err).WithFields(logrus.Fields{"name": cfg.Name}).Fatalf("Could not create TechDocs instance")
+			log.Fatal(nil, "Could not create TechDocs instance.", zap.Error(err), zap.String("name", cfg.Name))
 		}
 
 		instances = append(instances, instance)

--- a/plugins/users/users.go
+++ b/plugins/users/users.go
@@ -9,18 +9,15 @@ import (
 	"github.com/kobsio/kobs/pkg/api/clusters"
 	"github.com/kobsio/kobs/pkg/api/middleware/errresponse"
 	"github.com/kobsio/kobs/pkg/api/plugins/plugin"
+	"github.com/kobsio/kobs/pkg/log"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 )
 
 // Route is the route under which the plugin should be registered in our router for the rest api.
 const Route = "/users"
-
-var (
-	log = logrus.WithFields(logrus.Fields{"package": "users"})
-)
 
 // Config is the structure of the configuration for the users plugin.
 type Config struct{}
@@ -59,13 +56,14 @@ func isMember(teams []user.TeamReference, defaultCluster, defaultNamespace, clus
 // getUsers returns a list of users for all clusters and namespaces. We always return all users for all clusters and
 // namespaces. For this we are looping though the loaded clusters and callend the GetUsers function for each one.
 func (router *Router) getUsers(w http.ResponseWriter, r *http.Request) {
-	log.Tracef("getUsers")
+	log.Debug(r.Context(), "Get users.")
 
 	var users []user.UserSpec
 
 	for _, cluster := range router.clusters.Clusters {
 		user, err := cluster.GetUsers(r.Context(), "")
 		if err != nil {
+			log.Error(r.Context(), "Could not get users.")
 			errresponse.Render(w, r, err, http.StatusBadRequest, "Could not get users")
 			return
 		}
@@ -73,7 +71,7 @@ func (router *Router) getUsers(w http.ResponseWriter, r *http.Request) {
 		users = append(users, user...)
 	}
 
-	log.WithFields(logrus.Fields{"count": len(users)}).Tracef("getUsers")
+	log.Debug(r.Context(), "Get users result.", zap.Int("usersCount", len(users)))
 	render.JSON(w, r, users)
 }
 
@@ -85,16 +83,18 @@ func (router *Router) getUser(w http.ResponseWriter, r *http.Request) {
 	namespace := r.URL.Query().Get("namespace")
 	name := r.URL.Query().Get("name")
 
-	log.WithFields(logrus.Fields{"cluster": clusterName, "namespace": namespace, "name": name}).Tracef("getUser")
+	log.Debug(r.Context(), "Get User parameters.", zap.String("cluster", clusterName), zap.String("namespace", namespace), zap.String("name", name))
 
 	cluster := router.clusters.GetCluster(clusterName)
 	if cluster == nil {
+		log.Error(r.Context(), "Invalid cluster name.", zap.String("cluster", clusterName))
 		errresponse.Render(w, r, nil, http.StatusBadRequest, "Invalid cluster name")
 		return
 	}
 
 	user, err := cluster.GetUser(r.Context(), namespace, name)
 	if err != nil {
+		log.Error(r.Context(), "Could not get user.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusBadRequest, "Could not get user")
 		return
 	}
@@ -107,10 +107,13 @@ func (router *Router) getTeams(w http.ResponseWriter, r *http.Request) {
 	defaultClusterName := r.URL.Query().Get("cluster")
 	defaultNamespace := r.URL.Query().Get("namespace")
 
+	log.Debug(r.Context(), "Get User parameters.", zap.String("defaultCluster", defaultClusterName), zap.String("defaultNamespace", defaultNamespace))
+
 	var data getTeamsData
 
 	err := json.NewDecoder(r.Body).Decode(&data)
 	if err != nil {
+		log.Error(r.Context(), "could not decode request body.", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusBadRequest, "Could not decode request body")
 		return
 	}
@@ -130,12 +133,14 @@ func (router *Router) getTeams(w http.ResponseWriter, r *http.Request) {
 
 		cluster := router.clusters.GetCluster(c)
 		if cluster == nil {
+			log.Error(r.Context(), "Invalid cluster name.", zap.String("cluster", c))
 			errresponse.Render(w, r, nil, http.StatusBadRequest, "Invalid cluster name")
 			return
 		}
 
 		t, err := cluster.GetTeam(r.Context(), n, team.Name)
 		if err != nil {
+			log.Error(r.Context(), "Could not get team.", zap.String("team", team.Name))
 			errresponse.Render(w, r, err, http.StatusBadRequest, "Could not get team")
 			return
 		}
@@ -152,7 +157,7 @@ func (router *Router) getTeam(w http.ResponseWriter, r *http.Request) {
 	teamNamespace := r.URL.Query().Get("namespace")
 	teamName := r.URL.Query().Get("name")
 
-	log.WithFields(logrus.Fields{"cluster": teamCluster, "namespace": teamNamespace, "name": teamName}).Tracef("getTeam")
+	log.Debug(r.Context(), "Get team parameters.", zap.String("cluster", teamCluster), zap.String("namespace", teamNamespace), zap.String("name", teamName))
 
 	var users []user.UserSpec
 	var filteredUsers []user.UserSpec
@@ -160,6 +165,7 @@ func (router *Router) getTeam(w http.ResponseWriter, r *http.Request) {
 	for _, cluster := range router.clusters.Clusters {
 		user, err := cluster.GetUsers(r.Context(), "")
 		if err != nil {
+			log.Error(r.Context(), "Could not get users.")
 			errresponse.Render(w, r, err, http.StatusBadRequest, "Could not get users")
 			return
 		}


### PR DESCRIPTION
We are now using "go.uber.org/zap" for logging instead of
"github.com/sirupsen/logrus".

It is now also possible to enrich each log line via a context. This way
we can add the "userID" and "requestID" to most of the log lines and we
can add additional fields to the logging context via the
"ContextWithValue" function. For that we should always use our custom
"github.com/kobsio/kobs/pkg/log" package instead of directly using zap.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
