### PR TITLE
[core] Rework variables handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#241](https://github.com/kobsio/kobs/pull/241): [core] :warning: _Breaking change:_ :warning: Rework authentication / authorization middleware and adjust the Custom Resource Definition for Users and Teams.
 - [#236](https://github.com/kobsio/kobs/pull/236): [core] Improve filtering in select components for various plugins.
 - [#260](https://github.com/kobsio/kobs/pull/260): [opsgenie] Adjust permission handling and add actions for incidents.
+- [#262](https://github.com/kobsio/kobs/pull/262): [core] Rework variables handling in dashboards.
 
 ## [v0.7.0](https://github.com/kobsio/kobs/releases/tag/v0.7.0) (2021-11-19)
 

--- a/docs/plugins/prometheus.md
+++ b/docs/plugins/prometheus.md
@@ -71,6 +71,17 @@ The y axis can be customized for line and area charts. It is possible to use the
 | unit | string | An optional unit for the column values. | No |
 | mappings | map<string, string> | Specify value mappings for the column. **Note:** The value must be provided as string (e.g. `"1": "Green"`). | No |
 
+## Variables
+
+If the Prometheus plugin is used to set variables in a dashboard, the following options can be used.
+
+| Field | Type | Description | Required |
+| ----- | ---- | ----------- | -------- |
+| type | string | The query type to get the values for the variable. At the moment this must be `labelValues` | Yes |
+| label | string | The Prometheus label which should be used to get the values for the variable. | Yes |
+| query | string | The PromQL query. | Yes |
+| allowAll | boolean | If this is set to `true` an additional option for the variable will be added, which contains all other values. | No |
+
 ## Example
 
 The following dashboard, shows the CPU and Memory usage of a selected Pod. When this dashboard is used in via a team or application, it is possible to set the namespace and a regular expression to pre select all the Pods. These values are then used to get the names of all Pods and a user can then select the name of a Pod via the `var_pod` variable.

--- a/docs/resources/dashboards.md
+++ b/docs/resources/dashboards.md
@@ -101,14 +101,9 @@ If the `core` plugin is used to get the values for a variable the options from t
                 - myvalue3
     ```
 
-If a Prometheus instance is used to get the variable values, the options from the following table can be used.
+It is also possible to use other plugins, to get a list of variable values. These plugins are:
 
-| Field | Type | Description | Required |
-| ----- | ---- | ----------- | -------- |
-| type | string | The query type to get the values for the variable. At the moment this must be `labelValues` | Yes |
-| label | string | The Prometheus label which should be used to get the values for the variable. | Yes |
-| query | string | The PromQL query. | Yes |
-| allowAll | boolean | If this is set to `true` an additional option for the variable will be added, which contains all other values. | No |
+- [Prometheus](../plugins/prometheus.md#variables)
 
 ### Row
 

--- a/plugins/core/src/context/PluginsContext.tsx
+++ b/plugins/core/src/context/PluginsContext.tsx
@@ -2,6 +2,8 @@ import { Alert, AlertActionLink, AlertVariant, Spinner } from '@patternfly/react
 import { QueryObserverResult, useQuery } from 'react-query';
 import React from 'react';
 
+import { IDashboardVariableValues } from '../crds/dashboard';
+
 // TTime is the type with all possible values for the time property. A value of "custom" identifies that a user
 // specified a custom start and end time via the text input fields. The other values are used for the quick select
 // options.
@@ -97,6 +99,11 @@ export interface IPluginComponent {
   page?: React.FunctionComponent<IPluginPageProps>;
   panel: React.FunctionComponent<IPluginPanelProps>;
   preview?: React.FunctionComponent<IPluginPreviewProps>;
+  variables?: (
+    variable: IDashboardVariableValues,
+    variables: IDashboardVariableValues[],
+    times: IPluginTimes,
+  ) => Promise<IDashboardVariableValues>;
 }
 
 // IPlugins is the interface for a list of plugins. The key of this interface is the plugin type and must correspond

--- a/plugins/core/src/crds/application.ts
+++ b/plugins/core/src/crds/application.ts
@@ -1,4 +1,4 @@
-import { IReference as IDashboardReference, IPlugin } from './dashboard';
+import { IDashboardPlugin, IDashboardReference } from './dashboard';
 
 // IApplication implements the Application CR, which can be created by a user to describe an application. While we have
 // to omit the cluster, namespace and name field in the Go implementation of the CR, we can assume that these fields are
@@ -12,13 +12,13 @@ export interface IApplication {
   links?: IApplicationLink[];
   teams?: IApplicationReference[];
   dependencies?: IApplicationReference[];
-  preview?: IPreview;
+  preview?: IApplicationPreview;
   dashboards?: IDashboardReference[];
 }
 
-export interface IPreview {
+export interface IApplicationPreview {
   title: string;
-  plugin: IPlugin;
+  plugin: IDashboardPlugin;
 }
 
 export interface IApplicationLink {

--- a/plugins/core/src/crds/dashboard.ts
+++ b/plugins/core/src/crds/dashboard.ts
@@ -7,61 +7,69 @@ export interface IDashboard {
   name: string;
   title: string;
   description?: string;
-  placeholders?: IPlaceholder[];
-  variables?: IVariable[];
-  rows: IRow[];
+  placeholders?: IDashboardPlaceholder[];
+  variables?: IDashboardVariable[];
+  rows: IDashboardRow[];
 }
 
-export interface IPlaceholder {
+export interface IDashboardPlaceholder {
   name: string;
   description?: string;
 }
 
-export interface IVariable {
+export interface IDashboardVariable {
   name: string;
   label?: string;
   hide?: boolean;
-  plugin: IPlugin;
+  plugin: IDashboardPlugin;
 }
 
-export interface IRow {
+export interface IDashboardRow {
   title?: string;
   description?: string;
   size?: number;
-  panels: IPanel[];
+  panels: IDashboardPanel[];
 }
 
-export interface IPanel {
+export interface IDashboardPanel {
   title: string;
   description?: string;
   colSpan?: number;
   rowSpan?: number;
-  plugin: IPlugin;
+  plugin: IDashboardPlugin;
 }
 
-export interface IPlugin {
+export interface IDashboardPlugin {
   name: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   options?: any;
 }
 
-// IReference is the interface for a dashboard reference in the Team or Application CR. If the cluster or namespace is
-// not specified in the reference we assume the dashboard is in the same namespace as the team or application.
-export interface IReference {
+// IDashboardReference is the interface for a dashboard reference in the Team or Application CR. If the cluster or
+// namespace is not specified in the reference we assume the dashboard is in the same namespace as the team or
+// application.
+export interface IDashboardReference {
   cluster?: string;
   namespace?: string;
   name?: string;
   title: string;
   description?: string;
   placeholders?: IPlaceholders;
-  inline?: IReferenceInline;
+  inline?: IDashboardReferenceInline;
 }
 
 export interface IPlaceholders {
   [key: string]: string;
 }
 
-export interface IReferenceInline {
-  variables?: IVariable[];
-  rows: IRow[];
+export interface IDashboardReferenceInline {
+  variables?: IDashboardVariable[];
+  rows: IDashboardRow[];
+}
+
+// IDashboardVariableValues is an extension of the IDashboardVariable interface. It contains the additional fields for the
+// selected variable value and all possible variable values.
+export interface IDashboardVariableValues extends IDashboardVariable {
+  value: string;
+  values: string[];
 }

--- a/plugins/core/src/crds/team.ts
+++ b/plugins/core/src/crds/team.ts
@@ -1,4 +1,4 @@
-import { IReference as IDashboardReference } from './dashboard';
+import { IDashboardReference } from './dashboard';
 
 // The ITeam interface implements the Team CRD.
 export interface ITeam {

--- a/plugins/core/src/index.ts
+++ b/plugins/core/src/index.ts
@@ -31,6 +31,7 @@ export * from './utils/chart';
 export * from './utils/colors';
 export * from './utils/fileDownload';
 export * from './utils/gravatar';
+export * from './utils/interpolate';
 export * from './utils/manifests';
 export * from './utils/resources';
 export * from './utils/time';

--- a/plugins/core/src/utils/interpolate.ts
+++ b/plugins/core/src/utils/interpolate.ts
@@ -1,0 +1,53 @@
+import { IDashboardVariableValues } from '../crds/dashboard';
+import { IPluginTimes } from '../context/PluginsContext';
+
+// IVariables is a map of variable names with the current value. This interface should only be used by the interpolate
+// function, to convert a given array of variables to the format, which is required by the function.
+interface IVariables {
+  [key: string]: string;
+}
+
+// interpolate is used to replace the variables in a given string with the current value for this variable. Before we
+// can replace the variables in a string we have to convert the array of variables to a map of variable names and there
+// value.
+// The default interpolator/delimiter is "{%" and "%}", so that it doesn't conflict with the delimiter used for the
+// placeholder. We can not use the same, because the are replaced at different points in our app logic.
+// See: https://stackoverflow.com/a/57598892/4104109
+export const interpolate = (
+  str: string,
+  variables: IDashboardVariableValues[],
+  times: IPluginTimes,
+  interpolator: string[] = ['{%', '%}'],
+): string => {
+  const vars: IVariables = {};
+
+  for (const variable of variables) {
+    vars[variable.name] = variable.value;
+  }
+
+  vars['__timeStart'] = `${times.timeStart}`;
+  vars['__timeEnd'] = `${times.timeEnd}`;
+
+  return str
+    .split(interpolator[0])
+    .map((s1, i) => {
+      if (i === 0) {
+        return s1;
+      }
+
+      const s2 = s1.split(interpolator[1]);
+      if (s1 === s2[0]) {
+        return interpolator[0] + s2[0];
+      }
+
+      if (s2.length > 1) {
+        s2[0] =
+          s2[0] && vars.hasOwnProperty(s2[0].trim().substring(1))
+            ? vars[s2[0].trim().substring(1)]
+            : interpolator.join(` ${s2[0]} `);
+      }
+
+      return s2.join('');
+    })
+    .join('');
+};

--- a/plugins/dashboards/src/components/dashboards/DashboardToolbar.tsx
+++ b/plugins/dashboards/src/components/dashboards/DashboardToolbar.tsx
@@ -1,13 +1,12 @@
 import { Card, ToolbarItem } from '@patternfly/react-core';
 import React from 'react';
 
-import { IOptionsAdditionalFields, IPluginTimes, Toolbar } from '@kobsio/plugin-core';
+import { IDashboardVariableValues, IOptionsAdditionalFields, IPluginTimes, Toolbar } from '@kobsio/plugin-core';
 import DashboardToolbarVariable from './DashboardToolbarVariable';
-import { IVariableValues } from '../../utils/interfaces';
 
 interface IDashboardToolbarProps {
-  variables: IVariableValues[];
-  setVariables: (variables: IVariableValues[]) => void;
+  variables: IDashboardVariableValues[];
+  setVariables: (variables: IDashboardVariableValues[]) => void;
   times: IPluginTimes;
   setTimes: (times: IPluginTimes) => void;
 }

--- a/plugins/dashboards/src/components/dashboards/DashboardToolbarVariable.tsx
+++ b/plugins/dashboards/src/components/dashboards/DashboardToolbarVariable.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import { Select, SelectGroup, SelectOption, SelectOptionObject, SelectVariant } from '@patternfly/react-core';
 
-import { IVariableValues } from '../../utils/interfaces';
+import { IDashboardVariableValues } from '@kobsio/plugin-core';
 
 interface IDashboardToolbarVariableProps {
-  variable: IVariableValues;
+  variable: IDashboardVariableValues;
   selectValue: (value: string) => void;
 }
 

--- a/plugins/dashboards/src/components/dashboards/Dashboards.tsx
+++ b/plugins/dashboards/src/components/dashboards/Dashboards.tsx
@@ -13,14 +13,14 @@ import { QueryObserverResult, useQuery } from 'react-query';
 import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
-import { IDashboard, IPluginDefaults, IReference } from '@kobsio/plugin-core';
+import { IDashboard, IDashboardReference, IPluginDefaults } from '@kobsio/plugin-core';
 import Dashboard from './Dashboard';
 import { IDashboardsOptions } from '../../utils/interfaces';
 import { getInitialOptions } from '../../utils/dashboard';
 
 interface IDashboardsProps {
   defaults: IPluginDefaults;
-  references: IReference[];
+  references: IDashboardReference[];
   setDetails?: (details: React.ReactNode) => void;
   forceDefaultSpan: boolean;
 }

--- a/plugins/dashboards/src/components/dashboards/DashboardsWrapper.tsx
+++ b/plugins/dashboards/src/components/dashboards/DashboardsWrapper.tsx
@@ -1,11 +1,11 @@
 import React, { useRef } from 'react';
 
-import { IPluginDefaults, IReference, useDimensions } from '@kobsio/plugin-core';
+import { IDashboardReference, IPluginDefaults, useDimensions } from '@kobsio/plugin-core';
 import Dashboards from './Dashboards';
 
 interface IDashboardsWrapperProps {
   defaults: IPluginDefaults;
-  references: IReference[];
+  references: IDashboardReference[];
   setDetails?: (details: React.ReactNode) => void;
 }
 

--- a/plugins/dashboards/src/components/panel/Panel.tsx
+++ b/plugins/dashboards/src/components/panel/Panel.tsx
@@ -1,11 +1,11 @@
 import { Menu, MenuContent, MenuList } from '@patternfly/react-core';
 import React, { memo } from 'react';
 
-import { IPluginPanelProps, IReference, PluginCard, PluginOptionsMissing } from '@kobsio/plugin-core';
+import { IDashboardReference, IPluginPanelProps, PluginCard, PluginOptionsMissing } from '@kobsio/plugin-core';
 import PanelItem from './PanelItem';
 
 interface IPanelProps extends IPluginPanelProps {
-  options?: IReference[];
+  options?: IDashboardReference[];
 }
 
 // Panel implements the panel component for the dashboards plugin.

--- a/plugins/dashboards/src/components/panel/PanelItem.tsx
+++ b/plugins/dashboards/src/components/panel/PanelItem.tsx
@@ -1,11 +1,11 @@
 import { MenuItem } from '@patternfly/react-core';
 import React from 'react';
 
-import { IPluginDefaults, IReference, LinkWrapper } from '@kobsio/plugin-core';
+import { IDashboardReference, IPluginDefaults, LinkWrapper } from '@kobsio/plugin-core';
 
 interface IPanelItemProps {
   defaults: IPluginDefaults;
-  reference: IReference;
+  reference: IDashboardReference;
 }
 
 const PanelItem: React.FunctionComponent<IPanelItemProps> = ({ defaults, reference }: IPanelItemProps) => {

--- a/plugins/dashboards/src/utils/dashboard.ts
+++ b/plugins/dashboards/src/utils/dashboard.ts
@@ -1,7 +1,7 @@
 import { gridSpans } from '@patternfly/react-core';
 
-import { IDashboard, IPlaceholders, IPluginDefaults, IPluginTimes, IReference } from '@kobsio/plugin-core';
-import { IDashboardsOptions, IVariableValues } from './interfaces';
+import { IDashboard, IDashboardReference, IPlaceholders, IPluginDefaults } from '@kobsio/plugin-core';
+import { IDashboardsOptions } from './interfaces';
 
 // toGridSpans is used to convert the provided col and row span value to the corresponding gridSpans value, so that it
 // can be used within the Patternfly Grid component. The function requires a default value which is 12 for columns and
@@ -31,61 +31,14 @@ export const rowHeight = (rowSize: number | undefined, rowSpan: number | undefin
   return `${rowSize * 150}px`;
 };
 
-// IVariables is a map of variable names with the current value. This interface should only be used by the interpolate
-// function, to convert a given array of variables to the format, which is required by the function.
-interface IVariables {
-  [key: string]: string;
-}
-
-// interpolate is used to replace the variables in a given string with the current value for this variable. Before we
-// can replace the variables in a string we have to convert the array of variables to a map of variable names and there
-// value.
-// The default interpolator/delimiter is "{%" and "%}", so that it doesn't conflict with the delimiter used for the
-// placeholder. We can not use the same, because the are replaced at different points in our app logic.
-// See: https://stackoverflow.com/a/57598892/4104109
-export const interpolate = (
-  str: string,
-  variables: IVariableValues[],
-  times: IPluginTimes,
-  interpolator: string[] = ['{%', '%}'],
-): string => {
-  const vars: IVariables = {};
-
-  for (const variable of variables) {
-    vars[variable.name] = variable.value;
-  }
-
-  vars['__timeStart'] = `${times.timeStart}`;
-  vars['__timeEnd'] = `${times.timeEnd}`;
-
-  return str
-    .split(interpolator[0])
-    .map((s1, i) => {
-      if (i === 0) {
-        return s1;
-      }
-
-      const s2 = s1.split(interpolator[1]);
-      if (s1 === s2[0]) {
-        return interpolator[0] + s2[0];
-      }
-
-      if (s2.length > 1) {
-        s2[0] =
-          s2[0] && vars.hasOwnProperty(s2[0].trim().substring(1))
-            ? vars[s2[0].trim().substring(1)]
-            : interpolator.join(` ${s2[0]} `);
-      }
-
-      return s2.join('');
-    })
-    .join('');
-};
-
 // getOptionsFromSearch is used to parse the given search location and return is as options for Prometheus. This is
 // needed, so that a user can explore his Prometheus data from a chart. When the user selects the explore action, we
 // pass him to this page and pass the data via the URL parameters.
-export const getInitialOptions = (search: string, references: IReference[], useDrawer: boolean): IDashboardsOptions => {
+export const getInitialOptions = (
+  search: string,
+  references: IDashboardReference[],
+  useDrawer: boolean,
+): IDashboardsOptions => {
   const params = new URLSearchParams(search);
   const dashboard = params.get('dashboard');
 

--- a/plugins/dashboards/src/utils/interfaces.ts
+++ b/plugins/dashboards/src/utils/interfaces.ts
@@ -1,12 +1,3 @@
-import { IVariable } from '@kobsio/plugin-core';
-
-// IVariableValues is an extension of the IVariable interface. It contains the additional fields for the selected
-// variable value and all possible variable values.
-export interface IVariableValues extends IVariable {
-  value: string;
-  values: string[];
-}
-
 // IDashboardsOptions are the options for the Dashboards component. Currently is only contains the active dashboard, but
 // we can extend this later to also include the selected time and variables, so that we can pass this values with the
 // current url as query parameters.

--- a/plugins/prometheus/src/index.ts
+++ b/plugins/prometheus/src/index.ts
@@ -5,6 +5,7 @@ import icon from './assets/icon.png';
 import Page from './components/page/Page';
 import Panel from './components/panel/Panel';
 import Preview from './components/preview/Preview';
+import { variables } from './utils/variables';
 
 const prometheusPlugin: IPluginComponents = {
   prometheus: {
@@ -12,6 +13,7 @@ const prometheusPlugin: IPluginComponents = {
     page: Page,
     panel: Panel,
     preview: Preview,
+    variables: variables,
   },
 };
 

--- a/plugins/prometheus/src/utils/variables.ts
+++ b/plugins/prometheus/src/utils/variables.ts
@@ -1,0 +1,45 @@
+import { IDashboardVariableValues, IPluginTimes, interpolate } from '@kobsio/plugin-core';
+
+export const variables = async (
+  variable: IDashboardVariableValues,
+  variables: IDashboardVariableValues[],
+  times: IPluginTimes,
+): Promise<IDashboardVariableValues> => {
+  try {
+    const response = await fetch(`/api/plugins/prometheus/${variable.plugin.name}/variable`, {
+      body: JSON.stringify({
+        label: variable.plugin.options.label,
+        query: interpolate(variable.plugin.options.query, variables, times),
+        timeEnd: times.timeEnd,
+        timeStart: times.timeStart,
+        type: variable.plugin.options.type,
+      }),
+      method: 'post',
+    });
+    const json = await response.json();
+
+    if (response.status >= 200 && response.status < 300) {
+      if (json && Array.isArray(json) && json.length > 0) {
+        if (json && json.length > 1 && variable.plugin.options.allowAll) {
+          json.unshift(json.join('|'));
+        }
+
+        return {
+          ...variable,
+          value: json && json.includes(variable.value) ? variable.value : json ? json[0] : '',
+          values: json ? json : [''],
+        };
+      } else {
+        return { ...variable, value: '', values: [''] };
+      }
+    } else {
+      if (json.error) {
+        throw new Error(json.error);
+      } else {
+        throw new Error('An unknown error occured');
+      }
+    }
+  } catch (err) {
+    throw err;
+  }
+};

--- a/plugins/resources/src/components/panel/details/Dashboards.tsx
+++ b/plugins/resources/src/components/panel/details/Dashboards.tsx
@@ -2,13 +2,13 @@ import { Alert, AlertVariant } from '@patternfly/react-core';
 import { JSONPath } from 'jsonpath-plus';
 import React from 'react';
 
-import { IReference, IResourceRow } from '@kobsio/plugin-core';
+import { IDashboardReference, IResourceRow } from '@kobsio/plugin-core';
 import { DashboardsWrapper } from '@kobsio/plugin-dashboards';
 
 // getDashboards parses the kobs.io/dashboards annotation of a Kubernetes resources and returns all provided dashboards.
 // Before we are returning the dashboards we are checking all the provided placeholder and if one of the placeholders
 // uses an JSONPath we are replacing it with the correct value.
-const getDashboards = (resource: IResourceRow): IReference[] | undefined => {
+const getDashboards = (resource: IResourceRow): IDashboardReference[] | undefined => {
   try {
     if (
       resource.props &&
@@ -16,7 +16,7 @@ const getDashboards = (resource: IResourceRow): IReference[] | undefined => {
       resource.props.metadata.annotations &&
       resource.props.metadata.annotations['kobs.io/dashboards']
     ) {
-      const dashboards: IReference[] = JSON.parse(
+      const dashboards: IDashboardReference[] = JSON.parse(
         resource.props.metadata.annotations['kobs.io/dashboards'],
         resource.props,
       );

--- a/plugins/techdocs/src/components/KobsCode.tsx
+++ b/plugins/techdocs/src/components/KobsCode.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { IPanel, IPluginTimes, PluginPanel } from '@kobsio/plugin-core';
+import { IDashboardPanel, IPluginTimes, PluginPanel } from '@kobsio/plugin-core';
 
 interface IKobsCodeProps {
-  panel: IPanel;
+  panel: IDashboardPanel;
   setDetails?: (details: React.ReactNode) => void;
 }
 

--- a/plugins/techdocs/src/utils/renderers.tsx
+++ b/plugins/techdocs/src/utils/renderers.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import yaml from 'js-yaml';
 
 import { flatten, getPathWithoutFile } from './helpers';
-import { IPanel } from '@kobsio/plugin-core';
+import { IDashboardPanel } from '@kobsio/plugin-core';
 import KobsCode from '../components/KobsCode';
 import { normalizePath } from './path';
 
@@ -55,7 +55,7 @@ export const renderCode = (
   const match = /language-(\w+)/.exec(props.className || '');
 
   if (match && match.length === 2 && match[1] === 'kobs') {
-    const panel = yaml.load(props.children) as IPanel;
+    const panel = yaml.load(props.children) as IDashboardPanel;
     return <KobsCode panel={panel} setDetails={setDetails} />;
   }
 


### PR DESCRIPTION
This commit changes the variables handling, like it was discussed in
issue #250. This means that each plugin can now export a "variables"
function to load variables in a dashboard. The only exception is the
"core" plugin, where the variables are still handled within the
Dashboards component.

This change allows us, to introduced variables for more plugins, like a
list of resource groups via the Azure plugin or a list of field values
via the klogs plugin.

We also adjusted the naming and location of some interfaces for this
change. So that the interfaces for the CRDs are now prefixed with the
name of the CRD (e.g. "IPlaceholder" becomes "IDashboardPlaceholder").
This was necessary to reduce conflicts in names and to avoid cycle
imports.

The documentation for the variables options which can be used in a
dashboard, should be placed on the corresponding plugin page and a link
should be added to the "Variable Plugin Options" section in the
dashboards documentation.

Closes #250.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
