### PR TITLE
[app] Fix namespace handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#351](https://github.com/kobsio/kobs/pull/#351): [jaeger] Fix links and colors in Jaeger plugin.
 - [#352](https://github.com/kobsio/kobs/pull/#352): [app] Fix plugin filter and allow filtering by the name of a satellite.
 - [#356](https://github.com/kobsio/kobs/pull/#356): [app] Fix tooltip in documents table of the klogs plugin. Fix filtering of services and operations in the Jaeger plugin. Add max height to all select boxes.
+- [#358](https://github.com/kobsio/kobs/pull/#358): [app] Fix namespace handling, when multiple namespaces are selected.
 
 ### Changed
 

--- a/pkg/hub/api/clusters/clusters.go
+++ b/pkg/hub/api/clusters/clusters.go
@@ -2,6 +2,7 @@ package clusters
 
 import (
 	"net/http"
+	"sort"
 
 	"github.com/kobsio/kobs/pkg/hub/store"
 	"github.com/kobsio/kobs/pkg/hub/store/shared"
@@ -56,6 +57,7 @@ func (router *Router) getNamespaces(w http.ResponseWriter, r *http.Request) {
 		uniqueNamespaces = appendIfMissing(uniqueNamespaces, namespace.Namespace)
 	}
 
+	sort.Strings(uniqueNamespaces)
 	render.JSON(w, r, uniqueNamespaces)
 }
 

--- a/plugins/app/src/components/applications/ApplicationsList.tsx
+++ b/plugins/app/src/components/applications/ApplicationsList.tsx
@@ -28,11 +28,13 @@ const ApplicationsList: React.FunctionComponent<IApplicationsListProps> = ({
     ['app/applications/applications', options],
     async () => {
       const c = options.clusterIDs.map((clusterID) => `&clusterID=${encodeURIComponent(clusterID)}`);
-      const n = options.clusterIDs.map((clusterID) =>
-        options.namespaces.map(
-          (namespace) => `&namespaceID=${encodeURIComponent(`${clusterID}/namespace/${namespace}`)}`,
-        ),
-      );
+      const n = options.clusterIDs
+        .map((clusterID) =>
+          options.namespaces.map(
+            (namespace) => `&namespaceID=${encodeURIComponent(`${clusterID}/namespace/${namespace}`)}`,
+          ),
+        )
+        .flat();
       const t = options.tags.map((tag) => `&tag=${encodeURIComponent(tag)}`);
 
       const response = await fetch(

--- a/plugins/app/src/components/applications/ApplicationsPagination.tsx
+++ b/plugins/app/src/components/applications/ApplicationsPagination.tsx
@@ -25,11 +25,13 @@ const Applications: React.FunctionComponent<IApplicationsPagination> = ({
     ],
     async () => {
       const c = options.clusterIDs.map((clusterID) => `&clusterID=${encodeURIComponent(clusterID)}`);
-      const n = options.clusterIDs.map((clusterID) =>
-        options.namespaces.map(
-          (namespace) => `&namespaceID=${encodeURIComponent(`${clusterID}/namespace/${namespace}`)}`,
-        ),
-      );
+      const n = options.clusterIDs
+        .map((clusterID) =>
+          options.namespaces.map(
+            (namespace) => `&namespaceID=${encodeURIComponent(`${clusterID}/namespace/${namespace}`)}`,
+          ),
+        )
+        .flat();
       const t = options.tags.map((tag) => `&tag=${encodeURIComponent(tag)}`);
 
       const response = await fetch(

--- a/plugins/app/src/components/resources/ResourcesPanel.tsx
+++ b/plugins/app/src/components/resources/ResourcesPanel.tsx
@@ -39,11 +39,13 @@ const ResourcesPanel: React.FunctionComponent<IResourcesPanelProps> = ({
     ['app/resources/resources/_', options],
     async () => {
       const c = options.clusterIDs.map((clusterID) => `&clusterID=${encodeURIComponent(clusterID)}`);
-      const n = options.clusterIDs.map((clusterID) =>
-        options.namespaces.map(
-          (namespace) => `&namespaceID=${encodeURIComponent(`${clusterID}/namespace/${namespace}`)}`,
-        ),
-      );
+      const n = options.clusterIDs
+        .map((clusterID) =>
+          options.namespaces.map(
+            (namespace) => `&namespaceID=${encodeURIComponent(`${clusterID}/namespace/${namespace}`)}`,
+          ),
+        )
+        .flat();
       const r = options.resourceIDs.map((resourceID) => `&resourceID=${encodeURIComponent(resourceID)}`);
 
       const response = await fetch(


### PR DESCRIPTION
When a user selected multiple clusters and multiple namespaces, there
was a bug so that we didn't show a complete list of resources.

This bug was caused, by the ways how we build the namespace ids in the
frontend: For that we used the map feature over the clusters and
namespaces which resulted in a two dimensonal array. We are now using
"flat()" on this array to get the correct list of namespace ids.

We also sorting the list of namespaces before it is shown to the user
now.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
