### PR TITLE
[resources] Fix formatting of cells for CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#292](https://github.com/kobsio/kobs/pull/292): [resources] Fix shown conditions in details view.
 - [#297](https://github.com/kobsio/kobs/pull/297): [prometheus] Fix metrics, when Prometheus returns `Inf` value.
 - [#303](https://github.com/kobsio/kobs/pull/303): [core] Fix missing borders for select elements.
+- [#304](https://github.com/kobsio/kobs/pull/304): [resources] Fix formatting of cells for Custom Resource Definition.
 
 ### Changed
 

--- a/plugins/core/src/utils/resources.tsx
+++ b/plugins/core/src/utils/resources.tsx
@@ -1678,11 +1678,16 @@ export const customResourceDefinition = (crds: ICRD[]): IResources => {
               const crdCells =
                 crd.columns && crd.columns.length > 0
                   ? crd.columns.map((column) => {
-                      const value = JSONPath({ json: cr, path: `$.${column.jsonPath}` })[0];
-                      if (!value) return '';
-                      if (column.type === 'date')
+                      const value = JSONPath<string | string[]>({ json: cr, path: `$.${column.jsonPath}` })[0];
+                      if (!value) {
+                        return '';
+                      } else if (column.type === 'date') {
                         return timeDifference(new Date().getTime(), new Date(value).getTime());
-                      return value;
+                      } else if (Array.isArray(value)) {
+                        return value.join(', ');
+                      } else {
+                        return value;
+                      }
                     })
                   : [timeDifference(new Date().getTime(), new Date(cr.metadata?.creationTimestamp).getTime())];
 


### PR DESCRIPTION
The cell values for CRDs were not correctly formatted, so that it could
happen that all values of an array are displayed without a ", " between
the values. This is now fixed and all cells which are displayed for a
Curstom Resource Definition should be formatted correctly.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
