### PR TITLE
[helm] Add permission handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#272](https://github.com/kobsio/kobs/pull/272): [helm] Add Helm plugin, to manage Helm releases via kobs.
 - [#273](https://github.com/kobsio/kobs/pull/273): [azure] Add tests for Azure plugin.
 - [#277](https://github.com/kobsio/kobs/pull/277): Support multiple versions for the documentation.
+- [#282](https://github.com/kobsio/kobs/pull/282): [helm] Add permission handling based on clusters, namespaces and the names of Helm releases.
 
 ### Fixed
 

--- a/docs/plugins/azure.md
+++ b/docs/plugins/azure.md
@@ -132,7 +132,6 @@ In the following example each member of `team1@kobs.io` will get access to all A
               - "*"
             verbs:
               - "*"
-        custom:
     ```
 
 ??? note "team2"

--- a/docs/plugins/helm.md
+++ b/docs/plugins/helm.md
@@ -17,6 +17,66 @@ The following options can be used for a panel with the Helm plugin:
 | namespaces |[]string | A list of namespaces for which the Helm releases should be shown. | Yes |
 | name | string | The name of the Helm release for whih the history should be shown, when the type is `releasehistory`. | No |
 
+## Usage
+
+### Permissions
+
+You can define fine grained permissions to access your Helm releases via kobs. The permissions are defined via the `permissions.plugins[].permissions` field of a [User](../resources/users.md) or [Team](../resources/teams.md). The team membership of an user is defined via the values of the `X-Auth-Request-Groups` header.
+
+In the following example each member of `team1@kobs.io` will get access to all Helm releases, while members of `team2@kobs.io` can only view the `kobs` Helm release in the `kobs` namespace and the `prometheus` release in the `monitoring` namespace:
+
+??? note "team1"
+
+    ```yaml
+    ---
+    apiVersion: kobs.io/v1beta1
+    kind: Team
+    metadata:
+      name: team1
+    spec:
+      id: team1@kobs.io
+      permissions:
+        plugins:
+          - name: "*"
+          - name: helm
+            permissions:
+              - clusters:
+                  - "*"
+                namespaces:
+                  - "*"
+                names:
+                  - "*"
+    ```
+
+??? note "team2"
+
+    ```yaml
+    ---
+    apiVersion: kobs.io/v1beta1
+    kind: Team
+    metadata:
+      name: team2
+    spec:
+      id: team2@kobs.io
+      permissions:
+        plugins:
+          - name: "*"
+          - name: helm
+            permissions:
+              - clusters:
+                  - "kobs-demo"
+                namespaces:
+                  - "kobs"
+                names:
+                  - "kobs"
+              - clusters:
+                  - "kobs-demo"
+                namespaces:
+                  - "monitoring"
+                names:
+                  - "prometheus"
+    ```
+
 ## Example
 
 The following dashboards shows all Helm releases from the `kobs` and `monitoring` namespace and the history of the `kobs` and `prometheus-operator` releases.

--- a/plugins/azure/pkg/instance/permissions_test.go
+++ b/plugins/azure/pkg/instance/permissions_test.go
@@ -7,7 +7,7 @@ import (
 	authContext "github.com/kobsio/kobs/pkg/api/middleware/auth/context"
 
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 func TestCheckPermissions(t *testing.T) {
@@ -18,19 +18,19 @@ func TestCheckPermissions(t *testing.T) {
 
 	t.Run("invalid permission format", func(t *testing.T) {
 		instance := instance{permissionsEnabled: true}
-		user := &authContext.User{Permissions: user.Permissions{Plugins: []user.Plugin{{Name: "azure", Permissions: v1.JSON{Raw: []byte(`"resources": "*"`)}}}}}
+		user := &authContext.User{Permissions: user.Permissions{Plugins: []user.Plugin{{Name: "azure", Permissions: apiextensionsv1.JSON{Raw: []byte(`"resources": "*"`)}}}}}
 		require.Error(t, instance.CheckPermissions("azure", user, "", "", ""))
 	})
 
 	t.Run("access forbidden", func(t *testing.T) {
 		instance := instance{permissionsEnabled: true}
-		user := &authContext.User{Permissions: user.Permissions{Plugins: []user.Plugin{{Name: "azure", Permissions: v1.JSON{Raw: []byte(`[{"resources": ["*"], "resourceGroups": ["helloworld"], "verbs": ["*"]}]`)}}}}}
+		user := &authContext.User{Permissions: user.Permissions{Plugins: []user.Plugin{{Name: "azure", Permissions: apiextensionsv1.JSON{Raw: []byte(`[{"resources": ["*"], "resourceGroups": ["helloworld"], "verbs": ["*"]}]`)}}}}}
 		require.Error(t, instance.CheckPermissions("azure", user, "kubernetesservices", "foobar", "get"))
 	})
 
-	t.Run("invalid permission format", func(t *testing.T) {
+	t.Run("access allowed", func(t *testing.T) {
 		instance := instance{permissionsEnabled: true}
-		user := &authContext.User{Permissions: user.Permissions{Plugins: []user.Plugin{{Name: "azure", Permissions: v1.JSON{Raw: []byte(`[{"resources": ["*"], "resourceGroups": ["*"], "verbs": ["*"]}]`)}}}}}
+		user := &authContext.User{Permissions: user.Permissions{Plugins: []user.Plugin{{Name: "azure", Permissions: apiextensionsv1.JSON{Raw: []byte(`[{"resources": ["*"], "resourceGroups": ["*"], "verbs": ["*"]}]`)}}}}}
 		require.NoError(t, instance.CheckPermissions("azure", user, "kubernetesservices", "foobar", "get"))
 	})
 }

--- a/plugins/helm/helm_test.go
+++ b/plugins/helm/helm_test.go
@@ -1,70 +1,126 @@
 package helm
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	user "github.com/kobsio/kobs/pkg/api/apis/user/v1beta1"
 	"github.com/kobsio/kobs/pkg/api/clusters"
 	"github.com/kobsio/kobs/pkg/api/clusters/cluster"
+	authContext "github.com/kobsio/kobs/pkg/api/middleware/auth/context"
 	"github.com/kobsio/kobs/pkg/api/plugins/plugin"
 	"github.com/kobsio/kobs/plugins/helm/pkg/client"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 func TestGetReleases(t *testing.T) {
 	for _, tt := range []struct {
 		name               string
+		config             Config
 		url                string
 		expectedStatusCode int
 		expectedBody       string
 		prepare            func(mockHelmClient *client.MockClient)
+		do                 func(router Router, w *httptest.ResponseRecorder, req *http.Request)
 	}{
 		{
+			name:               "no user context",
+			config:             Config{PermissionsEnabled: false},
+			url:                "/releases",
+			expectedStatusCode: http.StatusUnauthorized,
+			expectedBody:       "{\"error\":\"You are not authorized to get the Helm releases: Unauthorized\"}\n",
+			prepare:            func(mockHelmClient *client.MockClient) {},
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				router.getReleases(w, req)
+			},
+		},
+		{
 			name:               "invalid cluster name",
+			config:             Config{PermissionsEnabled: false},
 			url:                "/releases?cluster=cluster2",
 			expectedStatusCode: http.StatusBadRequest,
 			expectedBody:       "{\"error\":\"Invalid cluster name\"}\n",
 			prepare:            func(mockHelmClient *client.MockClient) {},
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				req = req.WithContext(context.WithValue(req.Context(), authContext.UserKey, authContext.User{}))
+				router.getReleases(w, req)
+			},
 		},
 		{
 			name:               "namespaces nil: could not list helm releases",
+			config:             Config{PermissionsEnabled: false},
 			url:                "/releases?cluster=cluster1",
 			expectedStatusCode: http.StatusBadRequest,
 			expectedBody:       "{\"error\":\"Could not list Helm releases: could not list helm releases\"}\n",
 			prepare: func(mockHelmClient *client.MockClient) {
 				mockHelmClient.On("List", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("could not list helm releases"))
+			},
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				req = req.WithContext(context.WithValue(req.Context(), authContext.UserKey, authContext.User{}))
+				router.getReleases(w, req)
 			},
 		},
 		{
 			name:               "namespaces: could not list helm releases",
+			config:             Config{PermissionsEnabled: false},
 			url:                "/releases?cluster=cluster1&namespace=namespace1",
 			expectedStatusCode: http.StatusBadRequest,
 			expectedBody:       "{\"error\":\"Could not list Helm releases: could not list helm releases\"}\n",
 			prepare: func(mockHelmClient *client.MockClient) {
 				mockHelmClient.On("List", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("could not list helm releases"))
 			},
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				req = req.WithContext(context.WithValue(req.Context(), authContext.UserKey, authContext.User{}))
+				router.getReleases(w, req)
+			},
 		},
 		{
 			name:               "namespaces nil: return releases",
+			config:             Config{PermissionsEnabled: false},
 			url:                "/releases?cluster=cluster1",
 			expectedStatusCode: http.StatusOK,
 			expectedBody:       "[{\"cluster\":\"cluster1\",\"name\":\"kobs\",\"version\":2,\"namespace\":\"kobs\"}]\n",
 			prepare: func(mockHelmClient *client.MockClient) {
 				mockHelmClient.On("List", mock.Anything, mock.Anything).Return([]*client.Release{{Name: "kobs", Namespace: "kobs", Version: 2, Cluster: "cluster1"}}, nil)
 			},
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				req = req.WithContext(context.WithValue(req.Context(), authContext.UserKey, authContext.User{}))
+				router.getReleases(w, req)
+			},
 		},
 		{
 			name:               "namespaces: return releases",
+			config:             Config{PermissionsEnabled: false},
 			url:                "/releases?cluster=cluster1&namespace=namespace1",
 			expectedStatusCode: http.StatusOK,
 			expectedBody:       "[{\"cluster\":\"cluster1\",\"name\":\"kobs\",\"version\":2,\"namespace\":\"kobs\"}]\n",
 			prepare: func(mockHelmClient *client.MockClient) {
 				mockHelmClient.On("List", mock.Anything, mock.Anything).Return([]*client.Release{{Name: "kobs", Namespace: "kobs", Version: 2, Cluster: "cluster1"}}, nil)
+			},
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				req = req.WithContext(context.WithValue(req.Context(), authContext.UserKey, authContext.User{}))
+				router.getReleases(w, req)
+			},
+		},
+		{
+			name:               "return filtered releases",
+			config:             Config{PermissionsEnabled: true},
+			url:                "/releases?cluster=cluster1",
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       "[{\"cluster\":\"cluster1\",\"name\":\"kobs\",\"version\":2,\"namespace\":\"kobs\"}]\n",
+			prepare: func(mockHelmClient *client.MockClient) {
+				mockHelmClient.On("List", mock.Anything, mock.Anything).Return([]*client.Release{{Name: "kobs", Namespace: "kobs", Version: 2, Cluster: "cluster1"}, {Name: "prometheus", Namespace: "monitoring", Version: 1, Cluster: "cluster1"}}, nil)
+			},
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				req = req.WithContext(context.WithValue(req.Context(), authContext.UserKey, authContext.User{Permissions: user.Permissions{Plugins: []user.Plugin{{Name: "helm", Permissions: apiextensionsv1.JSON{Raw: []byte(`[{"clusters": ["*"], "namespaces": ["kobs"], "names": ["*"]}]`)}}}}}))
+				router.getReleases(w, req)
 			},
 		},
 	} {
@@ -87,13 +143,13 @@ func TestGetReleases(t *testing.T) {
 
 			newHelmClient = testNewHelmClient
 
-			router := Router{chi.NewRouter(), mockClustersClient, Config{}}
+			router := Router{chi.NewRouter(), mockClustersClient, tt.config}
 			router.Get("/releases", router.getReleases)
 
 			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
 
 			w := httptest.NewRecorder()
-			router.getReleases(w, req)
+			tt.do(router, w, req)
 
 			require.Equal(t, tt.expectedStatusCode, w.Code)
 			require.Equal(t, tt.expectedBody, string(w.Body.Bytes()))
@@ -104,33 +160,75 @@ func TestGetReleases(t *testing.T) {
 func TestGetRelease(t *testing.T) {
 	for _, tt := range []struct {
 		name               string
+		config             Config
 		url                string
 		expectedStatusCode int
 		expectedBody       string
+		do                 func(router Router, w *httptest.ResponseRecorder, req *http.Request)
 	}{
 		{
+			name:               "no user context",
+			config:             Config{PermissionsEnabled: false},
+			url:                "/release",
+			expectedStatusCode: http.StatusUnauthorized,
+			expectedBody:       "{\"error\":\"You are not authorized to get the Helm release: Unauthorized\"}\n",
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				router.getRelease(w, req)
+			},
+		},
+		{
+			name:               "no permissions",
+			config:             Config{PermissionsEnabled: true},
+			url:                "/release",
+			expectedStatusCode: http.StatusForbidden,
+			expectedBody:       "{\"error\":\"You are not allowed to get the Helm release: access forbidden\"}\n",
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				req = req.WithContext(context.WithValue(req.Context(), authContext.UserKey, authContext.User{}))
+				router.getRelease(w, req)
+			},
+		},
+		{
 			name:               "invalid version",
+			config:             Config{PermissionsEnabled: false},
 			url:                "/release?cluster=cluster2",
 			expectedStatusCode: http.StatusBadRequest,
 			expectedBody:       "{\"error\":\"Could not parse version parameter: strconv.Atoi: parsing \\\"\\\": invalid syntax\"}\n",
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				req = req.WithContext(context.WithValue(req.Context(), authContext.UserKey, authContext.User{}))
+				router.getRelease(w, req)
+			},
 		},
 		{
 			name:               "invalid cluster name",
+			config:             Config{PermissionsEnabled: false},
 			url:                "/release?cluster=cluster2&version=1",
 			expectedStatusCode: http.StatusBadRequest,
 			expectedBody:       "{\"error\":\"Invalid cluster name\"}\n",
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				req = req.WithContext(context.WithValue(req.Context(), authContext.UserKey, authContext.User{}))
+				router.getRelease(w, req)
+			},
 		},
 		{
 			name:               "could not get release",
 			url:                "/release?cluster=cluster1&namespace=namespace2&version=1",
 			expectedStatusCode: http.StatusBadRequest,
 			expectedBody:       "{\"error\":\"Could not get Helm release: could not get helm release\"}\n",
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				req = req.WithContext(context.WithValue(req.Context(), authContext.UserKey, authContext.User{}))
+				router.getRelease(w, req)
+			},
 		},
 		{
 			name:               "return release",
+			config:             Config{PermissionsEnabled: false},
 			url:                "/release?cluster=cluster1&namespace=namespace1&version=1",
 			expectedStatusCode: http.StatusOK,
 			expectedBody:       "{\"cluster\":\"cluster1\",\"name\":\"kobs\",\"version\":1,\"namespace\":\"kobs\"}\n",
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				req = req.WithContext(context.WithValue(req.Context(), authContext.UserKey, authContext.User{}))
+				router.getRelease(w, req)
+			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -153,13 +251,13 @@ func TestGetRelease(t *testing.T) {
 
 			newHelmClient = testNewHelmClient
 
-			router := Router{chi.NewRouter(), mockClustersClient, Config{}}
+			router := Router{chi.NewRouter(), mockClustersClient, tt.config}
 			router.Get("/release", router.getRelease)
 
 			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
 
 			w := httptest.NewRecorder()
-			router.getRelease(w, req)
+			tt.do(router, w, req)
 
 			require.Equal(t, tt.expectedStatusCode, w.Code)
 			require.Equal(t, tt.expectedBody, string(w.Body.Bytes()))
@@ -170,27 +268,65 @@ func TestGetRelease(t *testing.T) {
 func TestGetReleaseHistory(t *testing.T) {
 	for _, tt := range []struct {
 		name               string
+		config             Config
 		url                string
 		expectedStatusCode int
 		expectedBody       string
+		do                 func(router Router, w *httptest.ResponseRecorder, req *http.Request)
 	}{
 		{
+			name:               "no user context",
+			config:             Config{PermissionsEnabled: false},
+			url:                "/release/history",
+			expectedStatusCode: http.StatusUnauthorized,
+			expectedBody:       "{\"error\":\"You are not authorized to get the Helm release history: Unauthorized\"}\n",
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				router.getReleaseHistory(w, req)
+			},
+		},
+		{
+			name:               "no permissions",
+			config:             Config{PermissionsEnabled: true},
+			url:                "/release/history",
+			expectedStatusCode: http.StatusForbidden,
+			expectedBody:       "{\"error\":\"You are not allowed to get the Helm release history: access forbidden\"}\n",
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				req = req.WithContext(context.WithValue(req.Context(), authContext.UserKey, authContext.User{}))
+				router.getReleaseHistory(w, req)
+			},
+		},
+		{
 			name:               "invalid cluster name",
+			config:             Config{PermissionsEnabled: false},
 			url:                "/release/history?cluster=cluster2",
 			expectedStatusCode: http.StatusBadRequest,
 			expectedBody:       "{\"error\":\"Invalid cluster name\"}\n",
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				req = req.WithContext(context.WithValue(req.Context(), authContext.UserKey, authContext.User{}))
+				router.getReleaseHistory(w, req)
+			},
 		},
 		{
 			name:               "could not get release",
+			config:             Config{PermissionsEnabled: false},
 			url:                "/release?cluster=cluster1&namespace=namespace2",
 			expectedStatusCode: http.StatusBadRequest,
 			expectedBody:       "{\"error\":\"Could not get Helm release: could not get helm release history\"}\n",
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				req = req.WithContext(context.WithValue(req.Context(), authContext.UserKey, authContext.User{}))
+				router.getReleaseHistory(w, req)
+			},
 		},
 		{
 			name:               "return release",
+			config:             Config{PermissionsEnabled: false},
 			url:                "/release?cluster=cluster1&namespace=namespace1",
 			expectedStatusCode: http.StatusOK,
 			expectedBody:       "[{\"cluster\":\"cluster1\",\"name\":\"kobs\",\"version\":1,\"namespace\":\"kobs\"},{\"cluster\":\"cluster1\",\"name\":\"kobs\",\"version\":2,\"namespace\":\"kobs\"}]\n",
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				req = req.WithContext(context.WithValue(req.Context(), authContext.UserKey, authContext.User{}))
+				router.getReleaseHistory(w, req)
+			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -213,13 +349,13 @@ func TestGetReleaseHistory(t *testing.T) {
 
 			newHelmClient = testNewHelmClient
 
-			router := Router{chi.NewRouter(), mockClustersClient, Config{}}
+			router := Router{chi.NewRouter(), mockClustersClient, tt.config}
 			router.Get("/release/history", router.getReleaseHistory)
 
 			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
 
 			w := httptest.NewRecorder()
-			router.getReleaseHistory(w, req)
+			tt.do(router, w, req)
 
 			require.Equal(t, tt.expectedStatusCode, w.Code)
 			require.Equal(t, tt.expectedBody, string(w.Body.Bytes()))

--- a/plugins/helm/pkg/permissions/permissions.go
+++ b/plugins/helm/pkg/permissions/permissions.go
@@ -1,0 +1,59 @@
+package permissions
+
+import (
+	"encoding/json"
+	"fmt"
+
+	authContext "github.com/kobsio/kobs/pkg/api/middleware/auth/context"
+)
+
+// Permissions is the structure of the custom permissions field for the Helm plugin.
+type Permissions struct {
+	Clusters   []string `json:"clusters"`
+	Namespaces []string `json:"namespaces"`
+	Names      []string `json:"names"`
+}
+
+// CheckPermissions can be used to check if a user has the permissions to access a helm release in a specific cluster
+// and namespace
+func CheckPermissions(permissionsEnabled bool, user *authContext.User, cluster, namespace, name string) error {
+	if !permissionsEnabled {
+		return nil
+	}
+
+	permissions := user.GetPluginPermissions("helm")
+
+	for _, permission := range permissions {
+		var p []Permissions
+		err := json.Unmarshal(permission, &p)
+		if err != nil {
+			return fmt.Errorf("invalid permission format: %w", err)
+		}
+
+		if hasAccess(cluster, namespace, name, p) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("access forbidden")
+}
+
+func hasAccess(cluster, namespace, name string, permissions []Permissions) bool {
+	for _, p := range permissions {
+		for _, c := range p.Clusters {
+			if c == cluster || c == "*" {
+				for _, n := range p.Namespaces {
+					if n == namespace || n == "*" {
+						for _, n := range p.Names {
+							if n == name || n == "*" {
+								return true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return false
+}

--- a/plugins/helm/pkg/permissions/permissions_test.go
+++ b/plugins/helm/pkg/permissions/permissions_test.go
@@ -1,0 +1,43 @@
+package permissions
+
+import (
+	"testing"
+
+	user "github.com/kobsio/kobs/pkg/api/apis/user/v1beta1"
+	authContext "github.com/kobsio/kobs/pkg/api/middleware/auth/context"
+
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func TestCheckPermissions(t *testing.T) {
+	t.Run("permissions disabled", func(t *testing.T) {
+		require.NoError(t, CheckPermissions(false, nil, "", "", ""))
+	})
+
+	t.Run("invalid permission format", func(t *testing.T) {
+		user := &authContext.User{Permissions: user.Permissions{Plugins: []user.Plugin{{Name: "helm", Permissions: apiextensionsv1.JSON{Raw: []byte(`"clusters": "*"`)}}}}}
+		require.Error(t, CheckPermissions(true, user, "", "", ""))
+	})
+
+	t.Run("access forbidden", func(t *testing.T) {
+		user := &authContext.User{Permissions: user.Permissions{Plugins: []user.Plugin{{Name: "helm", Permissions: apiextensionsv1.JSON{Raw: []byte(`[{"clusters": ["*"], "namespaces": ["namespace2"], "names": ["*"]}]`)}}}}}
+		require.Error(t, CheckPermissions(true, user, "cluster1", "namespace1", "name1"))
+	})
+
+	t.Run("access allowed", func(t *testing.T) {
+		user := &authContext.User{Permissions: user.Permissions{Plugins: []user.Plugin{{Name: "helm", Permissions: apiextensionsv1.JSON{Raw: []byte(`[{"clusters": ["*"], "namespaces": ["*"], "names": ["*"]}]`)}}}}}
+		require.NoError(t, CheckPermissions(true, user, "cluster1", "namespace1", "name1"))
+	})
+}
+
+func TestHasAccess(t *testing.T) {
+	require.Equal(t, true, hasAccess("cluster1", "namespace1", "name1", []Permissions{{Clusters: []string{"*"}, Namespaces: []string{"*"}, Names: []string{"*"}}}))
+	require.Equal(t, true, hasAccess("cluster1", "namespace1", "name1", []Permissions{{Clusters: []string{"*"}, Namespaces: []string{"namespace1"}, Names: []string{"*"}}}))
+	require.Equal(t, true, hasAccess("cluster1", "namespace1", "name1", []Permissions{{Clusters: []string{"cluster1"}, Namespaces: []string{"*"}, Names: []string{"*"}}}))
+	require.Equal(t, true, hasAccess("cluster1", "namespace1", "name1", []Permissions{{Clusters: []string{"*"}, Namespaces: []string{"*"}, Names: []string{"*"}}}))
+
+	require.Equal(t, false, hasAccess("cluster2", "namespace1", "name1", []Permissions{{Clusters: []string{"cluster1"}, Namespaces: []string{"namespace1"}, Names: []string{"name1"}}}))
+	require.Equal(t, false, hasAccess("cluster1", "namespace2", "name1", []Permissions{{Clusters: []string{"cluster1"}, Namespaces: []string{"namespace1"}, Names: []string{"name1"}}}))
+	require.Equal(t, false, hasAccess("cluster1", "namespace1", "name2", []Permissions{{Clusters: []string{"cluster1"}, Namespaces: []string{"namespace1"}, Names: []string{"name1"}}}))
+}


### PR DESCRIPTION
It is now possible to restrict access to Helm releases. For this a user
can set the permissions for the Helm plugin in the User and Team CRs,
where it is possible to restrict access based on the cluster, namespace
and Helm release name.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
