### PR TITLE
[flux] Fix sync action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 - [#227](https://github.com/kobsio/kobs/pull/227): [techdocs] Ignore comments in code blocks in table of contents.
 - [#234](https://github.com/kobsio/kobs/pull/234): [azure] Fix json tags in Azure permissions struct.
+- [#242](https://github.com/kobsio/kobs/pull/242): [flux] Fix sync action for Kustomizations / Helm Releases and reload resources when search button is clicked.
 
 ### Changed
 

--- a/plugins/flux/src/components/page/Page.tsx
+++ b/plugins/flux/src/components/page/Page.tsx
@@ -26,7 +26,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
   const changeOptions = (opts: IOptions): void => {
     history.push({
       pathname: location.pathname,
-      search: `?type=${opts.type}&cluster=${opts.cluster}`,
+      search: `?time=${opts.times.time}&timeEnd=${opts.times.timeEnd}&timeStart=${opts.times.timeStart}&type=${opts.type}&cluster=${opts.cluster}`,
     });
   };
 

--- a/plugins/flux/src/components/panel/details/actions/Sync.tsx
+++ b/plugins/flux/src/components/panel/details/actions/Sync.tsx
@@ -29,9 +29,9 @@ const Sync: React.FunctionComponent<ISyncProps> = ({
   const handleSync = async (): Promise<void> => {
     try {
       const response = await fetch(
-        `/api/plugins/flux/sync?cluster=${resource.cluster.title}${
-          resource.namespace ? `&namespace=${resource.namespace.title}` : ''
-        }&name=${resource.name.title}&resource=${request.resource}`,
+        `/api/plugins/flux/sync?cluster=${resource.cluster}${
+          resource.namespace ? `&namespace=${resource.namespace}` : ''
+        }&name=${resource.name}&resource=${request.resource}`,
         {
           method: 'get',
         },
@@ -40,7 +40,7 @@ const Sync: React.FunctionComponent<ISyncProps> = ({
 
       if (response.status >= 200 && response.status < 300) {
         setShow(false);
-        setAlert({ title: `${resource.name.title} is syncing`, variant: AlertVariant.success });
+        setAlert({ title: `${resource.name} is syncing`, variant: AlertVariant.success });
         refetch();
       } else {
         if (json.error) {
@@ -58,7 +58,7 @@ const Sync: React.FunctionComponent<ISyncProps> = ({
   return (
     <Modal
       variant={ModalVariant.small}
-      title={`Sync ${resource.name.title}`}
+      title={`Sync ${resource.name}`}
       isOpen={show}
       onClose={(): void => setShow(false)}
       actions={[
@@ -71,8 +71,8 @@ const Sync: React.FunctionComponent<ISyncProps> = ({
       ]}
     >
       <p>
-        Do you really want to sync <b>{resource.name.title}</b> (
-        {resource.namespace ? `${resource.namespace.title}/${resource.cluster.title}` : resource.cluster.title})?
+        Do you really want to sync <b>{resource.name}</b> (
+        {resource.namespace ? `${resource.namespace}/${resource.cluster}` : resource.cluster})?
       </p>
     </Modal>
   );


### PR DESCRIPTION
This commit fixes the sync action in the Flux plugin for Kustomizations
and Helm Releases. After #235 we forgot to adjust the sync action, so
that the cluster, namespace and name of the Kustomization / Helm Release
was "undefined" in the action. Therefore the API call failed, because
the resource was not found and an error was shown to the user.

We also changed the behaviour of the "Search" button, so that the
resources are always reloaded, when the user clicks the button.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
