### PR TITLE
[core] Remove "transparent" option for plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#294](https://github.com/kobsio/kobs/pull/294): Improve shutdown of kobs by extending context timeout and adding `terminationGracePeriodSeconds` property.
 - [#305](https://github.com/kobsio/kobs/pull/305): [resources] Show state and last state of container in containers overview.
 - [#308](https://github.com/kobsio/kobs/pull/308): [core] Hide scrollbars to have a cleaner UI.
+- [#309](https://github.com/kobsio/kobs/pull/309): [core] :warning: _Breaking change:_ :warning: Remove `transparent` option for plugin panels.
 
 ## [v0.7.0](https://github.com/kobsio/kobs/releases/tag/v0.7.0) (2021-11-19)
 

--- a/plugins/applications/src/components/panel/Panel.tsx
+++ b/plugins/applications/src/components/panel/Panel.tsx
@@ -65,7 +65,6 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
         <PluginCard
           title={title}
           description={description}
-          transparent={true}
           actions={
             <PanelActions
               view="topology"
@@ -92,7 +91,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
 
     if (title) {
       return (
-        <PluginCard title={title} description={description} transparent={true}>
+        <PluginCard title={title} description={description}>
           {gallery}
         </PluginCard>
       );
@@ -119,7 +118,6 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
         <PluginCard
           title={title}
           description={description}
-          transparent={true}
           actions={
             <PanelActions
               view="gallery"
@@ -155,7 +153,6 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
         <PluginCard
           title={title}
           description={description}
-          transparent={true}
           actions={
             options.team ? undefined : (
               <PanelActions

--- a/plugins/azure/src/components/panel/Panel.tsx
+++ b/plugins/azure/src/components/panel/Panel.tsx
@@ -46,7 +46,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
     options.containerinstances.resourceGroups
   ) {
     return (
-      <PluginCard title={title} description={description} transparent={true}>
+      <PluginCard title={title} description={description}>
         <CIContainerGroups
           name={name}
           resourceGroups={options.containerinstances.resourceGroups}
@@ -157,7 +157,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
     options.kubernetesservices.resourceGroups
   ) {
     return (
-      <PluginCard title={title} description={description} transparent={true}>
+      <PluginCard title={title} description={description}>
         <KSKubernetesServices
           name={name}
           resourceGroups={options.kubernetesservices.resourceGroups}
@@ -239,7 +239,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
     options.virtualmachinescalesets.resourceGroups
   ) {
     return (
-      <PluginCard title={title} description={description} transparent={true}>
+      <PluginCard title={title} description={description}>
         <VMSSVirtualMachineScaleSets
           name={name}
           resourceGroups={options.virtualmachinescalesets.resourceGroups}

--- a/plugins/core/src/components/plugin/PluginCard.tsx
+++ b/plugins/core/src/components/plugin/PluginCard.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 interface IPluginCardProps {
   title: string;
   description?: string;
-  transparent?: boolean;
   children: React.ReactElement | null;
   actions?: React.ReactElement;
 }
@@ -15,7 +14,6 @@ interface IPluginCardProps {
 export const PluginCard: React.FunctionComponent<IPluginCardProps> = ({
   title,
   description,
-  transparent,
   children,
   actions,
 }: IPluginCardProps) => {
@@ -24,14 +22,7 @@ export const PluginCard: React.FunctionComponent<IPluginCardProps> = ({
   }
 
   return (
-    <Card
-      isCompact={true}
-      style={
-        transparent
-          ? { backgroundColor: '#f0f0f0', boxShadow: 'none', height: '100%', width: '100%' }
-          : { height: '100%', width: '100%' }
-      }
-    >
+    <Card isCompact={true} style={{ height: '100%', width: '100%' }}>
       <CardHeader>
         <CardHeaderMain>
           {description ? (
@@ -44,7 +35,7 @@ export const PluginCard: React.FunctionComponent<IPluginCardProps> = ({
         </CardHeaderMain>
         {actions || null}
       </CardHeader>
-      <CardBody className="kobsio-hide-scrollbar" style={{ overflow: 'auto' }}>
+      <CardBody className="kobsio-hide-scrollbar" style={{ overflow: 'auto', paddingTop: '8px' }}>
         {children}
       </CardBody>
     </Card>

--- a/plugins/dashboards/src/components/panel/Panel.tsx
+++ b/plugins/dashboards/src/components/panel/Panel.tsx
@@ -22,7 +22,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({ title, description
   }
 
   return (
-    <PluginCard title={title} description={description} transparent={true}>
+    <PluginCard title={title} description={description}>
       <Menu>
         <MenuContent>
           <MenuList>

--- a/plugins/grafana/src/components/panel/Panel.tsx
+++ b/plugins/grafana/src/components/panel/Panel.tsx
@@ -45,7 +45,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
     options.dashboards.length > 0
   ) {
     return (
-      <PluginCard title={title} description={description} transparent={true}>
+      <PluginCard title={title} description={description}>
         <Dashboards
           name={name}
           dashboardIDs={options.dashboards}

--- a/plugins/harbor/src/components/panel/Panel.tsx
+++ b/plugins/harbor/src/components/panel/Panel.tsx
@@ -22,7 +22,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
 }: IPanelProps) => {
   if (options && options.type === 'projects') {
     return (
-      <PluginCard title={title} description={description} transparent={true}>
+      <PluginCard title={title} description={description}>
         <Projects name={name} />
       </PluginCard>
     );
@@ -30,7 +30,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
 
   if (options && options.type === 'repositories' && options.repositories && options.repositories.projectName) {
     return (
-      <PluginCard title={title} description={description} transparent={true}>
+      <PluginCard title={title} description={description}>
         <Repositories
           name={name}
           projectName={options.repositories.projectName}
@@ -48,7 +48,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
     options.artifacts.repositoryName
   ) {
     return (
-      <PluginCard title={title} description={description} transparent={true}>
+      <PluginCard title={title} description={description}>
         <Artifacts
           name={name}
           address={pluginOptions && pluginOptions.address ? pluginOptions.address : ''}

--- a/plugins/istio/src/components/panel/Panel.tsx
+++ b/plugins/istio/src/components/panel/Panel.tsx
@@ -38,7 +38,6 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
       <PluginCard
         title={title}
         description={description}
-        transparent={false}
         actions={
           <PanelActions
             link={`/${name}?time=${times.time}&timeEnd=${times.timeEnd}&timeStart=${times.timeStart}${namespaceParams}`}
@@ -75,7 +74,6 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
       <PluginCard
         title={title}
         description={description}
-        transparent={false}
         actions={
           <PanelActions
             link={`/${name}/${options.namespaces[0]}/${options.application}?timeEnd=${times.timeEnd}&timeStart=${times.timeStart}&view=metrics`}
@@ -110,7 +108,6 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
       <PluginCard
         title={title}
         description={description}
-        transparent={false}
         actions={
           <PanelActions
             link={`/${name}/${options.namespaces[0]}/${options.application}?timeEnd=${times.timeEnd}&timeStart=${times.timeStart}&view=metrics`}
@@ -145,7 +142,6 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
       <PluginCard
         title={title}
         description={description}
-        transparent={true}
         actions={
           <PanelActions
             link={`/${name}/${options.namespaces[0]}/${options.application}?timeEnd=${times.timeEnd}&timeStart=${times.timeStart}&view=metrics`}
@@ -182,7 +178,6 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
       <PluginCard
         title={title}
         description={description}
-        transparent={false}
         actions={
           <PanelActions
             link={`/${name}/${options.namespaces[0]}/${options.application}?timeEnd=${times.timeEnd}&timeStart=${
@@ -225,7 +220,6 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
       <PluginCard
         title={title}
         description={description}
-        transparent={false}
         actions={
           <PanelActions
             link={`/${name}/${options.namespaces[0]}/${options.application}?timeEnd=${times.timeEnd}&timeStart=${

--- a/plugins/jaeger/src/components/panel/Traces.tsx
+++ b/plugins/jaeger/src/components/panel/Traces.tsx
@@ -103,7 +103,6 @@ const Traces: React.FunctionComponent<ITracesProps> = ({
     <PluginCard
       title={title}
       description={description}
-      transparent={true}
       actions={<TracesActions name={name} queries={queries} times={times} />}
     >
       <div>

--- a/plugins/kiali/src/components/panel/Panel.tsx
+++ b/plugins/kiali/src/components/panel/Panel.tsx
@@ -32,7 +32,6 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
     <PluginCard
       title={title}
       description={description}
-      transparent={true}
       actions={<GraphActions name={name} namespaces={options.namespaces} times={times} />}
     >
       <GraphWrapper name={name} namespaces={options.namespaces} times={times} setDetails={setDetails} />

--- a/plugins/opsgenie/src/components/panel/Panel.tsx
+++ b/plugins/opsgenie/src/components/panel/Panel.tsx
@@ -35,7 +35,6 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
       <PluginCard
         title={title}
         description={description}
-        transparent={true}
         actions={<IncidentsActions name={name} query={options.query || ''} times={times} type="incidents" />}
       >
         <Incidents
@@ -53,7 +52,6 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
     <PluginCard
       title={title}
       description={description}
-      transparent={true}
       actions={<AlertsActions name={name} query={options.query || ''} times={times} type="alerts" />}
     >
       <Alerts

--- a/plugins/resources/src/components/panel/Panel.tsx
+++ b/plugins/resources/src/components/panel/Panel.tsx
@@ -25,12 +25,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
     // the component is used in the resources page and we do not wrap it in the PluginCard component.
     if (title) {
       return (
-        <PluginCard
-          title={title}
-          description={description}
-          transparent={true}
-          actions={<PanelActions options={options} />}
-        >
+        <PluginCard title={title} description={description} actions={<PanelActions options={options} />}>
           <PanelList resources={options} times={times} setDetails={setDetails} />
         </PluginCard>
       );

--- a/plugins/rss/src/components/panel/Panel.tsx
+++ b/plugins/rss/src/components/panel/Panel.tsx
@@ -26,7 +26,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
   }
 
   return (
-    <PluginCard title={title} description={description} transparent={true}>
+    <PluginCard title={title} description={description}>
       <Feed urls={options.urls} sortBy={options.sortBy || 'published'} setDetails={setDetails} />
     </PluginCard>
   );

--- a/plugins/sonarqube/src/components/panel/Panel.tsx
+++ b/plugins/sonarqube/src/components/panel/Panel.tsx
@@ -32,7 +32,6 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
     <PluginCard
       title={title}
       description={description}
-      transparent={true}
       actions={<PanelActions url={pluginOptions ? pluginOptions.url : ''} project={options.project} />}
     >
       <Measures name={name} project={options.project} metricKeys={options.metricKeys} />

--- a/plugins/teams/src/components/panel/Panel.tsx
+++ b/plugins/teams/src/components/panel/Panel.tsx
@@ -7,7 +7,7 @@ import Teams from './Teams';
 // because it can only be used to display all teams from all clusters and namespaces.
 export const Panel: React.FunctionComponent<IPluginPanelProps> = ({ title, description }: IPluginPanelProps) => {
   return (
-    <PluginCard title={title} description={description} transparent={true}>
+    <PluginCard title={title} description={description}>
       <Teams />
     </PluginCard>
   );

--- a/plugins/techdocs/src/components/panel/Panel.tsx
+++ b/plugins/techdocs/src/components/panel/Panel.tsx
@@ -18,7 +18,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({
 }: IPanelProps) => {
   if (options && options.type && options.type === 'list') {
     return (
-      <PluginCard title={title} description={description} transparent={true}>
+      <PluginCard title={title} description={description}>
         <TechDocsList name={name} />
       </PluginCard>
     );

--- a/plugins/users/src/components/panel/Panel.tsx
+++ b/plugins/users/src/components/panel/Panel.tsx
@@ -21,7 +21,7 @@ export const Panel: React.FunctionComponent<IPanelProps> = ({ title, description
   }
 
   return (
-    <PluginCard title={title} description={description} transparent={true}>
+    <PluginCard title={title} description={description}>
       <Users cluster={options.cluster} namespace={options.namespace} name={options.name} />
     </PluginCard>
   );


### PR DESCRIPTION
We decided to remove the "transparent" option for plugin panels. This
means that all panels are now look more similar.

If you have developed an plugin which uses this option you have to
remove the property, so that your plugin is working with the latest
version of kobs.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
