### PR TITLE
[app] Fix plugin filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#349](https://github.com/kobsio/kobs/pull/#349): [app] Fix the creation of a VirtualService in the Helm chart when no `additionalRoutes` are set.
 - [#350](https://github.com/kobsio/kobs/pull/#350): [app] Fix Docker image and request proxy.
 - [#351](https://github.com/kobsio/kobs/pull/#351): [jaeger] Fix links and colors in Jaeger plugin.
+- [#352](https://github.com/kobsio/kobs/pull/#352): [app] Fix plugin filter and allow filtering by the name of a satellite.
 
 ### Changed
 

--- a/plugins/app/src/components/plugins/PluginInstances.tsx
+++ b/plugins/app/src/components/plugins/PluginInstances.tsx
@@ -29,10 +29,20 @@ const PluginInstances: React.FunctionComponent = () => {
   const [state, setState] = useState<{
     page: number;
     perPage: number;
+    pluginSatellite: string;
+    pluginSatelliteIsOpen: boolean;
     pluginType: string;
     pluginTypeIsOpen: boolean;
     searchTerm: string;
-  }>({ page: 1, perPage: 10, pluginType: '', pluginTypeIsOpen: false, searchTerm: '' });
+  }>({
+    page: 1,
+    perPage: 10,
+    pluginSatellite: '',
+    pluginSatelliteIsOpen: false,
+    pluginType: '',
+    pluginTypeIsOpen: false,
+    searchTerm: '',
+  });
   const debouncedSearchTerm = useDebounce<string>(state.searchTerm, 500);
 
   return (
@@ -47,6 +57,27 @@ const PluginInstances: React.FunctionComponent = () => {
         toolbarContent={
           <ToolbarContent>
             <ToolbarGroup variant={ToolbarGroupVariant['filter-group']}>
+              <ToolbarItem>
+                <Select
+                  variant={SelectVariant.single}
+                  aria-label="Select satellite input"
+                  placeholderText="Satellite"
+                  onToggle={(): void => setState({ ...state, pluginSatelliteIsOpen: !state.pluginSatelliteIsOpen })}
+                  onSelect={(
+                    event: React.MouseEvent<Element, MouseEvent> | React.ChangeEvent<Element>,
+                    value: string | SelectOptionObject,
+                  ): void =>
+                    setState({ ...state, page: 1, pluginSatellite: value.toString(), pluginSatelliteIsOpen: false })
+                  }
+                  onClear={(): void => setState({ ...state, page: 1, pluginSatellite: '' })}
+                  selections={state.pluginSatellite}
+                  isOpen={state.pluginSatelliteIsOpen}
+                >
+                  {pluginsContext.getPluginSatellites().map((option) => (
+                    <SelectOption key={option} value={option} />
+                  ))}
+                </Select>
+              </ToolbarItem>
               <ToolbarItem>
                 <Select
                   variant={SelectVariant.single}
@@ -81,11 +112,11 @@ const PluginInstances: React.FunctionComponent = () => {
       >
         <Gallery hasGutter={true}>
           {pluginsContext
-            .getInstances(state.pluginType, debouncedSearchTerm)
+            .getInstances(state.pluginSatellite, state.pluginType, debouncedSearchTerm)
             .slice((state.page - 1) * state.perPage, state.page * state.perPage)
             .map((instance) => (
               <Module
-                key={`${instance.type}-${instance.name}`}
+                key={instance.id}
                 name={instance.type}
                 module="./Instance"
                 props={instance}
@@ -103,7 +134,7 @@ const PluginInstances: React.FunctionComponent = () => {
         variant={PageSectionVariants.light}
       >
         <Pagination
-          itemCount={pluginsContext.getInstances(state.pluginType, debouncedSearchTerm).length}
+          itemCount={pluginsContext.getInstances(state.pluginSatellite, state.pluginType, debouncedSearchTerm).length}
           perPage={state.perPage}
           page={state.page}
           variant={PaginationVariant.bottom}


### PR DESCRIPTION
This commit fixes the filter on the plugin instances page. We didn't
used the plugin id as key for rendering the plugin gallery items, which
lead to some strange behaviour, so that plugins were still shown also
when the filter was changed. This should be fixed now.

It is now also possible to filter the list of plugins by the name of a
satellite, so that only plugins are shown that are configured at the
specific satellite instance.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
