### PR TITLE
[klogs] Fix out of time range documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#234](https://github.com/kobsio/kobs/pull/234): [azure] Fix json tags in Azure permissions struct.
 - [#242](https://github.com/kobsio/kobs/pull/242): [flux] Fix sync action for Kustomizations / Helm Releases and reload resources when search button is clicked.
 - [#243](https://github.com/kobsio/kobs/pull/243): [resources] Fix reload of resources, when the user clicks on the search button.
+- [#245](https://github.com/kobsio/kobs/pull/245): [klogs] Fix that the returned documents could be out of the selected time range.
 
 ### Changed
 

--- a/pkg/api/middleware/auth/context/context_test.go
+++ b/pkg/api/middleware/auth/context/context_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestHasPluginAccess(t *testing.T) {
-	for _, tc := range []struct {
+	for _, tt := range []struct {
 		user              User
 		expectedHasAccess bool
 	}{
@@ -20,15 +20,15 @@ func TestHasPluginAccess(t *testing.T) {
 		{user: User{ID: "user4", Permissions: user.Permissions{Plugins: []user.Plugin{{Name: "plugin2"}}}}, expectedHasAccess: false},
 		{user: User{ID: "user5", Permissions: user.Permissions{Plugins: []user.Plugin{{Name: "plugin2"}, {Name: "*"}}}}, expectedHasAccess: true},
 	} {
-		t.Run(tc.user.ID, func(t *testing.T) {
-			actualHasAccess := tc.user.HasPluginAccess("plugin1")
-			require.Equal(t, tc.expectedHasAccess, actualHasAccess)
+		t.Run(tt.user.ID, func(t *testing.T) {
+			actualHasAccess := tt.user.HasPluginAccess("plugin1")
+			require.Equal(t, tt.expectedHasAccess, actualHasAccess)
 		})
 	}
 }
 
 func TestHasClusterAccess(t *testing.T) {
-	for _, tc := range []struct {
+	for _, tt := range []struct {
 		user              User
 		expectedHasAccess bool
 	}{
@@ -41,15 +41,15 @@ func TestHasClusterAccess(t *testing.T) {
 		{user: User{ID: "user7", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster2"}}, {Clusters: []string{"cluster1"}}}}}, expectedHasAccess: true},
 		{user: User{ID: "user8", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster2"}}, {Clusters: []string{"cluster3"}}}}}, expectedHasAccess: false},
 	} {
-		t.Run(tc.user.ID, func(t *testing.T) {
-			actualHasAccess := tc.user.HasClusterAccess("cluster1")
-			require.Equal(t, tc.expectedHasAccess, actualHasAccess)
+		t.Run(tt.user.ID, func(t *testing.T) {
+			actualHasAccess := tt.user.HasClusterAccess("cluster1")
+			require.Equal(t, tt.expectedHasAccess, actualHasAccess)
 		})
 	}
 }
 
 func TestHasNamespaceAccess(t *testing.T) {
-	for _, tc := range []struct {
+	for _, tt := range []struct {
 		user              User
 		expectedHasAccess bool
 	}{
@@ -69,15 +69,15 @@ func TestHasNamespaceAccess(t *testing.T) {
 		{user: User{ID: "user11", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster2"}, Namespaces: []string{"*"}}, {Clusters: []string{"cluster1"}, Namespaces: []string{"namespace1"}}}}}, expectedHasAccess: true},
 		{user: User{ID: "user12", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster2"}, Namespaces: []string{"*"}}, {Clusters: []string{"cluster1"}, Namespaces: []string{"namespace2"}}}}}, expectedHasAccess: false},
 	} {
-		t.Run(tc.user.ID, func(t *testing.T) {
-			actualHasAccess := tc.user.HasNamespaceAccess("cluster1", "namespace1")
-			require.Equal(t, tc.expectedHasAccess, actualHasAccess)
+		t.Run(tt.user.ID, func(t *testing.T) {
+			actualHasAccess := tt.user.HasNamespaceAccess("cluster1", "namespace1")
+			require.Equal(t, tt.expectedHasAccess, actualHasAccess)
 		})
 	}
 }
 
 func TestHasResourceAccess(t *testing.T) {
-	for _, tc := range []struct {
+	for _, tt := range []struct {
 		user              User
 		expectedHasAccess bool
 	}{
@@ -99,9 +99,9 @@ func TestHasResourceAccess(t *testing.T) {
 		{user: User{ID: "user11", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster2"}, Namespaces: []string{"*"}, Resources: []string{"resource1"}}, {Clusters: []string{"cluster1"}, Namespaces: []string{"namespace1"}, Resources: []string{"resource1"}}}}}, expectedHasAccess: true},
 		{user: User{ID: "user12", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster2"}, Namespaces: []string{"*"}, Resources: []string{"resource1"}}, {Clusters: []string{"cluster1"}, Namespaces: []string{"namespace2"}, Resources: []string{"resource1"}}}}}, expectedHasAccess: false},
 	} {
-		t.Run(tc.user.ID, func(t *testing.T) {
-			actualHasAccess := tc.user.HasResourceAccess("cluster1", "namespace1", "resource1")
-			require.Equal(t, tc.expectedHasAccess, actualHasAccess)
+		t.Run(tt.user.ID, func(t *testing.T) {
+			actualHasAccess := tt.user.HasResourceAccess("cluster1", "namespace1", "resource1")
+			require.Equal(t, tt.expectedHasAccess, actualHasAccess)
 		})
 	}
 }
@@ -116,7 +116,7 @@ func TestGetPluginPermissions(t *testing.T) {
 }
 
 func TestGetUser(t *testing.T) {
-	for _, tc := range []struct {
+	for _, tt := range []struct {
 		test    string
 		ctx     context.Context
 		isError bool
@@ -125,9 +125,9 @@ func TestGetUser(t *testing.T) {
 		{test: "test2", ctx: context.WithValue(context.Background(), UserKey, User{}), isError: false},
 		{test: "test3", ctx: context.WithValue(context.Background(), UserKey, ""), isError: true},
 	} {
-		t.Run(tc.test, func(t *testing.T) {
-			_, err := GetUser(tc.ctx)
-			if tc.isError {
+		t.Run(tt.test, func(t *testing.T) {
+			_, err := GetUser(tt.ctx)
+			if tt.isError {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)

--- a/plugins/applications/pkg/topology/topology_test.go
+++ b/plugins/applications/pkg/topology/topology_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestDoesNodeExists(t *testing.T) {
-	for _, tn := range []struct {
+	for _, tt := range []struct {
 		nodes          []Node
 		nodeID         string
 		expectedExists bool
@@ -16,15 +16,15 @@ func TestDoesNodeExists(t *testing.T) {
 		{nodes: []Node{{Data: NodeData{ID: "node2"}}}, nodeID: "node1", expectedExists: false},
 		{nodes: []Node{{Data: NodeData{ID: "node2"}}, {Data: NodeData{ID: "node2"}}}, nodeID: "node2", expectedExists: true},
 	} {
-		t.Run(tn.nodeID, func(t *testing.T) {
-			actualExists := doesNodeExists(tn.nodes, tn.nodeID)
-			require.Equal(t, tn.expectedExists, actualExists)
+		t.Run(tt.nodeID, func(t *testing.T) {
+			actualExists := doesNodeExists(tt.nodes, tt.nodeID)
+			require.Equal(t, tt.expectedExists, actualExists)
 		})
 	}
 }
 
 func TestAppendEdgeIfMissing(t *testing.T) {
-	for _, te := range []struct {
+	for _, tt := range []struct {
 		edges         []Edge
 		edge          Edge
 		expectedEdges []Edge
@@ -32,15 +32,15 @@ func TestAppendEdgeIfMissing(t *testing.T) {
 		{edges: []Edge{{Data: EdgeData{ID: "edge1"}}}, edge: Edge{Data: EdgeData{ID: "edge1"}}, expectedEdges: []Edge{{Data: EdgeData{ID: "edge1"}}}},
 		{edges: []Edge{{Data: EdgeData{ID: "edge1"}}}, edge: Edge{Data: EdgeData{ID: "edge2"}}, expectedEdges: []Edge{{Data: EdgeData{ID: "edge1"}}, {Data: EdgeData{ID: "edge2"}}}},
 	} {
-		t.Run(te.edge.Data.ID, func(t *testing.T) {
-			actualExists := appendEdgeIfMissing(te.edges, te.edge)
-			require.Equal(t, te.expectedEdges, actualExists)
+		t.Run(tt.edge.Data.ID, func(t *testing.T) {
+			actualExists := appendEdgeIfMissing(tt.edges, tt.edge)
+			require.Equal(t, tt.expectedEdges, actualExists)
 		})
 	}
 }
 
 func TestAppendNodeIfMissing(t *testing.T) {
-	for _, tn := range []struct {
+	for _, tt := range []struct {
 		nodes         []Node
 		node          Node
 		expectedNodes []Node
@@ -48,9 +48,9 @@ func TestAppendNodeIfMissing(t *testing.T) {
 		{nodes: []Node{{Data: NodeData{ID: "node1"}}}, node: Node{Data: NodeData{ID: "node1"}}, expectedNodes: []Node{{Data: NodeData{ID: "node1"}}}},
 		{nodes: []Node{{Data: NodeData{ID: "node1"}}}, node: Node{Data: NodeData{ID: "node2"}}, expectedNodes: []Node{{Data: NodeData{ID: "node1"}}, {Data: NodeData{ID: "node2"}}}},
 	} {
-		t.Run(tn.node.Data.ID, func(t *testing.T) {
-			actualExists := appendNodeIfMissing(tn.nodes, tn.node)
-			require.Equal(t, tn.expectedNodes, actualExists)
+		t.Run(tt.node.Data.ID, func(t *testing.T) {
+			actualExists := appendNodeIfMissing(tt.nodes, tt.node)
+			require.Equal(t, tt.expectedNodes, actualExists)
 		})
 	}
 }

--- a/plugins/klogs/pkg/instance/aggregation_test.go
+++ b/plugins/klogs/pkg/instance/aggregation_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestGenerateFieldName(t *testing.T) {
-	for _, tc := range []struct {
+	for _, tt := range []struct {
 		field      string
 		mustNumber bool
 		expect     string
@@ -18,15 +18,15 @@ func TestGenerateFieldName(t *testing.T) {
 		{field: "content.duration", mustNumber: true, expect: "fields_number.value[indexOf(fields_number.key, 'content.duration')]"},
 		{field: "content.duration", mustNumber: false, expect: "fields_number.value[indexOf(fields_number.key, 'content.duration')]"},
 	} {
-		t.Run(tc.field, func(t *testing.T) {
-			actual := generateFieldName(tc.field, nil, Fields{String: nil, Number: []string{"content.duration"}}, false)
-			require.Equal(t, tc.expect, actual)
+		t.Run(tt.field, func(t *testing.T) {
+			actual := generateFieldName(tt.field, nil, Fields{String: nil, Number: []string{"content.duration"}}, tt.mustNumber)
+			require.Equal(t, tt.expect, actual)
 		})
 	}
 }
 
 func TestGetOrderBy(t *testing.T) {
-	for _, tc := range []struct {
+	for _, tt := range []struct {
 		order  string
 		expect string
 	}{
@@ -34,9 +34,9 @@ func TestGetOrderBy(t *testing.T) {
 		{order: "ascending", expect: "ASC"},
 		{order: "foo bar", expect: "ASC"},
 	} {
-		t.Run(tc.order, func(t *testing.T) {
-			actual := getOrderBy(tc.order)
-			require.Equal(t, tc.expect, actual)
+		t.Run(tt.order, func(t *testing.T) {
+			actual := getOrderBy(tt.order)
+			require.Equal(t, tt.expect, actual)
 		})
 	}
 }

--- a/plugins/klogs/pkg/instance/helpers.go
+++ b/plugins/klogs/pkg/instance/helpers.go
@@ -1,9 +1,5 @@
 package instance
 
-import (
-	"sync"
-)
-
 // appendIfMissing appends a value to a slice, when this values doesn't exist in the slice already.
 func appendIfMissing(items []string, item string) []string {
 	for _, ele := range items {
@@ -25,19 +21,4 @@ func contains(items []string, item string) bool {
 	}
 
 	return false
-}
-
-// parallelize runs the given functions in parallel.
-func parallelize(functions ...func()) {
-	var waitGroup sync.WaitGroup
-	waitGroup.Add(len(functions))
-
-	defer waitGroup.Wait()
-
-	for _, function := range functions {
-		go func(copy func()) {
-			defer waitGroup.Done()
-			copy()
-		}(function)
-	}
 }

--- a/plugins/klogs/pkg/instance/logs.go
+++ b/plugins/klogs/pkg/instance/logs.go
@@ -211,3 +211,17 @@ func parseOrder(order, orderBy string, materializedColumns []string) string {
 
 	return fmt.Sprintf("fields_string.value[indexOf(fields_string.key, '%s')] %s, fields_number.value[indexOf(fields_number.key, '%s')] %s", orderBy, order, orderBy, order)
 }
+
+// getBucketTimes determines the start and end time of an bucket. This is necessary, because the first and last bucket
+// time can be outside of the user defined time range.
+func getBucketTimes(interval, bucketTime, timeStart, timeEnd int64) (int64, int64) {
+	if bucketTime < timeStart {
+		return timeStart, timeStart + interval - (timeStart - bucketTime)
+	}
+
+	if bucketTime+interval > timeEnd {
+		return bucketTime, bucketTime + timeEnd - bucketTime
+	}
+
+	return bucketTime, bucketTime + interval
+}

--- a/plugins/klogs/pkg/instance/logs_test.go
+++ b/plugins/klogs/pkg/instance/logs_test.go
@@ -1,13 +1,14 @@
 package instance
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestParseLogsQuery(t *testing.T) {
-	for _, tc := range []struct {
+	for _, tt := range []struct {
 		query     string
 		where     string
 		isInvalid bool
@@ -17,15 +18,128 @@ func TestParseLogsQuery(t *testing.T) {
 		{query: "kubernetes.label_foo = 'bar'", where: "fields_string.value[indexOf(fields_string.key, 'kubernetes.label_foo')] = 'bar'", isInvalid: false},
 		{query: "kubernetes.label_foo_bar =~ '\\%hellow\\%world\\%'", where: "fields_string.value[indexOf(fields_string.key, 'kubernetes.label_foo_bar')] ILIKE '\\%hellow\\%world\\%'", isInvalid: false},
 		{query: "kubernetes.label_foo_bar ~ 'hello.*'", where: "match(fields_string.value[indexOf(fields_string.key, 'kubernetes.label_foo_bar')], 'hello.*')", isInvalid: false},
+		{query: "kubernetes.label_foo_bar / 'hello.*'", isInvalid: true},
 	} {
-		t.Run(tc.query, func(t *testing.T) {
-			parsedWhere, err := parseLogsQuery(tc.query, nil)
-			if tc.isInvalid {
+		t.Run(tt.query, func(t *testing.T) {
+			parsedWhere, err := parseLogsQuery(tt.query, nil)
+			if tt.isInvalid {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tc.where, parsedWhere)
+				require.Equal(t, tt.where, parsedWhere)
 			}
+		})
+	}
+}
+
+func TestSplitOperator(t *testing.T) {
+	for _, tt := range []struct {
+		query             string
+		expectedCondition string
+		isInvalid         bool
+	}{
+		{query: "cluster >= 'foo'", expectedCondition: "cluster>='foo'", isInvalid: false},
+		{query: "cluster > 'foo'", expectedCondition: "cluster>'foo'", isInvalid: false},
+		{query: "cluster <= 'foo'", expectedCondition: "cluster<='foo'", isInvalid: false},
+		{query: "cluster < 'foo'", expectedCondition: "cluster<'foo'", isInvalid: false},
+		{query: "cluster =~ 'foo'", expectedCondition: "cluster ILIKE 'foo'", isInvalid: false},
+		{query: "cluster != 'foo'", expectedCondition: "cluster!='foo'", isInvalid: false},
+		{query: "cluster !~ 'foo'", expectedCondition: "cluster NOT ILIKE 'foo'", isInvalid: false},
+		{query: "cluster ~ 'foo'", expectedCondition: "match(cluster, 'foo')", isInvalid: false},
+		{query: "cluster = 'foo'", expectedCondition: "cluster='foo'", isInvalid: false},
+		{query: "_exists_ cluster", expectedCondition: "cluster IS NOT NULL", isInvalid: false},
+		{query: " ", expectedCondition: "", isInvalid: false},
+		{query: "cluster / 'foo'", isInvalid: true},
+	} {
+		t.Run(tt.query, func(t *testing.T) {
+			actualCondition, err := splitOperator(tt.query, nil)
+			if tt.isInvalid {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedCondition, actualCondition)
+			}
+		})
+	}
+}
+
+func TestHandleConditionParts(t *testing.T) {
+	for _, tt := range []struct {
+		key               string
+		value             string
+		operator          string
+		expectedCondition string
+	}{
+		{key: "cluster", value: "'foobar'", operator: "=~", expectedCondition: "cluster ILIKE 'foobar'"},
+		{key: "cluster", value: "'foobar'", operator: "!~", expectedCondition: "cluster NOT ILIKE 'foobar'"},
+		{key: "cluster", value: "'foobar'", operator: "~", expectedCondition: "match(cluster, 'foobar')"},
+		{key: "cluster", value: "'foobar'", operator: "=", expectedCondition: "cluster='foobar'"},
+		{key: "helloworld", value: "'foobar'", operator: "=~", expectedCondition: "fields_string.value[indexOf(fields_string.key, 'helloworld')] ILIKE 'foobar'"},
+		{key: "helloworld", value: "'foobar'", operator: "!~", expectedCondition: "fields_string.value[indexOf(fields_string.key, 'helloworld')] NOT ILIKE 'foobar'"},
+		{key: "helloworld", value: "'foobar'", operator: "~", expectedCondition: "match(fields_string.value[indexOf(fields_string.key, 'helloworld')], 'foobar')"},
+		{key: "helloworld", value: "'foobar'", operator: "=", expectedCondition: "fields_string.value[indexOf(fields_string.key, 'helloworld')] = 'foobar'"},
+		{key: "helloworld", value: "42", operator: "=~", expectedCondition: "fields_number.value[indexOf(fields_number.key, 'helloworld')] ILIKE 42"},
+		{key: "helloworld", value: "42", operator: "!~", expectedCondition: "fields_number.value[indexOf(fields_number.key, 'helloworld')] NOT ILIKE 42"},
+		{key: "helloworld", value: "42", operator: "~", expectedCondition: "match(fields_number.value[indexOf(fields_number.key, 'helloworld')], 42)"},
+		{key: "helloworld", value: "42", operator: "=", expectedCondition: "fields_number.value[indexOf(fields_number.key, 'helloworld')] = 42"},
+	} {
+		t.Run(tt.key, func(t *testing.T) {
+			actualCondition, _ := handleConditionParts(tt.key, tt.value, tt.operator, nil)
+			require.Equal(t, tt.expectedCondition, actualCondition)
+		})
+	}
+}
+
+func TestHandleExistsCondition(t *testing.T) {
+	for _, tt := range []struct {
+		key               string
+		expectedCondition string
+	}{
+		{key: "cluster", expectedCondition: "cluster IS NOT NULL"},
+		{key: "foobar", expectedCondition: "(has(fields_string.key, 'foobar') = 1 OR has(fields_number.key, 'foobar') = 1)"},
+	} {
+		t.Run(tt.key, func(t *testing.T) {
+			actualCondition := handleExistsCondition(tt.key, nil)
+			require.Equal(t, tt.expectedCondition, actualCondition)
+		})
+	}
+}
+
+func TestParseOrder(t *testing.T) {
+	for _, tt := range []struct {
+		order             string
+		orderBy           string
+		expectedCondition string
+	}{
+		{order: "", orderBy: "", expectedCondition: "timestamp DESC"},
+		{order: "ascending", orderBy: "cluster", expectedCondition: "cluster ASC"},
+		{order: "descending", orderBy: "cluster", expectedCondition: "cluster DESC"},
+		{order: "ascending", orderBy: "foobar", expectedCondition: "fields_string.value[indexOf(fields_string.key, 'foobar')] ASC, fields_number.value[indexOf(fields_number.key, 'foobar')] ASC"},
+	} {
+		t.Run(tt.order+tt.orderBy, func(t *testing.T) {
+			actualCondition := parseOrder(tt.order, tt.orderBy, nil)
+			require.Equal(t, tt.expectedCondition, actualCondition)
+		})
+	}
+}
+
+func TestGetInterval(t *testing.T) {
+	for _, tt := range []struct {
+		interval          int64
+		bucketTime        int64
+		timeStart         int64
+		timeEnd           int64
+		expectedTimeStart int64
+		expectedTimeEnd   int64
+	}{
+		{interval: 124, bucketTime: 1640188920, timeStart: 1640189016, timeEnd: 1640192745, expectedTimeStart: 1640189016, expectedTimeEnd: 1640189044},
+		{interval: 124, bucketTime: 1640190780, timeStart: 1640189016, timeEnd: 1640192745, expectedTimeStart: 1640190780, expectedTimeEnd: 1640190904},
+		{interval: 124, bucketTime: 1640192640, timeStart: 1640189016, timeEnd: 1640192745, expectedTimeStart: 1640192640, expectedTimeEnd: 1640192745},
+	} {
+		t.Run(fmt.Sprintf("%d", tt.bucketTime), func(t *testing.T) {
+			actualTimeStart, actualTimeEnd := getBucketTimes(tt.interval, tt.bucketTime, tt.timeStart, tt.timeEnd)
+			require.Equal(t, tt.expectedTimeStart, actualTimeStart)
+			require.Equal(t, tt.expectedTimeEnd, actualTimeEnd)
 		})
 	}
 }


### PR DESCRIPTION
This commit fixes a bug in the klogs plugin, where it could happen that
the returned documents were not in the users selected time range. This
was caused by the buckets we determine before the actual query, were the
bucket timestamp could be not within the selected time range.

We also improved the test coverage for the klogs plugin and unify the
style of the used "table" tests.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
