### PR TITLE
[jaeger] Add new "publicAddress" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#224](https://github.com/kobsio/kobs/pull/224): [harbor] Add support for multi-arch images.
 - [#226](https://github.com/kobsio/kobs/pull/226): [klogs] Add option to sort fields.
 - [#228](https://github.com/kobsio/kobs/pull/228): [azure] :warning: _Breaking change:_ :warning: Add support for virtual machine scale sets and change required values to display metrics from Azure.
+- [#246](https://github.com/kobsio/kobs/pull/246): [jaeger] Add new configuration field `publicAddress`. When this options is set we add a link to the Jaeger UI.
 
 ### Fixed
 

--- a/docs/plugins/jaeger.md
+++ b/docs/plugins/jaeger.md
@@ -30,6 +30,7 @@ plugins:
 | username | string | Username to access a Jaeger instance via basic authentication. | No |
 | password | string | Password to access a Jaeger instance via basic authentication. | No |
 | token | string | Token to access a Jaeger instance via token based authentication. | No |
+| publicAddress | string | The public accessible address of the Jaeger instance. | No |
 
 ## Options
 

--- a/plugins/jaeger/jaeger.go
+++ b/plugins/jaeger/jaeger.go
@@ -162,11 +162,16 @@ func Register(clusters *clusters.Clusters, plugins *plugin.Plugins, config Confi
 
 		instances = append(instances, instance)
 
+		var options map[string]interface{}
+		options = make(map[string]interface{})
+		options["publicAddress"] = cfg.PublicAddress
+
 		plugins.Append(plugin.Plugin{
 			Name:        cfg.Name,
 			DisplayName: cfg.DisplayName,
 			Description: cfg.Description,
 			Type:        "jaeger",
+			Options:     options,
 		})
 	}
 

--- a/plugins/jaeger/pkg/instance/instance.go
+++ b/plugins/jaeger/pkg/instance/instance.go
@@ -11,13 +11,14 @@ import (
 
 // Config is the structure of the configuration for a single Jaeger instance.
 type Config struct {
-	Name        string `json:"name"`
-	DisplayName string `json:"displayName"`
-	Description string `json:"description"`
-	Address     string `json:"address"`
-	Username    string `json:"username"`
-	Password    string `json:"password"`
-	Token       string `json:"token"`
+	Name          string `json:"name"`
+	DisplayName   string `json:"displayName"`
+	Description   string `json:"description"`
+	Address       string `json:"address"`
+	Username      string `json:"username"`
+	Password      string `json:"password"`
+	Token         string `json:"token"`
+	PublicAddress string `json:"publicAddress"`
 }
 
 // ResponseError is the structure for a failed Jaeger API request.

--- a/plugins/jaeger/src/components/panel/details/Span.tsx
+++ b/plugins/jaeger/src/components/panel/details/Span.tsx
@@ -1,6 +1,6 @@
 import { AccordionContent, AccordionItem, AccordionToggle } from '@patternfly/react-core';
-import React, { useState } from 'react';
 import { ExclamationIcon } from '@patternfly/react-icons';
+import React from 'react';
 
 import { IProcess, ISpan } from '../../../utils/interfaces';
 import SpanLogs from './SpanLogs';
@@ -15,11 +15,19 @@ export interface ISpanProps {
   duration: number;
   startTime: number;
   processes: Record<string, IProcess>;
+  expanded: boolean;
+  setExpanded: (spanID: string) => void;
 }
 
-const Span: React.FunctionComponent<ISpanProps> = ({ name, span, duration, startTime, processes }: ISpanProps) => {
-  const [expanded, setExpanded] = useState<boolean>(false);
-
+const Span: React.FunctionComponent<ISpanProps> = ({
+  name,
+  span,
+  duration,
+  startTime,
+  processes,
+  expanded,
+  setExpanded,
+}: ISpanProps) => {
   const offset = ((span.startTime - startTime) / 1000 / (duration / 1000)) * 100;
   const fill = (span.duration / 1000 / (duration / 1000)) * 100;
 
@@ -72,7 +80,7 @@ const Span: React.FunctionComponent<ISpanProps> = ({ name, span, duration, start
         id={`span-${span.spanID}`}
         className="kobsio-jaeger-accordion-toggle"
         style={{ paddingLeft: `${(span.depth + 1) * PADDING}px` }}
-        onClick={(): void => setExpanded(!expanded)}
+        onClick={(): void => setExpanded(span.spanID)}
         isExpanded={expanded}
       >
         <span>

--- a/plugins/jaeger/src/components/panel/details/Spans.tsx
+++ b/plugins/jaeger/src/components/panel/details/Spans.tsx
@@ -14,6 +14,19 @@ export interface ISpansProps {
 const Spans: React.FunctionComponent<ISpansProps> = ({ name, trace }: ISpansProps) => {
   const refContainer = useRef<HTMLDivElement>(null);
   const [height, setHeight] = useState<number>(0);
+  const [expanded, setExpanded] = useState<string[]>([]);
+
+  const changeExpanded = (spanID: string): void => {
+    let tmpExpanded: string[] = [...expanded];
+
+    if (tmpExpanded.includes(spanID)) {
+      tmpExpanded = tmpExpanded.filter((s) => s !== spanID);
+    } else {
+      tmpExpanded.push(spanID);
+    }
+
+    setExpanded(tmpExpanded);
+  };
 
   useEffect(() => {
     if (refContainer.current?.offsetHeight) {
@@ -64,11 +77,14 @@ const Spans: React.FunctionComponent<ISpansProps> = ({ name, trace }: ISpansProp
               data={trace.spans}
               itemContent={(index, span): React.ReactNode => (
                 <Span
+                  key={span.spanID}
                   name={name}
                   span={span}
                   duration={trace.duration}
                   startTime={trace.startTime}
                   processes={trace.processes}
+                  expanded={expanded.includes(span.spanID)}
+                  setExpanded={changeExpanded}
                 />
               )}
             />


### PR DESCRIPTION
The new "publicAddress" option in the Jaeger plugin configuration, can
be used to define the address of a Jaeger UI instance, which can be
accessed by the users. If this option is set, we add a link to each
trace, which allows the users to open the trace in the Jaeger UI.

We are now saving the state of all spans, if they are expanded or not.
This ways we can also render an expanded span, when the user scrolled
the span out of the viewport and when he later scrolls back to the
expanded span.

Before this change, the span was not expanded anymore, when the user
scrolls through the list of spans.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
