### PR TITLE
Fix Docker build by setting export CGO_ENABLED=0

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -12,6 +12,7 @@ on:
       - '.github/**'
       - '.vscode/**'
       - 'deploy/**'
+      - 'cmd/kobs/Dockerfile'
       - 'docs/**'
       - '.dockerignore'
       - '.editorconfig'
@@ -29,6 +30,7 @@ on:
     paths-ignore:
       - '.github/**'
       - '.vscode/**'
+      - 'cmd/kobs/Dockerfile'
       - 'deploy/**'
       - 'docs/**'
       - '.dockerignore'

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -6,6 +6,7 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/PULL_REQUEST_TEMPLATE.md'
       - '.vscode/**'
+      - 'cmd/kobs/Dockerfile'
       - 'deploy/**'
       - 'docs/**'
       - '.dockerignore'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#243](https://github.com/kobsio/kobs/pull/243): [resources] Fix reload of resources, when the user clicks on the search button.
 - [#245](https://github.com/kobsio/kobs/pull/245): [klogs] Fix that the returned documents could be out of the selected time range.
 - [#247](https://github.com/kobsio/kobs/pull/247): [azure] Fix documentation about the permission handling.
+- [#274](https://github.com/kobsio/kobs/pull/274): Fix Docker build by setting `CGO_ENABLED=0`.
 
 ### Changed
 

--- a/cmd/kobs/Dockerfile
+++ b/cmd/kobs/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /kobs
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN make build
+RUN export CGO_ENABLED=0 && make build
 
 FROM alpine:3.14.2
 RUN apk update && apk add --no-cache ca-certificates


### PR DESCRIPTION
This fixes the Docker build, which is broken since the Helm plugin was
added in #272. To fix the build we have to set CGO_ENABLED to 0.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
