### PR TITLE
[app] Update Permission Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 ### Fixed
 
+
 ### Changed
 
 - [#346](https://github.com/kobsio/kobs/pull/346): [app] :warning: _Breaking change:_ :warning: Rework kobs architecture, by introducing a `hub` and a `satellite` component. This new architecture allows us to run the kobs `hub` component in a central cluster and access clusters / services (plugins) through the kobs `satellite` component. More information regarding the new kobs architecture can be found in the documentation at [kobs.io](https://kobs.io).
+- [#348](https://github.com/kobsio/kobs/pull/348): [app] Update permission handling.
 
 ## [v0.8.0](https://github.com/kobsio/kobs/releases/tag/v0.8.0) (2022-03-24)
 

--- a/deploy/helm/satellite/crds/kobs.io_teams.yaml
+++ b/deploy/helm/satellite/crds/kobs.io_teams.yaml
@@ -188,9 +188,6 @@ spec:
                         type:
                           type: string
                       required:
-                      - clusters
-                      - namespaces
-                      - satellites
                       - type
                       type: object
                     type: array
@@ -203,9 +200,12 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                         satellite:
                           type: string
+                        type:
+                          type: string
                       required:
                       - name
                       - satellite
+                      - type
                       type: object
                     type: array
                   resources:
@@ -243,11 +243,6 @@ spec:
                     items:
                       type: string
                     type: array
-                required:
-                - applications
-                - plugins
-                - resources
-                - teams
                 type: object
               satellite:
                 type: string

--- a/deploy/helm/satellite/crds/kobs.io_users.yaml
+++ b/deploy/helm/satellite/crds/kobs.io_users.yaml
@@ -172,9 +172,6 @@ spec:
                         type:
                           type: string
                       required:
-                      - clusters
-                      - namespaces
-                      - satellites
                       - type
                       type: object
                     type: array
@@ -187,9 +184,12 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                         satellite:
                           type: string
+                        type:
+                          type: string
                       required:
                       - name
                       - satellite
+                      - type
                       type: object
                     type: array
                   resources:
@@ -227,11 +227,6 @@ spec:
                     items:
                       type: string
                     type: array
-                required:
-                - applications
-                - plugins
-                - resources
-                - teams
                 type: object
               satellite:
                 type: string

--- a/deploy/kustomize/crds/kobs.io_teams.yaml
+++ b/deploy/kustomize/crds/kobs.io_teams.yaml
@@ -188,9 +188,6 @@ spec:
                         type:
                           type: string
                       required:
-                      - clusters
-                      - namespaces
-                      - satellites
                       - type
                       type: object
                     type: array
@@ -203,9 +200,12 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                         satellite:
                           type: string
+                        type:
+                          type: string
                       required:
                       - name
                       - satellite
+                      - type
                       type: object
                     type: array
                   resources:
@@ -243,11 +243,6 @@ spec:
                     items:
                       type: string
                     type: array
-                required:
-                - applications
-                - plugins
-                - resources
-                - teams
                 type: object
               satellite:
                 type: string

--- a/deploy/kustomize/crds/kobs.io_users.yaml
+++ b/deploy/kustomize/crds/kobs.io_users.yaml
@@ -172,9 +172,6 @@ spec:
                         type:
                           type: string
                       required:
-                      - clusters
-                      - namespaces
-                      - satellites
                       - type
                       type: object
                     type: array
@@ -187,9 +184,12 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                         satellite:
                           type: string
+                        type:
+                          type: string
                       required:
                       - name
                       - satellite
+                      - type
                       type: object
                     type: array
                   resources:
@@ -227,11 +227,6 @@ spec:
                     items:
                       type: string
                     type: array
-                required:
-                - applications
-                - plugins
-                - resources
-                - teams
                 type: object
               satellite:
                 type: string

--- a/pkg/hub/api/teams/teams_test.go
+++ b/pkg/hub/api/teams/teams_test.go
@@ -71,7 +71,7 @@ func TestGetTeams(t *testing.T) {
 			name:               "get all teams",
 			url:                "/teams?all=true",
 			expectedStatusCode: http.StatusOK,
-			expectedBody:       "[{\"group\":\"team1\",\"permissions\":{\"applications\":null,\"teams\":null,\"plugins\":null,\"resources\":null}},{\"group\":\"team2\",\"permissions\":{\"applications\":null,\"teams\":null,\"plugins\":null,\"resources\":null}},{\"group\":\"team3\",\"permissions\":{\"applications\":null,\"teams\":null,\"plugins\":null,\"resources\":null}}]\n",
+			expectedBody:       "[{\"group\":\"team1\",\"permissions\":{}},{\"group\":\"team2\",\"permissions\":{}},{\"group\":\"team3\",\"permissions\":{}}]\n",
 			prepare: func(t *testing.T, mockStoreClient *store.MockClient) {
 				mockStoreClient.On("GetTeams", mock.Anything).Return([]teamv1.TeamSpec{{Group: "team1"}, {Group: "team2"}, {Group: "team3"}, {Group: "team1"}, {Group: "team2"}}, nil)
 				mockStoreClient.AssertNotCalled(t, "GetTeamsByGroups", mock.Anything, mock.Anything)
@@ -99,7 +99,7 @@ func TestGetTeams(t *testing.T) {
 			name:               "get own teams",
 			url:                "/teams",
 			expectedStatusCode: http.StatusOK,
-			expectedBody:       "[{\"group\":\"team1\",\"permissions\":{\"applications\":null,\"teams\":null,\"plugins\":null,\"resources\":null}}]\n",
+			expectedBody:       "[{\"group\":\"team1\",\"permissions\":{}}]\n",
 			prepare: func(t *testing.T, mockStoreClient *store.MockClient) {
 				mockStoreClient.AssertNotCalled(t, "GetTeams", mock.Anything)
 				mockStoreClient.On("GetTeamsByGroups", mock.Anything, []string{"team1"}).Return([]teamv1.TeamSpec{{Group: "team1"}, {Group: "team1"}}, nil)
@@ -181,7 +181,7 @@ func TestGetTeam(t *testing.T) {
 			name:               "get team",
 			url:                "/teams/team?group=team1",
 			expectedStatusCode: http.StatusOK,
-			expectedBody:       "{\"group\":\"team1\",\"permissions\":{\"applications\":null,\"teams\":null,\"plugins\":null,\"resources\":null}}\n",
+			expectedBody:       "{\"group\":\"team1\",\"permissions\":{}}\n",
 			prepare: func(t *testing.T, mockStoreClient *store.MockClient) {
 				mockStoreClient.On("GetTeamByGroup", mock.Anything, "team1").Return(&teamv1.TeamSpec{Group: "team1"}, nil)
 			},

--- a/pkg/hub/hub.go
+++ b/pkg/hub/hub.go
@@ -88,7 +88,7 @@ func New(debugUsername, debugPassword, hubAddress string, authEnabled bool, auth
 		r.Use(middleware.URLFormat)
 		r.Use(metrics.Metrics)
 		r.Use(httplog.Logger)
-		r.Use(userauth.Handler(authEnabled, authHeaderUser, authHeaderTeams, authSessionToken, authSessionInterval, nil))
+		r.Use(userauth.Handler(authEnabled, authHeaderUser, authHeaderTeams, authSessionToken, authSessionInterval, storeClient))
 		r.Use(render.SetContentType(render.ContentTypeJSON))
 
 		r.Mount("/auth", userauth.Mount(authLogoutRedirect))

--- a/pkg/hub/middleware/userauth/auth.go
+++ b/pkg/hub/middleware/userauth/auth.go
@@ -113,6 +113,8 @@ func (a *Auth) Handler(next http.Handler) http.Handler {
 				http.SetCookie(w, &http.Cookie{
 					Name:     "kobs-auth",
 					Value:    token,
+					Path:     "/",
+					Expires:  time.Now().Add(a.sessionInterval),
 					Secure:   true,
 					HttpOnly: true,
 				})
@@ -144,6 +146,8 @@ func (a *Auth) Handler(next http.Handler) http.Handler {
 					http.SetCookie(w, &http.Cookie{
 						Name:     "kobs-auth",
 						Value:    token,
+						Path:     "/",
+						Expires:  time.Now().Add(a.sessionInterval),
 						Secure:   true,
 						HttpOnly: true,
 					})
@@ -162,7 +166,7 @@ func (a *Auth) Handler(next http.Handler) http.Handler {
 				Permissions: userv1.Permissions{
 					Applications: []userv1.ApplicationPermissions{{Type: "all"}},
 					Teams:        []string{"*"},
-					Plugins:      []userv1.Plugin{{Satellite: "*", Name: "*"}},
+					Plugins:      []userv1.Plugin{{Satellite: "*", Type: "*", Name: "*"}},
 					Resources:    []userv1.Resources{{Satellites: []string{"*"}, Clusters: []string{"*"}, Namespaces: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"*"}}},
 				},
 			})

--- a/pkg/hub/middleware/userauth/auth_test.go
+++ b/pkg/hub/middleware/userauth/auth_test.go
@@ -86,7 +86,7 @@ func TestAuthHandler(t *testing.T) {
 			name:               "auth disabled",
 			auth:               Auth{enabled: false},
 			expectedStatusCode: http.StatusOK,
-			expectedBody:       "{\"email\":\"\",\"teams\":[\"*\"],\"permissions\":{\"applications\":[{\"type\":\"all\",\"satellites\":null,\"clusters\":null,\"namespaces\":null}],\"teams\":[\"*\"],\"plugins\":[{\"satellite\":\"*\",\"name\":\"*\",\"permissions\":null}],\"resources\":[{\"satellites\":[\"*\"],\"clusters\":[\"*\"],\"namespaces\":[\"*\"],\"resources\":[\"*\"],\"verbs\":[\"*\"]}]}}\n",
+			expectedBody:       "{\"email\":\"\",\"teams\":[\"*\"],\"permissions\":{\"applications\":[{\"type\":\"all\"}],\"teams\":[\"*\"],\"plugins\":[{\"satellite\":\"*\",\"name\":\"*\",\"type\":\"*\",\"permissions\":null}],\"resources\":[{\"satellites\":[\"*\"],\"clusters\":[\"*\"],\"namespaces\":[\"*\"],\"resources\":[\"*\"],\"verbs\":[\"*\"]}]}}\n",
 			prepareRequest:     func(r *http.Request) {},
 			prepareStoreClient: func(mockStoreClient *store.MockClient) {},
 		},
@@ -145,7 +145,7 @@ func TestAuthHandler(t *testing.T) {
 			name:               "auth enabled, request without cookie, success",
 			auth:               Auth{enabled: true, headerUser: "X-Auth-Request-Email"},
 			expectedStatusCode: http.StatusOK,
-			expectedBody:       "{\"email\":\"user1@kobs.io\",\"teams\":null,\"permissions\":{\"applications\":null,\"teams\":null,\"plugins\":null,\"resources\":null}}\n",
+			expectedBody:       "{\"email\":\"user1@kobs.io\",\"teams\":null,\"permissions\":{}}\n",
 			prepareRequest: func(r *http.Request) {
 				r.Header.Add("X-Auth-Request-Email", "user1@kobs.io")
 			},
@@ -189,7 +189,7 @@ func TestAuthHandler(t *testing.T) {
 			name:               "auth enabled, request with cookie, validate token error, success",
 			auth:               Auth{enabled: true, headerUser: "X-Auth-Request-Email"},
 			expectedStatusCode: http.StatusOK,
-			expectedBody:       "{\"email\":\"user1@kobs.io\",\"teams\":null,\"permissions\":{\"applications\":null,\"teams\":null,\"plugins\":null,\"resources\":null}}\n",
+			expectedBody:       "{\"email\":\"user1@kobs.io\",\"teams\":null,\"permissions\":{}}\n",
 			prepareRequest: func(r *http.Request) {
 				token, _ := jwt.CreateToken(authContext.User{}, "sessionToken", 10*time.Second)
 				r.AddCookie(&http.Cookie{Name: "kobs-auth", Value: token})
@@ -204,7 +204,7 @@ func TestAuthHandler(t *testing.T) {
 			name:               "auth enabled, request with cookie, valid token, success",
 			auth:               Auth{enabled: true, headerUser: "X-Auth-Request-Email"},
 			expectedStatusCode: http.StatusOK,
-			expectedBody:       "{\"email\":\"user1@kobs.io\",\"teams\":null,\"permissions\":{\"applications\":null,\"teams\":null,\"plugins\":null,\"resources\":null}}\n",
+			expectedBody:       "{\"email\":\"user1@kobs.io\",\"teams\":null,\"permissions\":{}}\n",
 			prepareRequest: func(r *http.Request) {
 				token, _ := jwt.CreateToken(authContext.User{Email: "user1@kobs.io"}, "", 10*time.Minute)
 				r.AddCookie(&http.Cookie{Name: "kobs-auth", Value: token})

--- a/pkg/hub/middleware/userauth/context/context.go
+++ b/pkg/hub/middleware/userauth/context/context.go
@@ -77,11 +77,13 @@ func (u *User) HasTeamAccess(teamGroup string) bool {
 }
 
 // HasPluginAccess checks if the user has access to the given plugin.
-func (u *User) HasPluginAccess(satellite, plugin string) bool {
+func (u *User) HasPluginAccess(satellite, pluginType, pluginName string) bool {
 	for _, p := range u.Permissions.Plugins {
 		if p.Satellite == satellite || p.Satellite == "*" {
-			if p.Name == plugin || p.Name == "*" {
-				return true
+			if p.Type == pluginType || p.Type == "*" {
+				if p.Name == pluginName || p.Name == "*" {
+					return true
+				}
 			}
 		}
 	}

--- a/pkg/hub/middleware/userauth/context/context_test.go
+++ b/pkg/hub/middleware/userauth/context/context_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestToString(t *testing.T) {
 	u := User{Email: "test1"}
-	require.Equal(t, "{\"email\":\"test1\",\"teams\":null,\"permissions\":{\"applications\":null,\"teams\":null,\"plugins\":null,\"resources\":null}}", u.ToString())
+	require.Equal(t, "{\"email\":\"test1\",\"teams\":null,\"permissions\":{}}", u.ToString())
 }
 
 func TestHasApplicationAccess(t *testing.T) {
@@ -60,16 +60,18 @@ func TestHasPluginAccess(t *testing.T) {
 		user              User
 		expectedHasAccess bool
 	}{
-		{user: User{Email: "user1@kobs.io", Permissions: userv1.Permissions{Plugins: []userv1.Plugin{{Satellite: "*", Name: "*"}}}}, expectedHasAccess: true},
-		{user: User{Email: "user2@kobs.io", Permissions: userv1.Permissions{Plugins: []userv1.Plugin{{Satellite: "*", Name: "plugin1"}}}}, expectedHasAccess: true},
-		{user: User{Email: "user3@kobs.io", Permissions: userv1.Permissions{Plugins: []userv1.Plugin{{Satellite: "*", Name: "plugin1"}, {Satellite: "*", Name: "plugin2"}}}}, expectedHasAccess: true},
-		{user: User{Email: "user4@kobs.io", Permissions: userv1.Permissions{Plugins: []userv1.Plugin{{Satellite: "*", Name: "plugin2"}}}}, expectedHasAccess: false},
-		{user: User{Email: "user5@kobs.io", Permissions: userv1.Permissions{Plugins: []userv1.Plugin{{Satellite: "*", Name: "plugin2"}, {Satellite: "*", Name: "*"}}}}, expectedHasAccess: true},
-		{user: User{Email: "user6@kobs.io", Permissions: userv1.Permissions{Plugins: []userv1.Plugin{{Satellite: "test-satellite1", Name: "*"}}}}, expectedHasAccess: true},
-		{user: User{Email: "user7@kobs.io", Permissions: userv1.Permissions{Plugins: []userv1.Plugin{{Satellite: "test-satellite2", Name: "*"}}}}, expectedHasAccess: false},
+		{user: User{Email: "user1@kobs.io", Permissions: userv1.Permissions{Plugins: []userv1.Plugin{{Satellite: "*", Type: "prometheus", Name: "*"}}}}, expectedHasAccess: true},
+		{user: User{Email: "user2@kobs.io", Permissions: userv1.Permissions{Plugins: []userv1.Plugin{{Satellite: "*", Type: "prometheus", Name: "plugin1"}}}}, expectedHasAccess: true},
+		{user: User{Email: "user3@kobs.io", Permissions: userv1.Permissions{Plugins: []userv1.Plugin{{Satellite: "*", Type: "prometheus", Name: "plugin1"}, {Satellite: "*", Type: "prometheus", Name: "plugin2"}}}}, expectedHasAccess: true},
+		{user: User{Email: "user4@kobs.io", Permissions: userv1.Permissions{Plugins: []userv1.Plugin{{Satellite: "*", Type: "prometheus", Name: "plugin2"}}}}, expectedHasAccess: false},
+		{user: User{Email: "user5@kobs.io", Permissions: userv1.Permissions{Plugins: []userv1.Plugin{{Satellite: "*", Type: "prometheus", Name: "plugin2"}, {Satellite: "*", Type: "prometheus", Name: "*"}}}}, expectedHasAccess: true},
+		{user: User{Email: "user6@kobs.io", Permissions: userv1.Permissions{Plugins: []userv1.Plugin{{Satellite: "test-satellite1", Type: "prometheus", Name: "*"}}}}, expectedHasAccess: true},
+		{user: User{Email: "user7@kobs.io", Permissions: userv1.Permissions{Plugins: []userv1.Plugin{{Satellite: "test-satellite2", Type: "prometheus", Name: "*"}}}}, expectedHasAccess: false},
+		{user: User{Email: "user1@kobs.io", Permissions: userv1.Permissions{Plugins: []userv1.Plugin{{Satellite: "*", Type: "klogs", Name: "*"}}}}, expectedHasAccess: false},
+		{user: User{Email: "user1@kobs.io", Permissions: userv1.Permissions{Plugins: []userv1.Plugin{{Satellite: "*", Type: "*", Name: "*"}}}}, expectedHasAccess: true},
 	} {
 		t.Run(tt.user.Email, func(t *testing.T) {
-			actualHasAccess := tt.user.HasPluginAccess("test-satellite1", "plugin1")
+			actualHasAccess := tt.user.HasPluginAccess("test-satellite1", "prometheus", "plugin1")
 			require.Equal(t, tt.expectedHasAccess, actualHasAccess)
 		})
 	}

--- a/pkg/hub/middleware/userauth/router_test.go
+++ b/pkg/hub/middleware/userauth/router_test.go
@@ -22,7 +22,7 @@ func TestUserAuthHandler(t *testing.T) {
 			name:               "get user",
 			user:               authContext.User{},
 			expectedStatusCode: http.StatusOK,
-			expectedBody:       "{\"email\":\"\",\"teams\":null,\"permissions\":{\"applications\":null,\"teams\":null,\"plugins\":null,\"resources\":null}}\n",
+			expectedBody:       "{\"email\":\"\",\"teams\":null,\"permissions\":{}}\n",
 		},
 		{
 			name:               "could not get user",

--- a/pkg/kube/apis/user/v1/types.go
+++ b/pkg/kube/apis/user/v1/types.go
@@ -43,22 +43,23 @@ type UserSpec struct {
 }
 
 type Permissions struct {
-	Applications []ApplicationPermissions `json:"applications"`
-	Teams        []string                 `json:"teams"`
-	Plugins      []Plugin                 `json:"plugins"`
-	Resources    []Resources              `json:"resources"`
+	Applications []ApplicationPermissions `json:"applications,omitempty"`
+	Teams        []string                 `json:"teams,omitempty"`
+	Plugins      []Plugin                 `json:"plugins,omitempty"`
+	Resources    []Resources              `json:"resources,omitempty"`
 }
 
 type ApplicationPermissions struct {
 	Type       string   `json:"type"`
-	Satellites []string `json:"satellites"`
-	Clusters   []string `json:"clusters"`
-	Namespaces []string `json:"namespaces"`
+	Satellites []string `json:"satellites,omitempty"`
+	Clusters   []string `json:"clusters,omitempty"`
+	Namespaces []string `json:"namespaces,omitempty"`
 }
 
 type Plugin struct {
 	Satellite   string               `json:"satellite"`
 	Name        string               `json:"name"`
+	Type        string               `json:"type"`
 	Permissions apiextensionsv1.JSON `json:"permissions,omitempty"`
 }
 

--- a/pkg/satellite/api/teams/teams_test.go
+++ b/pkg/satellite/api/teams/teams_test.go
@@ -33,7 +33,7 @@ func TestGetTeams(t *testing.T) {
 		{
 			name:               "get teams",
 			expectedStatusCode: http.StatusOK,
-			expectedBody:       "[{\"cluster\":\"cluster1\",\"namespace\":\"namespace1\",\"name\":\"name1\",\"group\":\"team1@kobs.io\",\"permissions\":{\"applications\":null,\"teams\":null,\"plugins\":null,\"resources\":null}}]\n",
+			expectedBody:       "[{\"cluster\":\"cluster1\",\"namespace\":\"namespace1\",\"name\":\"name1\",\"group\":\"team1@kobs.io\",\"permissions\":{}}]\n",
 			prepare: func(mockClusterClient *cluster.MockClient) {
 				mockClusterClient.On("GetTeams", mock.Anything, "").Return([]teamv1.TeamSpec{{Cluster: "cluster1", Namespace: "namespace1", Name: "name1", Group: "team1@kobs.io"}}, nil)
 			},

--- a/pkg/satellite/api/users/users_test.go
+++ b/pkg/satellite/api/users/users_test.go
@@ -32,7 +32,7 @@ func TestGetUsers(t *testing.T) {
 		{
 			name:               "get users",
 			expectedStatusCode: http.StatusOK,
-			expectedBody:       "[{\"cluster\":\"cluster1\",\"namespace\":\"namespace1\",\"name\":\"name1\",\"email\":\"user1@kobs.io\",\"permissions\":{\"applications\":null,\"teams\":null,\"plugins\":null,\"resources\":null}}]\n",
+			expectedBody:       "[{\"cluster\":\"cluster1\",\"namespace\":\"namespace1\",\"name\":\"name1\",\"email\":\"user1@kobs.io\",\"permissions\":{}}]\n",
 			prepare: func(mockClusterClient *cluster.MockClient) {
 				mockClusterClient.On("GetUsers", mock.Anything, "").Return([]userv1.UserSpec{{Cluster: "cluster1", Namespace: "namespace1", Name: "name1", Email: "user1@kobs.io"}}, nil)
 			},

--- a/pkg/satellite/plugins/plugins.go
+++ b/pkg/satellite/plugins/plugins.go
@@ -75,17 +75,20 @@ func NewClient(pluginDir string, instances []plugin.Instance, clustersClient clu
 
 		mountSymbol, err := p.Lookup("Mount")
 		if err != nil {
+			log.Error(nil, "Could not find mount symbol", zap.Error(err), zap.String("type", pluginType))
 			return nil, err
 		}
 
 		mountFunc, ok := mountSymbol.(func(instances []plugin.Instance, clustersClient clusters.Client) (chi.Router, error))
 		if !ok {
+			log.Error(nil, "Mount function has wrong type", zap.Error(err), zap.String("type", pluginType))
 			return nil, fmt.Errorf("mount function is not of type \"func(instances []plugin.Instance, clustersClient clusters.Client) chi.Router\" for plugin %s", pluginType)
 		}
 
 		pluginRouter, err := mountFunc(filterInstances(pluginType, instances), clustersClient)
 		if err != nil {
-			log.Fatal(nil, "Could not load plugin", zap.Error(err), zap.String("type", pluginType))
+			log.Error(nil, "Could not load plugin", zap.Error(err), zap.String("type", pluginType))
+			return nil, err
 		}
 
 		router.Mount(fmt.Sprintf("/%s", pluginType), pluginRouter)

--- a/plugins/app/src/components/applications/Applications.tsx
+++ b/plugins/app/src/components/applications/Applications.tsx
@@ -25,7 +25,7 @@ const Applications: React.FunctionComponent = () => {
     navigate(
       `${location.pathname}?all=${opts.all}&external=${opts.external}&searchTerm=${encodeURIComponent(
         opts.searchTerm,
-      )}&page=${opts.page}&=perPage=${opts.perPage}${c.length > 0 ? c.join('') : ''}${n.length > 0 ? n.join('') : ''}${
+      )}&page=${opts.page}&perPage=${opts.perPage}${c.length > 0 ? c.join('') : ''}${n.length > 0 ? n.join('') : ''}${
         t.length > 0 ? t.join('') : ''
       }`,
     );

--- a/plugins/app/src/context/AuthContext.tsx
+++ b/plugins/app/src/context/AuthContext.tsx
@@ -17,14 +17,15 @@ export interface IPermissions {
 
 export interface IApplicationPermission {
   type: string;
-  satellites: string[];
-  clusters: string[];
-  namespaces: string[];
+  satellites?: string[];
+  clusters?: string[];
+  namespaces?: string[];
 }
 
 export interface IPluginPermission {
   satellite: string;
   name: string;
+  type: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   permissions: any;
 }
@@ -38,12 +39,12 @@ export interface IResourcesPermission {
 // IAuthContext is the plugin context, is contains all plugins.
 export interface IAuthContext {
   user: IUser;
-  hasPluginAccess: (satellite: string, name: string) => boolean;
+  hasPluginAccess: (satellite: string, pluginType: string, pluginName: string) => boolean;
 }
 
 // AuthContext is the plugin context object.
 export const AuthContext = React.createContext<IAuthContext>({
-  hasPluginAccess: (satellite: string, name: string) => {
+  hasPluginAccess: (satellite: string, pluginType: string, pluginName: string) => {
     return false;
   },
   user: {
@@ -83,12 +84,13 @@ export const AuthContextProvider: React.FunctionComponent<IAuthContextProviderPr
     }
   });
 
-  const hasPluginAccess = (satellite: string, name: string): boolean => {
+  const hasPluginAccess = (satellite: string, pluginType: string, pluginName: string): boolean => {
     if (data && data.permissions && data.permissions.plugins) {
       for (const plugin of data.permissions.plugins) {
         if (
           (plugin.satellite === satellite || plugin.satellite === '*') &&
-          (plugin.name === name || plugin.name === '*')
+          (plugin.type === pluginType || plugin.type === '*') &&
+          (plugin.name === pluginName || plugin.name === '*')
         ) {
           return true;
         }


### PR DESCRIPTION
We have updated the CRDs to have a better permission handling when the
kobs hub component is started with the "--auth.enabled" flag. In detail
we did the following changes:

- Do not require all fields in the User / Team permissions
- Check the plugin type. Until now we only checked the satellite and
  name of a plugin, but not the plugin type.
- Adjust cookie settings (include path and expire date).

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
