### PR TITLE
[core] Disable unnecessary scrollbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#293](https://github.com/kobsio/kobs/pull/293): [azure] It is now possible to set a custom value for the number of logs lines which should be shown and if the timestamps should be shown for the logs of a container.
 - [#294](https://github.com/kobsio/kobs/pull/294): Improve shutdown of kobs by extending context timeout and adding `terminationGracePeriodSeconds` property.
 - [#305](https://github.com/kobsio/kobs/pull/305): [resources] Show state and last state of container in containers overview.
+- [#308](https://github.com/kobsio/kobs/pull/308): [core] Hide scrollbars to have a cleaner UI.
 
 ## [v0.7.0](https://github.com/kobsio/kobs/releases/tag/v0.7.0) (2021-11-19)
 

--- a/plugins/applications/src/components/home/Home.tsx
+++ b/plugins/applications/src/components/home/Home.tsx
@@ -134,7 +134,7 @@ const Home: React.FunctionComponent<IPluginPageProps> = () => {
                     </span>
                   </CardTitle>
                   <CardBody style={{ height: '150px', maxHeight: '150px', minHeight: '150px' }}>
-                    <div style={{ height: '124px', overflow: 'scroll' }}>
+                    <div style={{ height: '124px', overflow: 'auto' }}>
                       {application.tags && (
                         <p>
                           {application.tags.map((tag) => (

--- a/plugins/applications/src/components/home/Home.tsx
+++ b/plugins/applications/src/components/home/Home.tsx
@@ -134,7 +134,7 @@ const Home: React.FunctionComponent<IPluginPageProps> = () => {
                     </span>
                   </CardTitle>
                   <CardBody style={{ height: '150px', maxHeight: '150px', minHeight: '150px' }}>
-                    <div style={{ height: '124px', overflow: 'auto' }}>
+                    <div className="kobsio-hide-scrollbar" style={{ height: '124px', overflow: 'auto' }}>
                       {application.tags && (
                         <p>
                           {application.tags.map((tag) => (

--- a/plugins/applications/src/components/panel/ApplicationsGalleryItem.tsx
+++ b/plugins/applications/src/components/panel/ApplicationsGalleryItem.tsx
@@ -36,7 +36,7 @@ const ApplicationsGalleryItem: React.FunctionComponent<IApplicationsGalleryItemP
               />
             </div>
           ) : (
-            <div style={{ height: '124px', overflow: 'scroll' }}>
+            <div style={{ height: '124px', overflow: 'auto' }}>
               {application.tags && (
                 <p>
                   {application.tags.map((tag) => (

--- a/plugins/applications/src/components/panel/ApplicationsGalleryItem.tsx
+++ b/plugins/applications/src/components/panel/ApplicationsGalleryItem.tsx
@@ -36,7 +36,7 @@ const ApplicationsGalleryItem: React.FunctionComponent<IApplicationsGalleryItemP
               />
             </div>
           ) : (
-            <div style={{ height: '124px', overflow: 'auto' }}>
+            <div className="kobsio-hide-scrollbar" style={{ height: '124px', overflow: 'auto' }}>
               {application.tags && (
                 <p>
                   {application.tags.map((tag) => (

--- a/plugins/azure/src/components/containerinstances/DetailsContainerGroup.tsx
+++ b/plugins/azure/src/components/containerinstances/DetailsContainerGroup.tsx
@@ -88,7 +88,7 @@ const DetailsContainerGroup: React.FunctionComponent<IDetailsContainerGroupProps
   }
 
   return (
-    <div style={{ maxWidth: '100%', overflow: 'scroll' }}>
+    <div style={{ maxWidth: '100%', overflow: 'auto' }}>
       <DescriptionList className="pf-u-text-break-word" isHorizontal={true}>
         <DescriptionListGroup>
           <DescriptionListTerm>OS Type</DescriptionListTerm>

--- a/plugins/azure/src/components/containerinstances/DetailsContainerGroup.tsx
+++ b/plugins/azure/src/components/containerinstances/DetailsContainerGroup.tsx
@@ -88,7 +88,7 @@ const DetailsContainerGroup: React.FunctionComponent<IDetailsContainerGroupProps
   }
 
   return (
-    <div style={{ maxWidth: '100%', overflow: 'auto' }}>
+    <div className="kobsio-hide-scrollbar" style={{ maxWidth: '100%', overflow: 'auto' }}>
       <DescriptionList className="pf-u-text-break-word" isHorizontal={true}>
         <DescriptionListGroup>
           <DescriptionListTerm>OS Type</DescriptionListTerm>

--- a/plugins/azure/src/components/containerinstances/DetailsLogs.tsx
+++ b/plugins/azure/src/components/containerinstances/DetailsLogs.tsx
@@ -71,7 +71,11 @@ const DetailsLogs: React.FunctionComponent<IDetailsLogsProps> = ({
   };
 
   return (
-    <div style={{ height: '100%', maxWidth: '100%', overflow: 'auto' }} ref={refWrapper}>
+    <div
+      className="kobsio-hide-scrollbar"
+      style={{ height: '100%', maxWidth: '100%', overflow: 'auto' }}
+      ref={refWrapper}
+    >
       <Select
         variant={SelectVariant.single}
         typeAheadAriaLabel="Select container"

--- a/plugins/azure/src/components/containerinstances/DetailsLogs.tsx
+++ b/plugins/azure/src/components/containerinstances/DetailsLogs.tsx
@@ -71,7 +71,7 @@ const DetailsLogs: React.FunctionComponent<IDetailsLogsProps> = ({
   };
 
   return (
-    <div style={{ height: '100%', maxWidth: '100%', overflow: 'scroll' }} ref={refWrapper}>
+    <div style={{ height: '100%', maxWidth: '100%', overflow: 'auto' }} ref={refWrapper}>
       <Select
         variant={SelectVariant.single}
         typeAheadAriaLabel="Select container"

--- a/plugins/azure/src/components/kubernetesservices/DetailsKubernetesService.tsx
+++ b/plugins/azure/src/components/kubernetesservices/DetailsKubernetesService.tsx
@@ -83,7 +83,7 @@ const DetailsKubernetesService: React.FunctionComponent<IDetailsKubernetesServic
   }
 
   return (
-    <div style={{ maxWidth: '100%', overflow: 'auto' }}>
+    <div className="kobsio-hide-scrollbar" style={{ maxWidth: '100%', overflow: 'auto' }}>
       <DescriptionList className="pf-u-text-break-word" isHorizontal={true}>
         <DescriptionListGroup>
           <DescriptionListTerm>Status</DescriptionListTerm>

--- a/plugins/azure/src/components/kubernetesservices/DetailsKubernetesService.tsx
+++ b/plugins/azure/src/components/kubernetesservices/DetailsKubernetesService.tsx
@@ -83,7 +83,7 @@ const DetailsKubernetesService: React.FunctionComponent<IDetailsKubernetesServic
   }
 
   return (
-    <div style={{ maxWidth: '100%', overflow: 'scroll' }}>
+    <div style={{ maxWidth: '100%', overflow: 'auto' }}>
       <DescriptionList className="pf-u-text-break-word" isHorizontal={true}>
         <DescriptionListGroup>
           <DescriptionListTerm>Status</DescriptionListTerm>

--- a/plugins/azure/src/components/kubernetesservices/DetailsNodePools.tsx
+++ b/plugins/azure/src/components/kubernetesservices/DetailsNodePools.tsx
@@ -78,7 +78,7 @@ const DetailsNodePools: React.FunctionComponent<IDetailsNodePoolsProps> = ({
   }
 
   return (
-    <div style={{ maxWidth: '100%', overflow: 'scroll' }}>
+    <div style={{ maxWidth: '100%', overflow: 'auto' }}>
       <TableComposable aria-label="Node Pools" variant={TableVariant.compact} borders={true}>
         <Thead>
           <Tr>

--- a/plugins/azure/src/components/kubernetesservices/DetailsNodePools.tsx
+++ b/plugins/azure/src/components/kubernetesservices/DetailsNodePools.tsx
@@ -78,7 +78,7 @@ const DetailsNodePools: React.FunctionComponent<IDetailsNodePoolsProps> = ({
   }
 
   return (
-    <div style={{ maxWidth: '100%', overflow: 'auto' }}>
+    <div className="kobsio-hide-scrollbar" style={{ maxWidth: '100%', overflow: 'auto' }}>
       <TableComposable aria-label="Node Pools" variant={TableVariant.compact} borders={true}>
         <Thead>
           <Tr>

--- a/plugins/azure/src/components/virtualmachinescalesets/DetailsVirtualMachineScaleSets.tsx
+++ b/plugins/azure/src/components/virtualmachinescalesets/DetailsVirtualMachineScaleSets.tsx
@@ -83,7 +83,7 @@ const DetailsVirtualMachineScaleSets: React.FunctionComponent<IDetailsVirtualMac
   }
 
   return (
-    <div style={{ maxWidth: '100%', overflow: 'scroll' }}>
+    <div style={{ maxWidth: '100%', overflow: 'auto' }}>
       <DescriptionList className="pf-u-text-break-word" isHorizontal={true}>
         <DescriptionListGroup>
           <DescriptionListTerm>Status</DescriptionListTerm>

--- a/plugins/azure/src/components/virtualmachinescalesets/DetailsVirtualMachineScaleSets.tsx
+++ b/plugins/azure/src/components/virtualmachinescalesets/DetailsVirtualMachineScaleSets.tsx
@@ -83,7 +83,7 @@ const DetailsVirtualMachineScaleSets: React.FunctionComponent<IDetailsVirtualMac
   }
 
   return (
-    <div style={{ maxWidth: '100%', overflow: 'auto' }}>
+    <div className="kobsio-hide-scrollbar" style={{ maxWidth: '100%', overflow: 'auto' }}>
       <DescriptionList className="pf-u-text-break-word" isHorizontal={true}>
         <DescriptionListGroup>
           <DescriptionListTerm>Status</DescriptionListTerm>

--- a/plugins/azure/src/components/virtualmachinescalesets/DetailsVirtualMachines.tsx
+++ b/plugins/azure/src/components/virtualmachinescalesets/DetailsVirtualMachines.tsx
@@ -76,7 +76,7 @@ const DetailsVirtualMachines: React.FunctionComponent<IDetailsVirtualMachinesPro
   }
 
   return (
-    <div style={{ maxWidth: '100%', overflow: 'scroll' }}>
+    <div style={{ maxWidth: '100%', overflow: 'auto' }}>
       <TableComposable aria-label="Virtual Machines" variant={TableVariant.compact} borders={true}>
         <Thead>
           <Tr>

--- a/plugins/azure/src/components/virtualmachinescalesets/DetailsVirtualMachines.tsx
+++ b/plugins/azure/src/components/virtualmachinescalesets/DetailsVirtualMachines.tsx
@@ -76,7 +76,7 @@ const DetailsVirtualMachines: React.FunctionComponent<IDetailsVirtualMachinesPro
   }
 
   return (
-    <div style={{ maxWidth: '100%', overflow: 'auto' }}>
+    <div className="kobsio-hide-scrollbar" style={{ maxWidth: '100%', overflow: 'auto' }}>
       <TableComposable aria-label="Virtual Machines" variant={TableVariant.compact} borders={true}>
         <Thead>
           <Tr>

--- a/plugins/core/src/assets/app.css
+++ b/plugins/core/src/assets/app.css
@@ -4,3 +4,15 @@
   height: calc(100% - 24px);
   overflow: hidden;
 }
+
+/* kobsio-hide-scrollbar
+ * The kobsio-hide-scrollbar CSS class can be used to hide the scrollbar on every platform, without loosing the
+ * functionality to scroll in a container. */
+.kobsio-hide-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+.kobsio-hide-scrollbar {
+  -ms-overflow-style: none;  /* IE and Edge */
+  scrollbar-width: none;  /* Firefox */
+}

--- a/plugins/core/src/components/plugin/PluginCard.tsx
+++ b/plugins/core/src/components/plugin/PluginCard.tsx
@@ -44,7 +44,9 @@ export const PluginCard: React.FunctionComponent<IPluginCardProps> = ({
         </CardHeaderMain>
         {actions || null}
       </CardHeader>
-      <CardBody style={{ overflow: 'auto' }}>{children}</CardBody>
+      <CardBody className="kobsio-hide-scrollbar" style={{ overflow: 'auto' }}>
+        {children}
+      </CardBody>
     </Card>
   );
 };

--- a/plugins/core/src/components/plugin/PluginCard.tsx
+++ b/plugins/core/src/components/plugin/PluginCard.tsx
@@ -44,7 +44,7 @@ export const PluginCard: React.FunctionComponent<IPluginCardProps> = ({
         </CardHeaderMain>
         {actions || null}
       </CardHeader>
-      <CardBody style={{ overflow: 'scroll' }}>{children}</CardBody>
+      <CardBody style={{ overflow: 'auto' }}>{children}</CardBody>
     </Card>
   );
 };

--- a/plugins/dashboards/src/components/dashboards/Dashboard.tsx
+++ b/plugins/dashboards/src/components/dashboards/Dashboard.tsx
@@ -178,6 +178,7 @@ const Dashboard: React.FunctionComponent<IDashboardProps> = ({
                     <div ref={ref}>
                       {inView ? (
                         <div
+                          className="kobsio-hide-scrollbar"
                           style={
                             row.size !== undefined && row.size === -1
                               ? undefined
@@ -195,6 +196,7 @@ const Dashboard: React.FunctionComponent<IDashboardProps> = ({
                         </div>
                       ) : (
                         <div
+                          className="kobsio-hide-scrollbar"
                           style={
                             row.size !== undefined && row.size === -1
                               ? undefined

--- a/plugins/dashboards/src/components/dashboards/Dashboard.tsx
+++ b/plugins/dashboards/src/components/dashboards/Dashboard.tsx
@@ -181,7 +181,7 @@ const Dashboard: React.FunctionComponent<IDashboardProps> = ({
                           style={
                             row.size !== undefined && row.size === -1
                               ? undefined
-                              : { height: rowHeight(row.size, panel.rowSpan), overflow: 'scroll' }
+                              : { height: rowHeight(row.size, panel.rowSpan), overflow: 'auto' }
                           }
                         >
                           <PluginPanel
@@ -198,7 +198,7 @@ const Dashboard: React.FunctionComponent<IDashboardProps> = ({
                           style={
                             row.size !== undefined && row.size === -1
                               ? undefined
-                              : { height: rowHeight(row.size, panel.rowSpan), overflow: 'scroll' }
+                              : { height: rowHeight(row.size, panel.rowSpan), overflow: 'auto' }
                           }
                         ></div>
                       )}

--- a/plugins/prometheus/src/components/panel/ChartWrapper.tsx
+++ b/plugins/prometheus/src/components/panel/ChartWrapper.tsx
@@ -128,11 +128,11 @@ export const ChartWrapper: React.FunctionComponent<IChartWrapperProps> = ({
             />
           </div>
           {options.legend === 'table' ? (
-            <div className="pf-u-mt-md" style={{ height: '60px', overflow: 'auto' }}>
+            <div className="pf-u-mt-md kobsio-hide-scrollbar" style={{ height: '60px', overflow: 'auto' }}>
               <ChartLegend series={data.series} unit={options.unit || ''} selected={selectedSeries} select={select} />
             </div>
           ) : options.legend === 'table-large' ? (
-            <div className="pf-u-mt-md" style={{ height: '120px', overflow: 'auto' }}>
+            <div className="pf-u-mt-md kobsio-hide-scrollbar" style={{ height: '120px', overflow: 'auto' }}>
               <ChartLegend series={data.series} unit={options.unit || ''} selected={selectedSeries} select={select} />
             </div>
           ) : null}

--- a/plugins/prometheus/src/components/panel/ChartWrapper.tsx
+++ b/plugins/prometheus/src/components/panel/ChartWrapper.tsx
@@ -128,11 +128,11 @@ export const ChartWrapper: React.FunctionComponent<IChartWrapperProps> = ({
             />
           </div>
           {options.legend === 'table' ? (
-            <div className="pf-u-mt-md" style={{ height: '60px', overflow: 'scroll' }}>
+            <div className="pf-u-mt-md" style={{ height: '60px', overflow: 'auto' }}>
               <ChartLegend series={data.series} unit={options.unit || ''} selected={selectedSeries} select={select} />
             </div>
           ) : options.legend === 'table-large' ? (
-            <div className="pf-u-mt-md" style={{ height: '120px', overflow: 'scroll' }}>
+            <div className="pf-u-mt-md" style={{ height: '120px', overflow: 'auto' }}>
               <ChartLegend series={data.series} unit={options.unit || ''} selected={selectedSeries} select={select} />
             </div>
           ) : null}

--- a/plugins/sql/src/components/panel/SQLChart.tsx
+++ b/plugins/sql/src/components/panel/SQLChart.tsx
@@ -110,7 +110,7 @@ const SQLChart: React.FunctionComponent<ISQLChartProps> = ({
             />
           </div>
 
-          <div className="pf-u-mt-md" style={{ height: '60px', overflow: 'auto' }}>
+          <div className="pf-u-mt-md kobsio-hide-scrollbar" style={{ height: '60px', overflow: 'auto' }}>
             <SQLChartLineLegend data={data} yAxisColumns={yAxisColumns} yAxisUnit={yAxisUnit} legend={legend} />
           </div>
         </React.Fragment>

--- a/plugins/sql/src/components/panel/SQLChart.tsx
+++ b/plugins/sql/src/components/panel/SQLChart.tsx
@@ -110,7 +110,7 @@ const SQLChart: React.FunctionComponent<ISQLChartProps> = ({
             />
           </div>
 
-          <div className="pf-u-mt-md" style={{ height: '60px', overflow: 'scroll' }}>
+          <div className="pf-u-mt-md" style={{ height: '60px', overflow: 'auto' }}>
             <SQLChartLineLegend data={data} yAxisColumns={yAxisColumns} yAxisUnit={yAxisUnit} legend={legend} />
           </div>
         </React.Fragment>

--- a/plugins/techdocs/src/components/KobsCode.tsx
+++ b/plugins/techdocs/src/components/KobsCode.tsx
@@ -15,7 +15,7 @@ const KobsCode: React.FunctionComponent<IKobsCodeProps> = ({ panel, setDetails }
   };
 
   return (
-    <div style={{ height: '300px', overflow: 'auto' }}>
+    <div className="kobsio-hide-scrollbar" style={{ height: '300px', overflow: 'auto' }}>
       <PluginPanel
         times={times}
         title={panel.title}

--- a/plugins/techdocs/src/components/KobsCode.tsx
+++ b/plugins/techdocs/src/components/KobsCode.tsx
@@ -15,7 +15,7 @@ const KobsCode: React.FunctionComponent<IKobsCodeProps> = ({ panel, setDetails }
   };
 
   return (
-    <div style={{ height: '300px', overflow: 'scroll' }}>
+    <div style={{ height: '300px', overflow: 'auto' }}>
       <PluginPanel
         times={times}
         title={panel.title}

--- a/plugins/techdocs/src/components/page/ServicePageTableOfContents.tsx
+++ b/plugins/techdocs/src/components/page/ServicePageTableOfContents.tsx
@@ -20,7 +20,7 @@ const ServicePageTableOfContents: React.FunctionComponent<IServicePageTableOfCon
 }: IServicePageTableOfContentsProps) => {
   return (
     <Card style={{ width: '100%' }} isCompact={true}>
-      <CardBody style={{ overflow: 'auto' }}>
+      <CardBody className="kobsio-hide-scrollbar" style={{ overflow: 'auto' }}>
         <TextContent>
           <ReactMarkdown
             components={{

--- a/plugins/techdocs/src/components/page/ServicePageTableOfContents.tsx
+++ b/plugins/techdocs/src/components/page/ServicePageTableOfContents.tsx
@@ -20,7 +20,7 @@ const ServicePageTableOfContents: React.FunctionComponent<IServicePageTableOfCon
 }: IServicePageTableOfContentsProps) => {
   return (
     <Card style={{ width: '100%' }} isCompact={true}>
-      <CardBody style={{ overflow: 'scroll' }}>
+      <CardBody style={{ overflow: 'auto' }}>
         <TextContent>
           <ReactMarkdown
             components={{

--- a/plugins/techdocs/src/components/page/ServicePageWrapper.tsx
+++ b/plugins/techdocs/src/components/page/ServicePageWrapper.tsx
@@ -60,7 +60,7 @@ const ServicePageWrapper: React.FunctionComponent<IServicePageWrapperProps> = ({
       <Grid hasGutter={true}>
         <GridItem sm={12} md={12} lg={3} xl={2} xl2={2}>
           <Card style={{ width: '100%' }} isCompact={true}>
-            <CardBody style={{ overflow: 'auto' }}>
+            <CardBody className="kobsio-hide-scrollbar" style={{ overflow: 'auto' }}>
               <TableOfContents name={name} service={index.key} toc={index.toc} />
             </CardBody>
           </Card>

--- a/plugins/techdocs/src/components/page/ServicePageWrapper.tsx
+++ b/plugins/techdocs/src/components/page/ServicePageWrapper.tsx
@@ -60,7 +60,7 @@ const ServicePageWrapper: React.FunctionComponent<IServicePageWrapperProps> = ({
       <Grid hasGutter={true}>
         <GridItem sm={12} md={12} lg={3} xl={2} xl2={2}>
           <Card style={{ width: '100%' }} isCompact={true}>
-            <CardBody style={{ overflow: 'scroll' }}>
+            <CardBody style={{ overflow: 'auto' }}>
               <TableOfContents name={name} service={index.key} toc={index.toc} />
             </CardBody>
           </Card>

--- a/plugins/techdocs/src/utils/renderers.tsx
+++ b/plugins/techdocs/src/utils/renderers.tsx
@@ -61,7 +61,7 @@ export const renderCode = (
 
   return (
     <CodeBlock style={{ maxWidth: '100%' }}>
-      <CodeBlockCode className="kobsio-techdocs-code" style={{ maxWidth: '100%', overflow: 'scroll' }}>
+      <CodeBlockCode className="kobsio-techdocs-code" style={{ maxWidth: '100%', overflow: 'auto' }}>
         {props.children}
       </CodeBlockCode>
     </CodeBlock>

--- a/plugins/techdocs/src/utils/renderers.tsx
+++ b/plugins/techdocs/src/utils/renderers.tsx
@@ -61,7 +61,10 @@ export const renderCode = (
 
   return (
     <CodeBlock style={{ maxWidth: '100%' }}>
-      <CodeBlockCode className="kobsio-techdocs-code" style={{ maxWidth: '100%', overflow: 'auto' }}>
+      <CodeBlockCode
+        className="kobsio-techdocs-code kobsio-hide-scrollbar"
+        style={{ maxWidth: '100%', overflow: 'auto' }}
+      >
         {props.children}
       </CodeBlockCode>
     </CodeBlock>


### PR DESCRIPTION
We displayed a lot of scrollbars (especially in the dashboards) also
when it was not necessary. By changing the overflow property from
"scroll" to "auto" most of the scrollbars should be gone, so that we
have a cleanier ui.

We are now hidding the scrollbars via css, with loosing the
functionality for scrolling as a next step for a cleaner ui. This should
be used across all the kobs plugins, as long as it is clear that there
might be more "text" which can be viewed when we scroll in a container.
If it isn't visible in the first place that there might be more text we
should still display the scrollbars.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
