### PR TITLE
[app] Several UI fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#350](https://github.com/kobsio/kobs/pull/#350): [app] Fix Docker image and request proxy.
 - [#351](https://github.com/kobsio/kobs/pull/#351): [jaeger] Fix links and colors in Jaeger plugin.
 - [#352](https://github.com/kobsio/kobs/pull/#352): [app] Fix plugin filter and allow filtering by the name of a satellite.
+- [#356](https://github.com/kobsio/kobs/pull/#356): [app] Fix tooltip in documents table of the klogs plugin. Fix filtering of services and operations in the Jaeger plugin. Add max height to all select boxes.
 
 ### Changed
 

--- a/plugins/app/src/components/dashboards/DashboardToolbarVariable.tsx
+++ b/plugins/app/src/components/dashboards/DashboardToolbarVariable.tsx
@@ -68,6 +68,7 @@ const DashboardToolbarVariable: React.FunctionComponent<IDashboardToolbarVariabl
       isOpen={show}
       isGrouped={true}
       width={250}
+      maxHeight="50vh"
     >
       {group}
     </Select>

--- a/plugins/app/src/components/plugins/PluginInstances.tsx
+++ b/plugins/app/src/components/plugins/PluginInstances.tsx
@@ -72,6 +72,7 @@ const PluginInstances: React.FunctionComponent = () => {
                   onClear={(): void => setState({ ...state, page: 1, pluginSatellite: '' })}
                   selections={state.pluginSatellite}
                   isOpen={state.pluginSatelliteIsOpen}
+                  maxHeight="50vh"
                 >
                   {pluginsContext.getPluginSatellites().map((option) => (
                     <SelectOption key={option} value={option} />
@@ -91,6 +92,7 @@ const PluginInstances: React.FunctionComponent = () => {
                   onClear={(): void => setState({ ...state, page: 1, pluginType: '' })}
                   selections={state.pluginType}
                   isOpen={state.pluginTypeIsOpen}
+                  maxHeight="50vh"
                 >
                   {pluginsContext.getPluginTypes().map((option) => (
                     <SelectOption key={option} value={option} />

--- a/plugins/plugin-azure/src/components/containerinstances/DetailsLogs.tsx
+++ b/plugins/plugin-azure/src/components/containerinstances/DetailsLogs.tsx
@@ -90,6 +90,7 @@ const DetailsLogs: React.FunctionComponent<IDetailsLogsProps> = ({
         onSelect={(e, value): void => selectContainer(value as string)}
         selections={container}
         isOpen={showSelect}
+        maxHeight="50vh"
       >
         {containers.map((container, index) => (
           <SelectOption key={index} value={container} />

--- a/plugins/plugin-azure/src/components/costmanagement/CostManagementToolbarItemScope.tsx
+++ b/plugins/plugin-azure/src/components/costmanagement/CostManagementToolbarItemScope.tsx
@@ -27,6 +27,7 @@ const CostManagementToolbarItemScope: React.FunctionComponent<ICostManagementToo
       onSelect={(e, value): void => setScope(value as string)}
       selections={scope}
       isOpen={showSelect}
+      maxHeight="50vh"
     >
       {options}
     </Select>

--- a/plugins/plugin-azure/src/components/costmanagement/CostManagementToolbarItemTimeframe.tsx
+++ b/plugins/plugin-azure/src/components/costmanagement/CostManagementToolbarItemTimeframe.tsx
@@ -23,6 +23,7 @@ const CostManagementToolbarItemTimeframe: React.FunctionComponent<ICostManagemen
       onSelect={(e, value): void => setTimeframe(value as number)}
       selections={timeframe}
       isOpen={showSelect}
+      maxHeight="50vh"
     >
       {options.map((tf, index) => (
         <SelectOption key={index} value={tf.value} description="days" />

--- a/plugins/plugin-azure/src/components/virtualmachinescalesets/DetailsMetricsVirtualMachineToolbar.tsx
+++ b/plugins/plugin-azure/src/components/virtualmachinescalesets/DetailsMetricsVirtualMachineToolbar.tsx
@@ -50,6 +50,7 @@ const DetailsMetricsVirtualMachineToolbar: React.FunctionComponent<IDetailsMetri
               onSelect={(e, value): void => changeSelectedVirtualMachine(value as string)}
               selections={selectedVirtualMachine}
               isOpen={show}
+              maxHeight="50vh"
             >
               {virtualMachines.map((virtualMachine) => (
                 <SelectOption key={virtualMachine} value={virtualMachine}>

--- a/plugins/plugin-istio/src/components/page/ApplicationsToolbar.tsx
+++ b/plugins/plugin-istio/src/components/page/ApplicationsToolbar.tsx
@@ -95,6 +95,7 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({
               onClear={(): void => setSelectedNamespaces([])}
               selections={selectedNamespaces}
               isOpen={showNamespaces}
+              maxHeight="50vh"
             >
               {isError || !data
                 ? [<SelectOption key="error" isDisabled={true} value={error?.message || 'Could not get namespaces.'} />]

--- a/plugins/plugin-jaeger/src/components/page/TracesToolbarOperations.tsx
+++ b/plugins/plugin-jaeger/src/components/page/TracesToolbarOperations.tsx
@@ -56,12 +56,15 @@ const TracesToolbarOperations: React.FunctionComponent<ITracesToolbarOperationsP
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): React.ReactElement<any, string | React.JSXElementConstructor<any>>[] => {
     if (value && data) {
-      return data
-        .filter((item) => item.toLowerCase().includes(value.toLowerCase()))
+      const filteredData = data.filter((item) => item.toLowerCase().includes(value.toLowerCase()));
+      return filteredData
+        .slice(0, data.length > 100 ? 100 : data.length)
         .map((item, index) => <SelectOption key={index} value={item} />);
     } else {
       if (data) {
-        return data.map((item, index) => <SelectOption key={index} value={item} />);
+        return data
+          .slice(0, data.length > 100 ? 100 : data.length)
+          .map((item, index) => <SelectOption key={index} value={item} />);
       }
       return [];
     }
@@ -85,12 +88,13 @@ const TracesToolbarOperations: React.FunctionComponent<ITracesToolbarOperationsP
       onSelect={(e, value): void => setOperation(value as string)}
       selections={operation}
       isOpen={show}
+      maxHeight="50vh"
     >
       {isError
         ? [<SelectOption key="error" isDisabled={true} value={error?.message || 'Could not get operations.'} />]
         : data
         ? data
-            .slice(0, data.length > 50 ? 50 : data.length)
+            .slice(0, data.length > 100 ? 100 : data.length)
             .map((operation, index) => <SelectOption key={index} value={operation} />)
         : []}
     </Select>

--- a/plugins/plugin-jaeger/src/components/page/TracesToolbarServices.tsx
+++ b/plugins/plugin-jaeger/src/components/page/TracesToolbarServices.tsx
@@ -50,12 +50,15 @@ const TracesToolbarServices: React.FunctionComponent<ITracesToolbarServicesProps
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): React.ReactElement<any, string | React.JSXElementConstructor<any>>[] => {
     if (value && data) {
-      return data
-        .filter((item) => item.toLowerCase().includes(value.toLowerCase()))
+      const filteredData = data.filter((item) => item.toLowerCase().includes(value.toLowerCase()));
+      return filteredData
+        .slice(0, filteredData.length > 100 ? 100 : filteredData.length)
         .map((item, index) => <SelectOption key={index} value={item} />);
     } else {
       if (data) {
-        return data.map((item, index) => <SelectOption key={index} value={item} />);
+        return data
+          .slice(0, data.length > 100 ? 100 : data.length)
+          .map((item, index) => <SelectOption key={index} value={item} />);
       }
       return [];
     }
@@ -79,12 +82,13 @@ const TracesToolbarServices: React.FunctionComponent<ITracesToolbarServicesProps
       onSelect={(e, value): void => setService(value as string)}
       selections={service}
       isOpen={show}
+      maxHeight="50vh"
     >
       {isError
         ? [<SelectOption key="error" isDisabled={true} value={error?.message || 'Could not get services.'} />]
         : data
         ? data
-            .slice(0, data.length > 50 ? 50 : data.length)
+            .slice(0, data.length > 100 ? 100 : data.length)
             .map((service, index) => <SelectOption key={index} value={service} />)
         : []}
     </Select>

--- a/plugins/plugin-kiali/src/components/page/PageToolbarNamespaces.tsx
+++ b/plugins/plugin-kiali/src/components/page/PageToolbarNamespaces.tsx
@@ -68,6 +68,7 @@ const PageToolbarNamespaces: React.FunctionComponent<IPageToolbarNamespacesProps
               .map((namespace: string) => <SelectOption key={namespace} value={namespace} />)
           : []
       }
+      maxHeight="50vh"
     >
       {isError
         ? [<SelectOption key="error" isDisabled={true} value={error?.message || 'Could not get namespaces.'} />]

--- a/plugins/plugin-klogs/src/components/panel/LogsDocuments.tsx
+++ b/plugins/plugin-klogs/src/components/panel/LogsDocuments.tsx
@@ -54,6 +54,7 @@ const LogsDocuments: React.FunctionComponent<ILogsDocumentsProps> = ({
         <Tr>
           <Th />
           <Th
+            tooltip={null}
             sort={{
               columnIndex: -1,
               onSort: (
@@ -75,6 +76,7 @@ const LogsDocuments: React.FunctionComponent<ILogsDocumentsProps> = ({
             fields.map((field, index) => (
               <Th
                 key={index}
+                tooltip={null}
                 sort={{
                   columnIndex: index,
                   onSort: (

--- a/plugins/plugin-sql/src/components/panel/SQL.tsx
+++ b/plugins/plugin-sql/src/components/panel/SQL.tsx
@@ -94,6 +94,7 @@ const SQL: React.FunctionComponent<ISQLProps> = ({ instance, title, description,
               onSelect={select}
               selections={queries[selectedQueryIndex].name}
               isOpen={showSelect}
+              maxHeight="50vh"
             >
               {queries.map((query, index) => (
                 <SelectOption key={index} value={query.name} description={query.query} />


### PR DESCRIPTION
- The tooltip in the documents table of the klogs plugin was rendered
  twice. This is now fixed so that the tooltip in the table is only
  rendered once for wrapped text.
- The filtering of services and operations doesn't used our defined
  limit of 50 (now set to 100). This is now fixed and we are also
  rendering only the first 100 results in the filtered items.
- Some of the used select boxes didn't had a "maxHeight" property. Now
  all select boxes have this property set to "50vh", so that we have a
  unique style across all plugins.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
