### PR TITLE
[azure] Improve cost management integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#263](https://github.com/kobsio/kobs/pull/263): [core] :warning: _Breaking change:_ :warning: Refactor `cluster` and `clusters` package.
 - [#265](https://github.com/kobsio/kobs/pull/265): [applications] Improve tags support by allow users to filter applications by tags and showing tags on application page.
 - [#269](https://github.com/kobsio/kobs/pull/269): [applications] :warning: _Breaking change:_ :warning: Improve topology graph, by allowing custom styles for applications.
+- [#275](https://github.com/kobsio/kobs/pull/275): [azure] Improve cost management integration by adjusting the chart style and allowing the usage in dashboard panels.
 
 ## [v0.7.0](https://github.com/kobsio/kobs/releases/tag/v0.7.0) (2021-11-19)
 

--- a/docs/plugins/azure.md
+++ b/docs/plugins/azure.md
@@ -46,8 +46,9 @@ The following options can be used for a panel with the Azure plugin:
 
 | Field | Type | Description | Required |
 | ----- | ---- | ----------- | -------- |
-| type | string | The service type which should be used for the panel Currently `containerinstances`, `kubernetesservices` and `virtualmachinescalesets` are supported values. | Yes |
+| type | string | The service type which should be used for the panel Currently `containerinstances`, `costmanagement`, `kubernetesservices` and `virtualmachinescalesets` are supported values. | Yes |
 | containerinstances | [Container Instances](#container-instances) | The configuration for the panel if the type is `containerinstances`. | No |
+| costmanagement | [Cost Management](#cost-management) | The configuration for the panel if the type is `costmanagement`. | No |
 | kubernetesservices | [Kubernetes Services](#kubernetes-services) | The configuration for the panel if the type is `kubernetesservices`. | No |
 | virtualmachinescalesets | [Virtual Machine Scale Sets](#virtual-machine-scale-sets) | The configuration for the panel if the type is `virtualmachinescalesets`. | No |
 
@@ -62,6 +63,13 @@ The following options can be used for a panel with the Azure plugin:
 | containers | string[] | A list of container names. This is only required if the type is `logs`. | No |
 | metricNames | string | The name of the metric for which the data should be displayed. Supported values are `CPUUsage`, `MemoryUsage`, `NetworkBytesReceivedPerSecond` and `NetworkBytesTransmittedPerSecond`. This is only required if the type is `metrics`. | No |
 | aggregationType | string | The aggregation type for the metric. Supported values are `Average`, `Minimum`, `Maximum`, `Total` and `Count`. This is only required if the type is `metrics`. | No |
+
+### Cost Management
+
+| Field | Type | Description | Required |
+| ----- | ---- | ----------- | -------- |
+| type | string | The type of the panel for which the Cost Management data should be displayed. Currently only `actualcosts` is supported. | Yes |
+| scope | string | The scope for the costs data. This could be the name of a resource group or `All`. The default value is `All`. | No |
 
 ### Kubernetes Services
 

--- a/plugins/azure/pkg/instance/costmanagement/costmanagement.go
+++ b/plugins/azure/pkg/instance/costmanagement/costmanagement.go
@@ -3,17 +3,14 @@ package costmanagement
 import (
 	"context"
 	"fmt"
-	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/services/costmanagement/mgmt/2019-11-01/costmanagement"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/date"
 )
 
 // Client is the interface for a client to interact with the Azure cost management api.
 type Client interface {
-	GetActualCost(ctx context.Context, timeframe int, scope string) (costmanagement.QueryResult, error)
+	GetActualCost(ctx context.Context, scope string, timeStart, timeEnd int64) (costmanagement.QueryResult, error)
 }
 
 type client struct {
@@ -22,7 +19,7 @@ type client struct {
 }
 
 // GetActualCost query the actual costs for the configured subscription and given timeframe grouped by resourceGroup
-func (c *client) GetActualCost(ctx context.Context, timeframe int, scope string) (costmanagement.QueryResult, error) {
+func (c *client) GetActualCost(ctx context.Context, scope string, timeStart, timeEnd int64) (costmanagement.QueryResult, error) {
 	var queryScope string
 	var subscriptionScope bool
 
@@ -33,55 +30,7 @@ func (c *client) GetActualCost(ctx context.Context, timeframe int, scope string)
 		queryScope = fmt.Sprintf("subscriptions/%s/resourceGroups/%s", c.subscriptionID, scope)
 	}
 
-	return c.queryClient.Usage(ctx, queryScope, buildQueryParams(timeframe, subscriptionScope))
-}
-
-func buildQueryParams(timeframe int, subscriptionScope bool) costmanagement.QueryDefinition {
-	agg := make(map[string]*costmanagement.QueryAggregation)
-	tc := costmanagement.QueryAggregation{
-		Name:     to.StringPtr("Cost"),
-		Function: costmanagement.FunctionTypeSum,
-	}
-	agg["totalCost"] = &tc
-
-	var grouping []costmanagement.QueryGrouping
-	if subscriptionScope {
-		grouping = []costmanagement.QueryGrouping{
-			{
-				Type: costmanagement.QueryColumnTypeDimension,
-				Name: to.StringPtr("resourceGroup"),
-			},
-		}
-	} else {
-		grouping = []costmanagement.QueryGrouping{
-			{
-				Type: costmanagement.QueryColumnTypeDimension,
-				Name: to.StringPtr("ServiceName"),
-			},
-		}
-	}
-
-	ds := costmanagement.QueryDataset{
-		Granularity:   "None",
-		Configuration: nil,
-		Aggregation:   agg,
-		Grouping:      &grouping,
-		Filter:        nil,
-	}
-
-	now := date.Time{Time: time.Now()}
-	from := date.Time{Time: now.AddDate(0, 0, timeframe*-1)}
-	tp := costmanagement.QueryTimePeriod{
-		From: &from,
-		To:   &now,
-	}
-
-	return costmanagement.QueryDefinition{
-		Type:       costmanagement.ExportTypeActualCost,
-		Timeframe:  costmanagement.TimeframeTypeCustom,
-		TimePeriod: &tp,
-		Dataset:    &ds,
-	}
+	return c.queryClient.Usage(ctx, queryScope, buildQueryParams(subscriptionScope, timeStart, timeEnd))
 }
 
 // New returns a new client to interact with the cost management API.

--- a/plugins/azure/pkg/instance/costmanagement/costmanagement_mock.go
+++ b/plugins/azure/pkg/instance/costmanagement/costmanagement_mock.go
@@ -14,20 +14,20 @@ type MockClient struct {
 	mock.Mock
 }
 
-// GetActualCost provides a mock function with given fields: ctx, timeframe, scope
-func (_m *MockClient) GetActualCost(ctx context.Context, timeframe int, scope string) (costmanagement.QueryResult, error) {
-	ret := _m.Called(ctx, timeframe, scope)
+// GetActualCost provides a mock function with given fields: ctx, scope, timeStart, timeEnd
+func (_m *MockClient) GetActualCost(ctx context.Context, scope string, timeStart int64, timeEnd int64) (costmanagement.QueryResult, error) {
+	ret := _m.Called(ctx, scope, timeStart, timeEnd)
 
 	var r0 costmanagement.QueryResult
-	if rf, ok := ret.Get(0).(func(context.Context, int, string) costmanagement.QueryResult); ok {
-		r0 = rf(ctx, timeframe, scope)
+	if rf, ok := ret.Get(0).(func(context.Context, string, int64, int64) costmanagement.QueryResult); ok {
+		r0 = rf(ctx, scope, timeStart, timeEnd)
 	} else {
 		r0 = ret.Get(0).(costmanagement.QueryResult)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, int, string) error); ok {
-		r1 = rf(ctx, timeframe, scope)
+	if rf, ok := ret.Get(1).(func(context.Context, string, int64, int64) error); ok {
+		r1 = rf(ctx, scope, timeStart, timeEnd)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/plugins/azure/pkg/instance/costmanagement/helpers.go
+++ b/plugins/azure/pkg/instance/costmanagement/helpers.go
@@ -1,0 +1,57 @@
+package costmanagement
+
+import (
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/services/costmanagement/mgmt/2019-11-01/costmanagement"
+	"github.com/Azure/go-autorest/autorest/date"
+)
+
+func buildQueryParams(subscriptionScope bool, timeStart, timeEnd int64) costmanagement.QueryDefinition {
+	agg := make(map[string]*costmanagement.QueryAggregation)
+	tc := costmanagement.QueryAggregation{
+		Name:     to.StringPtr("Cost"),
+		Function: costmanagement.FunctionTypeSum,
+	}
+	agg["totalCost"] = &tc
+
+	var grouping []costmanagement.QueryGrouping
+	if subscriptionScope {
+		grouping = []costmanagement.QueryGrouping{
+			{
+				Type: costmanagement.QueryColumnTypeDimension,
+				Name: to.StringPtr("resourceGroup"),
+			},
+		}
+	} else {
+		grouping = []costmanagement.QueryGrouping{
+			{
+				Type: costmanagement.QueryColumnTypeDimension,
+				Name: to.StringPtr("ServiceName"),
+			},
+		}
+	}
+
+	ds := costmanagement.QueryDataset{
+		Granularity:   "None",
+		Configuration: nil,
+		Aggregation:   agg,
+		Grouping:      &grouping,
+		Filter:        nil,
+	}
+
+	now := date.Time{Time: time.Unix(timeEnd, 0)}
+	from := date.Time{Time: time.Unix(timeStart, 0)}
+	tp := costmanagement.QueryTimePeriod{
+		From: &from,
+		To:   &now,
+	}
+
+	return costmanagement.QueryDefinition{
+		Type:       costmanagement.ExportTypeActualCost,
+		Timeframe:  costmanagement.TimeframeTypeCustom,
+		TimePeriod: &tp,
+		Dataset:    &ds,
+	}
+}

--- a/plugins/azure/pkg/instance/costmanagement/helpers_test.go
+++ b/plugins/azure/pkg/instance/costmanagement/helpers_test.go
@@ -1,0 +1,28 @@
+package costmanagement
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/costmanagement/mgmt/2019-11-01/costmanagement"
+	"github.com/Azure/go-autorest/autorest/date"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildQueryParams(t *testing.T) {
+	t.Run("subscription scope", func(t *testing.T) {
+		actualQueryParams := buildQueryParams(true, 0, 1)
+
+		require.Equal(t, costmanagement.ExportTypeActualCost, actualQueryParams.Type)
+		require.Equal(t, costmanagement.TimeframeTypeCustom, actualQueryParams.Timeframe)
+		require.Equal(t, costmanagement.QueryTimePeriod{From: &date.Time{Time: time.Unix(0, 0)}, To: &date.Time{Time: time.Unix(1, 0)}}, *actualQueryParams.TimePeriod)
+	})
+
+	t.Run("not subscription scope", func(t *testing.T) {
+		actualQueryParams := buildQueryParams(false, 0, 1)
+
+		require.Equal(t, costmanagement.ExportTypeActualCost, actualQueryParams.Type)
+		require.Equal(t, costmanagement.TimeframeTypeCustom, actualQueryParams.Timeframe)
+		require.Equal(t, costmanagement.QueryTimePeriod{From: &date.Time{Time: time.Unix(0, 0)}, To: &date.Time{Time: time.Unix(1, 0)}}, *actualQueryParams.TimePeriod)
+	})
+}

--- a/plugins/azure/src/components/costmanagement/CostManagementToolbar.tsx
+++ b/plugins/azure/src/components/costmanagement/CostManagementToolbar.tsx
@@ -1,39 +1,36 @@
-import { Toolbar, ToolbarContent, ToolbarItem, ToolbarToggleGroup } from '@patternfly/react-core';
-import { FilterIcon } from '@patternfly/react-icons';
-import React from 'react';
+import React, { useState } from 'react';
+import { ToolbarItem } from '@patternfly/react-core';
 
+import { IOptionsAdditionalFields, IPluginTimes, Toolbar } from '@kobsio/plugin-core';
 import CostManagementToolbarItemScope from './CostManagementToolbarItemScope';
-import CostManagementToolbarItemTimeframe from './CostManagementToolbarItemTimeframe';
+import { IOptions } from './interfaces';
 
 export interface ICostManagementToolbarProps {
-  timeframe: number;
-  setTimeframe: (timeframe: number) => void;
-  scope: string;
-  setScope: (scope: string) => void;
   resourceGroups: string[];
+  options: IOptions;
+  setOptions: (data: IOptions) => void;
 }
 
 const CostManagementToolbar: React.FunctionComponent<ICostManagementToolbarProps> = ({
-  timeframe,
-  setTimeframe,
-  scope,
-  setScope,
   resourceGroups,
+  options,
+  setOptions,
 }: ICostManagementToolbarProps) => {
+  const [scope, setScope] = useState<string>(options.scope);
+
+  const changeOptions = (times: IPluginTimes, additionalFields: IOptionsAdditionalFields[] | undefined): void => {
+    setOptions({
+      scope: scope,
+      times: times,
+    });
+  };
+
   return (
-    <Toolbar id="cost-management-toolbar" style={{ paddingBottom: '0px', zIndex: 300 }}>
-      <ToolbarContent style={{ padding: '0px' }}>
-        <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="lg">
-          <ToolbarItem variant="label">Scope</ToolbarItem>
-          <ToolbarItem>
-            <CostManagementToolbarItemScope scope={scope} setScope={setScope} resourceGroups={resourceGroups} />
-          </ToolbarItem>
-          <ToolbarItem variant="label">Timeframe</ToolbarItem>
-          <ToolbarItem>
-            <CostManagementToolbarItemTimeframe timeframe={timeframe} setTimeframe={setTimeframe} />
-          </ToolbarItem>
-        </ToolbarToggleGroup>
-      </ToolbarContent>
+    <Toolbar times={options.times} showOptions={true} showSearchButton={true} setOptions={changeOptions}>
+      <ToolbarItem variant="label">Scope</ToolbarItem>
+      <ToolbarItem style={{ width: '100%' }}>
+        <CostManagementToolbarItemScope scope={scope} setScope={setScope} resourceGroups={resourceGroups} />
+      </ToolbarItem>
     </Toolbar>
   );
 };

--- a/plugins/azure/src/components/costmanagement/CostManagementToolbarItemScope.tsx
+++ b/plugins/azure/src/components/costmanagement/CostManagementToolbarItemScope.tsx
@@ -16,7 +16,7 @@ const CostManagementToolbarItemScope: React.FunctionComponent<ICostManagementToo
   const [showSelect, setShowSelect] = useState<boolean>(false);
   const options = resourceGroups;
   if (options.indexOf('All') === -1) {
-    options.push('All');
+    options.unshift('All');
   }
 
   return (

--- a/plugins/azure/src/components/costmanagement/CostPieChart.tsx
+++ b/plugins/azure/src/components/costmanagement/CostPieChart.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ResponsivePie } from '@nivo/pie';
 
+import { CHART_THEME, COLOR_SCALE, ChartTooltip } from '@kobsio/plugin-core';
 import { IQueryResult } from './interfaces';
 import { convertQueryResult } from '../../utils/helpers';
 
@@ -11,23 +12,19 @@ interface ICostPieChartProps {
 export const CostPieChart: React.FunctionComponent<ICostPieChartProps> = ({ data }: ICostPieChartProps) => {
   return (
     <ResponsivePie
-      data={convertQueryResult(data)}
-      margin={{ bottom: 80, left: 80, right: 80, top: 40 }}
-      valueFormat=" >-.2f"
-      innerRadius={0.5}
-      padAngle={0.7}
-      cornerRadius={3}
       activeOuterRadiusOffset={8}
-      colors={{ scheme: 'paired' }}
-      borderWidth={2}
-      borderColor={{ from: 'color', modifiers: [['darker', 0.3]] }}
       arcLinkLabelsSkipAngle={5}
       arcLinkLabelsTextColor="#333333"
       arcLinkLabelsThickness={2}
       arcLinkLabelsColor={{ from: 'color' }}
       arcLabelsSkipAngle={10}
       arcLabelsTextColor={{ from: 'color', modifiers: [['darker', 2]] }}
-      motionConfig="gentle"
+      borderColor={{ from: 'color', modifiers: [['darker', 0.3]] }}
+      borderWidth={2}
+      colors={COLOR_SCALE}
+      cornerRadius={3}
+      data={convertQueryResult(data)}
+      innerRadius={0.5}
       legends={[
         {
           anchor: 'right',
@@ -42,6 +39,28 @@ export const CostPieChart: React.FunctionComponent<ICostPieChartProps> = ({ data
           translateY: 0,
         },
       ]}
+      margin={{ bottom: 80, left: 80, right: 80, top: 40 }}
+      motionConfig="gentle"
+      padAngle={0.7}
+      theme={CHART_THEME}
+      // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+      tooltip={(tooltip) => {
+        let currency = '';
+        const row = data.properties.rows.filter((row) => row[1] === tooltip.datum.label.toString());
+
+        if (row.length === 1) {
+          currency = row[0][2];
+        }
+
+        return (
+          <ChartTooltip
+            color={tooltip.datum.color}
+            label={`${tooltip.datum.formattedValue} ${currency}`}
+            title={tooltip.datum.label.toString()}
+          />
+        );
+      }}
+      valueFormat=" >-.2f"
     />
   );
 };

--- a/plugins/azure/src/components/costmanagement/helpers.ts
+++ b/plugins/azure/src/components/costmanagement/helpers.ts
@@ -1,0 +1,13 @@
+import { IOptions } from './interfaces';
+import { getTimeParams } from '@kobsio/plugin-core';
+
+// getInitialOptions returns the initial options for the applications page from the url.
+export const getInitialOptions = (search: string, isInitial: boolean): IOptions => {
+  const params = new URLSearchParams(search);
+  const scope = params.get('scope');
+
+  return {
+    scope: scope ? scope : 'All',
+    times: getTimeParams(params, isInitial),
+  };
+};

--- a/plugins/azure/src/components/costmanagement/interfaces.ts
+++ b/plugins/azure/src/components/costmanagement/interfaces.ts
@@ -1,3 +1,12 @@
+import { IPluginTimes } from '@kobsio/plugin-core';
+
+// IOptions is the interface for all options for the applications page.
+export interface IOptions {
+  scope: string;
+  times: IPluginTimes;
+}
+
+// IQueryResult is the interface for the data returned by the Azure api for the actual costs.
 export interface IQueryResult {
   properties: IQueryProperties;
 }

--- a/plugins/azure/src/components/panel/Panel.tsx
+++ b/plugins/azure/src/components/panel/Panel.tsx
@@ -9,6 +9,8 @@ import CIDetailsContainerGroup from '../containerinstances/DetailsContainerGroup
 import CIDetailsContainerGroupActions from '../containerinstances/DetailsContainerGroupActions';
 import CIDetailsLogs from '../containerinstances/DetailsLogs';
 
+import CMActualCosts from '../costmanagement/ActualCosts';
+
 import KSDetailsKubernetesService from '../kubernetesservices/DetailsKubernetesService';
 import KSDetailsNodePoolsWrapper from '../kubernetesservices/DetailsNodePoolsWrapper';
 import KSKubernetesServices from '../kubernetesservices/KubernetesServices';
@@ -126,6 +128,20 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
           aggregationType={options.containerinstances.aggregationType}
           times={times}
         />
+      </PluginCard>
+    );
+  }
+
+  if (
+    options?.type &&
+    options?.type === 'costmanagement' &&
+    options.costmanagement &&
+    options.costmanagement.type === 'actualcosts' &&
+    times
+  ) {
+    return (
+      <PluginCard title={title} description={description}>
+        <CMActualCosts name={name} scope={options.costmanagement.scope || 'All'} times={times} />
       </PluginCard>
     );
   }

--- a/plugins/azure/src/utils/interfaces.ts
+++ b/plugins/azure/src/utils/interfaces.ts
@@ -10,6 +10,10 @@ export interface IPanelOptions {
     metricNames?: string;
     aggregationType?: string;
   };
+  costmanagement?: {
+    type?: string;
+    scope?: string;
+  };
   kubernetesservices?: {
     type?: string;
     resourceGroups?: string[];


### PR DESCRIPTION
Improve the cost management integration in the Azure plugin. The pie
chart for the actual costs uses the same style as the other charts in
kobs. We are now using the chart theme, color scheme and tooltip from
the core package, so that the chart fits the style of the other charts
in kobs and the Azure plugin.

Instead of selecting the time from a dropdown in the cost management
page, it is now possible to select a time range via the Toolbar
component from the core package, like it is done in other plugins.

It is now possible to show the actual costs in a panel on a dashboard.
For this the type "costmanagement" with the sub type "actualcosts" can
be selected in the Azure plugin options. The user can also set a scope
(name of a resource group). If the user doesn't set this value it will
default to "All".

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
