### PR TITLE
[app] Change URLs for Application / Dashboard page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 - [#346](https://github.com/kobsio/kobs/pull/346): [app] :warning: _Breaking change:_ :warning: Rework kobs architecture, by introducing a `hub` and a `satellite` component. This new architecture allows us to run the kobs `hub` component in a central cluster and access clusters / services (plugins) through the kobs `satellite` component. More information regarding the new kobs architecture can be found in the documentation at [kobs.io](https://kobs.io).
 - [#348](https://github.com/kobsio/kobs/pull/348): [app] Update permission handling.
+- [#354](https://github.com/kobsio/kobs/pull/#354): [app] Change URLs for the details page of an Application and a Dashboard.
 
 ## [v0.8.0](https://github.com/kobsio/kobs/releases/tag/v0.8.0) (2022-03-24)
 

--- a/plugins/app/src/App.tsx
+++ b/plugins/app/src/App.tsx
@@ -48,8 +48,14 @@ const App: React.FunctionComponent = () => {
               <Routes>
                 <Route path="/" element={<Navigate to="/applications" replace={true} />} />
                 <Route path="/applications" element={<Applications />} />
-                <Route path="/applications/:application" element={<Application />} />
-                <Route path="/dashboards/:dashboard" element={<DashboardPage />} />
+                <Route
+                  path="/applications/satellite/:satellite/cluster/:cluster/namespace/:namespace/name/:name"
+                  element={<Application />}
+                />
+                <Route
+                  path="/dashboards/satellite/:satellite/cluster/:cluster/namespace/:namespace/name/:name"
+                  element={<DashboardPage />}
+                />
                 <Route path="/teams" element={<Teams />} />
                 <Route path="/teams/:team" element={<Team />} />
                 <Route path="/resources" element={<Resources />} />

--- a/plugins/app/src/components/applications/Application.tsx
+++ b/plugins/app/src/components/applications/Application.tsx
@@ -18,7 +18,10 @@ import { DashboardsWrapper } from '../dashboards/DashboardsWrapper';
 import { IApplication } from '../../crds/application';
 
 interface IApplicationParams extends Record<string, string | undefined> {
-  application?: string;
+  satellite?: string;
+  cluster?: string;
+  namespace?: string;
+  name?: string;
 }
 
 const Application: React.FunctionComponent = () => {
@@ -27,11 +30,16 @@ const Application: React.FunctionComponent = () => {
   const [details, setDetails] = useState<React.ReactNode>(undefined);
 
   const { isError, isLoading, error, data, refetch } = useQuery<IApplication, Error>(
-    ['app/applications/application', params.application],
+    ['app/applications/application', params.satellite, params.cluster, params.namespace, params.name],
     async () => {
-      const response = await fetch(`/api/applications/application?id=${encodeURIComponent(params.application || '')}`, {
-        method: 'get',
-      });
+      const response = await fetch(
+        `/api/applications/application?id=${encodeURIComponent(
+          `/satellite/${params.satellite}/cluster/${params.cluster}/namespace/${params.namespace}/name/${params.name}`,
+        )}`,
+        {
+          method: 'get',
+        },
+      );
       const json = await response.json();
 
       if (response.status >= 200 && response.status < 300) {

--- a/plugins/app/src/components/applications/ApplicationDetails.tsx
+++ b/plugins/app/src/components/applications/ApplicationDetails.tsx
@@ -50,9 +50,7 @@ const ApplicationDetails: React.FunctionComponent<IApplicationDetailsProps> = ({
           <Button
             style={{ paddingRight: 0 }}
             variant="plain"
-            component={(props): React.ReactElement => (
-              <Link {...props} to={`/applications/${encodeURIComponent(application.id)}`} />
-            )}
+            component={(props): React.ReactElement => <Link {...props} to={`/applications${application.id}`} />}
           >
             <ExternalLinkAltIcon />
           </Button>

--- a/plugins/app/src/components/applications/ApplicationDetailsLabels.tsx
+++ b/plugins/app/src/components/applications/ApplicationDetailsLabels.tsx
@@ -61,9 +61,7 @@ const ApplicationDetailsLabels: React.FunctionComponent<IApplicationDetailsLabel
               icon={<TopologyIcon />}
               render={({ className, content, componentRef }): React.ReactNode => (
                 <Link
-                  to={`/applications/${encodeURIComponent(
-                    `/satellite/${dependency.satellite}/cluster/${dependency.cluster}/namespace/${dependency.namespace}/name/${dependency.name}`,
-                  )}`}
+                  to={`/applications/satellite/${dependency.satellite}/cluster/${dependency.cluster}/namespace/${dependency.namespace}/name/${dependency.name}`}
                   className={className}
                   ref={componentRef}
                 >

--- a/plugins/app/src/components/applications/ApplicationsListItem.tsx
+++ b/plugins/app/src/components/applications/ApplicationsListItem.tsx
@@ -91,9 +91,7 @@ const ApplicationsListItem: React.FunctionComponent<IApplicationsListItemProps> 
         <DataListAction aria-labelledby={application.id} id={application.id} aria-label="Actions">
           <Button
             variant={ButtonVariant.link}
-            component={(props): React.ReactElement => (
-              <Link {...props} to={`/applications/${encodeURIComponent(application.id)}`} />
-            )}
+            component={(props): React.ReactElement => <Link {...props} to={`/applications${application.id}`} />}
           >
             View Details
           </Button>

--- a/plugins/app/src/components/dashboards/DashboardPage.tsx
+++ b/plugins/app/src/components/dashboards/DashboardPage.tsx
@@ -17,7 +17,10 @@ import Dashboard from './Dashboard';
 import { IDashboard } from '../../crds/dashboard';
 
 interface IDashboardPageParams extends Record<string, string | undefined> {
-  dashboard?: string;
+  satellite?: string;
+  cluster?: string;
+  namespace?: string;
+  name?: string;
 }
 
 const DashboardPage: React.FunctionComponent = () => {
@@ -27,10 +30,12 @@ const DashboardPage: React.FunctionComponent = () => {
   const [details, setDetails] = useState<React.ReactNode>(undefined);
 
   const { isError, isLoading, error, data, refetch } = useQuery<IDashboard, Error>(
-    ['app/dashboards/dashboard', params.application, location.search],
+    ['app/dashboards/dashboard', params.satellite, params.cluster, params.namespace, params.name, location.search],
     async () => {
       const response = await fetch(
-        `/api/dashboards/dashboard?id=${encodeURIComponent(params.dashboard || '')}${location.search.substring(1)}`,
+        `/api/dashboards/dashboard?id=${encodeURIComponent(
+          `/satellite/${params.satellite}/cluster/${params.cluster}/namespace/${params.namespace}/name/${params.name}`,
+        )}${location.search.substring(1)}`,
         {
           method: 'get',
         },

--- a/plugins/app/src/components/dashboards/DashboardsPanel.tsx
+++ b/plugins/app/src/components/dashboards/DashboardsPanel.tsx
@@ -23,7 +23,7 @@ const DashboardsPanel: React.FunctionComponent<IDashboardsPanelProps> = ({ optio
   const goToDashboard = (id: string): void => {
     const idParts = id.split('?');
 
-    navigate(`/dashboards/${encodeURIComponent(idParts[0])}?${idParts[1]}`);
+    navigate(`/dashboards${idParts[0]}?${idParts[1]}`);
   };
 
   if (options && Array.isArray(options)) {


### PR DESCRIPTION
Since our IDs are containing a slash ("/") to seperate the different
parts (satellite, cluster, namespace and name) we had to encode the ID
to use it as parameter in the React Router. This is not working
properly, so that it can happen that the encoded slash character is
replaced by a real slash when a user reloads an URL. This leads to the
situation that React Router isn't aware of this url format and so
nothing is rendered.

We decided to adjust the URLs in React Router, so that we can still use
slashes in our IDs, but instead of just a "type" parameter, we now have
a parameter for every id part, which results in the following routes:

- /applications/satellite/:satellite/cluster/:cluster/namespace/:namespace/name/:name
- /dashboards/satellite/:satellite/cluster/:cluster/namespace/:namespace/name/:name

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
