### PR TITLE
[resources] Add support to show custom columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#282](https://github.com/kobsio/kobs/pull/282): [helm] Add permission handling based on clusters, namespaces and the names of Helm releases.
 - [#283](https://github.com/kobsio/kobs/pull/283): [core] Add optional `defaultTime` argument to `getTimeParams` function to overwrite the default time range.
 - [#285](https://github.com/kobsio/kobs/pull/285): [core] Add `/api/debug` endpoints for debugging the API server.
+- [#288](https://github.com/kobsio/kobs/pull/288): [resources] Add support to show custom columns for a resource.
 
 ### Fixed
 

--- a/docs/plugins/resources.md
+++ b/docs/plugins/resources.md
@@ -46,12 +46,22 @@ plugins:
 | clusters | []string | A list of clusters. | Yes |
 | namespaces | []string | A list of namespaces. | Yes |
 | resources | []string | A list of resources. | Yes |
-| selector | string | An optional selector for the selection of resources | No |
+| selector | string | An optional selector for the selection of resources. | No |
+| columns | [[]Column](#column) | An optional list of columns to customize the shown fields for a resource. | No |
 
 !!! note
     The following strings can be used in the resources list: `cronjobs`, `daemonsets`, `deployments`, `jobs`, `pods`, `replicasets`, `statefulsets`, `endpoints`, `horizontalpodautoscalers`, `ingresses`, `networkpolicies`, `services`, `configmaps`, `persistentvolumeclaims`, `persistentvolumes`, `poddisruptionbudgets`, `secrets`, `serviceaccounts`, `storageclasses`, `clusterrolebindings`, `clusterroles`, `rolebindings`, `roles`, `events`, `nodes`, `podsecuritypolicies`.
 
     A Custom Resource can be specified in the following form `<name>.<group>/<version>` (e.g. `vaultsecrets.ricoberger.de/v1alpha1`).
+
+### Columns
+
+| Field | Type | Description | Required |
+| ----- | ---- | ----------- | -------- |
+| title | string | A title for the column. | Yes |
+| resource | string | The name of the resource for which the column should be used. | Yes |
+| jsonPath | string | The [JSONPath](https://goessner.net/articles/JsonPath/) which should be used to select the value from the resource manifest file. | Yes |
+| type | string | An optional type for formatting the column values. Currently only `date` is supported as special formatter. | No |
 
 ## Example
 
@@ -76,4 +86,63 @@ spec:
                   - pods
                   - deployments
                 selector: app=reviews
+```
+
+The following dashboard will display all Pods and Deployments from the `bookinfo` namespace. Besides that the dashboard also shows a list of all `VaultSecrets` in the namespace.
+
+The example also uses the `columns` field so that for Pods it will show the image for the `reviews` container and the creation time. For the selected deployments it will show all used images. For the `VaultSecrets` it will show all status fields.
+
+```yaml
+---
+apiVersion: kobs.io/v1
+kind: Dashboard
+spec:
+  rows:
+    - panels:
+        - title: Resources in the bookinfo namespace
+          plugin:
+            name: resources
+            options:
+              - clusters:
+                  - "{% .__cluster %}"
+                namespaces:
+                  - bookinfo
+                resources:
+                  - pods
+                  - deployments
+                selector: app=reviews
+                columns:
+                  - title: Image
+                    resource: pods
+                    jsonPath: "$.spec.containers[?(@.name==='bookinfo')].image"
+                  - title: Creation Time
+                    resource: pods
+                    jsonPath: "$.metadata.creationTimestamp"
+                    type: date
+                  - title: Image
+                    resource: deployments
+                    jsonPath: "$.spec.template.spec.containers[*].image"
+              - clusters:
+                  - "{% .__cluster %}"
+                namespaces:
+                  - bookinfo
+                resources:
+                  - vaultsecrets.ricoberger.de/v1alpha1
+                columns:
+                  - title: Status
+                    resource: vaultsecrets.ricoberger.de/v1alpha1
+                    jsonPath: "$.status.conditions[*].status"
+                  - title: Reason
+                    resource: vaultsecrets.ricoberger.de/v1alpha1
+                    jsonPath: "$.status.conditions[*].reason"
+                  - title: Type
+                    resource: vaultsecrets.ricoberger.de/v1alpha1
+                    jsonPath: "$.status.conditions[*].type"
+                  - title: Message
+                    resource: vaultsecrets.ricoberger.de/v1alpha1
+                    jsonPath: "$.status.conditions[*].message"
+                  - title: Last Transition Time
+                    resource: vaultsecrets.ricoberger.de/v1alpha1
+                    jsonPath: "$.status.conditions[*].lastTransitionTime"
+                    type: date
 ```

--- a/plugins/flux/src/components/page/PageList.tsx
+++ b/plugins/flux/src/components/page/PageList.tsx
@@ -46,7 +46,7 @@ const PageList: React.FunctionComponent<IPageListProps> = ({
         const json = await response.json();
 
         if (response.status >= 200 && response.status < 300) {
-          return resource.rows(json);
+          return resource.rows(json, undefined);
         } else {
           if (json.error) {
             throw new Error(json.error);

--- a/plugins/flux/src/components/panel/PanelList.tsx
+++ b/plugins/flux/src/components/panel/PanelList.tsx
@@ -49,7 +49,7 @@ const PanelList: React.FunctionComponent<IPanelListProps> = ({
         const json = await response.json();
 
         if (response.status >= 200 && response.status < 300) {
-          return resource.rows(json);
+          return resource.rows(json, undefined);
         } else {
           if (json.error) {
             throw new Error(json.error);

--- a/plugins/resources/src/components/panel/Panel.tsx
+++ b/plugins/resources/src/components/panel/Panel.tsx
@@ -20,42 +20,36 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
   times,
   setDetails,
 }: IPanelProps) => {
-  if (!options || !Array.isArray(options) || !times) {
-    return (
-      <PluginOptionsMissing
-        title={title}
-        message="Options for Resources panel are missing or invalid"
-        details="The panel doesn't contain the required options to get resources or the provided options are invalid."
-        documentation="https://kobs.io/plugins/resources"
-      />
-    );
-  }
+  if (options && Array.isArray(options) && options.length > 0 && times) {
+    // When a title is provided we can be sure that the component is used within a dashboard. When no title is provided
+    // the component is used in the resources page and we do not wrap it in the PluginCard component.
+    if (title) {
+      return (
+        <PluginCard
+          title={title}
+          description={description}
+          transparent={true}
+          actions={<PanelActions options={options} />}
+        >
+          <PanelList resources={options} times={times} setDetails={setDetails} />
+        </PluginCard>
+      );
+    }
 
-  // We replace the cluster and namespace in the provided options, when they were not set by the user. For that we are
-  // using the cluster/namespace of the parent team/application where the panel is used.
-  const opts: IPanelOptions[] = options.map((option) => {
-    return {
-      clusters: option.clusters,
-      namespaces: option.namespaces,
-      resources: option.resources,
-      selector: option.selector,
-    };
-  });
-
-  // When a title is provided we can be sure that the component is used within a dashboard. When no title is provided
-  // the component is used in the resources page and we do not wrap it in the PluginCard component.
-  if (title) {
     return (
-      <PluginCard title={title} description={description} transparent={true} actions={<PanelActions options={opts} />}>
-        <PanelList resources={opts} times={times} setDetails={setDetails} />
-      </PluginCard>
+      <Card>
+        <PanelList resources={options} times={times} setDetails={setDetails} />
+      </Card>
     );
   }
 
   return (
-    <Card>
-      <PanelList resources={opts} times={times} setDetails={setDetails} />
-    </Card>
+    <PluginOptionsMissing
+      title={title}
+      message="Options for Resources panel are missing or invalid"
+      details="The panel doesn't contain the required options to get resources or the provided options are invalid."
+      documentation="https://kobs.io/plugins/resources"
+    />
   );
 };
 

--- a/plugins/resources/src/components/panel/PanelList.tsx
+++ b/plugins/resources/src/components/panel/PanelList.tsx
@@ -52,6 +52,7 @@ const PanelList: React.FunctionComponent<IPanelListProps> = ({ resources, times,
                               namespaces={resource.namespaces || []}
                               resource={clustersContext.resources[item]}
                               selector={resource.selector || ''}
+                              columns={resource.columns?.filter((column) => column.resource === item)}
                               times={times}
                               setDetails={setDetails}
                             />

--- a/plugins/resources/src/components/panel/details/Events.tsx
+++ b/plugins/resources/src/components/panel/details/Events.tsx
@@ -28,7 +28,7 @@ const Events: React.FunctionComponent<IEventsProps> = ({ cluster, namespace, nam
 
         if (response.status >= 200 && response.status < 300) {
           if (clustersContext.resources && clustersContext.resources.hasOwnProperty('events')) {
-            return clustersContext.resources.events.rows(json);
+            return clustersContext.resources.events.rows(json, undefined);
           }
         }
 

--- a/plugins/resources/src/components/panel/details/Pods.tsx
+++ b/plugins/resources/src/components/panel/details/Pods.tsx
@@ -29,7 +29,7 @@ const Pods: React.FunctionComponent<IPodsProps> = ({ cluster, namespace, paramNa
 
         if (response.status >= 200 && response.status < 300) {
           if (clustersContext.resources && clustersContext.resources.hasOwnProperty('pods')) {
-            return clustersContext.resources.pods.rows(json);
+            return clustersContext.resources.pods.rows(json, undefined);
           }
         }
 

--- a/plugins/resources/src/utils/interfaces.ts
+++ b/plugins/resources/src/utils/interfaces.ts
@@ -1,6 +1,6 @@
 import { AlertVariant } from '@patternfly/react-core';
 
-import { IPluginTimes } from '@kobsio/plugin-core';
+import { IPluginTimes, IResourceColumn } from '@kobsio/plugin-core';
 
 // IOptions is the interface for the options of the page implementation of the resources.plugin.
 export interface IOptions {
@@ -19,6 +19,7 @@ export interface IPanelOptions {
   namespaces?: string[];
   resources?: string[];
   selector?: string;
+  columns?: IResourceColumn[];
 }
 
 // IMetric is the interface for the response for a metrics request.


### PR DESCRIPTION
It is now possible to customize the columns which should be shown for a
resource via the new "columns" field in the resource panel options.

To show a set of custom columns for a resource, a user can set a lost of
columns. For each column the "title", "resource" and "jsonPath" must be
provided. The "title" is used as header for the column. The "resource"
field is used to apply the custom style only for the specifed resource
in a list of resources. The "jsonPath" field is used to select the value
for the column from the resource manifest file. The optional "type"
field can be used to apply a special formatter for the field value
(currently only "date" is supported as special formatter).

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
