### PR TITLE
Fix VirtualService in Helm charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 ### Fixed
 
+- [#349](https://github.com/kobsio/kobs/pull/#349): [app] Fix the creation of a VirtualService in the Helm chart when no `additionalRoutes` are set.
+
 ### Changed
 
 - [#346](https://github.com/kobsio/kobs/pull/346): [app] :warning: _Breaking change:_ :warning: Rework kobs architecture, by introducing a `hub` and a `satellite` component. This new architecture allows us to run the kobs `hub` component in a central cluster and access clusters / services (plugins) through the kobs `satellite` component. More information regarding the new kobs architecture can be found in the documentation at [kobs.io](https://kobs.io).

--- a/deploy/helm/hub/Chart.yaml
+++ b/deploy/helm/hub/Chart.yaml
@@ -4,5 +4,5 @@ description: Kubernetes Observability Platform
 type: application
 home: https://kobs.io
 icon: https://kobs.io/assets/images/logo.svg
-version: 0.14.0
+version: 0.14.1
 appVersion: v0.8.0

--- a/deploy/helm/hub/templates/virtualservice.yaml
+++ b/deploy/helm/hub/templates/virtualservice.yaml
@@ -15,7 +15,9 @@ spec:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   http:
+    {{- with .Values.istio.virtualService.additionalRoutes }}
     {{- toYaml .Values.istio.virtualService.additionalRoutes | nindent 4 }}
+    {{- end }}
     - match:
         - uri:
             prefix: /api

--- a/deploy/helm/satellite/Chart.yaml
+++ b/deploy/helm/satellite/Chart.yaml
@@ -4,5 +4,5 @@ description: Kubernetes Observability Platform
 type: application
 home: https://kobs.io
 icon: https://kobs.io/assets/images/logo.svg
-version: 0.14.0
+version: 0.14.1
 appVersion: v0.8.0

--- a/deploy/helm/satellite/templates/virtualservice.yaml
+++ b/deploy/helm/satellite/templates/virtualservice.yaml
@@ -15,7 +15,9 @@ spec:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   http:
+    {{- with .Values.istio.virtualService.additionalRoutes }}
     {{- toYaml .Values.istio.virtualService.additionalRoutes | nindent 4 }}
+    {{- end }}
     - route:
         - destination:
             host: {{ include "satellite.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local


### PR DESCRIPTION
The VirtualService could not be created via the Helm chart, when no
value for "additionalRoutes" was specified in the values file. This
should now be fixed, so that the Helm chart can also be used to create a
VirtualService only with the default routes.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
