### PR TITLE
[azure] Fix documentation about permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#242](https://github.com/kobsio/kobs/pull/242): [flux] Fix sync action for Kustomizations / Helm Releases and reload resources when search button is clicked.
 - [#243](https://github.com/kobsio/kobs/pull/243): [resources] Fix reload of resources, when the user clicks on the search button.
 - [#245](https://github.com/kobsio/kobs/pull/245): [klogs] Fix that the returned documents could be out of the selected time range.
+- [#247](https://github.com/kobsio/kobs/pull/247): [azure] Fix documentation about the permission handling.
 
 ### Changed
 

--- a/docs/plugins/azure.md
+++ b/docs/plugins/azure.md
@@ -90,9 +90,9 @@ The following options can be used for a panel with the Azure plugin:
 
 ### Permissions
 
-You can define fine grained permissions to access your Azure resources via kobs. The permissions are defined via the `permissions.cusomt` field of a [Team](../resources/teams.md). Each user which is member of this team, will then get the defined permissions.
+You can define fine grained permissions to access your Azure resources via kobs. The permissions are defined via the `permissions.plugins[].permissions` field of a [User](../resources/users.md) or [Team](../resources/teams.md). The team membership of an user is defined via the values of the `X-Auth-Request-Groups` header.
 
-In the following example each member of `team1` will get access to all Azure resource, while members of `team2` can only access container instances in the `development` resource group:
+In the following example each member of `team1@kobs.io` will get access to all Azure resource, while members of `team2@kobs.io` can only access container instances in the `development` resource group:
 
 ??? note "team1"
 
@@ -103,17 +103,10 @@ In the following example each member of `team1` will get access to all Azure res
     metadata:
       name: team1
     spec:
+      id: team1@kobs.io
       permissions:
         plugins:
-          - "*"
-        resources:
-          - clusters:
-              - "*"
-            namespaces:
-              - "*"
-            resources:
-              - "*"
-        custom:
+          - name: "*"
           - name: azure
             permissions:
               - resources:
@@ -122,6 +115,14 @@ In the following example each member of `team1` will get access to all Azure res
                   - "*"
                 verbs:
                   - "*"
+        resources:
+          - clusters:
+              - "*"
+            namespaces:
+              - "*"
+            resources:
+              - "*"
+        custom:
     ```
 
 ??? note "team2"
@@ -133,17 +134,10 @@ In the following example each member of `team1` will get access to all Azure res
     metadata:
       name: team2
     spec:
+      id: team1@kobs.io
       permissions:
         plugins:
-          - "*"
-        resources:
-          - clusters:
-              - "*"
-            namespaces:
-              - "*"
-            resources:
-              - "*"
-        custom:
+          - name: "*"
           - name: azure
             permissions:
               - resources:
@@ -152,6 +146,13 @@ In the following example each member of `team1` will get access to all Azure res
                   - "development"
                 verbs:
                   - "*"
+        resources:
+          - clusters:
+              - "*"
+            namespaces:
+              - "*"
+            resources:
+              - "*"
     ```
 
 The `*` value is a special value, which allows access to all resources, resource groups and action. The following values can also be used for resources and verbs:


### PR DESCRIPTION
The documentation about the permission handling in the Azure plugin was
outdated, after #241. This commit fixes the documentation, so that we
are now showing the correct examples, how the permissions for the Azure
plugin can be set for a user / team.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
