### PR TITLE
[resources] Fix reload of resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#227](https://github.com/kobsio/kobs/pull/227): [techdocs] Ignore comments in code blocks in table of contents.
 - [#234](https://github.com/kobsio/kobs/pull/234): [azure] Fix json tags in Azure permissions struct.
 - [#242](https://github.com/kobsio/kobs/pull/242): [flux] Fix sync action for Kustomizations / Helm Releases and reload resources when search button is clicked.
+- [#243](https://github.com/kobsio/kobs/pull/243): [resources] Fix reload of resources, when the user clicks on the search button.
 
 ### Changed
 

--- a/plugins/applications/src/components/page/Applications.tsx
+++ b/plugins/applications/src/components/page/Applications.tsx
@@ -43,7 +43,9 @@ const Applications: React.FunctionComponent<IApplicationsProps> = ({
 
     history.push({
       pathname: location.pathname,
-      search: `?view=${opts.view}${c.length > 0 ? c.join('') : ''}${n.length > 0 ? n.join('') : ''}`,
+      search: `?time=${opts.times.time}&timeEnd=${opts.times.timeEnd}&timeStart=${opts.times.timeStart}&view=${
+        opts.view
+      }${c.length > 0 ? c.join('') : ''}${n.length > 0 ? n.join('') : ''}`,
     });
   };
 

--- a/plugins/resources/src/components/page/Page.tsx
+++ b/plugins/resources/src/components/page/Page.tsx
@@ -32,7 +32,9 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ name, displayName, de
 
     history.push({
       pathname: location.pathname,
-      search: `?selector=${opts.selector}${clusterParams.length > 0 ? clusterParams.join('') : ''}${
+      search: `?time=${opts.times.time}&timeEnd=${opts.times.timeEnd}&timeStart=${opts.times.timeStart}&selector=${
+        opts.selector
+      }${clusterParams.length > 0 ? clusterParams.join('') : ''}${
         namespaceParams.length > 0 ? namespaceParams.join('') : ''
       }${resourceParams.length > 0 ? resourceParams.join('') : ''}`,
     });


### PR DESCRIPTION
This fixes that resources were not reloaded when a user clicks on the
search button, without changing the selected clusters, namespaces or
resources. This bug was caused, because we forgot to add the time
parameters, which are returned within the search function, to the url.
So that the update of the options was not triggered via our "useEffect"
hook.

The same problem was also present in the applications plugin, which is
also fixed with this commit.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
