### PR TITLE
[app] Adjust namespace handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#346](https://github.com/kobsio/kobs/pull/346): [app] :warning: _Breaking change:_ :warning: Rework kobs architecture, by introducing a `hub` and a `satellite` component. This new architecture allows us to run the kobs `hub` component in a central cluster and access clusters / services (plugins) through the kobs `satellite` component. More information regarding the new kobs architecture can be found in the documentation at [kobs.io](https://kobs.io).
 - [#348](https://github.com/kobsio/kobs/pull/348): [app] Update permission handling.
 - [#354](https://github.com/kobsio/kobs/pull/#354): [app] Change URLs for the details page of an Application and a Dashboard.
+- [#357](https://github.com/kobsio/kobs/pull/#357): [app] Adjust namespace handling in the frontend, so that it is not required anymore to select the namespaces from all selected clusters.
 
 ## [v0.8.0](https://github.com/kobsio/kobs/releases/tag/v0.8.0) (2022-03-24)
 

--- a/pkg/hub/api/clusters/clusters.go
+++ b/pkg/hub/api/clusters/clusters.go
@@ -1,7 +1,6 @@
 package clusters
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/kobsio/kobs/pkg/hub/store"
@@ -51,20 +50,13 @@ func (router *Router) getNamespaces(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var groupedNamespaces map[string][]shared.Namespace
-	groupedNamespaces = make(map[string][]shared.Namespace)
+	var uniqueNamespaces []string
 
 	for _, namespace := range namespaces {
-		key := fmt.Sprintf("%s (%s)", namespace.Cluster, namespace.Satellite)
-
-		if _, ok := groupedNamespaces[key]; ok {
-			groupedNamespaces[key] = append(groupedNamespaces[key], namespace)
-		} else {
-			groupedNamespaces[key] = []shared.Namespace{namespace}
-		}
+		uniqueNamespaces = appendIfMissing(uniqueNamespaces, namespace.Namespace)
 	}
 
-	render.JSON(w, r, groupedNamespaces)
+	render.JSON(w, r, uniqueNamespaces)
 }
 
 func (router *Router) getResources(w http.ResponseWriter, r *http.Request) {

--- a/pkg/hub/api/clusters/clusters_test.go
+++ b/pkg/hub/api/clusters/clusters_test.go
@@ -98,7 +98,7 @@ func TestGetNamespaces(t *testing.T) {
 			name:               "get namespaces",
 			url:                "/namespaces",
 			expectedStatusCode: http.StatusOK,
-			expectedBody:       "{\"dev-de1 (satellite1)\":[{\"id\":\"\",\"namespace\":\"default\",\"cluster\":\"dev-de1\",\"satellite\":\"satellite1\",\"clusterID\":\"\",\"updatedAt\":0},{\"id\":\"\",\"namespace\":\"kube-system\",\"cluster\":\"dev-de1\",\"satellite\":\"satellite1\",\"clusterID\":\"\",\"updatedAt\":0}],\"stage-de1 (satellite2)\":[{\"id\":\"\",\"namespace\":\"default\",\"cluster\":\"stage-de1\",\"satellite\":\"satellite2\",\"clusterID\":\"\",\"updatedAt\":0}]}\n",
+			expectedBody:       "[\"default\",\"kube-system\"]\n",
 			prepare: func(t *testing.T, mockStoreClient *store.MockClient) {
 				mockStoreClient.On("GetNamespacesByClusterIDs", mock.Anything, mock.Anything).Return([]shared.Namespace{
 					{Namespace: "default", Cluster: "dev-de1", Satellite: "satellite1"},

--- a/pkg/hub/api/clusters/helpers.go
+++ b/pkg/hub/api/clusters/helpers.go
@@ -1,0 +1,12 @@
+package clusters
+
+// appendIfMissing appends a value to a slice, when this values doesn't exist in the slice already.
+func appendIfMissing(items []string, item string) []string {
+	for _, ele := range items {
+		if ele == item {
+			return items
+		}
+	}
+
+	return append(items, item)
+}

--- a/pkg/hub/api/clusters/helpers_test.go
+++ b/pkg/hub/api/clusters/helpers_test.go
@@ -1,0 +1,19 @@
+package clusters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppendIfMissing(t *testing.T) {
+	t.Run("append", func(t *testing.T) {
+		namespaces := appendIfMissing([]string{"test1"}, "test2")
+		require.Equal(t, []string{"test1", "test2"}, namespaces)
+	})
+
+	t.Run("do not append", func(t *testing.T) {
+		namespaces := appendIfMissing([]string{"test1"}, "test1")
+		require.Equal(t, []string{"test1"}, namespaces)
+	})
+}

--- a/plugins/app/src/components/applications/Applications.tsx
+++ b/plugins/app/src/components/applications/Applications.tsx
@@ -19,7 +19,7 @@ const Applications: React.FunctionComponent = () => {
 
   const changeOptions = (opts: IOptions): void => {
     const c = opts.clusterIDs.map((clusterID) => `&clusterID=${encodeURIComponent(clusterID)}`);
-    const n = opts.namespaceIDs.map((namespaceID) => `&namespaceID=${encodeURIComponent(namespaceID)}`);
+    const n = opts.namespaces.map((namespace) => `&namespace=${encodeURIComponent(namespace)}`);
     const t = opts.tags.map((tag) => `&tag=${encodeURIComponent(tag)}`);
 
     navigate(

--- a/plugins/app/src/components/applications/ApplicationsList.tsx
+++ b/plugins/app/src/components/applications/ApplicationsList.tsx
@@ -28,7 +28,11 @@ const ApplicationsList: React.FunctionComponent<IApplicationsListProps> = ({
     ['app/applications/applications', options],
     async () => {
       const c = options.clusterIDs.map((clusterID) => `&clusterID=${encodeURIComponent(clusterID)}`);
-      const n = options.namespaceIDs.map((namespaceID) => `&namespaceID=${encodeURIComponent(namespaceID)}`);
+      const n = options.clusterIDs.map((clusterID) =>
+        options.namespaces.map(
+          (namespace) => `&namespaceID=${encodeURIComponent(`${clusterID}/namespace/${namespace}`)}`,
+        ),
+      );
       const t = options.tags.map((tag) => `&tag=${encodeURIComponent(tag)}`);
 
       const response = await fetch(

--- a/plugins/app/src/components/applications/ApplicationsPagination.tsx
+++ b/plugins/app/src/components/applications/ApplicationsPagination.tsx
@@ -19,13 +19,17 @@ const Applications: React.FunctionComponent<IApplicationsPagination> = ({
       options.all,
       options.clusterIDs,
       options.external,
-      options.namespaceIDs,
+      options.namespaces,
       options.searchTerm,
       options.tags,
     ],
     async () => {
       const c = options.clusterIDs.map((clusterID) => `&clusterID=${encodeURIComponent(clusterID)}`);
-      const n = options.namespaceIDs.map((namespaceID) => `&namespaceID=${encodeURIComponent(namespaceID)}`);
+      const n = options.clusterIDs.map((clusterID) =>
+        options.namespaces.map(
+          (namespace) => `&namespaceID=${encodeURIComponent(`${clusterID}/namespace/${namespace}`)}`,
+        ),
+      );
       const t = options.tags.map((tag) => `&tag=${encodeURIComponent(tag)}`);
 
       const response = await fetch(

--- a/plugins/app/src/components/applications/ApplicationsToolbar.tsx
+++ b/plugins/app/src/components/applications/ApplicationsToolbar.tsx
@@ -41,14 +41,14 @@ const ApplicationsToolbar: React.FunctionComponent<IApplicationsToolbarProps> = 
     }
   };
 
-  const selectNamespaceID = (namespaceID: string): void => {
-    if (namespaceID === '') {
-      setState({ ...state, namespaceIDs: [] });
+  const selectNamespace = (namespace: string): void => {
+    if (namespace === '') {
+      setState({ ...state, namespaces: [] });
     } else {
-      if (state.namespaceIDs.includes(namespaceID)) {
-        setState({ ...state, namespaceIDs: state.namespaceIDs.filter((item) => item !== namespaceID) });
+      if (state.namespaces.includes(namespace)) {
+        setState({ ...state, namespaces: state.namespaces.filter((item) => item !== namespace) });
       } else {
-        setState({ ...state, namespaceIDs: [...state.namespaceIDs, namespaceID] });
+        setState({ ...state, namespaces: [...state.namespaces, namespace] });
       }
     }
   };
@@ -102,8 +102,8 @@ const ApplicationsToolbar: React.FunctionComponent<IApplicationsToolbarProps> = 
         <ToolbarItem>
           <ResourcesToolbarNamespaces
             selectedClusterIDs={state.clusterIDs}
-            selectedNamespaceIDs={state.namespaceIDs}
-            selectNamespaceID={selectNamespaceID}
+            selectedNamespaces={state.namespaces}
+            selectNamespace={selectNamespace}
           />
         </ToolbarItem>
         <ToolbarItem>

--- a/plugins/app/src/components/applications/utils/helpers.ts
+++ b/plugins/app/src/components/applications/utils/helpers.ts
@@ -7,7 +7,7 @@ export const getInitialOptions = (search: string): IOptions => {
   const all = params.get('all');
   const clusterIDs = params.getAll('clusterID');
   const external = params.get('external');
-  const namespaceIDs = params.getAll('namespaceID');
+  const namespaces = params.getAll('namespace');
   const page = params.get('page');
   const perPage = params.get('perPage');
   const searchTerm = params.get('searchTerm');
@@ -17,7 +17,7 @@ export const getInitialOptions = (search: string): IOptions => {
     all: all === 'true' ? true : false,
     clusterIDs: clusterIDs,
     external: external || 'include',
-    namespaceIDs: namespaceIDs,
+    namespaces: namespaces,
     page: page ? parseInt(page) : 1,
     perPage: perPage ? parseInt(perPage) : 10,
     searchTerm: searchTerm || '',

--- a/plugins/app/src/components/applications/utils/interfaces.ts
+++ b/plugins/app/src/components/applications/utils/interfaces.ts
@@ -2,7 +2,7 @@ export interface IOptions {
   all: boolean;
   clusterIDs: string[];
   external: string;
-  namespaceIDs: string[];
+  namespaces: string[];
   page: number;
   perPage: number;
   searchTerm: string;

--- a/plugins/app/src/components/resources/Resources.tsx
+++ b/plugins/app/src/components/resources/Resources.tsx
@@ -17,7 +17,7 @@ const Resources: React.FunctionComponent = () => {
 
   const changeOptions = (opts: IOptions): void => {
     const c = opts.clusterIDs.map((clusterID) => `&clusterID=${encodeURIComponent(clusterID)}`);
-    const n = opts.namespaceIDs.map((namespaceID) => `&namespaceID=${encodeURIComponent(namespaceID)}`);
+    const n = opts.namespaces.map((namespace) => `&namespace=${encodeURIComponent(namespace)}`);
     const r = opts.resourceIDs.map((resourceID) => `&resourceID=${encodeURIComponent(resourceID)}`);
 
     navigate(

--- a/plugins/app/src/components/resources/ResourcesPanel.tsx
+++ b/plugins/app/src/components/resources/ResourcesPanel.tsx
@@ -39,7 +39,11 @@ const ResourcesPanel: React.FunctionComponent<IResourcesPanelProps> = ({
     ['app/resources/resources/_', options],
     async () => {
       const c = options.clusterIDs.map((clusterID) => `&clusterID=${encodeURIComponent(clusterID)}`);
-      const n = options.namespaceIDs.map((namespaceID) => `&namespaceID=${encodeURIComponent(namespaceID)}`);
+      const n = options.clusterIDs.map((clusterID) =>
+        options.namespaces.map(
+          (namespace) => `&namespaceID=${encodeURIComponent(`${clusterID}/namespace/${namespace}`)}`,
+        ),
+      );
       const r = options.resourceIDs.map((resourceID) => `&resourceID=${encodeURIComponent(resourceID)}`);
 
       const response = await fetch(

--- a/plugins/app/src/components/resources/ResourcesPanelWrapper.tsx
+++ b/plugins/app/src/components/resources/ResourcesPanelWrapper.tsx
@@ -20,11 +20,6 @@ const ResourcesPanelWrapper: React.FunctionComponent<IResourcesPanelWrapperProps
     const clusterIDs: string[] = options.satellites.map((satellite: string) =>
       options.clusters.map((cluster: string) => `/satellite/${satellite}/cluster/${cluster}`),
     );
-    const namespaceIDs = options.namespaces
-      ? clusterIDs.map((clusterID) =>
-          options.namespaces.map((namespace: string) => `${clusterID}/namespace/${namespace}`),
-        )
-      : [];
 
     return (
       <ResourcesPanel
@@ -32,7 +27,7 @@ const ResourcesPanelWrapper: React.FunctionComponent<IResourcesPanelWrapperProps
         options={{
           clusterIDs: clusterIDs,
           columns: options.columns,
-          namespaceIDs: namespaceIDs,
+          namespaces: options.namespaces || [],
           param: options.selector || '',
           paramName: options.selectorType === 'fieldSelector' ? 'fieldSelector' : 'labelSelector',
           resourceIDs: options.resources || [],

--- a/plugins/app/src/components/resources/ResourcesToolbar.tsx
+++ b/plugins/app/src/components/resources/ResourcesToolbar.tsx
@@ -38,14 +38,14 @@ const ResourcesToolbar: React.FunctionComponent<IResourcesToolbarProps> = ({
     }
   };
 
-  const selectNamespaceID = (namespaceID: string): void => {
-    if (namespaceID === '') {
-      setState({ ...state, namespaceIDs: [] });
+  const selectNamespace = (namespace: string): void => {
+    if (namespace === '') {
+      setState({ ...state, namespaces: [] });
     } else {
-      if (state.namespaceIDs.includes(namespaceID)) {
-        setState({ ...state, namespaceIDs: state.namespaceIDs.filter((item) => item !== namespaceID) });
+      if (state.namespaces.includes(namespace)) {
+        setState({ ...state, namespaces: state.namespaces.filter((item) => item !== namespace) });
       } else {
-        setState({ ...state, namespaceIDs: [...state.namespaceIDs, namespaceID] });
+        setState({ ...state, namespaces: [...state.namespaces, namespace] });
       }
     }
   };
@@ -86,8 +86,8 @@ const ResourcesToolbar: React.FunctionComponent<IResourcesToolbarProps> = ({
         <ToolbarItem>
           <ResourcesToolbarNamespaces
             selectedClusterIDs={state.clusterIDs}
-            selectedNamespaceIDs={state.namespaceIDs}
-            selectNamespaceID={selectNamespaceID}
+            selectedNamespaces={state.namespaces}
+            selectNamespace={selectNamespace}
           />
         </ToolbarItem>
         <ToolbarItem>

--- a/plugins/app/src/components/resources/ResourcesToolbarClusters.tsx
+++ b/plugins/app/src/components/resources/ResourcesToolbarClusters.tsx
@@ -6,7 +6,7 @@ import { ICluster, IClusters } from '../../resources/clusters';
 
 interface IResourcesToolbarClustersProps {
   selectedClusterIDs: string[];
-  selectClusterID: (clusterIDs: string) => void;
+  selectClusterID: (clusterID: string) => void;
 }
 
 const ResourcesToolbarClusters: React.FunctionComponent<IResourcesToolbarClustersProps> = ({

--- a/plugins/app/src/components/resources/ResourcesToolbarNamespaces.tsx
+++ b/plugins/app/src/components/resources/ResourcesToolbarNamespaces.tsx
@@ -1,23 +1,21 @@
 import React, { useState } from 'react';
-import { Select, SelectGroup, SelectOption, SelectOptionObject, SelectVariant } from '@patternfly/react-core';
+import { Select, SelectOption, SelectOptionObject, SelectVariant } from '@patternfly/react-core';
 import { useQuery } from 'react-query';
-
-import { INamespace, INamespaces } from '../../resources/clusters';
 
 interface IResourcesToolbarNamespacesProps {
   selectedClusterIDs: string[];
-  selectedNamespaceIDs: string[];
-  selectNamespaceID: (clusterIDs: string) => void;
+  selectedNamespaces: string[];
+  selectNamespace: (namespace: string) => void;
 }
 
 const ResourcesToolbarNamespaces: React.FunctionComponent<IResourcesToolbarNamespacesProps> = ({
   selectedClusterIDs,
-  selectedNamespaceIDs,
-  selectNamespaceID,
+  selectedNamespaces,
+  selectNamespace,
 }: IResourcesToolbarNamespacesProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
-  const { data } = useQuery<INamespaces, Error>(['app/clusters/namespaces', selectedClusterIDs], async () => {
+  const { data } = useQuery<string[], Error>(['app/clusters/namespaces', selectedClusterIDs], async () => {
     const c = selectedClusterIDs.map((clusterID) => `&clusterID=${encodeURIComponent(clusterID)}`);
 
     const response = await fetch(`/api/clusters/namespaces?${c.length > 0 ? c.join('') : ''}`, {
@@ -45,23 +43,18 @@ const ResourcesToolbarNamespaces: React.FunctionComponent<IResourcesToolbarNames
       onSelect={(
         event: React.MouseEvent<Element, MouseEvent> | React.ChangeEvent<Element>,
         value: string | SelectOptionObject,
-      ): void => selectNamespaceID(value.toString())}
-      onClear={(): void => selectNamespaceID('')}
-      selections={selectedNamespaceIDs}
+      ): void => selectNamespace(value.toString())}
+      onClear={(): void => selectNamespace('')}
+      selections={selectedNamespaces}
       isOpen={isOpen}
-      isGrouped={true}
       hasInlineFilter={true}
       maxHeight="50vh"
     >
-      {data && Object.keys(data).length > 0
-        ? Object.keys(data).map((cluster) => (
-            <SelectGroup label={cluster} key={cluster}>
-              {data[cluster].map((namespace: INamespace) => (
-                <SelectOption key={namespace.id} value={namespace.id}>
-                  {namespace.namespace}
-                </SelectOption>
-              ))}
-            </SelectGroup>
+      {data && data.length > 0
+        ? data.map((namespace) => (
+            <SelectOption key={namespace} value={namespace}>
+              {namespace}
+            </SelectOption>
           ))
         : [<SelectOption key="noresultsfound" value="No results found" isDisabled={true} />]}
     </Select>

--- a/plugins/app/src/components/resources/details/overview/Selector.tsx
+++ b/plugins/app/src/components/resources/details/overview/Selector.tsx
@@ -17,7 +17,6 @@ const Selector: React.FunctionComponent<ISelectorProps> = ({
   selector,
 }: ISelectorProps) => {
   const clusterID = `/satellite/${satellite}/cluster/${cluster}`;
-  const namespaceID = `${clusterID}/namespace/${namespace}`;
 
   return (
     <DescriptionListGroup>
@@ -29,7 +28,7 @@ const Selector: React.FunctionComponent<ISelectorProps> = ({
               key={key}
               to={`/resources?paramName=labelSelector&param=${key}=${
                 selector.matchLabels ? selector.matchLabels[key] : ''
-              }&clusterID=${clusterID}&namespaceID=${encodeURIComponent(namespaceID)}&resourceID=pods`}
+              }&clusterID=${encodeURIComponent(clusterID)}&namespace=${namespace}&resourceID=pods`}
             >
               <div className="pf-c-chip pf-u-mr-md pf-u-mb-sm" style={{ maxWidth: '100%' }}>
                 <span className="pf-c-chip__text" style={{ maxWidth: '100%' }}>

--- a/plugins/app/src/components/resources/utils/helpers.ts
+++ b/plugins/app/src/components/resources/utils/helpers.ts
@@ -6,14 +6,14 @@ import { getTimeParams } from '@kobsio/shared';
 export const getInitialOptions = (search: string, isInitial: boolean): IOptions => {
   const params = new URLSearchParams(search);
   const clusterIDs = params.getAll('clusterID');
-  const namespaceIDs = params.getAll('namespaceID');
+  const namespaces = params.getAll('namespace');
   const resourceIDs = params.getAll('resourceID');
   const param = params.get('param');
   const paramName = params.get('paramName');
 
   return {
     clusterIDs: clusterIDs,
-    namespaceIDs: namespaceIDs,
+    namespaces: namespaces,
     param: param || '',
     paramName: paramName || '',
     resourceIDs: resourceIDs,

--- a/plugins/app/src/components/resources/utils/interfaces.ts
+++ b/plugins/app/src/components/resources/utils/interfaces.ts
@@ -5,7 +5,7 @@ import { ITimes } from '@kobsio/shared';
 
 export interface IOptions {
   clusterIDs: string[];
-  namespaceIDs: string[];
+  namespaces: string[];
   resourceIDs: string[];
   param: string;
   paramName: string;

--- a/plugins/app/src/resources/clusters.ts
+++ b/plugins/app/src/resources/clusters.ts
@@ -9,19 +9,6 @@ export interface ICluster {
   updatedAt: number;
 }
 
-export interface INamespaces {
-  [cluster: string]: INamespace[];
-}
-
-export interface INamespace {
-  id: string;
-  namespace: string;
-  cluster: string;
-  satellite: string;
-  clusterID: string;
-  updatedAt: number;
-}
-
 export interface IResource {
   id: string;
   description: string;


### PR DESCRIPTION
When a user selects multiple clusters and wanted to view the same
namespace in all clusters, he had to select the namespace for each
selected cluster.

This is now changed so that we do not have a cluster specific namespace
list anymore. Instead the list of namespaces is a unique list of
namespaces across all selected clusters.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
