### PR TITLE
[prometheus] Fix metrics with "Inf" values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#280](https://github.com/kobsio/kobs/pull/280): [core] Fix returned capacity value for persistent volumes.
 - [#286](https://github.com/kobsio/kobs/pull/286): [helm] Show warning when no Helm releases were found or the history of an Helm release was not found.
 - [#292](https://github.com/kobsio/kobs/pull/292): [resources] Fix shown conditions in details view.
+- [#297](https://github.com/kobsio/kobs/pull/297): [prometheus] Fix metrics, when Prometheus returns `Inf` value.
 
 ### Changed
 

--- a/plugins/prometheus/pkg/instance/instance.go
+++ b/plugins/prometheus/pkg/instance/instance.go
@@ -115,7 +115,7 @@ func (i *Instance) GetMetrics(ctx context.Context, queries []Query, resolution s
 					globalTimeEnd = timestamp
 				}
 
-				if math.IsNaN(val) {
+				if math.IsNaN(val) || math.IsInf(val, 0) {
 					data = append(data, Datum{
 						X: timestamp,
 					})


### PR DESCRIPTION
When the used Prometheus client returns a metric with "Inf" values, we
were not able to able to parse it as JSON and show the results in the
UI. This is now fixed by checking if the value is "Inf". If this is the
case we just add the timestamp but not the value to our data structure
in the same way how we did it for "NaN" values.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
