### PR TITLE
[core] Add debug endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#277](https://github.com/kobsio/kobs/pull/277): Support multiple versions for the documentation.
 - [#282](https://github.com/kobsio/kobs/pull/282): [helm] Add permission handling based on clusters, namespaces and the names of Helm releases.
 - [#283](https://github.com/kobsio/kobs/pull/283): [core] Add optional `defaultTime` argument to `getTimeParams` function to overwrite the default time range.
+- [#285](https://github.com/kobsio/kobs/pull/285): [core] Add `/api/debug` endpoints for debugging the API server.
 
 ### Fixed
 

--- a/deploy/helm/kobs/Chart.yaml
+++ b/deploy/helm/kobs/Chart.yaml
@@ -4,5 +4,5 @@ description: Kubernetes Observability Platform
 type: application
 home: https://kobs.io
 icon: https://kobs.io/assets/images/logo.svg
-version: 0.10.0
+version: 0.10.1
 appVersion: v0.7.0

--- a/deploy/helm/kobs/templates/deployment.yaml
+++ b/deploy/helm/kobs/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
           imagePullPolicy: {{ .Values.kobs.image.pullPolicy }}
           args:
             - --development={{ .Values.kobs.settings.development }}
+            - --api.debug={{ .Values.kobs.settings.debug }}
             - --api.auth.enabled={{ .Values.kobs.settings.auth.enabled }}
             - --api.auth.header.teams={{ .Values.kobs.settings.auth.headerTeams }}
             - --api.auth.header.user={{ .Values.kobs.settings.auth.headerUser }}

--- a/deploy/helm/kobs/values.yaml
+++ b/deploy/helm/kobs/values.yaml
@@ -113,6 +113,7 @@ kobs:
   ##
   settings:
     development: false
+    debug: false
     auth:
       enabled: false
       headerTeams: X-Auth-Request-Groups

--- a/docs/configuration/getting-started.md
+++ b/docs/configuration/getting-started.md
@@ -15,6 +15,7 @@ The following command-line arguments and environment variables are available.
 | `--api.auth.header.user string` | `KOBS_API_AUTH_HEADER_USER` | The header, which contains the user id. | `X-Auth-Request-Email` |
 | `--api.auth.session.interval duration` | `KOBS_API_AUTH_SESSION_INTERVAL` | The interval for how long a session is valid. | `48h0m0s` |
 | `--api.auth.session.token string` | `KOBS_API_AUTH_SESSION_TOKEN` | The token to encrypt the session cookie. | |
+| `--api.debug` | | Enable `/api/debug` endpoints for the API server. | `false` |
 | `--app.address` | `KOBS_APP_ADDRESS` | The address, where the Application server is listen on. | `:15219` |
 | `--app.assets` | `KOBS_APP_ASSETS` | The location of the assets directory. | `app/build` |
 | `--clusters.cache-duration.namespaces` | `KOBS_CLUSTERS_CACHE_DURATION_NAMESPACES` | The duration, for how long requests to get the list of namespaces should be cached. | `5m` |

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -67,6 +67,7 @@ helm upgrade --install kobs kobs/kobs
 | `kobs.volumeMounts` | Specify additional volumeMounts for the kobs container. | `[]` |
 | `kobs.env` | Set additional environment variables for the kobs container. | `[]` |
 | `kobs.settings.development` | Run kobs in development mode. | `false` |
+| `kobs.settings.debug` | Enable the `/api/debug` endpoints for the API server. | `false` |
 | `kobs.settings.auth.enabled` | Enable the authentication and authorization middleware. | `false` |
 | `kobs.settings.auth.headerTeams` | The header, which contains the team ids. | `X-Auth-Request-Email` |
 | `kobs.settings.auth.headerUser` | The header, which contains the user id. | `X-Auth-Request-Groups` |

--- a/docs/plugins/azure.md
+++ b/docs/plugins/azure.md
@@ -28,7 +28,7 @@ plugins:
 | name | string | Name of the Azure instance. | Yes |
 | displayName | string | Name of the Azure instance as it is shown in the UI. | Yes |
 | descriptions | string | Description of the Azure instance. | No |
-| permissionsEnabled | boolean | Enable the permission handling. The permissions can be defined via the [PermissionsCustom](../resources/teams.md#permissionscustom) in a team. An example of the permission format can be found in the [usage](#usage) section of this page. | No |
+| permissionsEnabled | boolean | Enable the permission handling. An example of the permission format can be found in the [usage](#usage) section of this page. | No |
 | credentials | [Credentials](#credentials) | The credentials to access the Azure API. | Yes |
 
 ### Credentials

--- a/docs/plugins/helm.md
+++ b/docs/plugins/helm.md
@@ -6,6 +6,20 @@ The Helm plugin can be used to manage Helm releases within kobs.
 
 ![Details](assets/helm-details.png)
 
+## Configuration
+
+The following configuration can be used for the Helm plugin.
+
+```yaml
+plugins:
+  helm:
+    permissionsEnabled: true
+```
+
+| Field | Type | Description | Required |
+| ----- | ---- | ----------- | -------- |
+| permissionsEnabled | boolean | Enable the permission handling. An example of the permission format can be found in the [usage](#usage) section of this page. | No |
+
 ## Options
 
 The following options can be used for a panel with the Helm plugin:

--- a/pkg/api/middleware/auth/auth.go
+++ b/pkg/api/middleware/auth/auth.go
@@ -128,8 +128,10 @@ func (a *Auth) Handler(next http.Handler) http.Handler {
 				}
 
 				http.SetCookie(w, &http.Cookie{
-					Name:  "kobs-auth",
-					Value: token,
+					Name:     "kobs-auth",
+					Value:    token,
+					Secure:   true,
+					HttpOnly: true,
 				})
 				ctx = context.WithValue(ctx, authContext.UserKey, user)
 			} else {
@@ -157,8 +159,10 @@ func (a *Auth) Handler(next http.Handler) http.Handler {
 					}
 
 					http.SetCookie(w, &http.Cookie{
-						Name:  "kobs-auth",
-						Value: token,
+						Name:     "kobs-auth",
+						Value:    token,
+						Secure:   true,
+						HttpOnly: true,
 					})
 					ctx = context.WithValue(ctx, authContext.UserKey, newUser)
 				} else {


### PR DESCRIPTION
The api server exposed some "/api/debug" endpoints now. These endpoints
can be used to get the "http/pprof" information and to dump an http
request. The debug endpoints can be enabled via the "--api.debug" flag.
By default these endpoints are disabled.

We also fixed some typos in the documentation for the Azure and Helm
plugin. In the Azure we had a wrong link for the permissions
documentation and in the Helm plugin the configuration section was
missing.

Besides the changes from above, we also enabled the secure and http only
flag for the cookie, which is created by the auth middleware when
authentication is enabled.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [x] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
