### PR TITLE
[dashboards] Disable Intersection Observer API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#308](https://github.com/kobsio/kobs/pull/308): [core] Hide scrollbars to have a cleaner UI.
 - [#309](https://github.com/kobsio/kobs/pull/309): [core] :warning: _Breaking change:_ :warning: Remove `transparent` option for plugin panels.
 - [#310](https://github.com/kobsio/kobs/pull/310): [core] :warning: _Breaking change:_ :warning: Rework home page, so that it can be customized by a user.
+- [#312](https://github.com/kobsio/kobs/pull/312): [dashboards] Do not use Intersection Observer API, when a dashboard contains a row with `size: -1`.
 
 ## [v0.7.0](https://github.com/kobsio/kobs/releases/tag/v0.7.0) (2021-11-19)
 

--- a/docs/resources/dashboards.md
+++ b/docs/resources/dashboards.md
@@ -113,7 +113,7 @@ A row can be used to create logical groups in the dashboard.
 | ----- | ---- | ----------- | -------- |
 | title | string | The title for a row. | No |
 | description | string | The description for the row, to provide additional details about the content of the row. | No |
-| size | number | The size of the row. This must be a value between `1` and `12`. The default value is `2`. You can also use the special value `-1` to not limit the height of the row. | No |
+| size | number | The size of the row. This must be a value between `1` and `12`. The default value is `2`. You can also use the special value `-1` to not limit the height of the row. **Note:** When a dashboard makes use of the `-1` value the Intersection Observer API is disabled, so that all dashboard panels are loaded at once. | No |
 | panels | [[]Panel](#panel) | A list of panels for the row. | Yes |
 
 ### Panel

--- a/plugins/dashboards/src/components/dashboards/Dashboard.tsx
+++ b/plugins/dashboards/src/components/dashboards/Dashboard.tsx
@@ -124,6 +124,7 @@ const Dashboard: React.FunctionComponent<IDashboardProps> = ({
   // in the dashboard first with users selected values. For that we have to convert the array to a string first so that
   // we can replace the variables in the string and then we have to convert it back to an array,
   const rows: IDashboardRow[] = JSON.parse(interpolate(JSON.stringify(dashboard.rows), data ? data : [], times));
+  const containsUnlimited = rows.filter((row) => row.size === -1).length > 0;
 
   if (isError) {
     return (
@@ -173,40 +174,60 @@ const Dashboard: React.FunctionComponent<IDashboardProps> = ({
                 span={toGridSpans(12, forceDefaultSpan, panel.colSpan)}
                 rowSpan={toGridSpans(1, forceDefaultSpan, panel.rowSpan)}
               >
-                <InView>
-                  {({ inView, ref }): React.ReactNode => (
-                    <div ref={ref}>
-                      {inView ? (
-                        <div
-                          className="kobsio-hide-scrollbar"
-                          style={
-                            row.size !== undefined && row.size === -1
-                              ? undefined
-                              : { height: rowHeight(row.size, panel.rowSpan), overflow: 'auto' }
-                          }
-                        >
-                          <PluginPanel
-                            times={times}
-                            title={panel.title}
-                            description={panel.description}
-                            name={panel.plugin.name}
-                            options={panel.plugin.options}
-                            setDetails={setDetails}
-                          />
-                        </div>
-                      ) : (
-                        <div
-                          className="kobsio-hide-scrollbar"
-                          style={
-                            row.size !== undefined && row.size === -1
-                              ? undefined
-                              : { height: rowHeight(row.size, panel.rowSpan), overflow: 'auto' }
-                          }
-                        ></div>
-                      )}
-                    </div>
-                  )}
-                </InView>
+                {containsUnlimited ? (
+                  <div
+                    className="kobsio-hide-scrollbar"
+                    style={
+                      row.size !== undefined && row.size === -1
+                        ? undefined
+                        : { height: rowHeight(row.size, panel.rowSpan), overflow: 'auto' }
+                    }
+                  >
+                    <PluginPanel
+                      times={times}
+                      title={panel.title}
+                      description={panel.description}
+                      name={panel.plugin.name}
+                      options={panel.plugin.options}
+                      setDetails={setDetails}
+                    />
+                  </div>
+                ) : (
+                  <InView>
+                    {({ inView, ref }): React.ReactNode => (
+                      <div ref={ref}>
+                        {inView ? (
+                          <div
+                            className="kobsio-hide-scrollbar"
+                            style={
+                              row.size !== undefined && row.size === -1
+                                ? undefined
+                                : { height: rowHeight(row.size, panel.rowSpan), overflow: 'auto' }
+                            }
+                          >
+                            <PluginPanel
+                              times={times}
+                              title={panel.title}
+                              description={panel.description}
+                              name={panel.plugin.name}
+                              options={panel.plugin.options}
+                              setDetails={setDetails}
+                            />
+                          </div>
+                        ) : (
+                          <div
+                            className="kobsio-hide-scrollbar"
+                            style={
+                              row.size !== undefined && row.size === -1
+                                ? undefined
+                                : { height: rowHeight(row.size, panel.rowSpan), overflow: 'auto' }
+                            }
+                          ></div>
+                        )}
+                      </div>
+                    )}
+                  </InView>
+                )}
               </GridItem>
             ))}
           </React.Fragment>


### PR DESCRIPTION
We decided to disable the Intersection Observer API for the case that a
row in dashboard contains the "size" property set to "-1".

The "size" property in a dashboard can be used to not set an "unlimited"
size for a row, with the goal that the row can take as much space as
needed to avoid unnecessary scrolling within the row panels. Since we
can not precalculate the height for such rows, we decided to disable the
usage of the Intersection Observer API for dashboards where the "size"
property is set to "-1", to not have some buggy scroll behaviour.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
