### PR TITLE
Add option to create NetworkPolicy via Helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#283](https://github.com/kobsio/kobs/pull/283): [core] Add optional `defaultTime` argument to `getTimeParams` function to overwrite the default time range.
 - [#285](https://github.com/kobsio/kobs/pull/285): [core] Add `/api/debug` endpoints for debugging the API server.
 - [#288](https://github.com/kobsio/kobs/pull/288): [resources] Add support to show custom columns for a resource.
+- [#289](https://github.com/kobsio/kobs/pull/289): Add an option to create a NetworkPolicy via the Helm chart.
 
 ### Fixed
 

--- a/deploy/helm/kobs/Chart.yaml
+++ b/deploy/helm/kobs/Chart.yaml
@@ -4,5 +4,5 @@ description: Kubernetes Observability Platform
 type: application
 home: https://kobs.io
 icon: https://kobs.io/assets/images/logo.svg
-version: 0.10.1
+version: 0.11.0
 appVersion: v0.7.0

--- a/deploy/helm/kobs/templates/networkpolicy.yaml
+++ b/deploy/helm/kobs/templates/networkpolicy.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.networkPolicy.create -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "kobs.fullname" . }}
+  labels:
+    {{- include "kobs.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "kobs.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    {{- toYaml .Values.networkPolicy.ingressRules | nindent 4 }}
+  egress:
+    {{- toYaml .Values.networkPolicy.egressRules | nindent 4 }}
+{{- end }}

--- a/deploy/helm/kobs/values.yaml
+++ b/deploy/helm/kobs/values.yaml
@@ -176,8 +176,9 @@ serviceAccount:
 ##
 rbac:
   create: true
-  # The name of the cluster role and cluster role binding to use.
-  # If not set and create is true, a name is generated using the fullname template.
+  ## The name of the cluster role and cluster role binding to use.
+  ## If not set and create is true, a name is generated using the fullname template.
+  ##
   name:
 
 ## Set the type for the created service: ClusterIP, NodePort, LoadBalancer.
@@ -188,6 +189,46 @@ service:
 
   annotations: {}
   labels: {}
+
+## Create a NetworkPolicy for kobs. To use network policies you must be using a networking solution which supports
+## NetworkPolicy.
+## See: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+##
+networkPolicy:
+  create: false
+  ## A list of ingress rules, to allow / deny traffic to kobs. By default all ingress traffic is allowed.
+  ##
+  ingressRules:
+    - {}
+    ## The following example allows only ingress traffic from the Istio Ingressgateway, which is running in the
+    ## istio-system namespace and from Prometheus which is running in the monitoring namespace.
+    ##
+    # - from:
+    #     - namespaceSelector:
+    #         matchLabels:
+    #           namespace: istio-system
+    #       podSelector:
+    #         matchLabels:
+    #           app: istio-ingressgateway
+    #   ports:
+    #     - protocol: TCP
+    #       port: 15219
+    #     - protocol: TCP
+    #       port: 15220
+    # - from:
+    #     - namespaceSelector:
+    #         matchLabels:
+    #           namespace: monitoring
+    #       podSelector:
+    #         matchLabels:
+    #           app.kubernetes.io/name: prometheus
+    #   ports:
+    #     - protocol: TCP
+    #       port: 15221
+  ## A list of egress rules, to allow / deny traffic from kobs. By default all egress traffic is allowed.
+  ##
+  egressRules:
+    - {}
 
 ## Create an Ingress to expose kobs.
 ## See: https://kubernetes.io/docs/concepts/services-networking/ingress/

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -89,6 +89,9 @@ helm upgrade --install kobs kobs/kobs
 | `service.type` | Set the type for the created Service: `ClusterIP`, `NodePort`, `LoadBalancer`. | `ClusterIP` |
 | `service.annotations` | Specify additional annotations for the created Service. | `{}` |
 | `service.labels` | Specify additional labels for the created Service. | `{}` |
+| `networkPolicy.create` | Enable the creation of a NetworkPolicy for kobs. | `false` |
+| `networkPolicy.ingressRules` | Ingress rules to allow / deny traffic from. | `[{}]` |
+| `networkPolicy.egressRules` | Egress rules to allow / deny traffic to. | `[{}]` |
 | `ingress.enabled` | Create an Ingress to expose kobs. | `false` |
 | `ingress.annotations` | Annotations to add to the ingress. | `{}` |
 | `ingress.hosts` | Hosts to use for the ingress. | `[]` |


### PR DESCRIPTION
It is now possible to create a NetworkPolicy via the Helm chart, to
allow / deny traffic from / to kobs. By default no NetworkPolicy is
created. The default ingress and egress rule allows all traffic from and
to kobs.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [x] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
