### PR TITLE
[app] Add profile page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 ### Added
 
+- [#355](https://github.com/kobsio/kobs/pull/#355): [app] Add profile page for authenticated users, which can be customized via dashboards.
+
 ### Fixed
 
 - [#349](https://github.com/kobsio/kobs/pull/#349): [app] Fix the creation of a VirtualService in the Helm chart when no `additionalRoutes` are set.

--- a/cmd/kobs/hub/config/config.go
+++ b/cmd/kobs/hub/config/config.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/kobsio/kobs/pkg/hub/api"
 	"github.com/kobsio/kobs/pkg/hub/satellites"
 
 	"sigs.k8s.io/yaml"
@@ -12,6 +13,7 @@ import (
 // Config is the complete configuration for kobs.
 type Config struct {
 	Satellites satellites.Config `json:"satellites"`
+	API        api.Config        `json:"api"`
 }
 
 // Load the configuration for kobs. Most of the configuration options are available as command-line flag, but we also

--- a/cmd/kobs/hub/hub.go
+++ b/cmd/kobs/hub/hub.go
@@ -97,7 +97,7 @@ var Cmd = &cobra.Command{
 		var appServer app.Server
 
 		if hubMode == "default" || hubMode == "server" {
-			hubSever, err = hub.New(debugUsername, debugPassword, hubAddress, authEnabled, authHeaderUser, authHeaderTeams, authLogoutRedirect, authSessionToken, authSessionInterval, satellitesClient, storeClient)
+			hubSever, err = hub.New(cfg.API, debugUsername, debugPassword, hubAddress, authEnabled, authHeaderUser, authHeaderTeams, authLogoutRedirect, authSessionToken, authSessionInterval, satellitesClient, storeClient)
 			if err != nil {
 				log.Fatal(nil, "Could not create hub server", zap.Error(err))
 			}

--- a/pkg/hub/api/api.go
+++ b/pkg/hub/api/api.go
@@ -1,0 +1,9 @@
+package api
+
+import (
+	"github.com/kobsio/kobs/pkg/hub/api/users"
+)
+
+type Config struct {
+	Users users.Config `json:"users"`
+}

--- a/pkg/hub/api/applications/applications_test.go
+++ b/pkg/hub/api/applications/applications_test.go
@@ -369,18 +369,48 @@ func TestGetApplicationsByTeam(t *testing.T) {
 			expectedBody:       "{\"error\":\"You are not authorized to access the applications: Unauthorized\"}\n",
 			prepare: func(t *testing.T, mockStoreClient *store.MockClient) {
 				mockStoreClient.AssertNotCalled(t, "GetApplicationsByFilter", mock.Anything)
+				mockStoreClient.AssertNotCalled(t, "GetApplicationsByFilterCount", mock.Anything)
 			},
 			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
 				router.getApplicationsByTeam(w, req)
 			},
 		},
 		{
+			name:               "parse limit fails",
+			url:                "/team",
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBody:       "{\"error\":\"Could not parse limit parameter: strconv.Atoi: parsing \\\"\\\": invalid syntax\"}\n",
+			prepare: func(t *testing.T, mockStoreClient *store.MockClient) {
+				mockStoreClient.AssertNotCalled(t, "GetApplicationsByFilter", mock.Anything)
+				mockStoreClient.AssertNotCalled(t, "GetApplicationsByFilterCount", mock.Anything)
+			},
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				req = req.WithContext(context.WithValue(req.Context(), authContext.UserKey, authContext.User{}))
+				router.getApplicationsByTeam(w, req)
+			},
+		},
+		{
+			name:               "parse offset fails",
+			url:                "/team?limit=10",
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBody:       "{\"error\":\"Could not parse offset parameter: strconv.Atoi: parsing \\\"\\\": invalid syntax\"}\n",
+			prepare: func(t *testing.T, mockStoreClient *store.MockClient) {
+				mockStoreClient.AssertNotCalled(t, "GetApplicationsByFilter", mock.Anything)
+				mockStoreClient.AssertNotCalled(t, "GetApplicationsByFilterCount", mock.Anything)
+			},
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				req = req.WithContext(context.WithValue(req.Context(), authContext.UserKey, authContext.User{}))
+				router.getApplicationsByTeam(w, req)
+			},
+		},
+		{
 			name:               "get team applications fails, because user is not authorized",
-			url:                "/team?team=team1",
+			url:                "/team?team=team1&limit=10&offset=0",
 			expectedStatusCode: http.StatusForbidden,
 			expectedBody:       "{\"error\":\"You are not allowed to view the applications of this team\"}\n",
 			prepare: func(t *testing.T, mockStoreClient *store.MockClient) {
 				mockStoreClient.AssertNotCalled(t, "GetApplicationsByFilter", mock.Anything)
+				mockStoreClient.AssertNotCalled(t, "GetApplicationsByFilterCount", mock.Anything)
 			},
 			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
 				req = req.WithContext(context.WithValue(req.Context(), authContext.UserKey, authContext.User{}))
@@ -389,11 +419,26 @@ func TestGetApplicationsByTeam(t *testing.T) {
 		},
 		{
 			name:               "get team applications fails",
-			url:                "/team?team=team1",
+			url:                "/team?team=team1&limit=10&offset=0",
 			expectedStatusCode: http.StatusInternalServerError,
 			expectedBody:       "{\"error\":\"Could not get applications: could not get applications\"}\n",
 			prepare: func(t *testing.T, mockStoreClient *store.MockClient) {
 				mockStoreClient.On("GetApplicationsByFilter", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("could not get applications"))
+				mockStoreClient.AssertNotCalled(t, "GetApplicationsByFilterCount", mock.Anything)
+			},
+			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
+				req = req.WithContext(context.WithValue(req.Context(), authContext.UserKey, authContext.User{Permissions: userv1.Permissions{Applications: []userv1.ApplicationPermissions{{Type: "all"}}}}))
+				router.getApplicationsByTeam(w, req)
+			},
+		},
+		{
+			name:               "get all applications count fails",
+			url:                "/team?team=team1&limit=10&offset=0",
+			expectedStatusCode: http.StatusInternalServerError,
+			expectedBody:       "{\"error\":\"Could not get applications: could not get applications count\"}\n",
+			prepare: func(t *testing.T, mockStoreClient *store.MockClient) {
+				mockStoreClient.On("GetApplicationsByFilter", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+				mockStoreClient.On("GetApplicationsByFilterCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(0, fmt.Errorf("could not get applications count"))
 			},
 			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
 				req = req.WithContext(context.WithValue(req.Context(), authContext.UserKey, authContext.User{Permissions: userv1.Permissions{Applications: []userv1.ApplicationPermissions{{Type: "all"}}}}))
@@ -402,11 +447,12 @@ func TestGetApplicationsByTeam(t *testing.T) {
 		},
 		{
 			name:               "get all applications",
-			url:                "/team?team=team1",
+			url:                "/team?team=team1&limit=10&offset=0",
 			expectedStatusCode: http.StatusOK,
-			expectedBody:       "null\n",
+			expectedBody:       "{\"count\":0,\"applications\":null}\n",
 			prepare: func(t *testing.T, mockStoreClient *store.MockClient) {
 				mockStoreClient.On("GetApplicationsByFilter", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+				mockStoreClient.On("GetApplicationsByFilterCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
 			},
 			do: func(router Router, w *httptest.ResponseRecorder, req *http.Request) {
 				req = req.WithContext(context.WithValue(req.Context(), authContext.UserKey, authContext.User{Permissions: userv1.Permissions{Applications: []userv1.ApplicationPermissions{{Type: "all"}}}}))

--- a/pkg/hub/api/users/users.go
+++ b/pkg/hub/api/users/users.go
@@ -1,0 +1,117 @@
+package users
+
+import (
+	"net/http"
+
+	authContext "github.com/kobsio/kobs/pkg/hub/middleware/userauth/context"
+	"github.com/kobsio/kobs/pkg/hub/store"
+	dashboardv1 "github.com/kobsio/kobs/pkg/kube/apis/dashboard/v1"
+	userv1 "github.com/kobsio/kobs/pkg/kube/apis/user/v1"
+	"github.com/kobsio/kobs/pkg/log"
+	"github.com/kobsio/kobs/pkg/middleware/errresponse"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	"go.uber.org/zap"
+)
+
+type Config struct {
+	DefaultDashboards []dashboardv1.Reference `json:"defaultDashboards"`
+}
+
+type Router struct {
+	*chi.Mux
+	config      Config
+	storeClient store.Client
+}
+
+func (router *Router) getUser(w http.ResponseWriter, r *http.Request) {
+	user, err := authContext.GetUser(r.Context())
+	if err != nil {
+		log.Warn(r.Context(), "The user is not authorized to access the user", zap.Error(err))
+		errresponse.Render(w, r, err, http.StatusUnauthorized, "You are not authorized to access the user")
+		return
+	}
+
+	email := r.URL.Query().Get("email")
+
+	if email != user.Email {
+		log.Warn(r.Context(), "The user is not authorized to access the user", zap.Error(err))
+		errresponse.Render(w, r, nil, http.StatusForbidden, "You can only access you own profile")
+		return
+	}
+
+	users, err := router.storeClient.GetUsersByEmail(r.Context(), email)
+	if err != nil {
+		log.Error(r.Context(), "Could not get user", zap.Error(err), zap.String("email", email))
+		errresponse.Render(w, r, err, http.StatusInternalServerError, "Could not get user")
+		return
+	}
+
+	profile := userv1.UserSpec{
+		Email: email,
+	}
+
+	for _, v := range users {
+		profile.Dashboards = append(profile.Dashboards, v.Dashboards...)
+	}
+
+	if len(profile.Dashboards) == 0 {
+		profile.Dashboards = router.config.DefaultDashboards
+	}
+
+	render.JSON(w, r, profile)
+}
+
+func Mount(config Config, storeClient store.Client) chi.Router {
+	defaultDashboards := []dashboardv1.Reference{
+		{
+			Title: "Teams",
+			Inline: &dashboardv1.ReferenceInline{
+				HideToolbar: true,
+				Rows: []dashboardv1.Row{{
+					Size: -1,
+					Panels: []dashboardv1.Panel{{
+						Title:       "Teams",
+						Description: "The teams you are part of",
+						Plugin: dashboardv1.Plugin{
+							Type: "app",
+							Name: "userteams",
+						},
+					}},
+				}},
+			},
+		},
+		{
+			Title: "Applications",
+			Inline: &dashboardv1.ReferenceInline{
+				HideToolbar: true,
+				Rows: []dashboardv1.Row{{
+					Size: -1,
+					Panels: []dashboardv1.Panel{{
+						Title:       "Applications",
+						Description: "The applications which are owned by your teams",
+						Plugin: dashboardv1.Plugin{
+							Type: "app",
+							Name: "userapplications",
+						},
+					}},
+				}},
+			},
+		},
+	}
+
+	if len(config.DefaultDashboards) == 0 {
+		config.DefaultDashboards = defaultDashboards
+	}
+
+	router := Router{
+		chi.NewRouter(),
+		config,
+		storeClient,
+	}
+
+	router.Get("/user", router.getUser)
+
+	return router
+}

--- a/pkg/hub/api/users/users_test.go
+++ b/pkg/hub/api/users/users_test.go
@@ -1,0 +1,14 @@
+package users
+
+import (
+	"testing"
+
+	dashboardv1 "github.com/kobsio/kobs/pkg/kube/apis/dashboard/v1"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMount(t *testing.T) {
+	router := Mount(Config{DefaultDashboards: []dashboardv1.Reference{}}, nil)
+	require.NotNil(t, router)
+}

--- a/pkg/hub/hub.go
+++ b/pkg/hub/hub.go
@@ -5,12 +5,14 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/kobsio/kobs/pkg/hub/api"
 	"github.com/kobsio/kobs/pkg/hub/api/applications"
 	"github.com/kobsio/kobs/pkg/hub/api/clusters"
 	"github.com/kobsio/kobs/pkg/hub/api/dashboards"
 	"github.com/kobsio/kobs/pkg/hub/api/plugins"
 	"github.com/kobsio/kobs/pkg/hub/api/resources"
 	"github.com/kobsio/kobs/pkg/hub/api/teams"
+	"github.com/kobsio/kobs/pkg/hub/api/users"
 	"github.com/kobsio/kobs/pkg/hub/middleware/userauth"
 	"github.com/kobsio/kobs/pkg/hub/satellites"
 	"github.com/kobsio/kobs/pkg/hub/store"
@@ -66,7 +68,7 @@ func (s *server) Stop() {
 // We exclude the health check from all middlewares, because the health check just returns 200. Therefore we do not need
 // our defined middlewares like request id, metrics, auth or loggin. This also makes it easier to analyze the logs in a
 // Kubernetes cluster where the health check is called every x seconds, because we generate less logs.
-func New(debugUsername, debugPassword, hubAddress string, authEnabled bool, authHeaderUser, authHeaderTeams, authLogoutRedirect, authSessionToken string, authSessionInterval time.Duration, satellitesClient satellites.Client, storeClient store.Client) (Server, error) {
+func New(config api.Config, debugUsername, debugPassword, hubAddress string, authEnabled bool, authHeaderUser, authHeaderTeams, authLogoutRedirect, authSessionToken string, authSessionInterval time.Duration, satellitesClient satellites.Client, storeClient store.Client) (Server, error) {
 	router := chi.NewRouter()
 	router.Use(cors.Handler(cors.Options{
 		AllowedOrigins: []string{"*"},
@@ -95,6 +97,7 @@ func New(debugUsername, debugPassword, hubAddress string, authEnabled bool, auth
 		r.Mount("/clusters", clusters.Mount(storeClient))
 		r.Mount("/applications", applications.Mount(storeClient))
 		r.Mount("/teams", teams.Mount(storeClient))
+		r.Mount("/users", users.Mount(config.Users, storeClient))
 		r.Mount("/dashboards", dashboards.Mount(storeClient))
 		r.Mount("/resources", resources.Mount(satellitesClient, storeClient))
 		r.Mount("/plugins", plugins.Mount(satellitesClient, storeClient))

--- a/plugins/app/src/components/applications/ApplicationsPanel.tsx
+++ b/plugins/app/src/components/applications/ApplicationsPanel.tsx
@@ -2,25 +2,34 @@ import { Alert, AlertVariant } from '@patternfly/react-core';
 import React from 'react';
 
 import ApplicationsPanelList from './ApplicationsPanelList';
+import { PluginPanel } from '@kobsio/shared';
 
 interface IApplicationsPanelProps {
+  title: string;
+  description?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   options?: any;
   setDetails?: (details: React.ReactNode) => void;
 }
 
 const ApplicationsPanel: React.FunctionComponent<IApplicationsPanelProps> = ({
+  title,
+  description,
   options,
   setDetails,
 }: IApplicationsPanelProps) => {
   if (options && options.team) {
-    return <ApplicationsPanelList team={options.team} setDetails={setDetails} />;
+    return (
+      <ApplicationsPanelList title={title} description={description} team={options.team} setDetails={setDetails} />
+    );
   }
 
   return (
-    <Alert isInline={true} variant={AlertVariant.danger} title="Invalid plugin configuration">
-      The provided options for the <b>applications</b> plugin are invalid.
-    </Alert>
+    <PluginPanel title={title} description={description}>
+      <Alert isInline={true} variant={AlertVariant.danger} title="Invalid plugin configuration">
+        The provided options for the <b>applications</b> plugin are invalid.
+      </Alert>
+    </PluginPanel>
   );
 };
 

--- a/plugins/app/src/components/applications/ApplicationsPanelList.tsx
+++ b/plugins/app/src/components/applications/ApplicationsPanelList.tsx
@@ -1,22 +1,38 @@
-import { Alert, AlertActionLink, AlertVariant, DataList, Spinner } from '@patternfly/react-core';
+import {
+  Alert,
+  AlertActionLink,
+  AlertVariant,
+  CardFooter,
+  DataList,
+  Pagination,
+  PaginationVariant,
+  Spinner,
+} from '@patternfly/react-core';
 import { QueryObserverResult, useQuery } from 'react-query';
-import React from 'react';
+import React, { useState } from 'react';
 
 import ApplicationDetails from './ApplicationDetails';
 import ApplicationsListItem from './ApplicationsListItem';
 import { IApplication } from '../../crds/application';
+import { PluginPanel } from '@kobsio/shared';
 
 export interface IApplicationsPanelListProps {
+  title: string;
+  description?: string;
   team: string;
   setDetails?: (details: React.ReactNode) => void;
 }
 
 const ApplicationsPanelList: React.FunctionComponent<IApplicationsPanelListProps> = ({
+  title,
+  description,
   team,
   setDetails,
 }: IApplicationsPanelListProps) => {
+  const [options, setOptions] = useState<{ page: number; perPage: number }>({ page: 1, perPage: 10 });
+
   const selectApplicationID = (id: string): void => {
-    const selectedApplications = data?.filter((application) => application.id === id);
+    const selectedApplications = data?.applications?.filter((application) => application.id === id);
     if (selectedApplications?.length === 1 && setDetails) {
       setDetails(
         <ApplicationDetails application={selectedApplications[0]} close={(): void => setDetails(undefined)} />,
@@ -24,12 +40,15 @@ const ApplicationsPanelList: React.FunctionComponent<IApplicationsPanelListProps
     }
   };
 
-  const { isError, isLoading, error, data, refetch } = useQuery<IApplication[], Error>(
-    ['app/applications/team', team],
+  const { isError, isLoading, error, data, refetch } = useQuery<{ count: number; applications: IApplication[] }, Error>(
+    ['app/applications/team', team, options.page, options.perPage],
     async () => {
-      const response = await fetch(`/api/applications/team?team=${team}`, {
-        method: 'get',
-      });
+      const response = await fetch(
+        `/api/applications/team?team=${team}&limit=${options.perPage}&offset=${(options.page - 1) * options.perPage}`,
+        {
+          method: 'get',
+        },
+      );
       const json = await response.json();
 
       if (response.status >= 200 && response.status < 300) {
@@ -42,49 +61,78 @@ const ApplicationsPanelList: React.FunctionComponent<IApplicationsPanelListProps
         }
       }
     },
+    { keepPreviousData: true },
   );
 
-  if (isLoading) {
-    return (
-      <div className="pf-u-text-align-center">
-        <Spinner />
-      </div>
-    );
-  }
-
-  if (isError) {
-    return (
-      <Alert
-        variant={AlertVariant.danger}
-        isInline={true}
-        title="An error occured while applications were fetched"
-        actionLinks={
-          <React.Fragment>
-            <AlertActionLink onClick={(): Promise<QueryObserverResult<IApplication[], Error>> => refetch()}>
-              Retry
-            </AlertActionLink>
-          </React.Fragment>
-        }
-      >
-        <p>{error?.message}</p>
-      </Alert>
-    );
-  }
-
-  if (!data || data.length === 0) {
-    return null;
-  }
-
   return (
-    <DataList
-      aria-label={`applications list ${team}`}
-      selectedDataListItemId={undefined}
-      onSelectDataListItem={selectApplicationID}
+    <PluginPanel
+      title={title}
+      description={description}
+      footer={
+        <CardFooter>
+          <Pagination
+            style={{ padding: 0 }}
+            itemCount={data && data.count ? data.count : 0}
+            perPage={options.perPage}
+            page={options.page}
+            variant={PaginationVariant.bottom}
+            onSetPage={(event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPage: number): void =>
+              setOptions({ ...options, page: newPage })
+            }
+            onPerPageSelect={(event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPerPage: number): void =>
+              setOptions({ ...options, perPage: newPerPage })
+            }
+            onFirstClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+              setOptions({ ...options, page: newPage })
+            }
+            onLastClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+              setOptions({ ...options, page: newPage })
+            }
+            onNextClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+              setOptions({ ...options, page: newPage })
+            }
+            onPreviousClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+              setOptions({ ...options, page: newPage })
+            }
+          />
+        </CardFooter>
+      }
     >
-      {data.map((application) => (
-        <ApplicationsListItem key={application.id} application={application} />
-      ))}
-    </DataList>
+      {isLoading ? (
+        <div className="pf-u-text-align-center">
+          <Spinner />
+        </div>
+      ) : isError ? (
+        <Alert
+          variant={AlertVariant.danger}
+          isInline={true}
+          title="An error occured while applications were fetched"
+          actionLinks={
+            <React.Fragment>
+              <AlertActionLink
+                onClick={(): Promise<QueryObserverResult<{ count: number; applications: IApplication[] }, Error>> =>
+                  refetch()
+                }
+              >
+                Retry
+              </AlertActionLink>
+            </React.Fragment>
+          }
+        >
+          <p>{error?.message}</p>
+        </Alert>
+      ) : data && data.applications && data.applications.length > 0 ? (
+        <DataList
+          aria-label={`applications list ${team}`}
+          selectedDataListItemId={undefined}
+          onSelectDataListItem={selectApplicationID}
+        >
+          {data.applications.map((application) => (
+            <ApplicationsListItem key={application.id} application={application} />
+          ))}
+        </DataList>
+      ) : null}
+    </PluginPanel>
   );
 };
 

--- a/plugins/app/src/components/plugins/AppPanel.tsx
+++ b/plugins/app/src/components/plugins/AppPanel.tsx
@@ -6,6 +6,8 @@ import ApplicationsPanel from '../applications/ApplicationsPanel';
 import DashboardsPanel from '../dashboards/DashboardsPanel';
 import Markdown from '../markdown/Markdown';
 import ResourcesPanelWrapper from '../resources/ResourcesPanelWrapper';
+import UserApplications from '../profile/UserApplications';
+import UserTeams from '../profile/UserTeams';
 
 interface IAppPanelProps {
   title: string;
@@ -28,9 +30,17 @@ const AppPanel: React.FunctionComponent<IAppPanelProps> = ({
   setDetails,
 }: IAppPanelProps) => {
   if (name === 'applications') {
+    return <ApplicationsPanel title={title} description={description} options={options} setDetails={setDetails} />;
+  }
+
+  if (name === 'userapplications') {
+    return <UserApplications title={title} description={description} setDetails={setDetails} />;
+  }
+
+  if (name === 'userteams') {
     return (
       <PluginPanel title={title} description={description}>
-        <ApplicationsPanel options={options} setDetails={setDetails} />
+        <UserTeams setDetails={setDetails} />
       </PluginPanel>
     );
   }

--- a/plugins/app/src/components/profile/Profile.tsx
+++ b/plugins/app/src/components/profile/Profile.tsx
@@ -1,10 +1,12 @@
 import { Alert, AlertVariant, PageSection } from '@patternfly/react-core';
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 
 import { AuthContext, IAuthContext } from '../../context/AuthContext';
 import { PageContentSection, PageHeaderSection } from '@kobsio/shared';
+import ProfileWrapper from './ProfileWrapper';
 
 const Profile: React.FunctionComponent = () => {
+  const [details, setDetails] = useState<React.ReactNode>(undefined);
   const authContext = useContext<IAuthContext>(AuthContext);
 
   if (authContext.user.email === '') {
@@ -21,8 +23,8 @@ const Profile: React.FunctionComponent = () => {
     <React.Fragment>
       <PageHeaderSection title={authContext.user.email} description="" />
 
-      <PageContentSection hasPadding={true} toolbarContent={undefined} panelContent={undefined}>
-        <div>TODO: Show dashboards</div>
+      <PageContentSection hasPadding={false} toolbarContent={undefined} panelContent={details}>
+        <ProfileWrapper email={authContext.user.email} setDetails={setDetails} />
       </PageContentSection>
     </React.Fragment>
   );

--- a/plugins/app/src/components/profile/ProfileWrapper.tsx
+++ b/plugins/app/src/components/profile/ProfileWrapper.tsx
@@ -1,0 +1,65 @@
+import { Alert, AlertActionLink, AlertVariant, Spinner } from '@patternfly/react-core';
+import { QueryObserverResult, useQuery } from 'react-query';
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { DashboardsWrapper } from '../dashboards/DashboardsWrapper';
+import { IUser } from '../../crds/user';
+
+interface IProfileWrapperProps {
+  email: string;
+  setDetails?: (details: React.ReactNode) => void;
+}
+
+const ProfileWrapper: React.FunctionComponent<IProfileWrapperProps> = ({ email, setDetails }: IProfileWrapperProps) => {
+  const navigate = useNavigate();
+
+  const { isError, isLoading, error, data, refetch } = useQuery<IUser, Error>(['app/users/user', email], async () => {
+    const response = await fetch(`/api/users/user?email=${email}`, {
+      method: 'get',
+    });
+    const json = await response.json();
+
+    if (response.status >= 200 && response.status < 300) {
+      return json;
+    } else {
+      if (json.error) {
+        throw new Error(json.error);
+      } else {
+        throw new Error('An unknown error occured');
+      }
+    }
+  });
+
+  if (isLoading) {
+    return <Spinner style={{ left: '50%', position: 'fixed', top: '50%', transform: 'translate(-50%, -50%)' }} />;
+  }
+
+  if (isError) {
+    return (
+      <Alert
+        style={{ left: '50%', position: 'fixed', top: '50%', transform: 'translate(-50%, -50%)' }}
+        variant={AlertVariant.danger}
+        title="Could not get profile"
+        actionLinks={
+          <React.Fragment>
+            <AlertActionLink onClick={(): void => navigate('/')}>Home</AlertActionLink>
+            <AlertActionLink onClick={(): Promise<QueryObserverResult<IUser, Error>> => refetch()}>
+              Retry
+            </AlertActionLink>
+          </React.Fragment>
+        }
+      >
+        <p>{error?.message}</p>
+      </Alert>
+    );
+  }
+
+  if (!data || !data.dashboards || data.dashboards.length === 0) {
+    return null;
+  }
+
+  return <DashboardsWrapper manifest={data} references={data.dashboards} setDetails={setDetails} />;
+};
+
+export default ProfileWrapper;

--- a/plugins/app/src/components/profile/UserApplications.tsx
+++ b/plugins/app/src/components/profile/UserApplications.tsx
@@ -1,0 +1,101 @@
+import { Alert, AlertActionLink, AlertVariant, CardFooter, DataList, Spinner } from '@patternfly/react-core';
+import { QueryObserverResult, useQuery } from 'react-query';
+import React, { useState } from 'react';
+
+import ApplicationDetails from '../applications/ApplicationDetails';
+import ApplicationsListItem from '../applications/ApplicationsListItem';
+import { IApplication } from '../../crds/application';
+import { PluginPanel } from '@kobsio/shared';
+import UserApplicationsPagination from './UserApplicationsPagination';
+
+export interface IUserApplicationsProps {
+  title: string;
+  description?: string;
+  setDetails?: (details: React.ReactNode) => void;
+}
+
+const UserApplications: React.FunctionComponent<IUserApplicationsProps> = ({
+  title,
+  description,
+  setDetails,
+}: IUserApplicationsProps) => {
+  const [options, setOptions] = useState<{ page: number; perPage: number }>({ page: 1, perPage: 10 });
+
+  const selectApplicationID = (id: string): void => {
+    const selectedApplications = data?.filter((application) => application.id === id);
+    if (selectedApplications?.length === 1 && setDetails) {
+      setDetails(
+        <ApplicationDetails application={selectedApplications[0]} close={(): void => setDetails(undefined)} />,
+      );
+    }
+  };
+
+  const { isError, isLoading, error, data, refetch } = useQuery<IApplication[], Error>(
+    ['app/applications/user', options.page, options.perPage],
+    async () => {
+      const response = await fetch(
+        `/api/applications?limit=${options.perPage}&offset=${(options.page - 1) * options.perPage}`,
+        {
+          method: 'get',
+        },
+      );
+      const json = await response.json();
+
+      if (response.status >= 200 && response.status < 300) {
+        return json;
+      } else {
+        if (json.error) {
+          throw new Error(json.error);
+        } else {
+          throw new Error('An unknown error occured');
+        }
+      }
+    },
+    { keepPreviousData: true },
+  );
+
+  return (
+    <PluginPanel
+      title={title}
+      description={description}
+      footer={
+        <CardFooter>
+          <UserApplicationsPagination options={options} setOptions={setOptions} />
+        </CardFooter>
+      }
+    >
+      {isLoading ? (
+        <div className="pf-u-text-align-center">
+          <Spinner />
+        </div>
+      ) : isError ? (
+        <Alert
+          variant={AlertVariant.danger}
+          isInline={true}
+          title="An error occured while applications were fetched"
+          actionLinks={
+            <React.Fragment>
+              <AlertActionLink onClick={(): Promise<QueryObserverResult<IApplication[], Error>> => refetch()}>
+                Retry
+              </AlertActionLink>
+            </React.Fragment>
+          }
+        >
+          <p>{error?.message}</p>
+        </Alert>
+      ) : data && data.length > 0 ? (
+        <DataList
+          aria-label="applications list"
+          selectedDataListItemId={undefined}
+          onSelectDataListItem={selectApplicationID}
+        >
+          {data.map((application) => (
+            <ApplicationsListItem key={application.id} application={application} />
+          ))}
+        </DataList>
+      ) : null}
+    </PluginPanel>
+  );
+};
+
+export default UserApplications;

--- a/plugins/app/src/components/profile/UserApplicationsPagination.tsx
+++ b/plugins/app/src/components/profile/UserApplicationsPagination.tsx
@@ -1,0 +1,60 @@
+import { Pagination, PaginationVariant } from '@patternfly/react-core';
+import React from 'react';
+import { useQuery } from 'react-query';
+
+export interface IApplicationsPagination {
+  options: { page: number; perPage: number };
+  setOptions: (data: { page: number; perPage: number }) => void;
+}
+
+const Applications: React.FunctionComponent<IApplicationsPagination> = ({
+  options,
+  setOptions,
+}: IApplicationsPagination) => {
+  const { data } = useQuery<{ count: number }, Error>(['app/applications/user/count'], async () => {
+    const response = await fetch(`/api/applications/count`, {
+      method: 'get',
+    });
+    const json = await response.json();
+
+    if (response.status >= 200 && response.status < 300) {
+      return json;
+    } else {
+      if (json.error) {
+        throw new Error(json.error);
+      } else {
+        throw new Error('An unknown error occured');
+      }
+    }
+  });
+
+  return (
+    <Pagination
+      style={{ padding: 0 }}
+      itemCount={data && data.count ? data.count : 0}
+      perPage={options.perPage}
+      page={options.page}
+      variant={PaginationVariant.bottom}
+      onSetPage={(event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPage: number): void =>
+        setOptions({ ...options, page: newPage })
+      }
+      onPerPageSelect={(event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPerPage: number): void =>
+        setOptions({ ...options, perPage: newPerPage })
+      }
+      onFirstClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+        setOptions({ ...options, page: newPage })
+      }
+      onLastClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+        setOptions({ ...options, page: newPage })
+      }
+      onNextClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+        setOptions({ ...options, page: newPage })
+      }
+      onPreviousClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+        setOptions({ ...options, page: newPage })
+      }
+    />
+  );
+};
+
+export default Applications;

--- a/plugins/app/src/components/profile/UserTeams.tsx
+++ b/plugins/app/src/components/profile/UserTeams.tsx
@@ -1,0 +1,112 @@
+import {
+  Alert,
+  AlertActionLink,
+  AlertVariant,
+  Avatar,
+  DataList,
+  DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+  Flex,
+  FlexItem,
+  Spinner,
+} from '@patternfly/react-core';
+import { QueryObserverResult, useQuery } from 'react-query';
+import React from 'react';
+
+import { ITeam } from '../../crds/team';
+import { LinkWrapper } from '@kobsio/shared';
+import { UserIcon } from '@patternfly/react-icons';
+
+export interface IUserTeamsProps {
+  setDetails?: (details: React.ReactNode) => void;
+}
+
+const UserTeams: React.FunctionComponent<IUserTeamsProps> = ({ setDetails }: IUserTeamsProps) => {
+  const { isError, isLoading, error, data, refetch } = useQuery<ITeam[], Error>(['app/teams/user'], async () => {
+    const response = await fetch(`/api/teams`, {
+      method: 'get',
+    });
+    const json = await response.json();
+
+    if (response.status >= 200 && response.status < 300) {
+      return json;
+    } else {
+      if (json.error) {
+        throw new Error(json.error);
+      } else {
+        throw new Error('An unknown error occured');
+      }
+    }
+  });
+
+  if (isLoading) {
+    return (
+      <div className="pf-u-text-align-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Alert
+        variant={AlertVariant.danger}
+        isInline={true}
+        title="An error occured while applications were fetched"
+        actionLinks={
+          <React.Fragment>
+            <AlertActionLink onClick={(): Promise<QueryObserverResult<ITeam[], Error>> => refetch()}>
+              Retry
+            </AlertActionLink>
+          </React.Fragment>
+        }
+      >
+        <p>{error?.message}</p>
+      </Alert>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return null;
+  }
+
+  return (
+    <DataList aria-label="teams list">
+      {data.map((team) => (
+        <LinkWrapper key={team.group} to={`/teams/${encodeURIComponent(team.group)}`}>
+          <DataListItem id={team.group} aria-labelledby={team.group}>
+            <DataListItemRow>
+              <DataListItemCells
+                dataListCells={[
+                  <DataListCell key="main">
+                    <Flex>
+                      <Flex direction={{ default: 'row' }} alignSelf={{ default: 'alignSelfCenter' }}>
+                        <FlexItem>
+                          {team.logo ? (
+                            <Avatar alt="team logo" src={team.logo} />
+                          ) : (
+                            <UserIcon style={{ fontSize: '36px' }} />
+                          )}
+                        </FlexItem>
+                      </Flex>
+                      <Flex direction={{ default: 'row' }} alignSelf={{ default: 'alignSelfCenter' }}>
+                        <FlexItem>
+                          <p>{team.group}</p>
+                          <small>{team.description}</small>
+                        </FlexItem>
+                      </Flex>
+                    </Flex>
+                  </DataListCell>,
+                ]}
+              />
+            </DataListItemRow>
+          </DataListItem>
+        </LinkWrapper>
+      ))}
+    </DataList>
+  );
+};
+
+export default UserTeams;

--- a/plugins/app/src/crds/user.ts
+++ b/plugins/app/src/crds/user.ts
@@ -9,5 +9,5 @@ export interface IUser {
   namespace: string;
   name: string;
   email: string;
-  rows?: IReference[];
+  dashboards?: IReference[];
 }


### PR DESCRIPTION
It is now possible to display a list of dashboards on the users profile
page. The dashboards can be configured by every user via the "dashboards"
field in the User CR, so that each user can have a custom profile page.
If we coudln't found a CR for the email address of the user an
administrator can add a list of default dashboards via the hub
configuration file. If no configuration for the dashboards is provided
we will use a default dashboards list, which contains two dashboards:
One to display the team, where a user is part of and another one to
display the applications which are owned by these teams.

We also improved the applications panel, which now supports pagination,
to reduce the amount of applications which are loaded at once and to
keep the list of applications shorter.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
