### PR TITLE
[azure] Allow custom value for tail and timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#287](https://github.com/kobsio/kobs/pull/287): [resources] :warning: _Breaking change:_ :warning: Refactor permission handling for `pods/logs`, `pods/exec` and the global forbidden resources configuration.
 - [#290](https://github.com/kobsio/kobs/pull/290): :warning: _Breaking change:_ :warning: Rename `create` values to `enabled` in the Helm chart.
 - [#291](https://github.com/kobsio/kobs/pull/291): [klogs] Show link to aggragations and documentation in dropdown.
+- [#293](https://github.com/kobsio/kobs/pull/293): [azure] It is now possible to set a custom value for the number of logs lines which should be shown and if the timestamps should be shown for the logs of a container.
 
 ## [v0.7.0](https://github.com/kobsio/kobs/releases/tag/v0.7.0) (2021-11-19)
 

--- a/docs/plugins/azure.md
+++ b/docs/plugins/azure.md
@@ -63,6 +63,8 @@ The following options can be used for a panel with the Azure plugin:
 | containers | string[] | A list of container names. This is only required if the type is `logs`. | No |
 | metricNames | string | The name of the metric for which the data should be displayed. Supported values are `CPUUsage`, `MemoryUsage`, `NetworkBytesReceivedPerSecond` and `NetworkBytesTransmittedPerSecond`. This is only required if the type is `metrics`. | No |
 | aggregationType | string | The aggregation type for the metric. Supported values are `Average`, `Minimum`, `Maximum`, `Total` and `Count`. This is only required if the type is `metrics`. | No |
+| tail | number | The number of log lines which should be shown. This is only required if the type is `logs`. The default value is `10000`. | No |
+| timestamps | boolean | Show timestamps infront of the log lines. This is only required if the type is `logs`. The default value is `false`. | No |
 
 ### Cost Management
 

--- a/plugins/azure/containerinstances_test.go
+++ b/plugins/azure/containerinstances_test.go
@@ -385,9 +385,34 @@ func TestGetContainerLogs(t *testing.T) {
 				router.getContainerLogs(w, req)
 			},
 		},
+
+		{
+			name:               "invalid tail parameter",
+			url:                "/azure/containerinstances/containergroup/logs",
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBody:       "{\"error\":\"Could not parse tail: strconv.ParseInt: parsing \\\"\\\": invalid syntax\"}\n",
+			prepare: func(mockClient *containerinstances.MockClient, mockInstance *instance.MockInstance) {
+				mockInstance.On("GetName").Return("azure")
+			},
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				router.getContainerLogs(w, req)
+			},
+		},
+		{
+			name:               "invalid timestamps paramter",
+			url:                "/azure/containerinstances/containergroup/logs?tail=10000",
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBody:       "{\"error\":\"Could not parse timestamps: strconv.ParseBool: parsing \\\"\\\": invalid syntax\"}\n",
+			prepare: func(mockClient *containerinstances.MockClient, mockInstance *instance.MockInstance) {
+				mockInstance.On("GetName").Return("azure")
+			},
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				router.getContainerLogs(w, req)
+			},
+		},
 		{
 			name:               "no user context",
-			url:                "/azure/containerinstances/containergroup/logs",
+			url:                "/azure/containerinstances/containergroup/logs?tail=10000&timestamps=false",
 			expectedStatusCode: http.StatusUnauthorized,
 			expectedBody:       "{\"error\":\"You are not authorized to get container logs: Unauthorized\"}\n",
 			prepare: func(mockClient *containerinstances.MockClient, mockInstance *instance.MockInstance) {
@@ -399,7 +424,7 @@ func TestGetContainerLogs(t *testing.T) {
 		},
 		{
 			name:               "check permissions fails",
-			url:                "/azure/containerinstances/containergroup/logs",
+			url:                "/azure/containerinstances/containergroup/logs?tail=10000&timestamps=false",
 			expectedStatusCode: http.StatusForbidden,
 			expectedBody:       "{\"error\":\"You are not allowed to get the logs of the container instance: access forbidden\"}\n",
 			prepare: func(mockClient *containerinstances.MockClient, mockInstance *instance.MockInstance) {
@@ -413,7 +438,7 @@ func TestGetContainerLogs(t *testing.T) {
 		},
 		{
 			name:               "get container logs fails",
-			url:                "/azure/containerinstances/containergroup/logs",
+			url:                "/azure/containerinstances/containergroup/logs?tail=10000&timestamps=false",
 			expectedStatusCode: http.StatusInternalServerError,
 			expectedBody:       "{\"error\":\"Could not get container logs: could not get container logs\"}\n",
 			prepare: func(mockClient *containerinstances.MockClient, mockInstance *instance.MockInstance) {
@@ -430,7 +455,7 @@ func TestGetContainerLogs(t *testing.T) {
 		},
 		{
 			name:               "get container logs",
-			url:                "/azure/containerinstances/containergroup/logs",
+			url:                "/azure/containerinstances/containergroup/logs?tail=10000&timestamps=false",
 			expectedStatusCode: http.StatusOK,
 			expectedBody:       "{\"logs\":\"log line\"}\n",
 			prepare: func(mockClient *containerinstances.MockClient, mockInstance *instance.MockInstance) {

--- a/plugins/azure/costmanagement_test.go
+++ b/plugins/azure/costmanagement_test.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -10,7 +11,9 @@ import (
 	"github.com/kobsio/kobs/plugins/azure/pkg/instance"
 	"github.com/kobsio/kobs/plugins/azure/pkg/instance/costmanagement"
 
+	azureCostmanagement "github.com/Azure/azure-sdk-for-go/services/costmanagement/mgmt/2019-11-01/costmanagement"
 	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -59,23 +62,36 @@ func TestGetActualCosts(t *testing.T) {
 				router.getActualCosts(w, req)
 			},
 		},
-		// TODO: Fix the test, currently this panics with the following error:
-		//   panic: interface conversion: *costmanagement.MockClient is not costmanagement.Client: missing method GetActualCost
-		// {
-		// 	name:               "could not get actual costs",
-		// 	url:                "/azure/costmanagement/actualcosts?timeStart=1&timeEnd=1",
-		// 	expectedStatusCode: http.StatusBadRequest,
-		// 	expectedBody:       "{\"error\":\"Could not find instance name\"}\n",
-		// 	prepare: func(mockClient *costmanagement.MockClient, mockInstance *instance.MockInstance) {
-		// 		mockClient.On("GetActualCost", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("could not get costs"))
+		{
+			name:               "could not get actual costs",
+			url:                "/azure/costmanagement/actualcosts?timeStart=1&timeEnd=1",
+			expectedStatusCode: http.StatusInternalServerError,
+			expectedBody:       "{\"error\":\"Could not query cost usage: could not get costs\"}\n",
+			prepare: func(mockClient *costmanagement.MockClient, mockInstance *instance.MockInstance) {
+				mockClient.On("GetActualCost", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(azureCostmanagement.QueryResult{}, fmt.Errorf("could not get costs"))
 
-		// 		mockInstance.On("GetName").Return("azure")
-		// 		mockInstance.On("CostManagementClient").Return(mockClient)
-		// 	},
-		// 	do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
-		// 		router.getActualCosts(w, req)
-		// 	},
-		// },
+				mockInstance.On("GetName").Return("azure")
+				mockInstance.On("CostManagementClient").Return(mockClient)
+			},
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				router.getActualCosts(w, req)
+			},
+		},
+		{
+			name:               "get actual costs",
+			url:                "/azure/costmanagement/actualcosts?timeStart=1&timeEnd=1",
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       "{}\n",
+			prepare: func(mockClient *costmanagement.MockClient, mockInstance *instance.MockInstance) {
+				mockClient.On("GetActualCost", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(azureCostmanagement.QueryResult{}, nil)
+
+				mockInstance.On("GetName").Return("azure")
+				mockInstance.On("CostManagementClient").Return(mockClient)
+			},
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				router.getActualCosts(w, req)
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			mockClient := &costmanagement.MockClient{}

--- a/plugins/azure/pkg/instance/costmanagement/costmanagement_mock.go
+++ b/plugins/azure/pkg/instance/costmanagement/costmanagement_mock.go
@@ -5,7 +5,8 @@ package costmanagement
 import (
 	context "context"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/costmanagement/mgmt/costmanagement"
+	"github.com/Azure/azure-sdk-for-go/services/costmanagement/mgmt/2019-11-01/costmanagement"
+
 	mock "github.com/stretchr/testify/mock"
 )
 

--- a/plugins/azure/pkg/instance/instance.go
+++ b/plugins/azure/pkg/instance/instance.go
@@ -81,7 +81,7 @@ func (i *instance) MonitorClient() monitor.Client {
 	return i.monitorClient
 }
 
-// New returns a new Elasticsearch instance for the given configuration.
+// New returns a new Azure instance for the given configuration.
 func New(config Config) (Instance, error) {
 	credentials, err := azidentity.NewClientSecretCredential(config.Credentials.TenantID, config.Credentials.ClientID, config.Credentials.ClientSecret, nil)
 	if err != nil {

--- a/plugins/azure/src/components/containerinstances/Details.tsx
+++ b/plugins/azure/src/components/containerinstances/Details.tsx
@@ -86,6 +86,8 @@ const Details: React.FunctionComponent<IDetailsProps> = ({
                       resourceGroup={resourceGroup}
                       containerGroup={containerGroup}
                       containers={containers}
+                      tail={10000}
+                      timestamps={false}
                     />
                   </CardBody>
                 </Card>

--- a/plugins/azure/src/components/containerinstances/DetailsLogs.tsx
+++ b/plugins/azure/src/components/containerinstances/DetailsLogs.tsx
@@ -19,6 +19,8 @@ interface IDetailsLogsProps {
   resourceGroup: string;
   containerGroup: string;
   containers: string[];
+  tail: number;
+  timestamps: boolean;
 }
 
 const DetailsLogs: React.FunctionComponent<IDetailsLogsProps> = ({
@@ -26,6 +28,8 @@ const DetailsLogs: React.FunctionComponent<IDetailsLogsProps> = ({
   resourceGroup,
   containerGroup,
   containers,
+  tail,
+  timestamps,
 }: IDetailsLogsProps) => {
   const [container, setContainer] = useState<string>(containers.length > 0 ? containers[0] : '');
   const [showSelect, setShowSelect] = useState<boolean>(false);
@@ -33,12 +37,12 @@ const DetailsLogs: React.FunctionComponent<IDetailsLogsProps> = ({
   const wrapperSize = useDimensions(refWrapper);
 
   const { isError, isLoading, error, data, refetch } = useQuery<IContainerLogs, Error>(
-    ['azure/containergroups/containergroup/logs', name, resourceGroup, containerGroup, container],
+    ['azure/containergroups/containergroup/logs', name, resourceGroup, containerGroup, container, tail, timestamps],
     async () => {
       try {
         if (container !== '') {
           const response = await fetch(
-            `/api/plugins/azure/${name}/containerinstances/containergroup/logs?resourceGroup=${resourceGroup}&containerGroup=${containerGroup}&container=${container}`,
+            `/api/plugins/azure/${name}/containerinstances/containergroup/logs?resourceGroup=${resourceGroup}&containerGroup=${containerGroup}&container=${container}&tail=${tail}&timestamps=${timestamps}`,
             {
               method: 'get',
             },
@@ -61,6 +65,11 @@ const DetailsLogs: React.FunctionComponent<IDetailsLogsProps> = ({
     },
   );
 
+  const selectContainer = (value: string): void => {
+    setContainer(value);
+    setShowSelect(false);
+  };
+
   return (
     <div style={{ height: '100%', maxWidth: '100%', overflow: 'scroll' }} ref={refWrapper}>
       <Select
@@ -68,7 +77,7 @@ const DetailsLogs: React.FunctionComponent<IDetailsLogsProps> = ({
         typeAheadAriaLabel="Select container"
         placeholderText="Select container"
         onToggle={(): void => setShowSelect(!showSelect)}
-        onSelect={(e, value): void => setContainer(value as string)}
+        onSelect={(e, value): void => selectContainer(value as string)}
         selections={container}
         isOpen={showSelect}
       >

--- a/plugins/azure/src/components/panel/Panel.tsx
+++ b/plugins/azure/src/components/panel/Panel.tsx
@@ -102,6 +102,8 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
           resourceGroup={options.containerinstances.resourceGroup}
           containerGroup={options.containerinstances.containerGroup}
           containers={options.containerinstances.containers}
+          tail={options.containerinstances.tail || 10000}
+          timestamps={options.containerinstances.timestamps || false}
         />
       </PluginCard>
     );

--- a/plugins/azure/src/utils/interfaces.ts
+++ b/plugins/azure/src/utils/interfaces.ts
@@ -9,6 +9,8 @@ export interface IPanelOptions {
     containers?: string[];
     metricNames?: string;
     aggregationType?: string;
+    tail?: number;
+    timestamps?: boolean;
   };
   costmanagement?: {
     type?: string;


### PR DESCRIPTION
It is now possible to set custom values for the tail and timestamps
paramter in the container instances panel. When a user wants to show the
logs of an container from a container group in a dashboard panel it is
now possible to set custom values for the "tail" and "timestamps"
paramter.

The "tail" paramter can be used to set the number of log lines which
should be shown (default "10000"). The "timestamps" paramter can be used
to show a timestamp infront of every log line (default "false").

We also fixed two bugs:

- When a user selected a container in logs tab, the select box wasn't
  closed. This is now fixed and after the user selects a container the
  options are not shown anymore.
- The second fix is in the mock client for the cost management
  integration, were the wrong version of the "costmanagement" package
  was used. With this fix we also added the missing tests for the cost
  management routes.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
