### PR TITLE
[helm] Show warning when no releases were found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#247](https://github.com/kobsio/kobs/pull/247): [azure] Fix documentation about the permission handling.
 - [#274](https://github.com/kobsio/kobs/pull/274): Fix Docker build by setting `CGO_ENABLED=0`.
 - [#280](https://github.com/kobsio/kobs/pull/280): [core] Fix returned capacity value for persistent volumes.
+- [#286](https://github.com/kobsio/kobs/pull/286): [helm] Show warning when no Helm releases were found or the history of an Helm release was not found.
 
 ### Changed
 

--- a/plugins/helm/src/components/panel/History.tsx
+++ b/plugins/helm/src/components/panel/History.tsx
@@ -110,7 +110,25 @@ const History: React.FunctionComponent<IHistoryProps> = ({
   }
 
   if (!data || data.length === 0) {
-    return null;
+    return (
+      <Alert
+        variant={AlertVariant.warning}
+        isInline={true}
+        title="Could not found Helm release history"
+        actionLinks={
+          <React.Fragment>
+            <AlertActionLink onClick={(): Promise<QueryObserverResult<IRelease[], Error>> => refetch()}>
+              Retry
+            </AlertActionLink>
+          </React.Fragment>
+        }
+      >
+        <p>
+          We did not found any history for the sepcified Helm release. It might be that that the Helm release does not
+          exists or that you do not have the permissions to view the history of the Helm release.
+        </p>
+      </Alert>
+    );
   }
 
   return (

--- a/plugins/helm/src/components/panel/Releases.tsx
+++ b/plugins/helm/src/components/panel/Releases.tsx
@@ -111,7 +111,25 @@ const Releases: React.FunctionComponent<IReleasesProps> = ({
   }
 
   if (!data || data.length === 0) {
-    return null;
+    return (
+      <Alert
+        variant={AlertVariant.warning}
+        isInline={true}
+        title="Could not found Helm releases"
+        actionLinks={
+          <React.Fragment>
+            <AlertActionLink onClick={(): Promise<QueryObserverResult<IRelease[], Error>> => refetch()}>
+              Retry
+            </AlertActionLink>
+          </React.Fragment>
+        }
+      >
+        <p>
+          We did not found any Helm releases for the selected cluster / namespace. It might be that there are no Helm
+          releases in the selected cluster / namespace or that you do not have the permissions to view them.
+        </p>
+      </Alert>
+    );
   }
 
   return (


### PR DESCRIPTION
We are now showing a warning when the list of returned Helm releases or
the release history returns an empty list of releases, to indicate that
the user may not have the permissions to view them.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
