### PR TITLE
Rename "create" to "enabled" in the Helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#281](https://github.com/kobsio/kobs/pull/281): [helm] Remove `helm.sh/helm/v3` package and use a custom implementation to get Helm releases.
 - [#284](https://github.com/kobsio/kobs/pull/284): [core] :warning: _Breaking change:_ :warning: Update CRD versions from `v1beta1` to `v1`.
 - [#287](https://github.com/kobsio/kobs/pull/287): [resources] :warning: _Breaking change:_ :warning: Refactor permission handling for `pods/logs`, `pods/exec` and the global forbidden resources configuration.
+- [#290](https://github.com/kobsio/kobs/pull/290): :warning: _Breaking change:_ :warning: Rename `create` values to `enabled` in the Helm chart.
 
 ## [v0.7.0](https://github.com/kobsio/kobs/releases/tag/v0.7.0) (2021-11-19)
 

--- a/deploy/helm/kobs/Chart.yaml
+++ b/deploy/helm/kobs/Chart.yaml
@@ -4,5 +4,5 @@ description: Kubernetes Observability Platform
 type: application
 home: https://kobs.io
 icon: https://kobs.io/assets/images/logo.svg
-version: 0.11.0
+version: 0.12.0
 appVersion: v0.7.0

--- a/deploy/helm/kobs/templates/_helpers.tpl
+++ b/deploy/helm/kobs/templates/_helpers.tpl
@@ -55,7 +55,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "kobs.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.enabled -}}
     {{ default (include "kobs.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}
@@ -66,7 +66,7 @@ Create the name of the service account to use
 Create the name of the cluster role and cluster role binding to use
 */}}
 {{- define "kobs.rbacName" -}}
-{{- if .Values.rbac.create -}}
+{{- if .Values.rbac.enabled -}}
     {{ default (include "kobs.fullname" .) .Values.rbac.name }}
 {{- else -}}
     {{ default "default" .Values.rbac.name }}

--- a/deploy/helm/kobs/templates/clusterrole.yaml
+++ b/deploy/helm/kobs/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if .Values.rbac.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/deploy/helm/kobs/templates/clusterrolebinding.yaml
+++ b/deploy/helm/kobs/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if .Values.rbac.enabled -}}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/deploy/helm/kobs/templates/networkpolicy.yaml
+++ b/deploy/helm/kobs/templates/networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.networkPolicy.create -}}
+{{- if .Values.networkPolicy.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/deploy/helm/kobs/templates/serviceaccount.yaml
+++ b/deploy/helm/kobs/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deploy/helm/kobs/templates/virtualservice.yaml
+++ b/deploy/helm/kobs/templates/virtualservice.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.istio.virtualService.create -}}
+{{- if .Values.istio.virtualService.enabled -}}
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:

--- a/deploy/helm/kobs/values.yaml
+++ b/deploy/helm/kobs/values.yaml
@@ -140,7 +140,7 @@ istio:
   ## of gateways and hosts for the VirtualService.
   ##
   virtualService:
-    create: false
+    enabled: false
 
     gateways: []
       # - gateway
@@ -159,7 +159,7 @@ istio:
 ## See: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 ##
 serviceAccount:
-  create: true
+  enabled: true
 
   ## Annotations to add to the service account
   ##
@@ -175,7 +175,7 @@ serviceAccount:
 ## See: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 ##
 rbac:
-  create: true
+  enabled: true
   ## The name of the cluster role and cluster role binding to use.
   ## If not set and create is true, a name is generated using the fullname template.
   ##
@@ -195,7 +195,7 @@ service:
 ## See: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 ##
 networkPolicy:
-  create: false
+  enabled: false
   ## A list of ingress rules, to allow / deny traffic to kobs. By default all ingress traffic is allowed.
   ##
   ingressRules:

--- a/docs/configuration/authentication.md
+++ b/docs/configuration/authentication.md
@@ -247,7 +247,7 @@ Now we have to adjust the `istio` section in the kobs Helm chart. In contrast to
 ```yaml
 istio:
   virtualService:
-    create: true
+    enabled: true
     gateways:
       - istio-system/istio-default-gateway
     hosts:

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -76,20 +76,20 @@ helm upgrade --install kobs kobs/kobs
 | `kobs.settings.logFormat` | Set the output format of the logs. Must be `console` or `json`. | `console` |
 | `kobs.settings.logLevel` | Set the log level. Must be `debug`, `info`, `warn`, `error`, `fatal` or `panic`. | `info` |
 | `kobs.config` | Content of the `config.yaml` file, which is loaded during the start of kobs and contains the configuration. | |
-| `istio.virtualService.create` | Specifies whether a VirtualService should be created. | `false` |
+| `istio.virtualService.enabled` | Specifies whether a VirtualService should be created. | `false` |
 | `istio.virtualService.gateways` | A list of gateways for the VirtualService. | `[]` |
 | `istio.virtualService.hosts` | A list of hosts for the VirtualService. | `[]` |
 | `istio.virtualService.timeout` | Timeout for gRPC requests. | `300s` |
 | `istio.virtualService.additionalRoutes` | A list of additional routes for the VirtualService. | `[]` |
-| `serviceAccount.create` | Specifies whether a service account should be created. | `true` |
+| `serviceAccount.enabled` | Specifies whether a service account should be created. | `true` |
 | `serviceAccount.annotations` | Annotations to add to the service account. | `{}` |
 | `serviceAccount.name` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template | `""` |
-| `rbac.create` | Specifies whether a cluster role and cluster role binding should be created. | `true` |
+| `rbac.enabled` | Specifies whether a cluster role and cluster role binding should be created. | `true` |
 | `rbac.name` | The name of the cluster role and cluster role binding to use. If not set and create is true, a name is generated using the fullname template. | `""` |
 | `service.type` | Set the type for the created Service: `ClusterIP`, `NodePort`, `LoadBalancer`. | `ClusterIP` |
 | `service.annotations` | Specify additional annotations for the created Service. | `{}` |
 | `service.labels` | Specify additional labels for the created Service. | `{}` |
-| `networkPolicy.create` | Enable the creation of a NetworkPolicy for kobs. | `false` |
+| `networkPolicy.enabled` | Enable the creation of a NetworkPolicy for kobs. | `false` |
 | `networkPolicy.ingressRules` | Ingress rules to allow / deny traffic from. | `[{}]` |
 | `networkPolicy.egressRules` | Egress rules to allow / deny traffic to. | `[{}]` |
 | `ingress.enabled` | Create an Ingress to expose kobs. | `false` |


### PR DESCRIPTION
We renamed all "create" values to "enabled" in the Helm chart. This was
done because in some places we were using "create" and in other places
we were using "enabled" to create a resource via the Helm chart. Now we
are only using "enabled".

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [x] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
