### PR TITLE
[resources] Show state and last state in overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#291](https://github.com/kobsio/kobs/pull/291): [klogs] Show link to aggragations and documentation in dropdown.
 - [#293](https://github.com/kobsio/kobs/pull/293): [azure] It is now possible to set a custom value for the number of logs lines which should be shown and if the timestamps should be shown for the logs of a container.
 - [#294](https://github.com/kobsio/kobs/pull/294): Improve shutdown of kobs by extending context timeout and adding `terminationGracePeriodSeconds` property.
+- [#305](https://github.com/kobsio/kobs/pull/305): [resources] Show state and last state of container in containers overview.
 
 ## [v0.7.0](https://github.com/kobsio/kobs/releases/tag/v0.7.0) (2021-11-19)
 

--- a/plugins/resources/src/components/panel/details/overview/Container.tsx
+++ b/plugins/resources/src/components/panel/details/overview/Container.tsx
@@ -162,6 +162,21 @@ const Container: React.FunctionComponent<IContainerProps> = ({
         <Td colSpan={11}>
           <ExpandableRowContent>
             <DescriptionList className="pf-u-text-break-word" isHorizontal={true}>
+              {containerStatus && containerStatus.state && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>State</DescriptionListTerm>
+                  <DescriptionListDescription>{getContainerStatus(containerStatus.state)}</DescriptionListDescription>
+                </DescriptionListGroup>
+              )}
+              {containerStatus && containerStatus.lastState && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Last State</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {getContainerStatus(containerStatus.lastState)}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              )}
+
               <DescriptionListGroup>
                 <DescriptionListTerm>Image</DescriptionListTerm>
                 <DescriptionListDescription>{container.image}</DescriptionListDescription>


### PR DESCRIPTION
We are now showing the state and the last state of an container in the
overview section of the Pods details view. So it is easier to see
potential "OOMKilled" messages within the overview section of the
containers.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
