### PR TITLE
[core] Fix capacity value for PVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#245](https://github.com/kobsio/kobs/pull/245): [klogs] Fix that the returned documents could be out of the selected time range.
 - [#247](https://github.com/kobsio/kobs/pull/247): [azure] Fix documentation about the permission handling.
 - [#274](https://github.com/kobsio/kobs/pull/274): Fix Docker build by setting `CGO_ENABLED=0`.
+- [#280](https://github.com/kobsio/kobs/pull/280): [core] Fix returned capacity value for persistent volumes.
 
 ### Changed
 

--- a/plugins/core/src/utils/resources.tsx
+++ b/plugins/core/src/utils/resources.tsx
@@ -903,7 +903,9 @@ export const resources: IResources = {
         const persistentVolumeList: V1PersistentVolumeList = item.resources;
         for (const persistentVolume of persistentVolumeList.items) {
           const capacity =
-            persistentVolume.spec && persistentVolume.spec.capacity ? persistentVolume.spec.capacity : '';
+            persistentVolume.spec && persistentVolume.spec.capacity && persistentVolume.spec.capacity.storage
+              ? persistentVolume.spec.capacity.storage
+              : '';
           const accessMode =
             persistentVolume.spec && persistentVolume.spec.accessModes
               ? persistentVolume.spec.accessModes.join(', ')


### PR DESCRIPTION
The returned value for the capacity of an persistent volume was an
object instead of a string. This caused a bug which leads to a crash of
the UI. We are now returning a string with the correct capacity of a
persistent volume.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
