### PR TITLE
[app] Fix pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#352](https://github.com/kobsio/kobs/pull/#352): [app] Fix plugin filter and allow filtering by the name of a satellite.
 - [#356](https://github.com/kobsio/kobs/pull/#356): [app] Fix tooltip in documents table of the klogs plugin. Fix filtering of services and operations in the Jaeger plugin. Add max height to all select boxes.
 - [#358](https://github.com/kobsio/kobs/pull/#358): [app] Fix namespace handling, when multiple namespaces are selected.
+- [#359](https://github.com/kobsio/kobs/pull/#359): [app] Fix pagination, when the number of items per page is changed.
 
 ### Changed
 

--- a/plugins/app/src/components/applications/ApplicationsPagination.tsx
+++ b/plugins/app/src/components/applications/ApplicationsPagination.tsx
@@ -72,7 +72,7 @@ const Applications: React.FunctionComponent<IApplicationsPagination> = ({
           setOptions({ ...options, page: newPage })
         }
         onPerPageSelect={(event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPerPage: number): void =>
-          setOptions({ ...options, perPage: newPerPage })
+          setOptions({ ...options, page: 1, perPage: newPerPage })
         }
         onFirstClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
           setOptions({ ...options, page: newPage })

--- a/plugins/app/src/components/applications/ApplicationsPanelList.tsx
+++ b/plugins/app/src/components/applications/ApplicationsPanelList.tsx
@@ -80,7 +80,7 @@ const ApplicationsPanelList: React.FunctionComponent<IApplicationsPanelListProps
               setOptions({ ...options, page: newPage })
             }
             onPerPageSelect={(event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPerPage: number): void =>
-              setOptions({ ...options, perPage: newPerPage })
+              setOptions({ ...options, page: 1, perPage: newPerPage })
             }
             onFirstClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
               setOptions({ ...options, page: newPage })

--- a/plugins/app/src/components/plugins/PluginInstances.tsx
+++ b/plugins/app/src/components/plugins/PluginInstances.tsx
@@ -144,7 +144,7 @@ const PluginInstances: React.FunctionComponent = () => {
             setState({ ...state, page: newPage })
           }
           onPerPageSelect={(event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPerPage: number): void =>
-            setState({ ...state, perPage: newPerPage })
+            setState({ ...state, page: 1, perPage: newPerPage })
           }
           onFirstClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
             setState({ ...state, page: newPage })

--- a/plugins/app/src/components/profile/UserApplicationsPagination.tsx
+++ b/plugins/app/src/components/profile/UserApplicationsPagination.tsx
@@ -39,7 +39,7 @@ const Applications: React.FunctionComponent<IApplicationsPagination> = ({
         setOptions({ ...options, page: newPage })
       }
       onPerPageSelect={(event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPerPage: number): void =>
-        setOptions({ ...options, perPage: newPerPage })
+        setOptions({ ...options, page: 1, perPage: newPerPage })
       }
       onFirstClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
         setOptions({ ...options, page: newPage })

--- a/plugins/app/src/components/teams/Teams.tsx
+++ b/plugins/app/src/components/teams/Teams.tsx
@@ -139,7 +139,7 @@ const Teams: React.FunctionComponent = () => {
             setState({ ...state, page: newPage })
           }
           onPerPageSelect={(event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPerPage: number): void =>
-            setState({ ...state, perPage: newPerPage })
+            setState({ ...state, page: 1, perPage: newPerPage })
           }
           onFirstClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
             setState({ ...state, page: newPage })

--- a/plugins/plugin-elasticsearch/src/components/panel/LogsDocuments.tsx
+++ b/plugins/plugin-elasticsearch/src/components/panel/LogsDocuments.tsx
@@ -66,23 +66,23 @@ const LogsDocuments: React.FunctionComponent<ILogsDocumentsProps> = ({
                 page={page.page}
                 variant={PaginationVariant.bottom}
                 onSetPage={(event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPage: number): void =>
-                  setPage({ page: newPage, perPage: page.perPage })
+                  setPage({ ...page, page: newPage })
                 }
                 onPerPageSelect={(
                   event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
                   newPerPage: number,
-                ): void => setPage({ page: page.page, perPage: newPerPage })}
+                ): void => setPage({ page: 1, perPage: newPerPage })}
                 onFirstClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
-                  setPage({ page: newPage, perPage: page.perPage })
+                  setPage({ ...page, page: newPage })
                 }
                 onLastClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
-                  setPage({ page: newPage, perPage: page.perPage })
+                  setPage({ ...page, page: newPage })
                 }
                 onNextClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
-                  setPage({ page: newPage, perPage: page.perPage })
+                  setPage({ ...page, page: newPage })
                 }
                 onPreviousClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
-                  setPage({ page: newPage, perPage: page.perPage })
+                  setPage({ ...page, page: newPage })
                 }
               />
             </Td>

--- a/plugins/plugin-harbor/src/components/panel/Pagination.tsx
+++ b/plugins/plugin-harbor/src/components/panel/Pagination.tsx
@@ -27,7 +27,7 @@ const Pagination: React.FunctionComponent<IPaginationProps> = ({
         setOptions({ ...options, page: newPage })
       }
       onPerPageSelect={(event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPerPage: number): void =>
-        setOptions({ ...options, perPage: newPerPage })
+        setOptions({ ...options, page: 1, perPage: newPerPage })
       }
       onFirstClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
         setOptions({ ...options, page: newPage })

--- a/plugins/plugin-klogs/src/components/panel/LogsDocuments.tsx
+++ b/plugins/plugin-klogs/src/components/panel/LogsDocuments.tsx
@@ -128,23 +128,23 @@ const LogsDocuments: React.FunctionComponent<ILogsDocumentsProps> = ({
                 page={page.page}
                 variant={PaginationVariant.bottom}
                 onSetPage={(event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPage: number): void =>
-                  setPage({ page: newPage, perPage: page.perPage })
+                  setPage({ ...page, page: newPage })
                 }
                 onPerPageSelect={(
                   event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
                   newPerPage: number,
-                ): void => setPage({ page: page.page, perPage: newPerPage })}
+                ): void => setPage({ page: 1, perPage: newPerPage })}
                 onFirstClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
-                  setPage({ page: newPage, perPage: page.perPage })
+                  setPage({ ...page, page: newPage })
                 }
                 onLastClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
-                  setPage({ page: newPage, perPage: page.perPage })
+                  setPage({ ...page, page: newPage })
                 }
                 onNextClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
-                  setPage({ page: newPage, perPage: page.perPage })
+                  setPage({ ...page, page: newPage })
                 }
                 onPreviousClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
-                  setPage({ page: newPage, perPage: page.perPage })
+                  setPage({ ...page, page: newPage })
                 }
               />
             </Td>

--- a/plugins/plugin-sonarqube/src/components/page/Page.tsx
+++ b/plugins/plugin-sonarqube/src/components/page/Page.tsx
@@ -139,7 +139,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ instance }: IPluginPa
             setOptions({ ...options, page: newPage })
           }
           onPerPageSelect={(event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPerPage: number): void =>
-            setOptions({ ...options, perPage: newPerPage })
+            setOptions({ ...options, page: 1, perPage: newPerPage })
           }
           onFirstClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
             setOptions({ ...options, page: newPage })


### PR DESCRIPTION
Our implementation for pagination doesn't worked correctly, because the
page number wasn't adjusted when the number of items per page was
changed (e.g. user is on the last page and selects a higher number for
the items per page).

This is now fixed, by setting the page to "1" when the number of items
per page is changed.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
