### PR TITLE
[app] Fix Docker image and request proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 ### Fixed
 
 - [#349](https://github.com/kobsio/kobs/pull/#349): [app] Fix the creation of a VirtualService in the Helm chart when no `additionalRoutes` are set.
+- [#350](https://github.com/kobsio/kobs/pull/#350): [app] Fix Docker image and request proxy.
 
 ### Changed
 

--- a/cmd/kobs/Dockerfile
+++ b/cmd/kobs/Dockerfile
@@ -5,15 +5,16 @@ COPY plugins /kobs/plugins
 RUN yarn install --frozen-lockfile --network-timeout 3600000
 RUN make generate-assets
 
-FROM golang:1.18.2 as api
+FROM golang:1.18.3 as api
 WORKDIR /kobs
 COPY go.mod go.sum /kobs/
 RUN go mod download
 COPY . .
-RUN export CGO_ENABLED=0 && make build && make build-plugins
+RUN export CGO_ENABLED=1 && make build && make build-plugins
 
-FROM alpine:3.14.2
-RUN apk update && apk add --no-cache ca-certificates
+FROM debian:stable-20220527
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
+RUN update-ca-certificates
 RUN mkdir /kobs
 COPY --from=api /kobs/bin/kobs /kobs
 COPY --from=api /kobs/bin/plugins /kobs/plugins

--- a/pkg/hub/satellites/satellite/request.go
+++ b/pkg/hub/satellites/satellite/request.go
@@ -20,11 +20,11 @@ func doRequest[T any](ctx context.Context, user *authContext.User, client *http.
 		return result, err
 	}
 
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	if user != nil {
-		req.Header.Add("x-kobs-user", user.ToString())
+		req.Header.Set("x-kobs-user", user.ToString())
 	} else {
-		req.Header.Add("x-kobs-user", "{\"email\": \"\"}")
+		req.Header.Set("x-kobs-user", "{\"email\": \"\"}")
 	}
 
 	resp, err := client.Do(req)

--- a/pkg/hub/satellites/satellite/satellite.go
+++ b/pkg/hub/satellites/satellite/satellite.go
@@ -95,8 +95,9 @@ func (c *client) Proxy(w http.ResponseWriter, r *http.Request) {
 	proxy.Director = func(req *http.Request) {
 		originalDirector(req)
 
-		req.Header.Add("Authorization", "Bearer "+c.config.Token)
-		req.Header.Add("x-kobs-satellite", c.config.Name)
+		req.Host = req.URL.Host
+		req.Header.Set("Authorization", "Bearer "+c.config.Token)
+		req.Header.Set("x-kobs-satellite", c.config.Name)
 	}
 
 	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {

--- a/pkg/satellite/middleware/tokenauth/tokenauth.go
+++ b/pkg/satellite/middleware/tokenauth/tokenauth.go
@@ -1,6 +1,7 @@
 package tokenauth
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -14,7 +15,7 @@ func Handler(token string) func(next http.Handler) http.Handler {
 			if token != "" {
 				authHeader := r.Header.Get("Authorization")
 				if !strings.HasPrefix(authHeader, "Bearer ") || strings.TrimLeft(authHeader, "Bearer ") != token {
-					errresponse.Render(w, r, nil, http.StatusUnauthorized, "You are not authorized to access the resource")
+					errresponse.Render(w, r, fmt.Errorf("authorization token is missing or invalid"), http.StatusUnauthorized, "You are not authorized to access the resource")
 					return
 				}
 			}

--- a/pkg/satellite/middleware/tokenauth/tokenauth_test.go
+++ b/pkg/satellite/middleware/tokenauth/tokenauth_test.go
@@ -20,13 +20,13 @@ func TestHandler(t *testing.T) {
 		{
 			name:               "authorization header missing",
 			expectedStatusCode: http.StatusUnauthorized,
-			expectedBody:       "{\"error\":\"You are not authorized to access the resource\"}\n",
+			expectedBody:       "{\"error\":\"You are not authorized to access the resource: authorization token is missing or invalid\"}\n",
 			prepareRequest:     func(r *http.Request) {},
 		},
 		{
 			name:               "authorization header invalid token",
 			expectedStatusCode: http.StatusUnauthorized,
-			expectedBody:       "{\"error\":\"You are not authorized to access the resource\"}\n",
+			expectedBody:       "{\"error\":\"You are not authorized to access the resource: authorization token is missing or invalid\"}\n",
 			prepareRequest: func(r *http.Request) {
 				r.Header.Add("Authorization", "Bearer faketoken")
 			},

--- a/pkg/satellite/plugins/plugins.go
+++ b/pkg/satellite/plugins/plugins.go
@@ -70,6 +70,7 @@ func NewClient(pluginDir string, instances []plugin.Instance, clustersClient clu
 	for _, pluginType := range pluginTypes {
 		p, err := goPlugin.Open(fmt.Sprintf("%s/%s.so", pluginDir, pluginType))
 		if err != nil {
+			log.Error(nil, "Could not open plugin", zap.Error(err), zap.String("dir", pluginDir), zap.String("type", pluginType))
 			return nil, err
 		}
 

--- a/plugins/plugin-azure/cmd/containerinstances_test.go
+++ b/plugins/plugin-azure/cmd/containerinstances_test.go
@@ -124,7 +124,7 @@ func TestGetContainerGroups(t *testing.T) {
 			})
 
 			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
-			req.Header.Add("x-kobs-plugin", tt.pluginName)
+			req.Header.Set("x-kobs-plugin", tt.pluginName)
 
 			w := httptest.NewRecorder()
 			tt.do(router, w, req)
@@ -241,7 +241,7 @@ func TestGetContainerGroup(t *testing.T) {
 			})
 
 			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
-			req.Header.Add("x-kobs-plugin", tt.pluginName)
+			req.Header.Set("x-kobs-plugin", tt.pluginName)
 
 			w := httptest.NewRecorder()
 			tt.do(router, w, req)
@@ -358,7 +358,7 @@ func TestRestartContainerGroup(t *testing.T) {
 			})
 
 			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
-			req.Header.Add("x-kobs-plugin", tt.pluginName)
+			req.Header.Set("x-kobs-plugin", tt.pluginName)
 
 			w := httptest.NewRecorder()
 			tt.do(router, w, req)
@@ -502,7 +502,7 @@ func TestGetContainerLogs(t *testing.T) {
 			})
 
 			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
-			req.Header.Add("x-kobs-plugin", tt.pluginName)
+			req.Header.Set("x-kobs-plugin", tt.pluginName)
 
 			w := httptest.NewRecorder()
 			tt.do(router, w, req)

--- a/plugins/plugin-azure/cmd/costmanagement_test.go
+++ b/plugins/plugin-azure/cmd/costmanagement_test.go
@@ -112,7 +112,7 @@ func TestGetActualCosts(t *testing.T) {
 			})
 
 			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
-			req.Header.Add("x-kobs-plugin", tt.pluginName)
+			req.Header.Set("x-kobs-plugin", tt.pluginName)
 
 			w := httptest.NewRecorder()
 			tt.do(router, w, req)

--- a/plugins/plugin-azure/cmd/kubernetesservices_test.go
+++ b/plugins/plugin-azure/cmd/kubernetesservices_test.go
@@ -124,7 +124,7 @@ func TestGetManagedClusters(t *testing.T) {
 			})
 
 			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
-			req.Header.Add("x-kobs-plugin", tt.pluginName)
+			req.Header.Set("x-kobs-plugin", tt.pluginName)
 
 			w := httptest.NewRecorder()
 			tt.do(router, w, req)
@@ -240,7 +240,7 @@ func TestGetManagedCluster(t *testing.T) {
 			})
 
 			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
-			req.Header.Add("x-kobs-plugin", tt.pluginName)
+			req.Header.Set("x-kobs-plugin", tt.pluginName)
 
 			w := httptest.NewRecorder()
 			tt.do(router, w, req)
@@ -356,7 +356,7 @@ func TestGetNodePools(t *testing.T) {
 			})
 
 			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
-			req.Header.Add("x-kobs-plugin", tt.pluginName)
+			req.Header.Set("x-kobs-plugin", tt.pluginName)
 
 			w := httptest.NewRecorder()
 			tt.do(router, w, req)

--- a/plugins/plugin-azure/cmd/monitor_test.go
+++ b/plugins/plugin-azure/cmd/monitor_test.go
@@ -149,7 +149,7 @@ func TestGetMetrics(t *testing.T) {
 			})
 
 			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
-			req.Header.Add("x-kobs-plugin", tt.pluginName)
+			req.Header.Set("x-kobs-plugin", tt.pluginName)
 
 			w := httptest.NewRecorder()
 			tt.do(router, w, req)

--- a/plugins/plugin-azure/cmd/resourcegroups_test.go
+++ b/plugins/plugin-azure/cmd/resourcegroups_test.go
@@ -87,7 +87,7 @@ func TestGetResourceGroups(t *testing.T) {
 			router.Get("/resourcegroups", router.getResourceGroups)
 
 			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
-			req.Header.Add("x-kobs-plugin", tt.pluginName)
+			req.Header.Set("x-kobs-plugin", tt.pluginName)
 
 			w := httptest.NewRecorder()
 			tt.do(router, w, req)

--- a/plugins/plugin-azure/cmd/virtualmachinescalesets_test.go
+++ b/plugins/plugin-azure/cmd/virtualmachinescalesets_test.go
@@ -123,7 +123,7 @@ func TestGetVirtualMachineScaleSets(t *testing.T) {
 			})
 
 			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
-			req.Header.Add("x-kobs-plugin", tt.pluginName)
+			req.Header.Set("x-kobs-plugin", tt.pluginName)
 
 			w := httptest.NewRecorder()
 			tt.do(router, w, req)
@@ -239,7 +239,7 @@ func TestGetVirtualMachineScaleSetDetails(t *testing.T) {
 			})
 
 			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
-			req.Header.Add("x-kobs-plugin", tt.pluginName)
+			req.Header.Set("x-kobs-plugin", tt.pluginName)
 
 			w := httptest.NewRecorder()
 			tt.do(router, w, req)
@@ -355,7 +355,7 @@ func TestGetVirtualMachines(t *testing.T) {
 			})
 
 			req, _ := http.NewRequest(http.MethodGet, tt.url, nil)
-			req.Header.Add("x-kobs-plugin", tt.pluginName)
+			req.Header.Set("x-kobs-plugin", tt.pluginName)
 
 			w := httptest.NewRecorder()
 			tt.do(router, w, req)

--- a/plugins/plugin-elasticsearch/pkg/instance/instance.go
+++ b/plugins/plugin-elasticsearch/pkg/instance/instance.go
@@ -56,7 +56,7 @@ func (i *instance) GetLogs(ctx context.Context, query string, timeStart, timeEnd
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("Content-Type", "application/json")
+	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := i.client.Do(req)
 	if err != nil {


### PR DESCRIPTION
We have to enable CGO to use kobs within Docker, for this we also
switched from alpine to debian for the final base image.

To proxy the requests for plugins and requests correctly from a hub to a
satellite, we had to:

- use "set" instead of "add" for the header manipulation, so that
  possible existing headers on the request are overwritten (e.g. the
  "Authorization" header from an OAuth2 Proxy running infornt of kobs)
- overwrite the host in the proxied request with the host of the target
  satellite, so that the satellite can be served via https

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
