### PR TITLE
[sql] Add columns option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#285](https://github.com/kobsio/kobs/pull/285): [core] Add `/api/debug` endpoints for debugging the API server.
 - [#288](https://github.com/kobsio/kobs/pull/288): [resources] Add support to show custom columns for a resource.
 - [#289](https://github.com/kobsio/kobs/pull/289): Add an option to create a NetworkPolicy via the Helm chart.
+- [#295](https://github.com/kobsio/kobs/pull/295): [sql] Add `columns` options to set the title and formation of the returned columns from a query.
 
 ### Fixed
 

--- a/docs/plugins/sql.md
+++ b/docs/plugins/sql.md
@@ -38,6 +38,14 @@ The following options can be used for a panel with the SQL plugin:
 | ----- | ---- | ----------- | -------- |
 | name | string | A name for the SQL query, which is displayed in the select box. | Yes |
 | query | string | The query which should be run against the configured SQL database. | Yes |
+| columns | map<string, [Column](#column)> | A map of columns to format the returned data for a query. The key must match the returned column name. | Yes |
+
+### Column
+
+| Field | Type | Description | Required |
+| ----- | ---- | ----------- | -------- |
+| title | string | Set a title for the column. | No |
+| format | string | Format the results for the column. This can be a string with `{% .value %}` as placeholder for the value or one of the following special keys: `time`. | No |
 
 ```yaml
 ---

--- a/plugins/sql/src/components/panel/SQLActions.tsx
+++ b/plugins/sql/src/components/panel/SQLActions.tsx
@@ -1,4 +1,4 @@
-import { CardActions, Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
+import { CardActions, Dropdown, DropdownItem, KebabToggle, Spinner } from '@patternfly/react-core';
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -7,22 +7,27 @@ import { IQuery } from '../../utils/interfaces';
 interface IActionsProps {
   name: string;
   queries: IQuery[];
+  isFetching: boolean;
 }
 
-export const Actions: React.FunctionComponent<IActionsProps> = ({ name, queries }: IActionsProps) => {
+export const Actions: React.FunctionComponent<IActionsProps> = ({ name, queries, isFetching }: IActionsProps) => {
   const [show, setShow] = useState<boolean>(false);
 
   return (
     <CardActions>
-      <Dropdown
-        toggle={<KebabToggle onToggle={(): void => setShow(!show)} />}
-        isOpen={show}
-        isPlain={true}
-        position="right"
-        dropdownItems={queries.map((query, index) => (
-          <DropdownItem key={index} component={<Link to={`/${name}?query=${query.query}`}>{query.name}</Link>} />
-        ))}
-      />
+      {isFetching ? (
+        <Spinner size="md" />
+      ) : (
+        <Dropdown
+          toggle={<KebabToggle onToggle={(): void => setShow(!show)} />}
+          isOpen={show}
+          isPlain={true}
+          position="right"
+          dropdownItems={queries.map((query, index) => (
+            <DropdownItem key={index} component={<Link to={`/${name}?query=${query.query}`}>{query.name}</Link>} />
+          ))}
+        />
+      )}
     </CardActions>
   );
 };

--- a/plugins/sql/src/components/panel/SQLTable.tsx
+++ b/plugins/sql/src/components/panel/SQLTable.tsx
@@ -1,12 +1,14 @@
 import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import React from 'react';
 
-import { ISQLData } from '../../utils/interfaces';
+import { IColumns, ISQLData } from '../../utils/interfaces';
 import { renderCellValue } from '../../utils/helpers';
 
-type ISQLTableProps = ISQLData;
+interface ISQLTableProps extends ISQLData {
+  columnOptions?: IColumns;
+}
 
-const SQLTable: React.FunctionComponent<ISQLTableProps> = ({ rows, columns }: ISQLTableProps) => {
+const SQLTable: React.FunctionComponent<ISQLTableProps> = ({ rows, columns, columnOptions }: ISQLTableProps) => {
   if (!columns || columns.length === 0) {
     return null;
   }
@@ -16,7 +18,11 @@ const SQLTable: React.FunctionComponent<ISQLTableProps> = ({ rows, columns }: IS
       <Thead>
         <Tr>
           {columns.map((column, index) => (
-            <Th key={index}>{column}</Th>
+            <Th key={index}>
+              {columnOptions && columnOptions.hasOwnProperty(column) && columnOptions[column].title
+                ? columnOptions[column].title
+                : column}
+            </Th>
           ))}
         </Tr>
       </Thead>
@@ -26,7 +32,14 @@ const SQLTable: React.FunctionComponent<ISQLTableProps> = ({ rows, columns }: IS
               <Tr key={rowIndex}>
                 {columns.map((column, columnIndex) => (
                   <Td key={`${rowIndex}_${columnIndex}`}>
-                    {row.hasOwnProperty(column) ? renderCellValue(row[column]) : ''}
+                    {row.hasOwnProperty(column)
+                      ? renderCellValue(
+                          row[column],
+                          columnOptions && columnOptions.hasOwnProperty(column)
+                            ? columnOptions[column].format
+                            : undefined,
+                        )
+                      : ''}
                   </Td>
                 ))}
               </Tr>

--- a/plugins/sql/src/utils/helpers.ts
+++ b/plugins/sql/src/utils/helpers.ts
@@ -1,4 +1,5 @@
 import { IOptions } from './interfaces';
+import { formatTime } from '@kobsio/plugin-core';
 
 // getInitialOptions is used to get the initial options from the url.
 export const getInitialOptions = (search: string): IOptions => {
@@ -10,10 +11,20 @@ export const getInitialOptions = (search: string): IOptions => {
   };
 };
 
-export const renderCellValue = (value: string | number | string[] | number[]): string => {
+export const renderCellValue = (value: string | number | string[] | number[], format?: string): string => {
+  let formattedValue = `${value}`;
+
   if (Array.isArray(value)) {
-    return `[${value.join(', ')}]`;
+    formattedValue = `[${value.join(', ')}]`;
   }
 
-  return `${value}`;
+  if (format) {
+    if (format === 'time') {
+      formatTime(Math.floor(new Date(formattedValue).getTime() / 1000));
+    } else {
+      formattedValue = format.replaceAll(`{% .value %}`, formattedValue);
+    }
+  }
+
+  return formattedValue;
 };

--- a/plugins/sql/src/utils/interfaces.ts
+++ b/plugins/sql/src/utils/interfaces.ts
@@ -12,6 +12,16 @@ export interface IPanelOptions {
 export interface IQuery {
   name?: string;
   query?: string;
+  columns?: IColumns;
+}
+
+export interface IColumns {
+  [key: string]: IColumn;
+}
+
+export interface IColumn {
+  title?: string;
+  format?: string;
 }
 
 // ISQLData is the interface of the data returned from our Go API for the get query results call.


### PR DESCRIPTION
It is now possible to format the returned column values for a SQL query.
For that a new "columns" property is available in the panel options,
which takes a map as value, where the key is the name of the column as
it is returned by the query and a columns object which allows users to
customize the title of a column and to format the column values.

We also fixed a bug, so that it is now possible to use the special time
variables within a SQL panel. For that we are now saving the index of
the selected query instead of the selected query themself.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
