### PR TITLE
[jaeger] Fix links and colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 - [#349](https://github.com/kobsio/kobs/pull/#349): [app] Fix the creation of a VirtualService in the Helm chart when no `additionalRoutes` are set.
 - [#350](https://github.com/kobsio/kobs/pull/#350): [app] Fix Docker image and request proxy.
+- [#351](https://github.com/kobsio/kobs/pull/#351): [jaeger] Fix links and colors in Jaeger plugin.
 
 ### Changed
 

--- a/plugins/plugin-jaeger/src/components/panel/details/TraceActions.tsx
+++ b/plugins/plugin-jaeger/src/components/panel/details/TraceActions.tsx
@@ -33,16 +33,13 @@ const TraceActions: React.FunctionComponent<ITraceActionsProps> = ({ instance, t
 
   const copy = (): void => {
     if (navigator.clipboard) {
-      navigator.clipboard.writeText(`${window.location.host}/${pluginBasePath(instance)}/trace/${trace.traceID}`);
+      navigator.clipboard.writeText(`${window.location.host}${pluginBasePath(instance)}/trace/${trace.traceID}`);
     }
     setShowDropdown(false);
   };
 
   const dropdownItems = [
-    <DropdownItem
-      key={0}
-      component={<Link to={`/${pluginBasePath(instance)}/trace/${trace.traceID}`}>Details</Link>}
-    />,
+    <DropdownItem key={0} component={<Link to={`${pluginBasePath(instance)}/trace/${trace.traceID}`}>Details</Link>} />,
     <DropdownItem key={1} onClick={compare}>
       Compare
     </DropdownItem>,
@@ -92,7 +89,7 @@ const TraceActions: React.FunctionComponent<ITraceActionsProps> = ({ instance, t
         isOpen={showModal}
         onClose={(): void => setShowModal(false)}
         actions={[
-          <Link key="compare" to={`/${pluginBasePath(instance)}/trace/${trace.traceID}?compare=${compareTrace}`}>
+          <Link key="compare" to={`${pluginBasePath(instance)}/trace/${trace.traceID}?compare=${compareTrace}`}>
             <Button variant={ButtonVariant.primary}>Compare</Button>
           </Link>,
 

--- a/plugins/plugin-jaeger/src/utils/colors.ts
+++ b/plugins/plugin-jaeger/src/utils/colors.ts
@@ -56,7 +56,7 @@ export const getColorValue = (labelColor?: LabelProps['color']): string => {
     case 'purple':
       return 'var(--pf-global--palette--purple-300)';
     case 'red':
-      return 'var(--pf-global--palette--red-300)';
+      return 'var(--pf-global--palette--red-100)';
     default:
       return 'var(--pf-global--palette--blue-300)';
   }


### PR DESCRIPTION
The details links in the actions of the Jaeger plugin were broken,
because of a leading slash ("/").

When we assigned the color "red" to a service, the border in the spans
chart and view was a bit to dark, so that we are now using a different
color for red.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
