### PR TITLE
[applications] Improve tags support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#260](https://github.com/kobsio/kobs/pull/260): [opsgenie] Adjust permission handling and add actions for incidents.
 - [#262](https://github.com/kobsio/kobs/pull/262): [core] Rework variables handling in dashboards.
 - [#263](https://github.com/kobsio/kobs/pull/263): [core] :warning: _Breaking change:_ :warning: Refactor `cluster` and `clusters` package.
+- [#265](https://github.com/kobsio/kobs/pull/265): [applications] Improve tags support by allow users to filter applications by tags and showing tags on application page.
 
 ## [v0.7.0](https://github.com/kobsio/kobs/releases/tag/v0.7.0) (2021-11-19)
 

--- a/docs/plugins/applications.md
+++ b/docs/plugins/applications.md
@@ -17,6 +17,7 @@ plugins:
 | ----- | ---- | ----------- | -------- |
 | topologyCacheDuration | [duration](https://pkg.go.dev/time#ParseDuration) | The duration for how long the topology graph should be cached. The default value is `1h`. | No |
 | teamsCacheDuration | [duration](https://pkg.go.dev/time#ParseDuration) | The duration for how long the teams for an application should be cached. The default value is `1h`. | No |
+| tagsCacheDuration | [duration](https://pkg.go.dev/time#ParseDuration) | The duration for how long the tags for all applications should be cached. The default value is `1h`. | No |
 
 ## Options
 
@@ -25,6 +26,7 @@ plugins:
 | view | string | The view, which should be used to show the applications. This must be `gallery` or `topology`. The default will be `gallery`. | No |
 | clusters | []string | A list of clusters. If this value isn't provided, it will be the cluster from the team or application where the dashboard is used. | No |
 | namespaces | []string | A list of namespaces. If this value isn't provided, it will be the namespace from the team or application where the dashboard is used. | No |
+| tags | []string | An optional list of tags. | No |
 | team | [Team](#team) | Get the applications for a team instead of clusters and namespaces. | No |
 
 ### Team

--- a/plugins/applications/applications_test.go
+++ b/plugins/applications/applications_test.go
@@ -1,0 +1,368 @@
+package applications
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	application "github.com/kobsio/kobs/pkg/api/apis/application/v1beta1"
+	team "github.com/kobsio/kobs/pkg/api/apis/team/v1beta1"
+	"github.com/kobsio/kobs/pkg/api/clusters"
+	"github.com/kobsio/kobs/pkg/api/clusters/cluster"
+	"github.com/kobsio/kobs/pkg/api/plugins/plugin"
+	"github.com/kobsio/kobs/plugins/applications/pkg/tags"
+	"github.com/kobsio/kobs/plugins/applications/pkg/teams"
+	"github.com/kobsio/kobs/plugins/applications/pkg/topology"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetApplications(t *testing.T) {
+	for _, tt := range []struct {
+		name               string
+		teamsCache         teams.Cache
+		topologyCache      topology.Cache
+		url                string
+		expectedStatusCode int
+		expectedBody       string
+		prepare            func(mockClusterClient *cluster.MockClient)
+	}{
+		{
+			name:               "invalid view property",
+			url:                "/applications",
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBody:       "{\"error\":\"Invalid view property\"}\n",
+			prepare:            func(mockClusterClient *cluster.MockClient) {},
+		},
+		// gallery - team
+		// The following tests are used for the gallery view, when the user requests the applications for a specific
+		// team via the teamCluster, teamNamespace and teamName parameters.
+		{
+			name:               "gallery return teams from cache",
+			teamsCache:         teams.Cache{LastFetch: time.Now().Add(-10 * time.Second), CacheDuration: 60 * time.Second},
+			url:                "/applications?view=gallery&teamCluster=cluster1&teamNamespace=namespace1&teamName=team1",
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       "null\n",
+			prepare: func(mockClusterClient *cluster.MockClient) {
+				mockClusterClient.On("GetTeams", mock.Anything, "").Return([]team.TeamSpec{{Cluster: "cluster1", Namespace: "namespace1", Name: "team1"}}, nil)
+				mockClusterClient.On("GetApplications", mock.Anything, "").Return([]application.ApplicationSpec{{Cluster: "cluster1", Namespace: "namespace1", Name: "application1", Teams: []application.Reference{{Cluster: "cluster1", Namespace: "namespace1", Name: "team1"}}}}, nil)
+			},
+		},
+		{
+			name:               "gallery return teams with cached teams nil",
+			url:                "/applications?view=gallery&teamCluster=cluster1&teamNamespace=namespace1&teamName=team1",
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       "[{\"cluster\":\"cluster1\",\"namespace\":\"namespace1\",\"name\":\"application1\",\"teams\":[{\"cluster\":\"cluster1\",\"namespace\":\"namespace1\",\"name\":\"team1\"}]}]\n",
+			prepare: func(mockClusterClient *cluster.MockClient) {
+				mockClusterClient.On("GetTeams", mock.Anything, "").Return([]team.TeamSpec{{Cluster: "cluster1", Namespace: "namespace1", Name: "team1"}}, nil)
+				mockClusterClient.On("GetApplications", mock.Anything, "").Return([]application.ApplicationSpec{{Cluster: "cluster1", Namespace: "namespace1", Name: "application1", Teams: []application.Reference{{Cluster: "cluster1", Namespace: "namespace1", Name: "team1"}}}}, nil)
+			},
+		},
+		{
+			name:               "gallery return teams with cached teams nil and get teams nil",
+			url:                "/applications?view=gallery&teamCluster=cluster1&teamNamespace=namespace1&teamName=team1",
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBody:       "{\"error\":\"Could not get applications\"}\n",
+			prepare: func(mockClusterClient *cluster.MockClient) {
+				mockClusterClient.On("GetTeams", mock.Anything, "").Return(nil, nil)
+				mockClusterClient.On("GetApplications", mock.Anything, "").Return([]application.ApplicationSpec{{Cluster: "cluster1", Namespace: "namespace1", Name: "application1", Teams: []application.Reference{{Cluster: "cluster1", Namespace: "namespace1", Name: "team1"}}}}, nil)
+			},
+		},
+		{
+			name:               "gallery return teams from cache and refresh cache",
+			teamsCache:         teams.Cache{Teams: []teams.Team{{Cluster: "cluster1", Namespace: "namespace1", Name: "team1", Applications: []application.ApplicationSpec{{Cluster: "cluster1", Namespace: "namespace1", Name: "application1", Teams: []application.Reference{{Cluster: "cluster1", Namespace: "namespace1", Name: "team1"}}}}}}},
+			url:                "/applications?view=gallery&teamCluster=cluster1&teamNamespace=namespace1&teamName=team1",
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       "[{\"cluster\":\"cluster1\",\"namespace\":\"namespace1\",\"name\":\"application1\",\"teams\":[{\"cluster\":\"cluster1\",\"namespace\":\"namespace1\",\"name\":\"team1\"}]}]\n",
+			prepare: func(mockClusterClient *cluster.MockClient) {
+				mockClusterClient.On("GetTeams", mock.Anything, "").Return([]team.TeamSpec{{Cluster: "cluster1", Namespace: "namespace1", Name: "team1"}}, nil)
+				mockClusterClient.On("GetApplications", mock.Anything, "").Return([]application.ApplicationSpec{{Cluster: "cluster1", Namespace: "namespace1", Name: "application1", Teams: []application.Reference{{Cluster: "cluster1", Namespace: "namespace1", Name: "team1"}}}}, nil)
+			},
+		},
+		// gallery
+		// The following tests are used for the gallery view, when the user requests the applications via the cluster,
+		// namespace and tag parameters.
+		{
+			name:               "gallery invalid cluster name",
+			url:                "/applications?view=gallery&cluster=cluster2",
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBody:       "{\"error\":\"Invalid cluster name\"}\n",
+			prepare:            func(mockClusterClient *cluster.MockClient) {},
+		},
+		{
+			name:               "gallery namespaces nil and get applications error",
+			url:                "/applications?view=gallery&cluster=cluster1",
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBody:       "{\"error\":\"Could not get applications: could not get applications\"}\n",
+			prepare: func(mockClusterClient *cluster.MockClient) {
+				mockClusterClient.On("GetApplications", mock.Anything, "").Return(nil, fmt.Errorf("could not get applications"))
+			},
+		},
+		{
+			name:               "gallery namespaces nil",
+			url:                "/applications?view=gallery&cluster=cluster1",
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       "[{\"cluster\":\"cluster1\",\"namespace\":\"namespace1\",\"name\":\"application1\",\"teams\":[{\"cluster\":\"cluster1\",\"namespace\":\"namespace1\",\"name\":\"team1\"}]}]\n",
+			prepare: func(mockClusterClient *cluster.MockClient) {
+				mockClusterClient.On("GetApplications", mock.Anything, "").Return([]application.ApplicationSpec{{Cluster: "cluster1", Namespace: "namespace1", Name: "application1", Teams: []application.Reference{{Cluster: "cluster1", Namespace: "namespace1", Name: "team1"}}}}, nil)
+			},
+		},
+		{
+			name:               "gallery get applications error",
+			url:                "/applications?view=gallery&cluster=cluster1&namespace=namespace1",
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBody:       "{\"error\":\"Could not get applications: could not get applications\"}\n",
+			prepare: func(mockClusterClient *cluster.MockClient) {
+				mockClusterClient.On("GetApplications", mock.Anything, "namespace1").Return(nil, fmt.Errorf("could not get applications"))
+			},
+		},
+		{
+			name:               "gallery",
+			url:                "/applications?view=gallery&cluster=cluster1&namespace=namespace1",
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       "[{\"cluster\":\"cluster1\",\"namespace\":\"namespace1\",\"name\":\"application1\",\"teams\":[{\"cluster\":\"cluster1\",\"namespace\":\"namespace1\",\"name\":\"team1\"}]}]\n",
+			prepare: func(mockClusterClient *cluster.MockClient) {
+				mockClusterClient.On("GetApplications", mock.Anything, "namespace1").Return([]application.ApplicationSpec{{Cluster: "cluster1", Namespace: "namespace1", Name: "application1", Teams: []application.Reference{{Cluster: "cluster1", Namespace: "namespace1", Name: "team1"}}}}, nil)
+			},
+		},
+		// topology
+		// The following tests are used when the user requests applications via the view=topology parameter.
+		{
+			name:               "topology return applications from cache",
+			topologyCache:      topology.Cache{LastFetch: time.Now().Add(-10 * time.Second), CacheDuration: 60 * time.Second},
+			url:                "/applications?view=topology",
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       "{\"edges\":null,\"nodes\":null}\n",
+			prepare:            func(mockClusterClient *cluster.MockClient) {},
+		},
+		{
+			name:               "topology return applications nodes are nil",
+			topologyCache:      topology.Cache{Topology: &topology.Topology{Edges: nil, Nodes: nil}},
+			url:                "/applications?view=topology&cluster=cluster1&namespace=namespace2",
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       "{\"edges\":[{\"data\":{\"id\":\"cluster1-namespace1-application2-cluster1-namespace2-application3\",\"source\":\"cluster1-namespace1-application2\",\"target\":\"cluster1-namespace2-application3\",\"description\":\"\"}},{\"data\":{\"id\":\"cluster1-namespace2-application3-cluster2-namespace3-application4\",\"source\":\"cluster1-namespace2-application3\",\"target\":\"cluster2-namespace3-application4\",\"description\":\"\"}},{\"data\":{\"id\":\"cluster1-namespace2-application3-cluster2-namespace3-application5\",\"source\":\"cluster1-namespace2-application3\",\"target\":\"cluster2-namespace3-application5\",\"description\":\"\"}}],\"nodes\":[{\"data\":{\"id\":\"cluster1-namespace1-application2\",\"type\":\"application\",\"label\":\"application2\",\"parent\":\"cluster1-namespace1\",\"cluster\":\"cluster1\",\"namespace\":\"namespace1\",\"name\":\"application2\",\"dependencies\":[{\"namespace\":\"namespace2\",\"name\":\"application3\"}]}},{\"data\":{\"id\":\"cluster1-namespace2-application3\",\"type\":\"application\",\"label\":\"application3\",\"parent\":\"cluster1-namespace2\",\"cluster\":\"cluster1\",\"namespace\":\"namespace2\",\"name\":\"application3\",\"dependencies\":[{\"cluster\":\"cluster2\",\"namespace\":\"namespace3\",\"name\":\"application4\"},{\"cluster\":\"cluster2\",\"namespace\":\"namespace3\",\"name\":\"application5\"}]}},{\"data\":{\"id\":\"cluster2-namespace3-application4\",\"type\":\"application\",\"label\":\"application4\",\"parent\":\"cluster2-namespace3\",\"cluster\":\"cluster2\",\"namespace\":\"namespace3\",\"name\":\"application4\"}},{\"data\":{\"id\":\"cluster2-namespace3-application5\",\"type\":\"application\",\"label\":\"application5\",\"parent\":\"cluster2-namespace3\",\"cluster\":\"cluster2\",\"namespace\":\"namespace3\",\"name\":\"application5\"}},{\"data\":{\"id\":\"cluster1\",\"type\":\"cluster\",\"label\":\"cluster1\",\"parent\":\"\"}},{\"data\":{\"id\":\"cluster2\",\"type\":\"cluster\",\"label\":\"cluster2\",\"parent\":\"\"}},{\"data\":{\"id\":\"cluster1-namespace1\",\"type\":\"namespace\",\"label\":\"namespace1\",\"parent\":\"cluster1\"}},{\"data\":{\"id\":\"cluster1-namespace2\",\"type\":\"namespace\",\"label\":\"namespace2\",\"parent\":\"cluster1\"}},{\"data\":{\"id\":\"cluster1-namespace2\",\"type\":\"namespace\",\"label\":\"namespace2\",\"parent\":\"cluster1\"}},{\"data\":{\"id\":\"cluster2-namespace3\",\"type\":\"namespace\",\"label\":\"namespace3\",\"parent\":\"cluster2\"}},{\"data\":{\"id\":\"cluster1-namespace2\",\"type\":\"namespace\",\"label\":\"namespace2\",\"parent\":\"cluster1\"}},{\"data\":{\"id\":\"cluster2-namespace3\",\"type\":\"namespace\",\"label\":\"namespace3\",\"parent\":\"cluster2\"}}]}\n",
+			prepare: func(mockClusterClient *cluster.MockClient) {
+				mockClusterClient.On("GetApplications", mock.Anything, "").Return([]application.ApplicationSpec{
+					{Cluster: "cluster1", Namespace: "namespace1", Name: "application1", Dependencies: []application.Reference{{Cluster: "", Namespace: "", Name: "application2"}}},
+					{Cluster: "cluster1", Namespace: "namespace1", Name: "application2", Dependencies: []application.Reference{{Cluster: "", Namespace: "namespace2", Name: "application3"}}},
+					{Cluster: "cluster1", Namespace: "namespace2", Name: "application3", Dependencies: []application.Reference{{Cluster: "cluster2", Namespace: "namespace3", Name: "application4"}, {Cluster: "cluster2", Namespace: "namespace3", Name: "application5"}}},
+					{Cluster: "cluster2", Namespace: "namespace3", Name: "application4"},
+					{Cluster: "cluster2", Namespace: "namespace3", Name: "application5"},
+				}, nil)
+			},
+		},
+		{
+			name:               "topology return applications nodes are nil and error generating topology",
+			topologyCache:      topology.Cache{Topology: &topology.Topology{Edges: nil, Nodes: nil}},
+			url:                "/applications?view=topology&cluster=cluster1&namespace=namespace2",
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBody:       "{\"error\":\"Could not generate topology\"}\n",
+			prepare: func(mockClusterClient *cluster.MockClient) {
+				mockClusterClient.On("GetApplications", mock.Anything, "").Return(nil, fmt.Errorf("could not get applications"))
+			},
+		},
+		{
+			name: "topology return applications from cache and rebuild topology chart",
+			topologyCache: topology.Cache{Topology: &topology.Topology{
+				Edges: []topology.Edge{
+					{Data: topology.EdgeData{ID: "cluster1-namespace1-application1-cluster1-namespace1-application2", Source: "cluster1-namespace1-application1", SourceCluster: "cluster1", SourceNamespace: "namespace1", SourceName: "application1", Target: "cluster1-namespace1-application2", TargetCluster: "cluster1", TargetNamespace: "namespace1", TargetName: "application2"}},
+					{Data: topology.EdgeData{ID: "cluster1-namespace1-application2-cluster1-namespace2-application3", Source: "cluster1-namespace1-application2", SourceCluster: "cluster1", SourceNamespace: "namespace1", SourceName: "application2", Target: "cluster1-namespace2-application3", TargetCluster: "cluster1", TargetNamespace: "namespace2", TargetName: "application3"}},
+					{Data: topology.EdgeData{ID: "cluster1-namespace2-application3-cluster2-namespace3-application4", Source: "cluster1-namespace2-application3", SourceCluster: "cluster1", SourceNamespace: "namespace2", SourceName: "application3", Target: "cluster2-namespace3-application4", TargetCluster: "cluster2", TargetNamespace: "namespace3", TargetName: "application4"}},
+					{Data: topology.EdgeData{ID: "cluster1-namespace2-application3-cluster2-namespace3-application5", Source: "cluster1-namespace2-application3", SourceCluster: "cluster1", SourceNamespace: "namespace2", SourceName: "application3", Target: "cluster2-namespace3-application5", TargetCluster: "cluster2", TargetNamespace: "namespace3", TargetName: "application5"}},
+				},
+				Nodes: []topology.Node{
+					{Data: topology.NodeData{ID: "cluster1-namespace1-application1", Type: "application", Label: "application1", Parent: "cluster1-namespace1", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster1", Namespace: "namespace1", Name: "application1", Dependencies: []application.Reference{{Cluster: "", Namespace: "", Name: "application2"}}}}},
+					{Data: topology.NodeData{ID: "cluster1-namespace1-application2", Type: "application", Label: "application2", Parent: "cluster1-namespace1", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster1", Namespace: "namespace1", Name: "application2", Dependencies: []application.Reference{{Cluster: "", Namespace: "namespace2", Name: "application3"}}}}},
+					{Data: topology.NodeData{ID: "cluster1-namespace2-application3", Type: "application", Label: "application3", Parent: "cluster1-namespace2", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster1", Namespace: "namespace2", Name: "application3", Dependencies: []application.Reference{{Cluster: "cluster2", Namespace: "namespace3", Name: "application4"}, {Cluster: "cluster2", Namespace: "namespace3", Name: "application5"}}}}},
+					{Data: topology.NodeData{ID: "cluster2-namespace3-application4", Type: "application", Label: "application4", Parent: "cluster2-namespace3", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster2", Namespace: "namespace3", Name: "application4"}}},
+					{Data: topology.NodeData{ID: "cluster2-namespace3-application5", Type: "application", Label: "application5", Parent: "cluster2-namespace3", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster2", Namespace: "namespace3", Name: "application5"}}},
+				},
+			}},
+			url:                "/applications?view=topology&cluster=cluster1&namespace=namespace2",
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       "{\"edges\":[{\"data\":{\"id\":\"cluster1-namespace1-application2-cluster1-namespace2-application3\",\"source\":\"cluster1-namespace1-application2\",\"target\":\"cluster1-namespace2-application3\",\"description\":\"\"}},{\"data\":{\"id\":\"cluster1-namespace2-application3-cluster2-namespace3-application4\",\"source\":\"cluster1-namespace2-application3\",\"target\":\"cluster2-namespace3-application4\",\"description\":\"\"}},{\"data\":{\"id\":\"cluster1-namespace2-application3-cluster2-namespace3-application5\",\"source\":\"cluster1-namespace2-application3\",\"target\":\"cluster2-namespace3-application5\",\"description\":\"\"}}],\"nodes\":[{\"data\":{\"id\":\"cluster1-namespace1-application2\",\"type\":\"application\",\"label\":\"application2\",\"parent\":\"cluster1-namespace1\",\"cluster\":\"cluster1\",\"namespace\":\"namespace1\",\"name\":\"application2\",\"dependencies\":[{\"namespace\":\"namespace2\",\"name\":\"application3\"}]}},{\"data\":{\"id\":\"cluster1-namespace2-application3\",\"type\":\"application\",\"label\":\"application3\",\"parent\":\"cluster1-namespace2\",\"cluster\":\"cluster1\",\"namespace\":\"namespace2\",\"name\":\"application3\",\"dependencies\":[{\"cluster\":\"cluster2\",\"namespace\":\"namespace3\",\"name\":\"application4\"},{\"cluster\":\"cluster2\",\"namespace\":\"namespace3\",\"name\":\"application5\"}]}},{\"data\":{\"id\":\"cluster2-namespace3-application4\",\"type\":\"application\",\"label\":\"application4\",\"parent\":\"cluster2-namespace3\",\"cluster\":\"cluster2\",\"namespace\":\"namespace3\",\"name\":\"application4\"}},{\"data\":{\"id\":\"cluster2-namespace3-application5\",\"type\":\"application\",\"label\":\"application5\",\"parent\":\"cluster2-namespace3\",\"cluster\":\"cluster2\",\"namespace\":\"namespace3\",\"name\":\"application5\"}},{\"data\":{\"id\":\"cluster1\",\"type\":\"cluster\",\"label\":\"cluster1\",\"parent\":\"\"}},{\"data\":{\"id\":\"cluster2\",\"type\":\"cluster\",\"label\":\"cluster2\",\"parent\":\"\"}},{\"data\":{\"id\":\"cluster1-namespace1\",\"type\":\"namespace\",\"label\":\"namespace1\",\"parent\":\"cluster1\"}},{\"data\":{\"id\":\"cluster1-namespace2\",\"type\":\"namespace\",\"label\":\"namespace2\",\"parent\":\"cluster1\"}},{\"data\":{\"id\":\"cluster1-namespace2\",\"type\":\"namespace\",\"label\":\"namespace2\",\"parent\":\"cluster1\"}},{\"data\":{\"id\":\"cluster2-namespace3\",\"type\":\"namespace\",\"label\":\"namespace3\",\"parent\":\"cluster2\"}},{\"data\":{\"id\":\"cluster1-namespace2\",\"type\":\"namespace\",\"label\":\"namespace2\",\"parent\":\"cluster1\"}},{\"data\":{\"id\":\"cluster2-namespace3\",\"type\":\"namespace\",\"label\":\"namespace3\",\"parent\":\"cluster2\"}}]}\n",
+			prepare: func(mockClusterClient *cluster.MockClient) {
+				mockClusterClient.On("GetApplications", mock.Anything, "").Return([]application.ApplicationSpec{
+					{Cluster: "cluster1", Namespace: "namespace1", Name: "application1", Dependencies: []application.Reference{{Cluster: "", Namespace: "", Name: "application2"}}},
+					{Cluster: "cluster1", Namespace: "namespace1", Name: "application2", Dependencies: []application.Reference{{Cluster: "", Namespace: "namespace2", Name: "application3"}}},
+					{Cluster: "cluster1", Namespace: "namespace2", Name: "application3", Dependencies: []application.Reference{{Cluster: "cluster2", Namespace: "namespace3", Name: "application4"}, {Cluster: "cluster2", Namespace: "namespace3", Name: "application5"}}},
+					{Cluster: "cluster2", Namespace: "namespace3", Name: "application4"},
+					{Cluster: "cluster2", Namespace: "namespace3", Name: "application5"},
+				}, nil)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClusterClient := &cluster.MockClient{}
+			mockClusterClient.AssertExpectations(t)
+
+			mockClustersClient := &clusters.MockClient{}
+			mockClustersClient.AssertExpectations(t)
+			mockClustersClient.On("GetClusters").Return([]cluster.Client{mockClusterClient})
+			mockClustersClient.On("GetCluster", "cluster1").Return(mockClusterClient)
+			mockClustersClient.On("GetCluster", "cluster2").Return(nil)
+
+			tt.prepare(mockClusterClient)
+
+			router := Router{chi.NewRouter(), mockClustersClient, Config{}, tt.topologyCache, tt.teamsCache, tags.Cache{}}
+			router.Get("/applications", router.getApplications)
+
+			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
+			w := httptest.NewRecorder()
+
+			router.getApplications(w, req)
+
+			require.Equal(t, tt.expectedStatusCode, w.Code)
+			require.Equal(t, tt.expectedBody, string(w.Body.Bytes()))
+		})
+	}
+}
+
+func TestGetApplication(t *testing.T) {
+	for _, tt := range []struct {
+		name               string
+		url                string
+		expectedStatusCode int
+		expectedBody       string
+	}{
+		{
+			name:               "could not get cluster",
+			url:                "/application",
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBody:       "{\"error\":\"Invalid cluster name\"}\n",
+		},
+		{
+			name:               "could not get application",
+			url:                "/application?cluster=cluster1",
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBody:       "{\"error\":\"Could not get application: could not get application\"}\n",
+		},
+		{
+			name:               "return application",
+			url:                "/application?cluster=cluster1&namespace=namespace1&name=application1",
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       "{\"cluster\":\"cluster1\",\"namespace\":\"namespace1\",\"name\":\"application1\"}\n",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClusterClient := &cluster.MockClient{}
+			mockClusterClient.AssertExpectations(t)
+			mockClusterClient.On("GetApplication", mock.Anything, "namespace1", "application1").Return(&application.ApplicationSpec{Cluster: "cluster1", Namespace: "namespace1", Name: "application1"}, nil)
+			mockClusterClient.On("GetApplication", mock.Anything, "", "").Return(nil, fmt.Errorf("could not get application"))
+
+			mockClustersClient := &clusters.MockClient{}
+			mockClustersClient.AssertExpectations(t)
+			mockClustersClient.On("GetCluster", "").Return(nil)
+			mockClustersClient.On("GetCluster", "cluster1").Return(mockClusterClient)
+
+			router := Router{chi.NewRouter(), mockClustersClient, Config{}, topology.Cache{}, teams.Cache{}, tags.Cache{}}
+			router.Get("/application", router.getApplication)
+
+			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
+			w := httptest.NewRecorder()
+
+			router.getApplication(w, req)
+
+			require.Equal(t, tt.expectedStatusCode, w.Code)
+			require.Equal(t, tt.expectedBody, string(w.Body.Bytes()))
+		})
+	}
+}
+
+func TestGetTags(t *testing.T) {
+	for _, tt := range []struct {
+		name               string
+		tagsCache          tags.Cache
+		expectedStatusCode int
+		expectedBody       string
+		prepare            func(mockClusterClient *cluster.MockClient)
+	}{
+		{
+			name: "return tags from cache",
+			tagsCache: tags.Cache{
+				LastFetch:     time.Now().Add(-10 * time.Second),
+				CacheDuration: 60 * time.Second,
+				Tags:          []string{"tag1", "tag2", "tag3"},
+			},
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       "[\"tag1\",\"tag2\",\"tag3\"]\n",
+			prepare: func(mockClusterClient *cluster.MockClient) {
+				mockClusterClient.On("GetApplications", mock.Anything, "").Return(nil, fmt.Errorf("could not get applications"))
+			},
+		},
+		{
+			name:               "get applications error",
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBody:       "{\"error\":\"Could not get tags: could not get applications\"}\n",
+			prepare: func(mockClusterClient *cluster.MockClient) {
+				mockClusterClient.On("GetApplications", mock.Anything, "").Return(nil, fmt.Errorf("could not get applications"))
+			},
+		},
+		{
+			name:               "return tags",
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       "[\"tag1\",\"tag2\",\"tag3\",\"tag4\",\"tag5\"]\n",
+			prepare: func(mockClusterClient *cluster.MockClient) {
+				mockClusterClient.On("GetApplications", mock.Anything, "").Return([]application.ApplicationSpec{
+					{Cluster: "cluster1", Namespace: "namespace1", Name: "application1", Tags: []string{"tag1", "tag2", "tag3"}},
+					{Cluster: "cluster1", Namespace: "namespace1", Name: "application2", Tags: []string{"tag1", "tag4", "tag5"}},
+					{Cluster: "cluster1", Namespace: "namespace1", Name: "application3", Tags: []string{"tag2"}},
+					{Cluster: "cluster1", Namespace: "namespace1", Name: "application4", Tags: []string{"tag2", "tag3"}},
+					{Cluster: "cluster1", Namespace: "namespace1", Name: "application5", Tags: []string{"tag3", "tag4", "tag5"}},
+				}, nil)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClusterClient := &cluster.MockClient{}
+			mockClusterClient.AssertExpectations(t)
+
+			mockClustersClient := &clusters.MockClient{}
+			mockClustersClient.AssertExpectations(t)
+			mockClustersClient.On("GetClusters").Return([]cluster.Client{mockClusterClient})
+
+			tt.prepare(mockClusterClient)
+
+			router := Router{chi.NewRouter(), mockClustersClient, Config{}, topology.Cache{}, teams.Cache{}, tt.tagsCache}
+			router.Get("/tags", router.getTags)
+
+			req, _ := http.NewRequest(http.MethodGet, "/tags", nil)
+			w := httptest.NewRecorder()
+
+			router.getTags(w, req)
+
+			require.Equal(t, tt.expectedStatusCode, w.Code)
+			require.Equal(t, tt.expectedBody, string(w.Body.Bytes()))
+		})
+	}
+}
+
+func TestRegister(t *testing.T) {
+	expectedPlugins := &plugin.Plugins{
+		plugin.Plugin{
+			Name:        "applications",
+			DisplayName: "Applications",
+			Description: "Monitor your Kubernetes workloads.",
+			Home:        true,
+			Type:        "applications",
+		},
+	}
+
+	t.Run("config without durations", func(t *testing.T) {
+		plugins := &plugin.Plugins{}
+		router := Register(nil, plugins, Config{})
+		require.NotEmpty(t, router)
+		require.Equal(t, expectedPlugins, plugins)
+	})
+
+	t.Run("config with durations", func(t *testing.T) {
+		plugins := &plugin.Plugins{}
+		router := Register(nil, plugins, Config{TopologyCacheDuration: "1m", TeamsCacheDuration: "1m", TagsCacheDuration: "1m"})
+		require.NotEmpty(t, router)
+		require.Equal(t, expectedPlugins, plugins)
+	})
+}

--- a/plugins/applications/pkg/tags/tags.go
+++ b/plugins/applications/pkg/tags/tags.go
@@ -1,0 +1,66 @@
+package tags
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	application "github.com/kobsio/kobs/pkg/api/apis/application/v1beta1"
+)
+
+// Cache is the structure which can be used for caching a list of loaded teams.
+type Cache struct {
+	LastFetch     time.Time
+	CacheDuration time.Duration
+	Tags          []string
+}
+
+// Unique returns all unique tags from a list of tags.
+func Unique(tags []string) []string {
+	keys := make(map[string]bool)
+	uniqueTags := []string{}
+	for _, tag := range tags {
+		if _, value := keys[tag]; !value {
+			keys[strings.ToLower(tag)] = true
+			uniqueTags = append(uniqueTags, strings.ToLower(tag))
+		}
+	}
+
+	sort.Slice(uniqueTags, func(i, j int) bool {
+		return uniqueTags[i] < uniqueTags[j]
+	})
+
+	return uniqueTags
+}
+
+// FilterApplications filters a list of applications and only returns applications, which are containing a tag from the
+// given list of tags. If the tags slice is empty we return all applications.
+func FilterApplications(applications []application.ApplicationSpec, tags []string) []application.ApplicationSpec {
+	if tags == nil {
+		return applications
+	}
+
+	var filteredApplications []application.ApplicationSpec
+
+	for _, application := range applications {
+		for _, tag := range tags {
+			if contains(application.Tags, tag) {
+				filteredApplications = append(filteredApplications, application)
+				break
+			}
+		}
+	}
+
+	return filteredApplications
+}
+
+// contains checks if a list of tags contains a specifc tag.
+func contains(tags []string, tag string) bool {
+	for _, t := range tags {
+		if strings.ToLower(t) == strings.ToLower(tag) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/plugins/applications/pkg/tags/tags_test.go
+++ b/plugins/applications/pkg/tags/tags_test.go
@@ -1,0 +1,38 @@
+package tags
+
+import (
+	"testing"
+
+	application "github.com/kobsio/kobs/pkg/api/apis/application/v1beta1"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnique(t *testing.T) {
+	require.Equal(t, []string{"tag1", "tag2", "tag3", "tag4", "tag5"}, Unique([]string{"tag1", "tag2", "tag3", "tag3", "tag4", "tag5", "tag1"}))
+}
+
+func TestFilterApplications(t *testing.T) {
+	applicationsList := []application.ApplicationSpec{
+		{Cluster: "cluster1", Namespace: "namespace1", Name: "application1", Tags: []string{"tag1", "tag2", "tag3"}},
+		{Cluster: "cluster1", Namespace: "namespace1", Name: "application2", Tags: []string{"tag1", "tag4", "tag5"}},
+		{Cluster: "cluster1", Namespace: "namespace1", Name: "application3", Tags: []string{"tag2"}},
+		{Cluster: "cluster1", Namespace: "namespace1", Name: "application4", Tags: []string{"tag2", "tag3"}},
+		{Cluster: "cluster1", Namespace: "namespace1", Name: "application5", Tags: []string{"tag3", "tag4", "tag5"}},
+	}
+
+	t.Run("empty tags", func(t *testing.T) {
+		actualApplications := FilterApplications(applicationsList, nil)
+		require.Equal(t, applicationsList, actualApplications)
+	})
+
+	t.Run("filter applications", func(t *testing.T) {
+		actualApplications := FilterApplications(applicationsList, []string{"tag1", "tag5"})
+		require.Equal(t, []application.ApplicationSpec{applicationsList[0], applicationsList[1], applicationsList[4]}, actualApplications)
+	})
+}
+
+func TestContains(t *testing.T) {
+	require.Equal(t, true, contains([]string{"tag1", "tag2", "tag3"}, "tag2"))
+	require.Equal(t, false, contains([]string{"tag1", "tag2", "tag3"}, "tag4"))
+}

--- a/plugins/applications/pkg/teams/teams.go
+++ b/plugins/applications/pkg/teams/teams.go
@@ -69,7 +69,8 @@ func Get(ctx context.Context, clustersClient clusters.Client) []Team {
 	return cachedTeams
 }
 
-// GetApplications returns the applications for the requested team.
+// GetApplications returns the applications for the requested team. The function takes a list of team and the cluster,
+// namespace and name of a team as arguments.
 func GetApplications(teams []Team, cluster, namespace, name string) []application.ApplicationSpec {
 	for _, t := range teams {
 		if t.Cluster == cluster && t.Namespace == namespace && t.Name == name {
@@ -80,7 +81,8 @@ func GetApplications(teams []Team, cluster, namespace, name string) []applicatio
 	return nil
 }
 
-// doesApplicationContainsTeam checks if the given team name exists in a slice of teams.
+// doesApplicationContainsTeam checks if the given team name exists in a slice of teams. The function takes an
+// application and the cluster, namespace and name of the team as arguments.
 func doesApplicationContainsTeam(application application.ApplicationSpec, cluster, namespace, name string) bool {
 	for _, t := range application.Teams {
 		if t.Cluster == "" {

--- a/plugins/applications/pkg/teams/teams_test.go
+++ b/plugins/applications/pkg/teams/teams_test.go
@@ -1,0 +1,67 @@
+package teams
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	application "github.com/kobsio/kobs/pkg/api/apis/application/v1beta1"
+	team "github.com/kobsio/kobs/pkg/api/apis/team/v1beta1"
+	"github.com/kobsio/kobs/pkg/api/clusters"
+	"github.com/kobsio/kobs/pkg/api/clusters/cluster"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGet(t *testing.T) {
+	mockClusterClient := &cluster.MockClient{}
+	mockClusterClient.AssertExpectations(t)
+	mockClusterClient.On("GetName").Return("cluster")
+
+	mockClustersClient := &clusters.MockClient{}
+	mockClustersClient.AssertExpectations(t)
+	mockClustersClient.On("GetClusters").Return([]cluster.Client{mockClusterClient})
+
+	t.Run("get teams and get applications error", func(t *testing.T) {
+		mockClusterClient.On("GetTeams", mock.Anything, "").Return(nil, fmt.Errorf("could not get teams")).Once()
+		mockClusterClient.On("GetApplications", mock.Anything, "").Return(nil, fmt.Errorf("could not get teams")).Once()
+		teams := Get(context.Background(), mockClustersClient)
+		require.Empty(t, teams)
+	})
+
+	t.Run("return teams", func(t *testing.T) {
+		mockClusterClient.On("GetTeams", mock.Anything, "").Return([]team.TeamSpec{
+			{Cluster: "cluster1", Namespace: "namespace1", Name: "team1"},
+		}, nil).Once()
+		mockClusterClient.On("GetApplications", mock.Anything, "").Return([]application.ApplicationSpec{
+			{Cluster: "cluster1", Namespace: "namespace1", Name: "application1", Teams: []application.Reference{{Cluster: "cluster1", Namespace: "namespace1", Name: "team1"}}},
+		}, nil).Once()
+
+		teams := Get(context.Background(), mockClustersClient)
+		require.Equal(t, []Team{{Cluster: "cluster1", Namespace: "namespace1", Name: "team1", Applications: []application.ApplicationSpec{{Cluster: "cluster1", Namespace: "namespace1", Name: "application1", Teams: []application.Reference{{Cluster: "cluster1", Namespace: "namespace1", Name: "team1"}}}}}}, teams)
+	})
+}
+
+func TestGetApplications(t *testing.T) {
+	applicationsList := []application.ApplicationSpec{
+		{Cluster: "cluster1", Namespace: "namespace1", Name: "application1"},
+		{Cluster: "cluster1", Namespace: "namespace1", Name: "application2"},
+		{Cluster: "cluster1", Namespace: "namespace1", Name: "application3"},
+	}
+
+	teamsList := []Team{
+		{Cluster: "cluster1", Namespace: "namespace1", Name: "team1", Applications: applicationsList},
+		{Cluster: "cluster1", Namespace: "namespace1", Name: "team2", Applications: applicationsList},
+	}
+
+	require.Equal(t, applicationsList, GetApplications(teamsList, "cluster1", "namespace1", "team1"))
+	require.Equal(t, []application.ApplicationSpec(nil), GetApplications(teamsList, "cluster1", "namespace1", "team3"))
+}
+
+func TestDoesApplicationContainsTeam(t *testing.T) {
+	require.Equal(t, true, doesApplicationContainsTeam(application.ApplicationSpec{Cluster: "cluster1", Namespace: "namespace1", Name: "application1", Teams: []application.Reference{{Cluster: "cluster1", Namespace: "namespace1", Name: "team1"}}}, "cluster1", "namespace1", "team1"))
+	require.Equal(t, true, doesApplicationContainsTeam(application.ApplicationSpec{Cluster: "cluster1", Namespace: "namespace1", Name: "application1", Teams: []application.Reference{{Cluster: "", Namespace: "namespace1", Name: "team1"}}}, "cluster1", "namespace1", "team1"))
+	require.Equal(t, true, doesApplicationContainsTeam(application.ApplicationSpec{Cluster: "cluster1", Namespace: "namespace1", Name: "application1", Teams: []application.Reference{{Cluster: "", Namespace: "", Name: "team1"}}}, "cluster1", "namespace1", "team1"))
+	require.Equal(t, false, doesApplicationContainsTeam(application.ApplicationSpec{Cluster: "cluster1", Namespace: "namespace1", Name: "application1", Teams: []application.Reference{{Cluster: "", Namespace: "", Name: "team1"}}}, "cluster1", "namespace1", "team2"))
+}

--- a/plugins/applications/pkg/topology/topology_test.go
+++ b/plugins/applications/pkg/topology/topology_test.go
@@ -1,10 +1,95 @@
 package topology
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	application "github.com/kobsio/kobs/pkg/api/apis/application/v1beta1"
+	"github.com/kobsio/kobs/pkg/api/clusters"
+	"github.com/kobsio/kobs/pkg/api/clusters/cluster"
+
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+var expectedGetTopology = Topology{
+	Edges: []Edge{
+		{Data: EdgeData{ID: "cluster1-namespace1-application1-cluster1-namespace1-application2", Source: "cluster1-namespace1-application1", SourceCluster: "cluster1", SourceNamespace: "namespace1", SourceName: "application1", Target: "cluster1-namespace1-application2", TargetCluster: "cluster1", TargetNamespace: "namespace1", TargetName: "application2"}},
+		{Data: EdgeData{ID: "cluster1-namespace1-application2-cluster1-namespace2-application3", Source: "cluster1-namespace1-application2", SourceCluster: "cluster1", SourceNamespace: "namespace1", SourceName: "application2", Target: "cluster1-namespace2-application3", TargetCluster: "cluster1", TargetNamespace: "namespace2", TargetName: "application3"}},
+		{Data: EdgeData{ID: "cluster1-namespace2-application3-cluster2-namespace3-application4", Source: "cluster1-namespace2-application3", SourceCluster: "cluster1", SourceNamespace: "namespace2", SourceName: "application3", Target: "cluster2-namespace3-application4", TargetCluster: "cluster2", TargetNamespace: "namespace3", TargetName: "application4"}},
+		{Data: EdgeData{ID: "cluster1-namespace2-application3-cluster2-namespace3-application5", Source: "cluster1-namespace2-application3", SourceCluster: "cluster1", SourceNamespace: "namespace2", SourceName: "application3", Target: "cluster2-namespace3-application5", TargetCluster: "cluster2", TargetNamespace: "namespace3", TargetName: "application5"}},
+	},
+	Nodes: []Node{
+		{Data: NodeData{ID: "cluster1-namespace1-application1", Type: "application", Label: "application1", Parent: "cluster1-namespace1", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster1", Namespace: "namespace1", Name: "application1", Dependencies: []application.Reference{{Cluster: "", Namespace: "", Name: "application2"}}}}},
+		{Data: NodeData{ID: "cluster1-namespace1-application2", Type: "application", Label: "application2", Parent: "cluster1-namespace1", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster1", Namespace: "namespace1", Name: "application2", Dependencies: []application.Reference{{Cluster: "", Namespace: "namespace2", Name: "application3"}}}}},
+		{Data: NodeData{ID: "cluster1-namespace2-application3", Type: "application", Label: "application3", Parent: "cluster1-namespace2", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster1", Namespace: "namespace2", Name: "application3", Dependencies: []application.Reference{{Cluster: "cluster2", Namespace: "namespace3", Name: "application4"}, {Cluster: "cluster2", Namespace: "namespace3", Name: "application5"}}}}},
+		{Data: NodeData{ID: "cluster2-namespace3-application4", Type: "application", Label: "application4", Parent: "cluster2-namespace3", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster2", Namespace: "namespace3", Name: "application4"}}},
+		{Data: NodeData{ID: "cluster2-namespace3-application5", Type: "application", Label: "application5", Parent: "cluster2-namespace3", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster2", Namespace: "namespace3", Name: "application5"}}},
+	},
+}
+
+var expectedGenerateTopology = Topology{
+	Edges: []Edge{
+		{Data: EdgeData{ID: "cluster1-namespace1-application1-cluster1-namespace1-application2", Source: "cluster1-namespace1-application1", SourceCluster: "cluster1", SourceNamespace: "namespace1", SourceName: "application1", Target: "cluster1-namespace1-application2", TargetCluster: "cluster1", TargetNamespace: "namespace1", TargetName: "application2"}},
+		{Data: EdgeData{ID: "cluster1-namespace1-application2-cluster1-namespace2-application3", Source: "cluster1-namespace1-application2", SourceCluster: "cluster1", SourceNamespace: "namespace1", SourceName: "application2", Target: "cluster1-namespace2-application3", TargetCluster: "cluster1", TargetNamespace: "namespace2", TargetName: "application3"}},
+		{Data: EdgeData{ID: "cluster1-namespace2-application3-cluster2-namespace3-application4", Source: "cluster1-namespace2-application3", SourceCluster: "cluster1", SourceNamespace: "namespace2", SourceName: "application3", Target: "cluster2-namespace3-application4", TargetCluster: "cluster2", TargetNamespace: "namespace3", TargetName: "application4"}},
+		{Data: EdgeData{ID: "cluster1-namespace2-application3-cluster2-namespace3-application5", Source: "cluster1-namespace2-application3", SourceCluster: "cluster1", SourceNamespace: "namespace2", SourceName: "application3", Target: "cluster2-namespace3-application5", TargetCluster: "cluster2", TargetNamespace: "namespace3", TargetName: "application5"}},
+	},
+	Nodes: []Node{
+		{Data: NodeData{ID: "cluster1-namespace1-application1", Type: "application", Label: "application1", Parent: "cluster1-namespace1", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster1", Namespace: "namespace1", Name: "application1", Dependencies: []application.Reference{{Cluster: "", Namespace: "", Name: "application2"}}}}},
+		{Data: NodeData{ID: "cluster1-namespace1-application2", Type: "application", Label: "application2", Parent: "cluster1-namespace1", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster1", Namespace: "namespace1", Name: "application2", Dependencies: []application.Reference{{Cluster: "", Namespace: "namespace2", Name: "application3"}}}}},
+		{Data: NodeData{ID: "cluster1-namespace2-application3", Type: "application", Label: "application3", Parent: "cluster1-namespace2", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster1", Namespace: "namespace2", Name: "application3", Dependencies: []application.Reference{{Cluster: "cluster2", Namespace: "namespace3", Name: "application4"}, {Cluster: "cluster2", Namespace: "namespace3", Name: "application5"}}}}},
+		{Data: NodeData{ID: "cluster2-namespace3-application4", Type: "application", Label: "application4", Parent: "cluster2-namespace3", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster2", Namespace: "namespace3", Name: "application4"}}},
+		{Data: NodeData{ID: "cluster2-namespace3-application5", Type: "application", Label: "application5", Parent: "cluster2-namespace3", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster2", Namespace: "namespace3", Name: "application5"}}},
+		{Data: NodeData{ID: "cluster1", Type: "cluster", Label: "cluster1", Parent: "", ApplicationSpec: application.ApplicationSpec{Cluster: "", Namespace: "", Name: ""}}},
+		{Data: NodeData{ID: "cluster2", Type: "cluster", Label: "cluster2", Parent: "", ApplicationSpec: application.ApplicationSpec{Cluster: "", Namespace: "", Name: ""}}},
+		{Data: NodeData{ID: "cluster1-namespace1", Type: "namespace", Label: "namespace1", Parent: "cluster1", ApplicationSpec: application.ApplicationSpec{Cluster: "", Namespace: "", Name: ""}}},
+		{Data: NodeData{ID: "cluster1-namespace1", Type: "namespace", Label: "namespace1", Parent: "cluster1", ApplicationSpec: application.ApplicationSpec{Cluster: "", Namespace: "", Name: ""}}},
+		{Data: NodeData{ID: "cluster1-namespace1", Type: "namespace", Label: "namespace1", Parent: "cluster1", ApplicationSpec: application.ApplicationSpec{Cluster: "", Namespace: "", Name: ""}}},
+		{Data: NodeData{ID: "cluster1-namespace2", Type: "namespace", Label: "namespace2", Parent: "cluster1", ApplicationSpec: application.ApplicationSpec{Cluster: "", Namespace: "", Name: ""}}},
+		{Data: NodeData{ID: "cluster1-namespace2", Type: "namespace", Label: "namespace2", Parent: "cluster1", ApplicationSpec: application.ApplicationSpec{Cluster: "", Namespace: "", Name: ""}}},
+		{Data: NodeData{ID: "cluster2-namespace3", Type: "namespace", Label: "namespace3", Parent: "cluster2", ApplicationSpec: application.ApplicationSpec{Cluster: "", Namespace: "", Name: ""}}},
+		{Data: NodeData{ID: "cluster1-namespace2", Type: "namespace", Label: "namespace2", Parent: "cluster1", ApplicationSpec: application.ApplicationSpec{Cluster: "", Namespace: "", Name: ""}}},
+		{Data: NodeData{ID: "cluster2-namespace3", Type: "namespace", Label: "namespace3", Parent: "cluster2", ApplicationSpec: application.ApplicationSpec{Cluster: "", Namespace: "", Name: ""}}},
+	},
+}
+
+func TestGet(t *testing.T) {
+	mockClusterClient := &cluster.MockClient{}
+	mockClusterClient.AssertExpectations(t)
+	mockClusterClient.On("GetName").Return("cluster")
+
+	mockClustersClient := &clusters.MockClient{}
+	mockClustersClient.AssertExpectations(t)
+	mockClustersClient.On("GetClusters").Return([]cluster.Client{mockClusterClient})
+
+	t.Run("get applications error", func(t *testing.T) {
+		mockClusterClient.On("GetApplications", mock.Anything, "").Return(nil, fmt.Errorf("could not get teams")).Once()
+		teams := Get(context.Background(), mockClustersClient)
+		require.Empty(t, teams)
+	})
+
+	t.Run("get topology", func(t *testing.T) {
+		mockClusterClient.On("GetApplications", mock.Anything, "").Return([]application.ApplicationSpec{
+			{Cluster: "cluster1", Namespace: "namespace1", Name: "application1", Dependencies: []application.Reference{{Cluster: "", Namespace: "", Name: "application2"}}},
+			{Cluster: "cluster1", Namespace: "namespace1", Name: "application2", Dependencies: []application.Reference{{Cluster: "", Namespace: "namespace2", Name: "application3"}}},
+			{Cluster: "cluster1", Namespace: "namespace2", Name: "application3", Dependencies: []application.Reference{{Cluster: "cluster2", Namespace: "namespace3", Name: "application4"}, {Cluster: "cluster2", Namespace: "namespace3", Name: "application5"}}},
+			{Cluster: "cluster2", Namespace: "namespace3", Name: "application4"},
+			{Cluster: "cluster2", Namespace: "namespace3", Name: "application5"},
+		}, nil).Once()
+		actualTopology := Get(context.Background(), mockClustersClient)
+		require.Equal(t, &expectedGetTopology, actualTopology)
+	})
+}
+
+func TestGenerate(t *testing.T) {
+	actualTopology1 := Generate(&expectedGetTopology, []string{"cluster1", "cluster2"}, []string{"namespace1", "namespace2", "namespace3"})
+	require.Equal(t, &expectedGenerateTopology, actualTopology1)
+
+	actualTopology2 := Generate(&expectedGetTopology, []string{"cluster1", "cluster2"}, nil)
+	require.Equal(t, &expectedGenerateTopology, actualTopology2)
+}
 
 func TestDoesNodeExists(t *testing.T) {
 	for _, tt := range []struct {

--- a/plugins/applications/src/components/page/Application.tsx
+++ b/plugins/applications/src/components/page/Application.tsx
@@ -2,6 +2,7 @@ import {
   Alert,
   AlertActionLink,
   AlertVariant,
+  Badge,
   Button,
   ButtonVariant,
   Drawer,
@@ -101,8 +102,17 @@ const Application: React.FunctionComponent = () => {
         <Title title={data.name} subtitle={`${data.namespace} (${data.cluster})`} size="xl" />
         <div>
           <p>{data.description}</p>
-          {(data.teams && data.teams.length > 0) || (data.links && data.links.length > 0) ? (
+          {(data.tags && data.tags.length > 0) ||
+          (data.teams && data.teams.length > 0) ||
+          (data.links && data.links.length > 0) ? (
             <List variant={ListVariant.inline}>
+              {data.tags &&
+                data.tags.map((tag) => (
+                  <ListItem key={tag}>
+                    <Badge className="pf-u-mr-sm">{tag.toLowerCase()}</Badge>
+                  </ListItem>
+                ))}
+
               {data.teams &&
                 data.teams.map((team, index) => (
                   <ListItem key={index}>

--- a/plugins/applications/src/components/page/Applications.tsx
+++ b/plugins/applications/src/components/page/Applications.tsx
@@ -40,12 +40,13 @@ const Applications: React.FunctionComponent<IApplicationsProps> = ({
   const changeOptions = (opts: IOptions): void => {
     const c = opts.clusters.map((cluster) => `&cluster=${cluster}`);
     const n = opts.namespaces.map((namespace) => `&namespace=${namespace}`);
+    const t = opts.tags.map((tag) => `&tag=${tag}`);
 
     history.push({
       pathname: location.pathname,
       search: `?time=${opts.times.time}&timeEnd=${opts.times.timeEnd}&timeStart=${opts.times.timeStart}&view=${
         opts.view
-      }${c.length > 0 ? c.join('') : ''}${n.length > 0 ? n.join('') : ''}`,
+      }${c.length > 0 ? c.join('') : ''}${n.length > 0 ? n.join('') : ''}${t.length > 0 ? t.join('') : ''}`,
     });
   };
 
@@ -86,6 +87,7 @@ const Applications: React.FunctionComponent<IApplicationsProps> = ({
                   options={{
                     clusters: options.clusters,
                     namespaces: options.namespaces,
+                    tags: options.tags,
                     team: undefined,
                     view: options.view,
                   }}

--- a/plugins/applications/src/components/page/ApplicationsToolbar.tsx
+++ b/plugins/applications/src/components/page/ApplicationsToolbar.tsx
@@ -5,6 +5,7 @@ import { ClustersContext, IClusterContext, IOptionsAdditionalFields, IPluginTime
 import { IOptions, TView } from '../../utils/interfaces';
 import ApplicationsToolbarItemClusters from './ApplicationsToolbarItemClusters';
 import ApplicationsToolbarItemNamespaces from './ApplicationsToolbarItemNamespaces';
+import ApplicationsToolbarItemTags from './ApplicationsToolbarItemTags';
 
 interface IApplicationsToolbarProps {
   options: IOptions;
@@ -22,6 +23,7 @@ const ApplicationsToolbar: React.FunctionComponent<IApplicationsToolbarProps> = 
     options.clusters.length > 0 ? options.clusters : [clustersContext.clusters[0]],
   );
   const [selectedNamespaces, setSelectedNamespaces] = useState<string[]>(options.namespaces);
+  const [selectedTags, setSelectedTags] = useState<string[]>(options.tags);
   const [selectedView, setSelectedView] = useState<TView>(options.view ? (options.view as TView) : 'gallery');
 
   // selectCluster adds/removes the given cluster to the list of selected clusters. When the cluster value is an empty
@@ -52,10 +54,30 @@ const ApplicationsToolbar: React.FunctionComponent<IApplicationsToolbarProps> = 
     }
   };
 
+  // selectTag adds/removes the given tag to/from the list of selected tags. When the tag value is an empty string the
+  // selected tags list is cleared.
+  const selectTag = (tag: string): void => {
+    if (tag === '') {
+      setSelectedTags([]);
+    } else {
+      if (selectedTags.includes(tag)) {
+        setSelectedTags(selectedTags.filter((item) => item !== tag));
+      } else {
+        setSelectedTags([...selectedTags, tag]);
+      }
+    }
+  };
+
   // changeOptions changes the Prometheus option. It is used when the user clicks the search button or selects a new
   // time range.
   const changeOptions = (times: IPluginTimes, additionalFields: IOptionsAdditionalFields[] | undefined): void => {
-    setOptions({ clusters: selectedClusters, namespaces: selectedNamespaces, times: times, view: selectedView });
+    setOptions({
+      clusters: selectedClusters,
+      namespaces: selectedNamespaces,
+      tags: selectedTags,
+      times: times,
+      view: selectedView,
+    });
   };
 
   return (
@@ -73,6 +95,9 @@ const ApplicationsToolbar: React.FunctionComponent<IApplicationsToolbarProps> = 
           selectedNamespaces={selectedNamespaces}
           selectNamespace={selectNamespace}
         />
+      </ToolbarItem>
+      <ToolbarItem style={{ width: '100%' }}>
+        <ApplicationsToolbarItemTags selectedTags={selectedTags} selectTag={selectTag} />
       </ToolbarItem>
       <ToolbarItem>
         <ToggleGroup aria-label="View">

--- a/plugins/applications/src/components/page/ApplicationsToolbarItemTags.tsx
+++ b/plugins/applications/src/components/page/ApplicationsToolbarItemTags.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+import { useQuery } from 'react-query';
+
+interface IToolbarItemTagsProps {
+  selectedTags: string[];
+  selectTag: (tag: string) => void;
+}
+
+const ToolbarItemTags: React.FunctionComponent<IToolbarItemTagsProps> = ({
+  selectedTags,
+  selectTag,
+}: IToolbarItemTagsProps) => {
+  const [showOptions, setShowOptions] = useState<boolean>(false);
+
+  const { isError, error, data } = useQuery<string[], Error>(['applications/tags'], async () => {
+    try {
+      const response = await fetch(`/api/plugins/applications/tags`, {
+        method: 'get',
+      });
+      const json = await response.json();
+
+      if (response.status >= 200 && response.status < 300) {
+        return json;
+      } else {
+        if (json.error) {
+          throw new Error(json.error);
+        } else {
+          throw new Error('An unknown error occured');
+        }
+      }
+    } catch (err) {
+      throw err;
+    }
+  });
+
+  return (
+    <Select
+      variant={SelectVariant.typeaheadMulti}
+      typeAheadAriaLabel="Select tags"
+      placeholderText="Select tags"
+      onToggle={(): void => setShowOptions(!showOptions)}
+      onSelect={(e, value): void => selectTag(value as string)}
+      onClear={(): void => selectTag('')}
+      selections={selectedTags}
+      isOpen={showOptions}
+      onFilter={(e: React.ChangeEvent<HTMLInputElement> | null, value: string): React.ReactElement[] =>
+        data
+          ? data
+              .filter((tag) => !value || tag.includes(value))
+              .map((tag: string) => <SelectOption key={tag} value={tag} />)
+          : []
+      }
+    >
+      {isError
+        ? [<SelectOption key="error" isDisabled={true} value={error?.message || 'Could not get tags.'} />]
+        : data
+        ? data.map((tag) => <SelectOption key={tag} value={tag} />)
+        : []}
+    </Select>
+  );
+};
+
+export default ToolbarItemTags;

--- a/plugins/applications/src/components/panel/ApplicationsGallery.tsx
+++ b/plugins/applications/src/components/panel/ApplicationsGallery.tsx
@@ -9,6 +9,7 @@ import ApplicationsGalleryItem from './ApplicationsGalleryItem';
 interface IApplicationsGalleryProps {
   clusters: string[];
   namespaces: string[];
+  tags: string[];
   team?: IApplicationReference;
   times: IPluginTimes;
 }
@@ -17,17 +18,19 @@ interface IApplicationsGalleryProps {
 const ApplicationsGallery: React.FunctionComponent<IApplicationsGalleryProps> = ({
   clusters,
   namespaces,
+  tags,
   team,
   times,
 }: IApplicationsGalleryProps) => {
   const history = useHistory();
 
   const { isError, isLoading, error, data, refetch } = useQuery<IApplication[], Error>(
-    ['applications/applications', 'gallery', clusters, namespaces, team, times],
+    ['applications/applications', 'gallery', clusters, namespaces, tags, team, times],
     async () => {
       try {
         const clusterParams = clusters.map((cluster) => `cluster=${cluster}`).join('&');
         const namespaceParams = namespaces.map((namespace) => `namespace=${namespace}`).join('&');
+        const tagParams = tags.map((tag) => `tag=${tag}`).join('&');
         const teamParams =
           team && team.cluster && team.namespace && team.name
             ? `&teamCluster=${team.cluster}&teamNamespace=${team.namespace}&teamName=${team.name}`
@@ -35,7 +38,7 @@ const ApplicationsGallery: React.FunctionComponent<IApplicationsGalleryProps> = 
 
         const response = await fetch(
           `/api/plugins/applications/applications?view=gallery&${
-            teamParams ? teamParams : `${clusterParams}&${namespaceParams}`
+            teamParams ? teamParams : `${clusterParams}&${namespaceParams}&${tagParams}`
           }`,
           {
             method: 'get',

--- a/plugins/applications/src/components/panel/ApplicationsTopology.tsx
+++ b/plugins/applications/src/components/panel/ApplicationsTopology.tsx
@@ -15,6 +15,7 @@ interface IDataState {
 interface IApplicationsTopologyProps {
   clusters: string[];
   namespaces: string[];
+  tags: string[];
   times: IPluginTimes;
   setDetails?: (details: React.ReactNode) => void;
 }
@@ -25,20 +26,22 @@ interface IApplicationsTopologyProps {
 const ApplicationsTopology: React.FunctionComponent<IApplicationsTopologyProps> = ({
   clusters,
   namespaces,
+  tags,
   times,
   setDetails,
 }: IApplicationsTopologyProps) => {
   const history = useHistory();
 
   const { isError, isLoading, error, data, refetch } = useQuery<IDataState, Error>(
-    ['applications/applications', 'topology', clusters, namespaces, times],
+    ['applications/applications', 'topology', clusters, namespaces, tags, times],
     async () => {
       try {
         const clusterParams = clusters.map((cluster) => `cluster=${cluster}`).join('&');
         const namespaceParams = namespaces.map((namespace) => `namespace=${namespace}`).join('&');
+        const tagParams = tags.map((tag) => `tag=${tag}`).join('&');
 
         const response = await fetch(
-          `/api/plugins/applications/applications?view=topology&${clusterParams}&${namespaceParams}`,
+          `/api/plugins/applications/applications?view=topology&${clusterParams}&${namespaceParams}&${tagParams}`,
           {
             method: 'get',
           },

--- a/plugins/applications/src/components/panel/Panel.tsx
+++ b/plugins/applications/src/components/panel/Panel.tsx
@@ -43,6 +43,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
       <ApplicationsTopology
         clusters={options.clusters || [defaults.cluster]}
         namespaces={options.namespaces || [defaults.namespace]}
+        tags={options.tags || []}
         times={times}
         setDetails={setDetails}
       />
@@ -59,6 +60,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
               view="topology"
               clusters={options.clusters || [defaults.cluster]}
               namespaces={options.namespaces || [defaults.namespace]}
+              tags={options.tags || []}
             />
           }
         >
@@ -76,6 +78,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
     <ApplicationsGallery
       clusters={options.clusters || [defaults.cluster]}
       namespaces={options.namespaces || [defaults.namespace]}
+      tags={options.tags || []}
       team={options.team}
       times={times}
     />
@@ -93,6 +96,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
               view="gallery"
               clusters={options.clusters || [defaults.cluster]}
               namespaces={options.namespaces || [defaults.namespace]}
+              tags={options.tags || []}
             />
           )
         }

--- a/plugins/applications/src/components/panel/PanelActions.tsx
+++ b/plugins/applications/src/components/panel/PanelActions.tsx
@@ -6,17 +6,20 @@ interface IPanelActionsProps {
   view: string;
   clusters: string[];
   namespaces: string[];
+  tags: string[];
 }
 
 export const PanelActions: React.FunctionComponent<IPanelActionsProps> = ({
   view,
   clusters,
   namespaces,
+  tags,
 }: IPanelActionsProps) => {
   const [show, setShow] = useState<boolean>(false);
 
   const clusterParams = clusters.map((cluster) => `&cluster=${cluster}`).join('');
   const namespaceParams = namespaces.map((namespace) => `&namespace=${namespace}`).join('');
+  const tagParams = tags.map((tag) => `&tag=${tag}`).join('');
 
   return (
     <CardActions>
@@ -28,7 +31,9 @@ export const PanelActions: React.FunctionComponent<IPanelActionsProps> = ({
         dropdownItems={[
           <DropdownItem
             key={0}
-            component={<Link to={`/applications?view=${view}${clusterParams}${namespaceParams}`}>Explore</Link>}
+            component={
+              <Link to={`/applications?view=${view}${clusterParams}${namespaceParams}${tagParams}`}>Explore</Link>
+            }
           />,
         ]}
       />

--- a/plugins/applications/src/utils/helpers.ts
+++ b/plugins/applications/src/utils/helpers.ts
@@ -6,11 +6,13 @@ export const getInitialOptions = (search: string, isInitial: boolean): IOptions 
   const params = new URLSearchParams(search);
   const clusters = params.getAll('cluster');
   const namespaces = params.getAll('namespace');
+  const tags = params.getAll('tag');
   const view = params.get('view');
 
   return {
     clusters: clusters,
     namespaces: namespaces,
+    tags: tags,
     times: getTimeParams(params, isInitial),
     view: view ? (view as TView) : 'gallery',
   };

--- a/plugins/applications/src/utils/interfaces.ts
+++ b/plugins/applications/src/utils/interfaces.ts
@@ -6,6 +6,7 @@ import { IApplication, IApplicationReference, IPluginTimes } from '@kobsio/plugi
 export interface IOptions {
   clusters: string[];
   namespaces: string[];
+  tags: string[];
   view: TView;
   times: IPluginTimes;
 }
@@ -21,6 +22,7 @@ export interface IPanelOptions {
   view?: TView;
   clusters?: string[];
   namespaces?: string[];
+  tags?: string[];
   team?: IApplicationReference;
 }
 


### PR DESCRIPTION
It is now possible to filter applications by tags, next to clusters and
namespaces. We also show the tags now on the applications page infront
of the teams and links list.

To implement these features we added a new cache layer, like the one for
teams and the topology graph. This layer is implemented by the new
"tags" package. It is used to cache all tags for a configurable amount
of time to reduce the load on the Kubernetes API server and shorter
response times. This is necessary because to get the list of tags we
have to look at all applications in all clusters.

NOTE: Currently the filtering by tags only works for the gallery view.
As part of the next task from #253 we should decide if we want to
display applications which doesn't match the query in the topology chart
or if we just want to render them in a different style (lower
"opacity" value).

With this commit we also increased the test coverage for the
applications package to 100%.

Relates #253.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
