### PR TITLE
[applications] Support for external applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#267](https://github.com/kobsio/kobs/pull/267): [users] Add tests for users plugin.
 - [#268](https://github.com/kobsio/kobs/pull/268): [teams] Add tests for teams plugin.
 - [#270](https://github.com/kobsio/kobs/pull/270): [applications] Allow the usage of dashboards in application dependencies.
+- [#271](https://github.com/kobsio/kobs/pull/271): [applications] Add support for external applications.
 
 ### Fixed
 

--- a/deploy/helm/kobs/Chart.yaml
+++ b/deploy/helm/kobs/Chart.yaml
@@ -4,5 +4,5 @@ description: Kubernetes Observability Platform
 type: application
 home: https://kobs.io
 icon: https://kobs.io/assets/images/logo.svg
-version: 0.9.1
+version: 0.9.2
 appVersion: v0.7.0

--- a/deploy/helm/kobs/crds/kobs.io_applications.yaml
+++ b/deploy/helm/kobs/crds/kobs.io_applications.yaml
@@ -284,6 +284,8 @@ spec:
                       - name
                       type: object
                     type: array
+                  external:
+                    type: boolean
                   type:
                     type: string
                 type: object

--- a/deploy/kustomize/crds/kobs.io_applications.yaml
+++ b/deploy/kustomize/crds/kobs.io_applications.yaml
@@ -284,6 +284,8 @@ spec:
                       - name
                       type: object
                     type: array
+                  external:
+                    type: boolean
                   type:
                     type: string
                 type: object

--- a/docs/resources/applications.md
+++ b/docs/resources/applications.md
@@ -48,7 +48,8 @@ Teams can be used to define the ownership for an application. It is also possibl
 
 | Field | Type | Description | Required |
 | ----- | ---- | ----------- | -------- |
-| type | string | The type of the application in the topology graph. This must be a node type as specified in the `topology` key in the [configuration](../plugins/applications#configuration). The default value is `application`.  | No |
+| type | string | The type of the application in the topology graph. This must be a node type as specified in the `topology` key in the [configuration](../plugins/applications#configuration). The default value is `application`. | No |
+| external | boolean | When this `true` the application will be marked as external. This means that we do not show the cluster and namespace of the Application CR in the UI and that the node for the application is rendered outside the cluster in the topology graph. | No |
 | dependencies | [[]Dependency](#dependency) | Add other applications as dependencies for this application. This can be used to render a topology graph for your applications. | No |
 
 ### Dependency

--- a/pkg/api/apis/application/v1beta1/types.go
+++ b/pkg/api/apis/application/v1beta1/types.go
@@ -47,6 +47,7 @@ type Link struct {
 
 type Topology struct {
 	Type         string       `json:"type,omitempty"`
+	External     bool         `json:"external,omitempty"`
 	Dependencies []Dependency `json:"dependencies,omitempty"`
 }
 

--- a/plugins/applications/pkg/topology/topology.go
+++ b/plugins/applications/pkg/topology/topology.go
@@ -84,12 +84,17 @@ func Get(ctx context.Context, clustersClient clusters.Client) *Topology {
 		}
 
 		for _, application := range applications {
+			parent := application.Cluster + "-" + application.Namespace
+			if application.Topology.External {
+				parent = ""
+			}
+
 			nodes = append(nodes, Node{
 				Data: NodeData{
 					application.Cluster + "-" + application.Namespace + "-" + application.Name,
 					application.Topology.Type,
 					application.Name,
-					application.Cluster + "-" + application.Namespace,
+					parent,
 					application,
 				},
 			})

--- a/plugins/applications/pkg/topology/topology_test.go
+++ b/plugins/applications/pkg/topology/topology_test.go
@@ -25,7 +25,7 @@ var expectedGetTopology = Topology{
 		{Data: NodeData{ID: "cluster1-namespace1-application2", Type: "application", Label: "application2", Parent: "cluster1-namespace1", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster1", Namespace: "namespace1", Name: "application2", Topology: application.Topology{Type: "application", Dependencies: []application.Dependency{{Cluster: "", Namespace: "namespace2", Name: "application3"}}}}}},
 		{Data: NodeData{ID: "cluster1-namespace2-application3", Type: "application", Label: "application3", Parent: "cluster1-namespace2", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster1", Namespace: "namespace2", Name: "application3", Topology: application.Topology{Type: "application", Dependencies: []application.Dependency{{Cluster: "cluster2", Namespace: "namespace3", Name: "application4"}, {Cluster: "cluster2", Namespace: "namespace3", Name: "application5"}}}}}},
 		{Data: NodeData{ID: "cluster2-namespace3-application4", Type: "application", Label: "application4", Parent: "cluster2-namespace3", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster2", Namespace: "namespace3", Name: "application4", Topology: application.Topology{Type: "application"}}}},
-		{Data: NodeData{ID: "cluster2-namespace3-application5", Type: "application", Label: "application5", Parent: "cluster2-namespace3", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster2", Namespace: "namespace3", Name: "application5", Topology: application.Topology{Type: "application"}}}},
+		{Data: NodeData{ID: "cluster2-namespace3-application5", Type: "application", Label: "application5", Parent: "", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster2", Namespace: "namespace3", Name: "application5", Topology: application.Topology{Type: "application", External: true}}}},
 	},
 }
 
@@ -41,7 +41,7 @@ var expectedGenerateTopology = Topology{
 		{Data: NodeData{ID: "cluster1-namespace1-application2", Type: "application", Label: "application2", Parent: "cluster1-namespace1", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster1", Namespace: "namespace1", Name: "application2", Topology: application.Topology{Type: "application", Dependencies: []application.Dependency{{Cluster: "", Namespace: "namespace2", Name: "application3"}}}}}},
 		{Data: NodeData{ID: "cluster1-namespace2-application3", Type: "application", Label: "application3", Parent: "cluster1-namespace2", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster1", Namespace: "namespace2", Name: "application3", Topology: application.Topology{Type: "application", Dependencies: []application.Dependency{{Cluster: "cluster2", Namespace: "namespace3", Name: "application4"}, {Cluster: "cluster2", Namespace: "namespace3", Name: "application5"}}}}}},
 		{Data: NodeData{ID: "cluster2-namespace3-application4", Type: "application", Label: "application4", Parent: "cluster2-namespace3", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster2", Namespace: "namespace3", Name: "application4", Topology: application.Topology{Type: "application"}}}},
-		{Data: NodeData{ID: "cluster2-namespace3-application5", Type: "application", Label: "application5", Parent: "cluster2-namespace3", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster2", Namespace: "namespace3", Name: "application5", Topology: application.Topology{Type: "application"}}}},
+		{Data: NodeData{ID: "cluster2-namespace3-application5", Type: "application", Label: "application5", Parent: "", ApplicationSpec: application.ApplicationSpec{Cluster: "cluster2", Namespace: "namespace3", Name: "application5", Topology: application.Topology{Type: "application", External: true}}}},
 		{Data: NodeData{ID: "cluster1", Type: "cluster", Label: "cluster1", Parent: "", ApplicationSpec: application.ApplicationSpec{Cluster: "", Namespace: "", Name: ""}}},
 		{Data: NodeData{ID: "cluster2", Type: "cluster", Label: "cluster2", Parent: "", ApplicationSpec: application.ApplicationSpec{Cluster: "", Namespace: "", Name: ""}}},
 		{Data: NodeData{ID: "cluster1-namespace1", Type: "namespace", Label: "namespace1", Parent: "cluster1", ApplicationSpec: application.ApplicationSpec{Cluster: "", Namespace: "", Name: ""}}},
@@ -76,7 +76,7 @@ func TestGet(t *testing.T) {
 			{Cluster: "cluster1", Namespace: "namespace1", Name: "application2", Topology: application.Topology{Type: "application", Dependencies: []application.Dependency{{Cluster: "", Namespace: "namespace2", Name: "application3"}}}},
 			{Cluster: "cluster1", Namespace: "namespace2", Name: "application3", Topology: application.Topology{Type: "application", Dependencies: []application.Dependency{{Cluster: "cluster2", Namespace: "namespace3", Name: "application4"}, {Cluster: "cluster2", Namespace: "namespace3", Name: "application5"}}}},
 			{Cluster: "cluster2", Namespace: "namespace3", Name: "application4", Topology: application.Topology{Type: "application"}},
-			{Cluster: "cluster2", Namespace: "namespace3", Name: "application5", Topology: application.Topology{Type: "application"}},
+			{Cluster: "cluster2", Namespace: "namespace3", Name: "application5", Topology: application.Topology{Type: "application", External: true}},
 		}, nil).Once()
 		actualTopology := Get(context.Background(), mockClustersClient)
 		require.Equal(t, &expectedGetTopology, actualTopology)

--- a/plugins/applications/src/components/home/Home.tsx
+++ b/plugins/applications/src/components/home/Home.tsx
@@ -128,7 +128,9 @@ const Home: React.FunctionComponent<IPluginPageProps> = () => {
                     {application.name}
                     <br />
                     <span className="pf-u-font-size-sm pf-u-color-400">
-                      {application.namespace} ({application.cluster})
+                      {application.topology?.external
+                        ? 'external'
+                        : `${application.namespace} (${application.cluster})`}
                     </span>
                   </CardTitle>
                   <CardBody style={{ height: '150px', maxHeight: '150px', minHeight: '150px' }}>

--- a/plugins/applications/src/components/page/Application.tsx
+++ b/plugins/applications/src/components/page/Application.tsx
@@ -99,7 +99,11 @@ const Application: React.FunctionComponent = () => {
   return (
     <React.Fragment>
       <PageSection variant={PageSectionVariants.light}>
-        <Title title={data.name} subtitle={`${data.namespace} (${data.cluster})`} size="xl" />
+        <Title
+          title={data.name}
+          subtitle={data.topology?.external ? 'external' : `${data.namespace} (${data.cluster})`}
+          size="xl"
+        />
         <div>
           <p>{data.description}</p>
           {(data.tags && data.tags.length > 0) ||

--- a/plugins/applications/src/components/panel/ApplicationsGalleryItem.tsx
+++ b/plugins/applications/src/components/panel/ApplicationsGalleryItem.tsx
@@ -22,7 +22,7 @@ const ApplicationsGalleryItem: React.FunctionComponent<IApplicationsGalleryItemP
           {application.name}
           <br />
           <span className="pf-u-font-size-sm pf-u-color-400">
-            {application.namespace} ({application.cluster})
+            {application.topology?.external ? 'external' : `${application.namespace} (${application.cluster})`}
           </span>
         </CardTitle>
         <CardBody style={{ height: '150px', maxHeight: '150px', minHeight: '150px' }}>

--- a/plugins/applications/src/components/panel/details/DependencyDetails.tsx
+++ b/plugins/applications/src/components/panel/details/DependencyDetails.tsx
@@ -34,14 +34,14 @@ const DependencyDetails: React.FunctionComponent<IDependencyDetailsProps> = ({
           <span className="pf-u-pl-sm pf-c-title pf-m-lg">
             <span className="pf-u-pl-sm">{source?.data.name} </span>
             <span className="pf-u-font-size-sm pf-u-color-400">
-              ({source?.data.namespace} / {source?.data.cluster})
+              {source?.data.topology?.external ? '(external)' : `(${source?.data.namespace} / ${source?.data.cluster})`}
             </span>
           </span>
           <span className="pf-u-pl-lg pf-u-font-size-sm pf-u-color-400">To:</span>
           <span className="pf-u-pl-sm pf-c-title pf-m-lg">
             <span className="pf-u-pl-sm">{target?.data.name} </span>
             <span className="pf-u-font-size-sm pf-u-color-400">
-              ({target?.data.namespace} / {target?.data.cluster})
+              {target?.data.topology?.external ? '(external)' : `(${target?.data.namespace} / ${target?.data.cluster})`}
             </span>
           </span>
         </span>

--- a/plugins/applications/src/components/panel/details/Details.tsx
+++ b/plugins/applications/src/components/panel/details/Details.tsx
@@ -31,7 +31,11 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ application, close }:
   return (
     <DrawerPanelContent minSize="50%">
       <DrawerHead>
-        <Title title={application.name} subtitle={`${application.namespace} (${application.cluster})`} size="lg" />
+        <Title
+          title={application.name}
+          subtitle={application.topology?.external ? 'external' : `${application.namespace} (${application.cluster})`}
+          size="lg"
+        />
         <DrawerActions style={{ padding: 0 }}>
           <DetailsLink application={application} />
           <DrawerCloseButton onClose={close} />

--- a/plugins/core/src/crds/application.ts
+++ b/plugins/core/src/crds/application.ts
@@ -28,6 +28,7 @@ export interface IApplicationLink {
 
 export interface IApplicationTopology {
   type?: string;
+  external?: boolean;
   dependencies?: IApplicationDependency[];
 }
 


### PR DESCRIPTION
This commit adds support for external applications. An external
application can be used to monitor your applications which are not
running within a Kubernetes cluster like managed databases.

To find external applications within kobs, you still can filter for the
cluster / namespace where the Application CR was created, but we will
then not show the cluster / namespace in the UI, instead we are showing
the term "external".

In the topology graph, external applications are rendered outside of the
cluster / namespace node, this means that they not have the cluster /
namespace as parent.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
