### PR TITLE
[resources] Fix shown conditions in details view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#274](https://github.com/kobsio/kobs/pull/274): Fix Docker build by setting `CGO_ENABLED=0`.
 - [#280](https://github.com/kobsio/kobs/pull/280): [core] Fix returned capacity value for persistent volumes.
 - [#286](https://github.com/kobsio/kobs/pull/286): [helm] Show warning when no Helm releases were found or the history of an Helm release was not found.
+- [#292](https://github.com/kobsio/kobs/pull/292): [resources] Fix shown conditions in details view.
 
 ### Changed
 

--- a/plugins/flux/src/components/panel/details/Conditions.tsx
+++ b/plugins/flux/src/components/panel/details/Conditions.tsx
@@ -24,16 +24,14 @@ const Conditions: React.FunctionComponent<IConditionsProps> = ({ conditions }: I
 
           <Tbody>
             {conditions
-              ? conditions
-                  .filter((condition) => condition.status === 'True')
-                  .map((condition, index) => (
-                    <Tr key={index}>
-                      <Td dataLabel="Type">{condition.type}</Td>
-                      <Td dataLabel="Status">{condition.status}</Td>
-                      <Td dataLabel="Reason">{condition.reason}</Td>
-                      <Td dataLabel="Message">{condition.message}</Td>
-                    </Tr>
-                  ))
+              ? conditions.map((condition, index) => (
+                  <Tr key={index}>
+                    <Td dataLabel="Type">{condition.type}</Td>
+                    <Td dataLabel="Status">{condition.status}</Td>
+                    <Td dataLabel="Reason">{condition.reason}</Td>
+                    <Td dataLabel="Message">{condition.message}</Td>
+                  </Tr>
+                ))
               : null}
           </Tbody>
         </TableComposable>

--- a/plugins/resources/src/components/panel/details/Overview.tsx
+++ b/plugins/resources/src/components/panel/details/Overview.tsx
@@ -31,7 +31,10 @@ const Overview: React.FunctionComponent<IOverviewProps> = ({ request, resource }
   // additions contains a React component with additional details for a resource. The default component just renders the
   // conditions of a resource.
   let additions =
-    resource.props && resource.props.status && resource.props.status.conditions ? (
+    resource.props &&
+    resource.props.status &&
+    resource.props.status.conditions &&
+    Array.isArray(resource.props.status.conditions) ? (
       <Conditions conditions={resource.props.status.conditions} />
     ) : null;
 

--- a/plugins/resources/src/components/panel/details/overview/Conditions.tsx
+++ b/plugins/resources/src/components/panel/details/overview/Conditions.tsx
@@ -1,5 +1,6 @@
 import { DescriptionListDescription, DescriptionListGroup, DescriptionListTerm, Tooltip } from '@patternfly/react-core';
 import {
+  V1Condition,
   V1DeploymentCondition,
   V1JobCondition,
   V1NodeCondition,
@@ -11,7 +12,10 @@ import {
 } from '@kubernetes/client-node';
 import React from 'react';
 
+import { formatTime } from '@kobsio/plugin-core';
+
 export type TCondition =
+  | V1Condition
   | V1DeploymentCondition
   | V1JobCondition
   | V1NodeCondition
@@ -30,27 +34,30 @@ const Conditions: React.FunctionComponent<IConditionsProps> = ({ conditions }: I
     <DescriptionListGroup>
       <DescriptionListTerm>Conditions</DescriptionListTerm>
       <DescriptionListDescription>
-        {conditions.map(
-          (condition, index) =>
-            condition.status === 'True' && (
-              <Tooltip
-                key={index}
-                content={
-                  <div>
-                    {condition.lastTransitionTime}
-                    {condition.reason ? ` - ${condition.reason}` : ''}
-                    {condition.message ? <div>{condition.message}</div> : ''}
-                  </div>
-                }
-              >
-                <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
-                  <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
-                    {condition.type}
-                  </span>
-                </div>
-              </Tooltip>
-            ),
-        )}
+        {conditions.map((condition, index) => (
+          <Tooltip
+            key={index}
+            content={
+              <div>
+                {condition.lastTransitionTime
+                  ? formatTime(Math.floor(new Date(condition.lastTransitionTime).getTime() / 1000))
+                  : 'Last Transition Time not found'}
+                {condition.reason ? ` - ${condition.reason}` : ''}
+                {condition.message ? <div>{condition.message}</div> : ''}
+              </div>
+            }
+          >
+            <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
+              <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>
+                {condition.status === 'True' ? (
+                  <span>{condition.type}</span>
+                ) : (
+                  <span style={{ textDecoration: 'line-through' }}>{condition.type}</span>
+                )}
+              </span>
+            </div>
+          </Tooltip>
+        ))}
       </DescriptionListDescription>
     </DescriptionListGroup>
   );

--- a/plugins/resources/src/components/panel/details/overview/Node.tsx
+++ b/plugins/resources/src/components/panel/details/overview/Node.tsx
@@ -5,6 +5,7 @@ import { Title } from '@patternfly/react-core';
 import { useQuery } from 'react-query';
 
 import { IMetric, IMetricUsage } from '../../../../utils/interfaces';
+import Conditions from './Conditions';
 import NodeChart from './NodeChart';
 import { formatResourceValue } from '../../../../utils/helpers';
 
@@ -161,6 +162,7 @@ const Node: React.FunctionComponent<INodeProps> = ({ cluster, namespace, name, n
 
   return (
     <React.Fragment>
+      {node.status?.conditions && <Conditions conditions={node.status.conditions} />}
       <Title headingLevel="h4" size="lg">
         CPU
       </Title>


### PR DESCRIPTION
The conditions where not shown correctly in the details view of a
resource. This happend because we filtered the conditions by the status
field when this was set to "True". We now do not filter the conditions
and instead strike through conditions which are not "True" to show them
all.

Besides that the node conditions were missing, which is now fixed and
the same fix was applied for the Flux plugin.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
