### PR TITLE
[resources] Fix creation of jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#297](https://github.com/kobsio/kobs/pull/297): [prometheus] Fix metrics, when Prometheus returns `Inf` value.
 - [#303](https://github.com/kobsio/kobs/pull/303): [core] Fix missing borders for select elements.
 - [#304](https://github.com/kobsio/kobs/pull/304): [resources] Fix formatting of cells for Custom Resource Definition.
+- [#307](https://github.com/kobsio/kobs/pull/307): [resources] Fix creation of Jobs.
 
 ### Changed
 


### PR DESCRIPTION
Jobs are now created by using the complete Job template from a CronJob,
so that we are also using the defined metadata like labels and
annotations for a created Job.

Before this changed we just copied all the specs from the Job template
of a CronJob, but didn't included the metadata.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
