### PR TITLE
[resources] Add "verbs" property for permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#265](https://github.com/kobsio/kobs/pull/265): [applications] Improve tags support by allow users to filter applications by tags and showing tags on application page.
 - [#269](https://github.com/kobsio/kobs/pull/269): [applications] :warning: _Breaking change:_ :warning: Improve topology graph, by allowing custom styles for applications.
 - [#275](https://github.com/kobsio/kobs/pull/275): [azure] Improve cost management integration by adjusting the chart style and allowing the usage in dashboard panels.
+- [#276](https://github.com/kobsio/kobs/pull/276): [resources] :warning: _Breaking change:_ :warning: Add new `verbs` property for resource permissions, to allow administrators more control about what users can do.
 
 ## [v0.7.0](https://github.com/kobsio/kobs/releases/tag/v0.7.0) (2021-11-19)
 

--- a/deploy/helm/kobs/Chart.yaml
+++ b/deploy/helm/kobs/Chart.yaml
@@ -4,5 +4,5 @@ description: Kubernetes Observability Platform
 type: application
 home: https://kobs.io
 icon: https://kobs.io/assets/images/logo.svg
-version: 0.9.2
+version: 0.9.3
 appVersion: v0.7.0

--- a/deploy/helm/kobs/crds/kobs.io_teams.yaml
+++ b/deploy/helm/kobs/crds/kobs.io_teams.yaml
@@ -173,10 +173,15 @@ spec:
                           items:
                             type: string
                           type: array
+                        verbs:
+                          items:
+                            type: string
+                          type: array
                       required:
                       - clusters
                       - namespaces
                       - resources
+                      - verbs
                       type: object
                     type: array
                 required:

--- a/deploy/helm/kobs/crds/kobs.io_users.yaml
+++ b/deploy/helm/kobs/crds/kobs.io_users.yaml
@@ -67,10 +67,15 @@ spec:
                           items:
                             type: string
                           type: array
+                        verbs:
+                          items:
+                            type: string
+                          type: array
                       required:
                       - clusters
                       - namespaces
                       - resources
+                      - verbs
                       type: object
                     type: array
                 required:

--- a/deploy/kustomize/crds/kobs.io_teams.yaml
+++ b/deploy/kustomize/crds/kobs.io_teams.yaml
@@ -173,10 +173,15 @@ spec:
                           items:
                             type: string
                           type: array
+                        verbs:
+                          items:
+                            type: string
+                          type: array
                       required:
                       - clusters
                       - namespaces
                       - resources
+                      - verbs
                       type: object
                     type: array
                 required:

--- a/deploy/kustomize/crds/kobs.io_users.yaml
+++ b/deploy/kustomize/crds/kobs.io_users.yaml
@@ -67,10 +67,15 @@ spec:
                           items:
                             type: string
                           type: array
+                        verbs:
+                          items:
+                            type: string
+                          type: array
                       required:
                       - clusters
                       - namespaces
                       - resources
+                      - verbs
                       type: object
                     type: array
                 required:

--- a/docs/plugins/azure.md
+++ b/docs/plugins/azure.md
@@ -130,6 +130,8 @@ In the following example each member of `team1@kobs.io` will get access to all A
               - "*"
             resources:
               - "*"
+            verbs:
+              - "*"
         custom:
     ```
 
@@ -160,6 +162,8 @@ In the following example each member of `team1@kobs.io` will get access to all A
             namespaces:
               - "*"
             resources:
+              - "*"
+            verbs:
               - "*"
     ```
 

--- a/docs/plugins/resources.md
+++ b/docs/plugins/resources.md
@@ -33,7 +33,7 @@ plugins:
 | selector | string | An optional selector for the selection of resources | No |
 
 !!! note
-    The following strings can be used as kinds: *cronjobs*, *daemonsets*, *deployments*, *jobs*, *pods*, *replicasets*, *statefulsets*, *endpoints*, *horizontalpodautoscalers*, *ingresses*, *networkpolicies*, *services*, *configmaps*, *persistentvolumeclaims*, *persistentvolumes*, *poddisruptionbudgets*, *secrets*, *serviceaccounts*, *storageclasses*, *clusterrolebindings*, *clusterroles*, *rolebindings*, *roles*, *events*, *nodes*, *podsecuritypolicies*.
+    The following strings can be used in the resources list: `cronjobs`, `daemonsets`, `deployments`, `jobs`, `pods`, `replicasets`, `statefulsets`, `endpoints`, `horizontalpodautoscalers`, `ingresses`, `networkpolicies`, `services`, `configmaps`, `persistentvolumeclaims`, `persistentvolumes`, `poddisruptionbudgets`, `secrets`, `serviceaccounts`, `storageclasses`, `clusterrolebindings`, `clusterroles`, `rolebindings`, `roles`, `events`, `nodes`, `podsecuritypolicies`.
 
     A Custom Resource can be specified in the following form `<name>.<group>/<version>` (e.g. `vaultsecrets.ricoberger.de/v1alpha1`).
 

--- a/docs/resources/teams.md
+++ b/docs/resources/teams.md
@@ -100,4 +100,6 @@ spec:
           - "*"
         resources:
           - "*"
+        verbs:
+          - "*"
 ```

--- a/docs/resources/users.md
+++ b/docs/resources/users.md
@@ -53,6 +53,14 @@ In the following you can found the specification for the User CRD.
 | clusters | []string | A list of clusters to allow access to. The special list entry `*` allows access to all clusters. | Yes |
 | namespaces | []string | A list of namespaces to allow access to. The special list entry `*` allows access to all namespaces. | Yes |
 | resources | []string | A list of resources to allow access to. The special list entry `*` allows access to all resources. | Yes |
+| verbs | []string | A list of verbs to allow access to. The following verbs are possible: `get`, `patch`, `post`, `delete` and `*`. The special list entry `*` allows access for all verbs. | Yes |
+
+!!! note
+    The following strings can be used in the resources list: `cronjobs`, `daemonsets`, `deployments`, `jobs`, `pods`, `replicasets`, `statefulsets`, `endpoints`, `horizontalpodautoscalers`, `ingresses`, `networkpolicies`, `services`, `configmaps`, `persistentvolumeclaims`, `persistentvolumes`, `poddisruptionbudgets`, `secrets`, `serviceaccounts`, `storageclasses`, `clusterrolebindings`, `clusterroles`, `rolebindings`, `roles`, `events`, `nodes`, `podsecuritypolicies`.
+
+    The special terms `pods/logs` and `pods/exec` can be used to allow users to get the logs or a terminal for a Pod. To download / upload a file from / to a Pod a user needs the `pods/exec` resource with the `get` / `post` verb.
+
+    A Custom Resource can be specified in the following form `<name>.<group>/<version>` (e.g. `vaultsecrets.ricoberger.de/v1alpha1`).
 
 ## Example
 

--- a/pkg/api/apis/user/v1beta1/types.go
+++ b/pkg/api/apis/user/v1beta1/types.go
@@ -63,4 +63,5 @@ type Resources struct {
 	Clusters   []string `json:"clusters"`
 	Namespaces []string `json:"namespaces"`
 	Resources  []string `json:"resources"`
+	Verbs      []string `json:"verbs"`
 }

--- a/pkg/api/apis/user/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/api/apis/user/v1beta1/zz_generated.deepcopy.go
@@ -106,6 +106,11 @@ func (in *Resources) DeepCopyInto(out *Resources) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Verbs != nil {
+		in, out := &in.Verbs, &out.Verbs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/api/middleware/auth/auth.go
+++ b/pkg/api/middleware/auth/auth.go
@@ -177,7 +177,7 @@ func (a *Auth) Handler(next http.Handler) http.Handler {
 				ID: userID,
 				Permissions: user.Permissions{
 					Plugins:   []user.Plugin{{Name: "*"}},
-					Resources: []user.Resources{{Clusters: []string{"*"}, Namespaces: []string{"*"}, Resources: []string{"*"}}},
+					Resources: []user.Resources{{Clusters: []string{"*"}, Namespaces: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"*"}}},
 				},
 			})
 		}

--- a/pkg/api/middleware/auth/auth_test.go
+++ b/pkg/api/middleware/auth/auth_test.go
@@ -103,7 +103,7 @@ func TestAuthHandler(t *testing.T) {
 			name:                 "auth disabled",
 			auth:                 Auth{enabled: false},
 			expectedStatusCode:   http.StatusOK,
-			expectedBody:         "{\"cluster\":\"\",\"namespace\":\"\",\"name\":\"\",\"id\":\"kobs.io\",\"profile\":{\"fullName\":\"\",\"email\":\"\"},\"teams\":null,\"permissions\":{\"plugins\":[{\"name\":\"*\",\"permissions\":null}],\"resources\":[{\"clusters\":[\"*\"],\"namespaces\":[\"*\"],\"resources\":[\"*\"]}]}}\n",
+			expectedBody:         "{\"cluster\":\"\",\"namespace\":\"\",\"name\":\"\",\"id\":\"kobs.io\",\"profile\":{\"fullName\":\"\",\"email\":\"\"},\"teams\":null,\"permissions\":{\"plugins\":[{\"name\":\"*\",\"permissions\":null}],\"resources\":[{\"clusters\":[\"*\"],\"namespaces\":[\"*\"],\"resources\":[\"*\"],\"verbs\":[\"*\"]}]}}\n",
 			prepareRequest:       func(r *http.Request) {},
 			prepareClusterClient: func(mockClusterClient *cluster.MockClient) {},
 		},

--- a/pkg/api/middleware/auth/context/context.go
+++ b/pkg/api/middleware/auth/context/context.go
@@ -67,7 +67,7 @@ func (u *User) HasNamespaceAccess(cluster, namespace string) bool {
 }
 
 // HasResourceAccess checks if the user has access to the given resource in the given cluster and namespace.
-func (u *User) HasResourceAccess(cluster, namespace, name string) bool {
+func (u *User) HasResourceAccess(cluster, namespace, name, verb string) bool {
 	for _, resource := range u.Permissions.Resources {
 		for _, c := range resource.Clusters {
 			if c == cluster || c == "*" {
@@ -75,7 +75,11 @@ func (u *User) HasResourceAccess(cluster, namespace, name string) bool {
 					if n == namespace || n == "*" {
 						for _, r := range resource.Resources {
 							if r == name || r == "*" {
-								return true
+								for _, v := range resource.Verbs {
+									if v == verb || v == "*" {
+										return true
+									}
+								}
 							}
 						}
 					}

--- a/pkg/api/middleware/auth/context/context_test.go
+++ b/pkg/api/middleware/auth/context/context_test.go
@@ -81,26 +81,30 @@ func TestHasResourceAccess(t *testing.T) {
 		user              User
 		expectedHasAccess bool
 	}{
-		{user: User{ID: "user1", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"*"}, Namespaces: []string{"*"}, Resources: []string{"resource1"}}}}}, expectedHasAccess: true},
-		{user: User{ID: "user2", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"*"}, Namespaces: []string{"namespace1"}, Resources: []string{"resource1"}}}}}, expectedHasAccess: true},
-		{user: User{ID: "user3", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"*"}, Namespaces: []string{"namespace2"}, Resources: []string{"resource1"}}}}}, expectedHasAccess: false},
-		{user: User{ID: "user2", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"*"}, Namespaces: []string{"namespace1"}, Resources: []string{"resource2"}}}}}, expectedHasAccess: false},
+		{user: User{ID: "user1", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"*"}, Namespaces: []string{"*"}, Resources: []string{"resource1"}, Verbs: []string{"get"}}}}}, expectedHasAccess: true},
+		{user: User{ID: "user2", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"*"}, Namespaces: []string{"namespace1"}, Resources: []string{"resource1"}, Verbs: []string{"get"}}}}}, expectedHasAccess: true},
+		{user: User{ID: "user3", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"*"}, Namespaces: []string{"namespace2"}, Resources: []string{"resource1"}, Verbs: []string{"get"}}}}}, expectedHasAccess: false},
+		{user: User{ID: "user2", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"*"}, Namespaces: []string{"namespace1"}, Resources: []string{"resource2"}, Verbs: []string{"get"}}}}}, expectedHasAccess: false},
 
-		{user: User{ID: "user4", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster1"}, Namespaces: []string{"*"}, Resources: []string{"resource1"}}}}}, expectedHasAccess: true},
-		{user: User{ID: "user5", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster1"}, Namespaces: []string{"namespace1"}, Resources: []string{"resource1"}}}}}, expectedHasAccess: true},
-		{user: User{ID: "user6", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster1"}, Namespaces: []string{"namespace2"}, Resources: []string{"resource1"}}}}}, expectedHasAccess: false},
-		{user: User{ID: "user6", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster1"}, Namespaces: []string{"namespace1"}, Resources: []string{"resource2"}}}}}, expectedHasAccess: false},
+		{user: User{ID: "user4", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster1"}, Namespaces: []string{"*"}, Resources: []string{"resource1"}, Verbs: []string{"get"}}}}}, expectedHasAccess: true},
+		{user: User{ID: "user5", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster1"}, Namespaces: []string{"namespace1"}, Resources: []string{"resource1"}, Verbs: []string{"get"}}}}}, expectedHasAccess: true},
+		{user: User{ID: "user6", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster1"}, Namespaces: []string{"namespace2"}, Resources: []string{"resource1"}, Verbs: []string{"get"}}}}}, expectedHasAccess: false},
+		{user: User{ID: "user6", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster1"}, Namespaces: []string{"namespace1"}, Resources: []string{"resource2"}, Verbs: []string{"get"}}}}}, expectedHasAccess: false},
 
-		{user: User{ID: "user7", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster2"}, Namespaces: []string{"*"}, Resources: []string{"resource1"}}}}}, expectedHasAccess: false},
-		{user: User{ID: "user8", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster2"}, Namespaces: []string{"namespace1"}, Resources: []string{"resource1"}}}}}, expectedHasAccess: false},
-		{user: User{ID: "user9", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster2"}, Namespaces: []string{"namespace2"}, Resources: []string{"resource1"}}}}}, expectedHasAccess: false},
+		{user: User{ID: "user7", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster2"}, Namespaces: []string{"*"}, Resources: []string{"resource1"}, Verbs: []string{"get"}}}}}, expectedHasAccess: false},
+		{user: User{ID: "user8", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster2"}, Namespaces: []string{"namespace1"}, Resources: []string{"resource1"}, Verbs: []string{"get"}}}}}, expectedHasAccess: false},
+		{user: User{ID: "user9", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster2"}, Namespaces: []string{"namespace2"}, Resources: []string{"resource1"}, Verbs: []string{"get"}}}}}, expectedHasAccess: false},
 
-		{user: User{ID: "user10", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster2"}, Namespaces: []string{"*"}, Resources: []string{"resource1"}}, {Clusters: []string{"cluster1"}, Namespaces: []string{"*"}, Resources: []string{"resource1"}}}}}, expectedHasAccess: true},
-		{user: User{ID: "user11", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster2"}, Namespaces: []string{"*"}, Resources: []string{"resource1"}}, {Clusters: []string{"cluster1"}, Namespaces: []string{"namespace1"}, Resources: []string{"resource1"}}}}}, expectedHasAccess: true},
-		{user: User{ID: "user12", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster2"}, Namespaces: []string{"*"}, Resources: []string{"resource1"}}, {Clusters: []string{"cluster1"}, Namespaces: []string{"namespace2"}, Resources: []string{"resource1"}}}}}, expectedHasAccess: false},
+		{user: User{ID: "user10", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster2"}, Namespaces: []string{"*"}, Resources: []string{"resource1"}}, {Clusters: []string{"cluster1"}, Namespaces: []string{"*"}, Resources: []string{"resource1"}, Verbs: []string{"get"}}}}}, expectedHasAccess: true},
+		{user: User{ID: "user11", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster2"}, Namespaces: []string{"*"}, Resources: []string{"resource1"}}, {Clusters: []string{"cluster1"}, Namespaces: []string{"namespace1"}, Resources: []string{"resource1"}, Verbs: []string{"get"}}}}}, expectedHasAccess: true},
+		{user: User{ID: "user12", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster2"}, Namespaces: []string{"*"}, Resources: []string{"resource1"}}, {Clusters: []string{"cluster1"}, Namespaces: []string{"namespace2"}, Resources: []string{"resource1"}, Verbs: []string{"get"}}}}}, expectedHasAccess: false},
+
+		{user: User{ID: "user13", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster2"}, Namespaces: []string{"*"}, Resources: []string{"resource1"}}, {Clusters: []string{"cluster1"}, Namespaces: []string{"*"}, Resources: []string{"resource1"}, Verbs: []string{"*"}}}}}, expectedHasAccess: true},
+		{user: User{ID: "user14", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster2"}, Namespaces: []string{"*"}, Resources: []string{"resource1"}}, {Clusters: []string{"cluster1"}, Namespaces: []string{"*"}, Resources: []string{"resource1"}, Verbs: []string{"get"}}}}}, expectedHasAccess: true},
+		{user: User{ID: "user15", Permissions: user.Permissions{Resources: []user.Resources{{Clusters: []string{"cluster2"}, Namespaces: []string{"*"}, Resources: []string{"resource1"}}, {Clusters: []string{"cluster1"}, Namespaces: []string{"*"}, Resources: []string{"resource1"}, Verbs: []string{"patch"}}}}}, expectedHasAccess: false},
 	} {
 		t.Run(tt.user.ID, func(t *testing.T) {
-			actualHasAccess := tt.user.HasResourceAccess("cluster1", "namespace1", "resource1")
+			actualHasAccess := tt.user.HasResourceAccess("cluster1", "namespace1", "resource1", "get")
 			require.Equal(t, tt.expectedHasAccess, actualHasAccess)
 		})
 	}


### PR DESCRIPTION
To define the permissions for a user / team it is now required to also
add a list of allowed "verbs". The list of verbs can have the following
entries: "get", "patch", "post", "delete" and "\*". The special entry "\*"
can be used to allow all verbs for a user.

The verbs can be used to have a better control about what users can do
with kobs. For example with "get" a user may be able to list all
resources, but since he doesn't have the "patch", "post" or "delete"
verb, he can not modify running resources.

We also added two new special entries for the "resources" list. These
are "pods/logs" and "pods/exec" which can be used to control if a user
can get the logs of a Pod or if the user can get a terminal for a Pod.
The "pods/exec" term can also be used to control if a user can download
/ upload a file from / to a Pod together with the "get" / "post" verbs.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
