### PR TITLE
Improve shutdown of kobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#290](https://github.com/kobsio/kobs/pull/290): :warning: _Breaking change:_ :warning: Rename `create` values to `enabled` in the Helm chart.
 - [#291](https://github.com/kobsio/kobs/pull/291): [klogs] Show link to aggragations and documentation in dropdown.
 - [#293](https://github.com/kobsio/kobs/pull/293): [azure] It is now possible to set a custom value for the number of logs lines which should be shown and if the timestamps should be shown for the logs of a container.
+- [#294](https://github.com/kobsio/kobs/pull/294): Improve shutdown of kobs by extending context timeout and adding `terminationGracePeriodSeconds` property.
 
 ## [v0.7.0](https://github.com/kobsio/kobs/releases/tag/v0.7.0) (2021-11-19)
 

--- a/cmd/kobs/kobs.go
+++ b/cmd/kobs/kobs.go
@@ -146,15 +146,15 @@ func main() {
 	// to gracefully shutdown the started kobs components. This ensures that established connections or tasks are not
 	// interrupted.
 	done := make(chan os.Signal, 1)
-	signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(done, os.Interrupt, syscall.SIGTERM)
 
 	log.Debug(nil, "Start listining for SIGINT and SIGTERM signal")
 	<-done
-	log.Debug(nil, "Start shutdown process")
+	log.Info(nil, "Shutdown kobs...")
 
 	metricsServer.Stop()
 	appServer.Stop()
 	apiServer.Stop()
 
-	log.Info(nil, "Shutdown kobs...")
+	log.Info(nil, "Shutdown is done")
 }

--- a/deploy/helm/kobs/Chart.yaml
+++ b/deploy/helm/kobs/Chart.yaml
@@ -4,5 +4,5 @@ description: Kubernetes Observability Platform
 type: application
 home: https://kobs.io
 icon: https://kobs.io/assets/images/logo.svg
-version: 0.12.0
+version: 0.12.1
 appVersion: v0.7.0

--- a/deploy/helm/kobs/templates/deployment.yaml
+++ b/deploy/helm/kobs/templates/deployment.yaml
@@ -73,6 +73,7 @@ spec:
             {{- if .Values.kobs.volumeMounts }}
             {{- toYaml .Values.kobs.volumeMounts | nindent 12 }}
             {{- end }}
+      terminationGracePeriodSeconds: 90
       volumes:
         - name: config
           configMap:

--- a/deploy/kustomize/kobs/deployment.yaml
+++ b/deploy/kustomize/kobs/deployment.yaml
@@ -57,6 +57,7 @@ spec:
               mountPath: /kobs/config.yaml
               subPath: config.yaml
               readOnly: true
+      terminationGracePeriodSeconds: 90
       volumes:
         - name: config
           configMap:

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -48,27 +48,25 @@ type Server struct {
 
 // Start starts serving the application server.
 func (s *Server) Start() {
-	log.Info(nil, "Application server started.", zap.String("address", s.server.Addr))
+	log.Info(nil, "Application server started", zap.String("address", s.server.Addr))
 
 	if err := s.server.ListenAndServe(); err != nil {
 		if err != http.ErrServerClosed {
-			log.Error(nil, "Application server died unexpected.", zap.Error(err))
-		} else {
-			log.Info(nil, "Application server was stopped.")
+			log.Error(nil, "Application server died unexpected", zap.Error(err))
 		}
 	}
 }
 
 // Stop terminates the application server gracefully.
 func (s *Server) Stop() {
-	log.Debug(nil, "Start shutdown of the Application server.")
+	log.Debug(nil, "Start shutdown of the Application server")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	err := s.server.Shutdown(ctx)
 	if err != nil {
-		log.Error(nil, "Graceful shutdown of the Application server failed.", zap.Error(err))
+		log.Error(nil, "Graceful shutdown of the Application server failed", zap.Error(err))
 	}
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -36,23 +36,25 @@ type Server struct {
 
 // Start starts serving the metrics server.
 func (s *Server) Start() {
-	log.Info(nil, "Metrics server started.", zap.String("address", s.Addr))
+	log.Info(nil, "Metrics server started", zap.String("address", s.Addr))
 
-	if err := s.ListenAndServe(); err != http.ErrServerClosed {
-		log.Error(nil, "Metrics server died unexpected.", zap.Error(err))
+	if err := s.ListenAndServe(); err != nil {
+		if err != http.ErrServerClosed {
+			log.Error(nil, "Metrics server died unexpected", zap.Error(err))
+		}
 	}
 }
 
 // Stop terminates the metrics server gracefully.
 func (s *Server) Stop() {
-	log.Debug(nil, "Start shutdown of the metrics server.")
+	log.Debug(nil, "Start shutdown of the metrics server")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	err := s.Shutdown(ctx)
 	if err != nil {
-		log.Error(nil, "Graceful shutdown of the metrics server failed.", zap.Error(err))
+		log.Error(nil, "Graceful shutdown of the metrics server failed", zap.Error(err))
 	}
 }
 


### PR DESCRIPTION
We are now waiting up to 60 seconds before all http servers of kobs are
stopped instead of the 5 seconds from before. This was done, because we
have some plugins which are having requests which could take a bit
longer, e.g. gettings logs via the klogs plugin.

We also added the "terminationGracePeriodSeconds" property to the
deployment for kobs in the Kustomize files and in the Helm chart. Since
we are waiting 60 seconds within kobs we set this value to 90 seconds.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
