### PR TITLE
[app] Rework Go plugin architecture

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
       "program": "${workspaceFolder}/cmd/kobs",
       "args": [
         "--log.level=debug",
-        "--hub.config=../../deploy/docker/kobs/config.yaml",
+        "--hub.config=../../deploy/docker/kobs/hub.yaml",
         "--app.assets=''"
       ]
     },
@@ -21,8 +21,7 @@
       "program": "${workspaceFolder}/cmd/kobs",
       "args": [
         "--log.level=debug",
-        "--satellite.config=../../deploy/docker/kobs/config.yaml",
-        "--satellite.plugins=../../bin/plugins",
+        "--satellite.config=../../deploy/docker/kobs/satellite.yaml",
         "--satellite.token=unsecuretoken"
       ]
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#354](https://github.com/kobsio/kobs/pull/#354): [app] Change URLs for the details page of an Application and a Dashboard.
 - [#357](https://github.com/kobsio/kobs/pull/#357): [app] Adjust namespace handling in the frontend, so that it is not required anymore to select the namespaces from all selected clusters.
 - [#362](https://github.com/kobsio/kobs/pull/#362): [app] :warning: _Breaking change:_ :warning: Rename `preview` field to `insights` in Application CRD.
+- [#366](https://github.com/kobsio/kobs/pull/#366): [app] :warning: _Breaking change:_ :warning: Rework Go plugin architecture, to not uses Go's `plugin` mode.
 
 ## [v0.8.0](https://github.com/kobsio/kobs/releases/tag/v0.8.0) (2022-03-24)
 

--- a/Makefile
+++ b/Makefile
@@ -17,22 +17,6 @@ build:
 		-X ${REPO}/pkg/version.BuildDate=${BUILDTIME}" \
 		-o ./bin/kobs ./cmd/kobs;
 
-.PHONY: build-plugins
-build-plugins:
-	@mkdir -p ./bin/plugins
-	@if [ "${PLUGIN}" = "" ]; then \
-		for plugin in plugins/plugin-*/; do \
-			if [ -d "$$plugin/cmd" ]; then \
-				plugin=`echo "$$plugin" | sed -e "s/^plugins\/plugin-//" -e "s/\/$///"`; \
-				echo "Build '$$plugin' plugin"; \
-				go build -buildmode=plugin -o ./bin/plugins/$$plugin.so ./plugins/plugin-$$plugin/cmd; \
-			fi \
-		done; \
-	else \
-		echo "Build '${PLUGIN}' plugin"; \
-		go build -buildmode=plugin -o ./bin/plugins/${PLUGIN}.so ./plugins/plugin-${PLUGIN}/cmd; \
-	fi
-
 .PHONY: test
 test:
 	@go test ./cmd/... ./pkg/... ./plugins/...

--- a/cmd/kobs/Dockerfile
+++ b/cmd/kobs/Dockerfile
@@ -10,14 +10,12 @@ WORKDIR /kobs
 COPY go.mod go.sum /kobs/
 RUN go mod download
 COPY . .
-RUN export CGO_ENABLED=1 && make build && make build-plugins
+RUN export CGO_ENABLED=0 && make build
 
-FROM debian:stable-20220527
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
-RUN update-ca-certificates
+FROM alpine:3.16.0
+RUN apk update && apk add --no-cache ca-certificates
 RUN mkdir /kobs
 COPY --from=api /kobs/bin/kobs /kobs
-COPY --from=api /kobs/bin/plugins /kobs/plugins
 COPY --from=app /kobs/bin/app /kobs/app
 WORKDIR /kobs
 USER nobody

--- a/cmd/kobs/hub/hub.go
+++ b/cmd/kobs/hub/hub.go
@@ -22,139 +22,25 @@ import (
 	"go.uber.org/zap"
 )
 
-var (
-	appAddress          string
-	appAssetsDir        string
-	hubAddress          string
-	hubConfigFile       string
-	hubMode             string
-	hubStoreDriver      string
-	hubStoreURI         string
-	hubWatcherInterval  time.Duration
-	hubWatcherWorker    int64
-	metricsAddress      string
-	authEnabled         bool
-	authHeaderUser      string
-	authHeaderTeams     string
-	authLogoutRedirect  string
-	authSessionToken    string
-	authSessionInterval time.Duration
-)
+// Command returns the cobra command for the "hub" command. The command can be used to start the hub component of kobs.
+func Command() *cobra.Command {
+	var appAddress string
+	var appAssetsDir string
+	var hubAddress string
+	var hubConfigFile string
+	var hubMode string
+	var hubStoreDriver string
+	var hubStoreURI string
+	var hubWatcherInterval time.Duration
+	var hubWatcherWorker int64
+	var metricsAddress string
+	var authEnabled bool
+	var authHeaderUser string
+	var authHeaderTeams string
+	var authLogoutRedirect string
+	var authSessionToken string
+	var authSessionInterval time.Duration
 
-// Cmd is the cobra command to start the kobs hub.
-var Cmd = &cobra.Command{
-	Use:   "hub",
-	Short: "Hub component of kobs.",
-	Long:  "Hub component of kobs.",
-	Run: func(cmd *cobra.Command, args []string) {
-		// Get our global flags for kobs and use them to setup our logging configuration. After our logging is
-		// configured we print the version information and build context of kobs.
-		debugUsername, _ := cmd.Flags().GetString("debug.username")
-		debugPassword, _ := cmd.Flags().GetString("debug.password")
-
-		logLevel, _ := cmd.Flags().GetString("log.level")
-		logFormat, _ := cmd.Flags().GetString("log.format")
-		log.Setup(logLevel, logFormat)
-
-		log.Info(nil, "Version information", version.Info()...)
-		log.Info(nil, "Build context", version.BuildContext()...)
-
-		traceEnabled, _ := cmd.Flags().GetBool("trace.enabled")
-		traceServiceName, _ := cmd.Flags().GetString("trace.service-name")
-		traceProvider, _ := cmd.Flags().GetString("trace.provider")
-		traceAddress, _ := cmd.Flags().GetString("trace.address")
-
-		if traceEnabled {
-			err := tracer.Setup(traceServiceName, traceProvider, traceAddress)
-			if err != nil {
-				log.Fatal(nil, "Could not setup tracing", zap.Error(err), zap.String("provider", traceProvider), zap.String("address", traceAddress))
-			}
-		}
-
-		// Load the configuration for the satellite from the provided configuration file.
-		cfg, err := config.Load(hubConfigFile)
-		if err != nil {
-			log.Fatal(nil, "Could not load configuration file", zap.Error(err), zap.String("config", hubConfigFile))
-		}
-
-		// Initialize the store, which is used to "cache" all clusters, plugins, applications, etc. from the satellites.
-		// So that we can directly interact with the store for these resources and do not have to call each satellite
-		// for every single API request.
-		// The store is then passed to the watcher. The watcher is used to get the resources from the satellites in a
-		// preconfigured interval and to pass them to the store. To watch the resources we start the "Watch" process in
-		// a new goroutine.
-		satellitesClient, err := satellites.NewClient(cfg.Satellites)
-		if err != nil {
-			log.Fatal(nil, "Could not create satellites client", zap.Error(err))
-		}
-
-		storeClient, err := store.NewClient(hubStoreDriver, hubStoreURI)
-		if err != nil {
-			log.Fatal(nil, "Could not create store", zap.Error(err))
-		}
-
-		var watcherClient watcher.Client
-		if hubMode == "default" || hubMode == "watcher" {
-			watcherClient, err = watcher.NewClient(hubWatcherInterval, hubWatcherWorker, satellitesClient, storeClient)
-			if err != nil {
-				log.Fatal(nil, "Could not create watcher", zap.Error(err))
-			}
-			go watcherClient.Watch()
-		}
-
-		// Initialize each component and start it in it's own goroutine, so that the main goroutine is only used as
-		// listener for terminal signals, to initialize the graceful shutdown of the components.
-		// The hubServer handles all requests from the kobs ui, which is served via the appServer. The metrics server is
-		// used to serve the kobs metrics.
-		var hubSever hub.Server
-		var appServer app.Server
-
-		if hubMode == "default" || hubMode == "server" {
-			hubSever, err = hub.New(cfg.API, debugUsername, debugPassword, hubAddress, authEnabled, authHeaderUser, authHeaderTeams, authLogoutRedirect, authSessionToken, authSessionInterval, satellitesClient, storeClient)
-			if err != nil {
-				log.Fatal(nil, "Could not create hub server", zap.Error(err))
-			}
-			go hubSever.Start()
-
-			appServer, err = app.New(hubAddress, appAddress, appAssetsDir)
-			if err != nil {
-				log.Fatal(nil, "Could not create Application server", zap.Error(err))
-			}
-			go appServer.Start()
-		}
-
-		metricsServer := metrics.New(metricsAddress)
-		go metricsServer.Start()
-
-		// All components should be terminated gracefully. For that we are listen for the SIGINT and SIGTERM signals and try
-		// to gracefully shutdown the started kobs components. This ensures that established connections or tasks are not
-		// interrupted.
-		done := make(chan os.Signal, 1)
-		signal.Notify(done, os.Interrupt, syscall.SIGTERM)
-
-		log.Debug(nil, "Start listining for SIGINT and SIGTERM signal")
-		<-done
-		log.Info(nil, "Shutdown kobs hub...")
-
-		if hubMode == "default" || hubMode == "watcher" {
-			err := watcherClient.Stop()
-			if err != nil {
-				log.Error(nil, "Failed to stop watcher", zap.Error(err))
-			}
-		}
-
-		metricsServer.Stop()
-
-		if hubMode == "default" || hubMode == "server" {
-			appServer.Stop()
-			hubSever.Stop()
-		}
-
-		log.Info(nil, "Shutdown is done")
-	},
-}
-
-func init() {
 	defaultAppAddress := ":15219"
 	if os.Getenv("KOBS_APP_ADDRESS") != "" {
 		defaultAppAddress = os.Getenv("KOBS_APP_ADDRESS")
@@ -239,20 +125,134 @@ func init() {
 		}
 	}
 
-	Cmd.PersistentFlags().StringVar(&appAddress, "app.address", defaultAppAddress, "The address, where the application server is listen on.")
-	Cmd.PersistentFlags().StringVar(&appAssetsDir, "app.assets", defaultAppAssetsDir, "The location of the assets directory.")
-	Cmd.PersistentFlags().StringVar(&hubAddress, "hub.address", defaultHubAddress, "The address, where the hub is listen on.")
-	Cmd.PersistentFlags().StringVar(&hubConfigFile, "hub.config", defaultHubConfigFile, "Path to the configuration file for the hub.")
-	Cmd.PersistentFlags().StringVar(&hubMode, "hub.mode", defaultHubMode, "The mode in which the hub should be started. Must be \"default\", \"server\" or \"watcher\".")
-	Cmd.PersistentFlags().StringVar(&hubStoreDriver, "hub.store.driver", defaultHubStoreDriver, "The database driver, which should be used for the store.")
-	Cmd.PersistentFlags().StringVar(&hubStoreURI, "hub.store.uri", defaultHubStoreURI, "The URI for the store.")
-	Cmd.PersistentFlags().DurationVar(&hubWatcherInterval, "hub.watcher.interval", defaultHubWatcherInterval, "The interval for the watcher to sync the satellite configuration.")
-	Cmd.PersistentFlags().Int64Var(&hubWatcherWorker, "hub.watcher.worker", defaultHubWatcherWorker, "The number of parallel sync processes for the watcher.")
-	Cmd.PersistentFlags().StringVar(&metricsAddress, "metrics.address", defaultMetricsAddress, "The address, where the metrics server is listen on.")
-	Cmd.PersistentFlags().BoolVar(&authEnabled, "auth.enabled", false, "Enable the authentication and authorization middleware.")
-	Cmd.PersistentFlags().StringVar(&authHeaderUser, "auth.header.user", defaultAuthHeaderUser, "The header, which contains the user id.")
-	Cmd.PersistentFlags().StringVar(&authHeaderTeams, "auth.header.teams", defaultAuthHeaderTeams, "The header, which contains the team ids.")
-	Cmd.PersistentFlags().StringVar(&authLogoutRedirect, "auth.logout.redirect", defaultAuthLogoutRedirect, "The redirect url which should be used, when the user clicks on the logout button.")
-	Cmd.PersistentFlags().StringVar(&authSessionToken, "auth.session.token", defaultAuthSessionToken, "The token to encrypt the session cookie.")
-	Cmd.PersistentFlags().DurationVar(&authSessionInterval, "auth.session.interval", defaultAuthSessionInterval, "The interval for how long a session is valid.")
+	hubCmd := &cobra.Command{
+		Use:   "hub",
+		Short: "Hub component of kobs.",
+		Long:  "Hub component of kobs.",
+		Run: func(cmd *cobra.Command, args []string) {
+			// Get our global flags for kobs and use them to setup our logging configuration. After our logging is
+			// configured we print the version information and build context of kobs.
+			debugUsername, _ := cmd.Flags().GetString("debug.username")
+			debugPassword, _ := cmd.Flags().GetString("debug.password")
+
+			logLevel, _ := cmd.Flags().GetString("log.level")
+			logFormat, _ := cmd.Flags().GetString("log.format")
+			log.Setup(logLevel, logFormat)
+
+			log.Info(nil, "Version information", version.Info()...)
+			log.Info(nil, "Build context", version.BuildContext()...)
+
+			traceEnabled, _ := cmd.Flags().GetBool("trace.enabled")
+			traceServiceName, _ := cmd.Flags().GetString("trace.service-name")
+			traceProvider, _ := cmd.Flags().GetString("trace.provider")
+			traceAddress, _ := cmd.Flags().GetString("trace.address")
+
+			if traceEnabled {
+				err := tracer.Setup(traceServiceName, traceProvider, traceAddress)
+				if err != nil {
+					log.Fatal(nil, "Could not setup tracing", zap.Error(err), zap.String("provider", traceProvider), zap.String("address", traceAddress))
+				}
+			}
+
+			// Load the configuration for the satellite from the provided configuration file.
+			cfg, err := config.Load(hubConfigFile)
+			if err != nil {
+				log.Fatal(nil, "Could not load configuration file", zap.Error(err), zap.String("config", hubConfigFile))
+			}
+
+			// Initialize the store, which is used to "cache" all clusters, plugins, applications, etc. from the satellites.
+			// So that we can directly interact with the store for these resources and do not have to call each satellite
+			// for every single API request.
+			// The store is then passed to the watcher. The watcher is used to get the resources from the satellites in a
+			// preconfigured interval and to pass them to the store. To watch the resources we start the "Watch" process in
+			// a new goroutine.
+			satellitesClient, err := satellites.NewClient(cfg.Satellites)
+			if err != nil {
+				log.Fatal(nil, "Could not create satellites client", zap.Error(err))
+			}
+
+			storeClient, err := store.NewClient(hubStoreDriver, hubStoreURI)
+			if err != nil {
+				log.Fatal(nil, "Could not create store", zap.Error(err))
+			}
+
+			var watcherClient watcher.Client
+			if hubMode == "default" || hubMode == "watcher" {
+				watcherClient, err = watcher.NewClient(hubWatcherInterval, hubWatcherWorker, satellitesClient, storeClient)
+				if err != nil {
+					log.Fatal(nil, "Could not create watcher", zap.Error(err))
+				}
+				go watcherClient.Watch()
+			}
+
+			// Initialize each component and start it in it's own goroutine, so that the main goroutine is only used as
+			// listener for terminal signals, to initialize the graceful shutdown of the components.
+			// The hubServer handles all requests from the kobs ui, which is served via the appServer. The metrics server is
+			// used to serve the kobs metrics.
+			var hubSever hub.Server
+			var appServer app.Server
+
+			if hubMode == "default" || hubMode == "server" {
+				hubSever, err = hub.New(cfg.API, debugUsername, debugPassword, hubAddress, authEnabled, authHeaderUser, authHeaderTeams, authLogoutRedirect, authSessionToken, authSessionInterval, satellitesClient, storeClient)
+				if err != nil {
+					log.Fatal(nil, "Could not create hub server", zap.Error(err))
+				}
+				go hubSever.Start()
+
+				appServer, err = app.New(hubAddress, appAddress, appAssetsDir)
+				if err != nil {
+					log.Fatal(nil, "Could not create Application server", zap.Error(err))
+				}
+				go appServer.Start()
+			}
+
+			metricsServer := metrics.New(metricsAddress)
+			go metricsServer.Start()
+
+			// All components should be terminated gracefully. For that we are listen for the SIGINT and SIGTERM signals and try
+			// to gracefully shutdown the started kobs components. This ensures that established connections or tasks are not
+			// interrupted.
+			done := make(chan os.Signal, 1)
+			signal.Notify(done, os.Interrupt, syscall.SIGTERM)
+
+			log.Debug(nil, "Start listining for SIGINT and SIGTERM signal")
+			<-done
+			log.Info(nil, "Shutdown kobs hub...")
+
+			if hubMode == "default" || hubMode == "watcher" {
+				err := watcherClient.Stop()
+				if err != nil {
+					log.Error(nil, "Failed to stop watcher", zap.Error(err))
+				}
+			}
+
+			metricsServer.Stop()
+
+			if hubMode == "default" || hubMode == "server" {
+				appServer.Stop()
+				hubSever.Stop()
+			}
+
+			log.Info(nil, "Shutdown is done")
+		},
+	}
+
+	hubCmd.PersistentFlags().StringVar(&appAddress, "app.address", defaultAppAddress, "The address, where the application server is listen on.")
+	hubCmd.PersistentFlags().StringVar(&appAssetsDir, "app.assets", defaultAppAssetsDir, "The location of the assets directory.")
+	hubCmd.PersistentFlags().StringVar(&hubAddress, "hub.address", defaultHubAddress, "The address, where the hub is listen on.")
+	hubCmd.PersistentFlags().StringVar(&hubConfigFile, "hub.config", defaultHubConfigFile, "Path to the configuration file for the hub.")
+	hubCmd.PersistentFlags().StringVar(&hubMode, "hub.mode", defaultHubMode, "The mode in which the hub should be started. Must be \"default\", \"server\" or \"watcher\".")
+	hubCmd.PersistentFlags().StringVar(&hubStoreDriver, "hub.store.driver", defaultHubStoreDriver, "The database driver, which should be used for the store.")
+	hubCmd.PersistentFlags().StringVar(&hubStoreURI, "hub.store.uri", defaultHubStoreURI, "The URI for the store.")
+	hubCmd.PersistentFlags().DurationVar(&hubWatcherInterval, "hub.watcher.interval", defaultHubWatcherInterval, "The interval for the watcher to sync the satellite configuration.")
+	hubCmd.PersistentFlags().Int64Var(&hubWatcherWorker, "hub.watcher.worker", defaultHubWatcherWorker, "The number of parallel sync processes for the watcher.")
+	hubCmd.PersistentFlags().StringVar(&metricsAddress, "metrics.address", defaultMetricsAddress, "The address, where the metrics server is listen on.")
+	hubCmd.PersistentFlags().BoolVar(&authEnabled, "auth.enabled", false, "Enable the authentication and authorization middleware.")
+	hubCmd.PersistentFlags().StringVar(&authHeaderUser, "auth.header.user", defaultAuthHeaderUser, "The header, which contains the user id.")
+	hubCmd.PersistentFlags().StringVar(&authHeaderTeams, "auth.header.teams", defaultAuthHeaderTeams, "The header, which contains the team ids.")
+	hubCmd.PersistentFlags().StringVar(&authLogoutRedirect, "auth.logout.redirect", defaultAuthLogoutRedirect, "The redirect url which should be used, when the user clicks on the logout button.")
+	hubCmd.PersistentFlags().StringVar(&authSessionToken, "auth.session.token", defaultAuthSessionToken, "The token to encrypt the session cookie.")
+	hubCmd.PersistentFlags().DurationVar(&authSessionInterval, "auth.session.interval", defaultAuthSessionInterval, "The interval for how long a session is valid.")
+
+	return hubCmd
 }

--- a/cmd/kobs/main.go
+++ b/cmd/kobs/main.go
@@ -1,75 +1,52 @@
 package main
 
 import (
-	"os"
-
-	"github.com/kobsio/kobs/cmd/kobs/hub"
-	"github.com/kobsio/kobs/cmd/kobs/satellite"
-	"github.com/kobsio/kobs/cmd/kobs/version"
+	"github.com/kobsio/kobs/cmd/kobs/root"
 	"github.com/kobsio/kobs/pkg/log"
+	"github.com/kobsio/kobs/pkg/satellite/plugins/plugin"
 
-	"github.com/spf13/cobra"
+	azure "github.com/kobsio/kobs/plugins/plugin-azure/cmd"
+	elasticsearch "github.com/kobsio/kobs/plugins/plugin-elasticsearch/cmd"
+	flux "github.com/kobsio/kobs/plugins/plugin-flux/cmd"
+	grafana "github.com/kobsio/kobs/plugins/plugin-grafana/cmd"
+	harbor "github.com/kobsio/kobs/plugins/plugin-harbor/cmd"
+	helm "github.com/kobsio/kobs/plugins/plugin-helm/cmd"
+	istio "github.com/kobsio/kobs/plugins/plugin-istio/cmd"
+	jaeger "github.com/kobsio/kobs/plugins/plugin-jaeger/cmd"
+	kiali "github.com/kobsio/kobs/plugins/plugin-kiali/cmd"
+	klogs "github.com/kobsio/kobs/plugins/plugin-klogs/cmd"
+	opsgenie "github.com/kobsio/kobs/plugins/plugin-opsgenie/cmd"
+	prometheus "github.com/kobsio/kobs/plugins/plugin-prometheus/cmd"
+	rss "github.com/kobsio/kobs/plugins/plugin-rss/cmd"
+	sonarqube "github.com/kobsio/kobs/plugins/plugin-sonarqube/cmd"
+	sql "github.com/kobsio/kobs/plugins/plugin-sql/cmd"
+	techdocs "github.com/kobsio/kobs/plugins/plugin-techdocs/cmd"
+
 	"go.uber.org/zap"
 )
 
-var rootCmd = &cobra.Command{
-	Use:   "kobs",
-	Short: "kobs - Kubernetes Observability Platform.",
-	Long:  "kobs - Kubernetes Observability Platform.",
-}
-
-func init() {
-	defaultDebugUsername := ""
-	if os.Getenv("KOBS_DEBUG_USERNAME") != "" {
-		defaultDebugUsername = os.Getenv("KOBS_DEBUG_USERNAME")
-	}
-
-	defaultDebugPassword := ""
-	if os.Getenv("KOBS_DEBUG_PASSWORD") != "" {
-		defaultDebugPassword = os.Getenv("KOBS_DEBUG_PASSWORD")
-	}
-
-	defaultLogFormat := "console"
-	if os.Getenv("KOBS_LOG_FORMAT") != "" {
-		defaultLogFormat = os.Getenv("KOBS_LOG_FORMAT")
-	}
-
-	defaultLogLevel := "info"
-	if os.Getenv("KOBS_LOG_LEVEL") != "" {
-		defaultLogLevel = os.Getenv("KOBS_LOG_LEVEL")
-	}
-
-	defaultTraceServiceName := "kobs"
-	if os.Getenv("KOBS_TRACE_SERVICE_NAME") != "" {
-		defaultTraceServiceName = os.Getenv("KOBS_TRACE_SERVICE_NAME")
-	}
-
-	defaultTraceProvider := "jaeger"
-	if os.Getenv("KOBS_TRACE_PROVIDER") != "" {
-		defaultTraceProvider = os.Getenv("KOBS_TRACE_PROVIDER")
-	}
-
-	defaultTraceAddress := "http://localhost:14268/api/traces"
-	if os.Getenv("KOBS_TRACE_ADDRESS") != "" {
-		defaultTraceAddress = os.Getenv("KOBS_TRACE_ADDRESS")
-	}
-
-	rootCmd.AddCommand(hub.Cmd)
-	rootCmd.AddCommand(satellite.Cmd)
-	rootCmd.AddCommand(version.Cmd)
-
-	rootCmd.PersistentFlags().String("debug.username", defaultDebugUsername, "The username for the debug endpoints. The endpoints are only available when a username is provided.")
-	rootCmd.PersistentFlags().String("debug.password", defaultDebugPassword, "The password for the debug endpoints. The endpoints are only available when a password is provided.")
-	rootCmd.PersistentFlags().String("log.format", defaultLogFormat, "Set the output format of the logs. Must be \"console\" or \"json\".")
-	rootCmd.PersistentFlags().String("log.level", defaultLogLevel, "Set the log level. Must be \"debug\", \"info\", \"warn\", \"error\", \"fatal\" or \"panic\".")
-	rootCmd.PersistentFlags().Bool("trace.enabled", false, "Enable / disable tracing.")
-	rootCmd.PersistentFlags().String("trace.service-name", defaultTraceServiceName, "The service name which should be used for tracing.")
-	rootCmd.PersistentFlags().String("trace.provider", defaultTraceProvider, "Set the trace exporter which should be used. Must be \"jaeger\" or \"zipkin\".")
-	rootCmd.PersistentFlags().String("trace.address", defaultTraceAddress, "Set the address of the Jaeger or Zipkin instance.")
-}
-
 func main() {
-	if err := rootCmd.Execute(); err != nil {
+	var pluginMounts map[string]plugin.MountFn
+	pluginMounts = make(map[string]plugin.MountFn)
+
+	pluginMounts[azure.PluginType] = azure.Mount
+	pluginMounts[elasticsearch.PluginType] = elasticsearch.Mount
+	pluginMounts[flux.PluginType] = flux.Mount
+	pluginMounts[grafana.PluginType] = grafana.Mount
+	pluginMounts[harbor.PluginType] = harbor.Mount
+	pluginMounts[helm.PluginType] = helm.Mount
+	pluginMounts[istio.PluginType] = istio.Mount
+	pluginMounts[jaeger.PluginType] = jaeger.Mount
+	pluginMounts[kiali.PluginType] = kiali.Mount
+	pluginMounts[klogs.PluginType] = klogs.Mount
+	pluginMounts[opsgenie.PluginType] = opsgenie.Mount
+	pluginMounts[prometheus.PluginType] = prometheus.Mount
+	pluginMounts[rss.PluginType] = rss.Mount
+	pluginMounts[sonarqube.PluginType] = sonarqube.Mount
+	pluginMounts[sql.PluginType] = sql.Mount
+	pluginMounts[techdocs.PluginType] = techdocs.Mount
+
+	if err := root.Command(pluginMounts).Execute(); err != nil {
 		log.Fatal(nil, "Failed to initialize kobs", zap.Error(err))
 	}
 }

--- a/cmd/kobs/root/root.go
+++ b/cmd/kobs/root/root.go
@@ -1,0 +1,74 @@
+package root
+
+import (
+	"os"
+
+	"github.com/kobsio/kobs/cmd/kobs/hub"
+	"github.com/kobsio/kobs/cmd/kobs/satellite"
+	"github.com/kobsio/kobs/cmd/kobs/version"
+	"github.com/kobsio/kobs/pkg/satellite/plugins/plugin"
+
+	"github.com/spf13/cobra"
+)
+
+// Command returns the root cobra command. If the user calls kobs without any additional command parameters, this
+// command does nothing.
+// The user has to pass in a custom map of MountFn functions. This map is then passed to the "satellite" command, so
+// that we can register the plugins in the satellite API.
+func Command(pluginMounts map[string]plugin.MountFn) *cobra.Command {
+	defaultDebugUsername := ""
+	if os.Getenv("KOBS_DEBUG_USERNAME") != "" {
+		defaultDebugUsername = os.Getenv("KOBS_DEBUG_USERNAME")
+	}
+
+	defaultDebugPassword := ""
+	if os.Getenv("KOBS_DEBUG_PASSWORD") != "" {
+		defaultDebugPassword = os.Getenv("KOBS_DEBUG_PASSWORD")
+	}
+
+	defaultLogFormat := "console"
+	if os.Getenv("KOBS_LOG_FORMAT") != "" {
+		defaultLogFormat = os.Getenv("KOBS_LOG_FORMAT")
+	}
+
+	defaultLogLevel := "info"
+	if os.Getenv("KOBS_LOG_LEVEL") != "" {
+		defaultLogLevel = os.Getenv("KOBS_LOG_LEVEL")
+	}
+
+	defaultTraceServiceName := "kobs"
+	if os.Getenv("KOBS_TRACE_SERVICE_NAME") != "" {
+		defaultTraceServiceName = os.Getenv("KOBS_TRACE_SERVICE_NAME")
+	}
+
+	defaultTraceProvider := "jaeger"
+	if os.Getenv("KOBS_TRACE_PROVIDER") != "" {
+		defaultTraceProvider = os.Getenv("KOBS_TRACE_PROVIDER")
+	}
+
+	defaultTraceAddress := "http://localhost:14268/api/traces"
+	if os.Getenv("KOBS_TRACE_ADDRESS") != "" {
+		defaultTraceAddress = os.Getenv("KOBS_TRACE_ADDRESS")
+	}
+
+	rootCmd := &cobra.Command{
+		Use:   "kobs",
+		Short: "kobs - Kubernetes Observability Platform.",
+		Long:  "kobs - Kubernetes Observability Platform.",
+	}
+
+	rootCmd.AddCommand(hub.Command())
+	rootCmd.AddCommand(satellite.Command(pluginMounts))
+	rootCmd.AddCommand(version.Command())
+
+	rootCmd.PersistentFlags().String("debug.username", defaultDebugUsername, "The username for the debug endpoints. The endpoints are only available when a username is provided.")
+	rootCmd.PersistentFlags().String("debug.password", defaultDebugPassword, "The password for the debug endpoints. The endpoints are only available when a password is provided.")
+	rootCmd.PersistentFlags().String("log.format", defaultLogFormat, "Set the output format of the logs. Must be \"console\" or \"json\".")
+	rootCmd.PersistentFlags().String("log.level", defaultLogLevel, "Set the log level. Must be \"debug\", \"info\", \"warn\", \"error\", \"fatal\" or \"panic\".")
+	rootCmd.PersistentFlags().Bool("trace.enabled", false, "Enable / disable tracing.")
+	rootCmd.PersistentFlags().String("trace.service-name", defaultTraceServiceName, "The service name which should be used for tracing.")
+	rootCmd.PersistentFlags().String("trace.provider", defaultTraceProvider, "Set the trace exporter which should be used. Must be \"jaeger\" or \"zipkin\".")
+	rootCmd.PersistentFlags().String("trace.address", defaultTraceAddress, "Set the address of the Jaeger or Zipkin instance.")
+
+	return rootCmd
+}

--- a/cmd/kobs/satellite/satellite.go
+++ b/cmd/kobs/satellite/satellite.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kobsio/kobs/pkg/metrics"
 	"github.com/kobsio/kobs/pkg/satellite"
 	"github.com/kobsio/kobs/pkg/satellite/plugins"
+	"github.com/kobsio/kobs/pkg/satellite/plugins/plugin"
 	"github.com/kobsio/kobs/pkg/tracer"
 	"github.com/kobsio/kobs/pkg/version"
 
@@ -18,96 +19,15 @@ import (
 	"go.uber.org/zap"
 )
 
-var (
-	satelliteAddress    string
-	satelliteConfigFile string
-	satellitePlugins    string
-	satelliteToken      string
-	metricsAddress      string
-)
+// Command returns the cobra command for the "satellite" command. The command can be used to start the satellite
+// component of kobs. To do so the user has to pass in a custom map of MountFn functions, which are used to register the
+// plugin routes in the satellite API.
+func Command(pluginMounts map[string]plugin.MountFn) *cobra.Command {
+	var satelliteAddress string
+	var satelliteConfigFile string
+	var satelliteToken string
+	var metricsAddress string
 
-// Cmd is the cobra command to start a kobs satellite.
-var Cmd = &cobra.Command{
-	Use:   "satellite",
-	Short: "Satellite component of kobs.",
-	Long:  "Satellite component of kobs.",
-	Run: func(cmd *cobra.Command, args []string) {
-		// Get our global flags for kobs and use them to setup our logging configuration. After our logging is
-		// configured we print the version information and build context of kobs.
-		debugUsername, _ := cmd.Flags().GetString("debug.username")
-		debugPassword, _ := cmd.Flags().GetString("debug.password")
-
-		logLevel, _ := cmd.Flags().GetString("log.level")
-		logFormat, _ := cmd.Flags().GetString("log.format")
-		log.Setup(logLevel, logFormat)
-
-		log.Info(nil, "Version information", version.Info()...)
-		log.Info(nil, "Build context", version.BuildContext()...)
-
-		traceEnabled, _ := cmd.Flags().GetBool("trace.enabled")
-		traceServiceName, _ := cmd.Flags().GetString("trace.service-name")
-		traceProvider, _ := cmd.Flags().GetString("trace.provider")
-		traceAddress, _ := cmd.Flags().GetString("trace.address")
-
-		if traceEnabled {
-			err := tracer.Setup(traceServiceName, traceProvider, traceAddress)
-			if err != nil {
-				log.Fatal(nil, "Could not setup tracing", zap.Error(err), zap.String("provider", traceProvider), zap.String("address", traceAddress))
-			}
-		}
-
-		// Load the configuration for the satellite from the provided configuration file.
-		cfg, err := config.Load(satelliteConfigFile)
-		if err != nil {
-			log.Fatal(nil, "Could not load configuration file", zap.Error(err), zap.String("config", satelliteConfigFile))
-		}
-
-		// Load all cluster for the given clusters configuration and initialize our plugin manager, which contains a
-		// router with all the routes for all plugins.
-		// The loaded clusters and the router for the plugins is then passed to the satellite api package, so we can
-		// access all the plugin routes via the kobs api.
-		clustersClient, err := clusters.NewClient(cfg.Clusters)
-		if err != nil {
-			log.Fatal(nil, "Could not load clusters", zap.Error(err))
-		}
-
-		pluginsClient, err := plugins.NewClient(satellitePlugins, cfg.Plugins, clustersClient)
-		if err != nil {
-			log.Fatal(nil, "Could not initialize plugins client", zap.Error(err))
-		}
-
-		// Initialize each component and start it in it's own goroutine, so that the main goroutine is only used as
-		// listener for terminal signals, to initialize the graceful shutdown of the components.
-		// The satelliteServer handles all requests from a kobs hub and serves the configuration, so the hub knows which
-		// clusters and plugins are available via this satellite instance. The metrics server is used to serve the kobs
-		// metrics.
-		satelliteServer, err := satellite.New(debugUsername, debugPassword, satelliteAddress, satelliteToken, cfg.API, clustersClient, pluginsClient)
-		if err != nil {
-			log.Fatal(nil, "Could not create satellite server", zap.Error(err))
-		}
-		go satelliteServer.Start()
-
-		metricsServer := metrics.New(metricsAddress)
-		go metricsServer.Start()
-
-		// All components should be terminated gracefully. For that we are listen for the SIGINT and SIGTERM signals and try
-		// to gracefully shutdown the started kobs components. This ensures that established connections or tasks are not
-		// interrupted.
-		done := make(chan os.Signal, 1)
-		signal.Notify(done, os.Interrupt, syscall.SIGTERM)
-
-		log.Debug(nil, "Start listining for SIGINT and SIGTERM signal")
-		<-done
-		log.Info(nil, "Shutdown kobs satellite...")
-
-		metricsServer.Stop()
-		satelliteServer.Stop()
-
-		log.Info(nil, "Shutdown is done")
-	},
-}
-
-func init() {
 	defaultSatelliteAddress := ":15221"
 	if os.Getenv("KOBS_SATELLITE_ADDRESS") != "" {
 		defaultSatelliteAddress = os.Getenv("KOBS_SATELLITE_ADDRESS")
@@ -123,19 +43,95 @@ func init() {
 		defaultSatelliteToken = os.Getenv("KOBS_SATELLITE_TOKEN")
 	}
 
-	defaultSatellitePlugins := "plugins"
-	if os.Getenv("KOBS_SATELLITE_PLUGINS") != "" {
-		defaultSatellitePlugins = os.Getenv("KOBS_SATELLITE_PLUGINS")
-	}
-
 	defaultMetricsAddress := ":15222"
 	if os.Getenv("KOBS_METRICS_ADDRESS") != "" {
 		defaultMetricsAddress = os.Getenv("KOBS_METRICS_ADDRESS")
 	}
 
-	Cmd.PersistentFlags().StringVar(&satelliteAddress, "satellite.address", defaultSatelliteAddress, "The address, where the satellite is listen on.")
-	Cmd.PersistentFlags().StringVar(&satelliteConfigFile, "satellite.config", defaultSatelliteConfigFile, "Path to the configuration file for the satellite.")
-	Cmd.PersistentFlags().StringVar(&satellitePlugins, "satellite.plugins", defaultSatellitePlugins, "The directory which contains the plugin files.")
-	Cmd.PersistentFlags().StringVar(&satelliteToken, "satellite.token", defaultSatelliteToken, "A token to protect the kobs satellite.")
-	Cmd.PersistentFlags().StringVar(&metricsAddress, "metrics.address", defaultMetricsAddress, "The address, where the metrics server is listen on.")
+	satelliteCmd := &cobra.Command{
+		Use:   "satellite",
+		Short: "Satellite component of kobs.",
+		Long:  "Satellite component of kobs.",
+		Run: func(cmd *cobra.Command, args []string) {
+			// Get our global flags for kobs and use them to setup our logging configuration. After our logging is
+			// configured we print the version information and build context of kobs.
+			debugUsername, _ := cmd.Flags().GetString("debug.username")
+			debugPassword, _ := cmd.Flags().GetString("debug.password")
+
+			logLevel, _ := cmd.Flags().GetString("log.level")
+			logFormat, _ := cmd.Flags().GetString("log.format")
+			log.Setup(logLevel, logFormat)
+
+			log.Info(nil, "Version information", version.Info()...)
+			log.Info(nil, "Build context", version.BuildContext()...)
+
+			traceEnabled, _ := cmd.Flags().GetBool("trace.enabled")
+			traceServiceName, _ := cmd.Flags().GetString("trace.service-name")
+			traceProvider, _ := cmd.Flags().GetString("trace.provider")
+			traceAddress, _ := cmd.Flags().GetString("trace.address")
+
+			if traceEnabled {
+				err := tracer.Setup(traceServiceName, traceProvider, traceAddress)
+				if err != nil {
+					log.Fatal(nil, "Could not setup tracing", zap.Error(err), zap.String("provider", traceProvider), zap.String("address", traceAddress))
+				}
+			}
+
+			// Load the configuration for the satellite from the provided configuration file.
+			cfg, err := config.Load(satelliteConfigFile)
+			if err != nil {
+				log.Fatal(nil, "Could not load configuration file", zap.Error(err), zap.String("config", satelliteConfigFile))
+			}
+
+			// Load all cluster for the given clusters configuration and initialize our plugin manager, which contains a
+			// router with all the routes for all plugins.
+			// The loaded clusters and the router for the plugins is then passed to the satellite api package, so we can
+			// access all the plugin routes via the kobs api.
+			clustersClient, err := clusters.NewClient(cfg.Clusters)
+			if err != nil {
+				log.Fatal(nil, "Could not load clusters", zap.Error(err))
+			}
+
+			pluginsClient, err := plugins.NewClient(pluginMounts, cfg.Plugins, clustersClient)
+			if err != nil {
+				log.Fatal(nil, "Could not initialize plugins client", zap.Error(err))
+			}
+
+			// Initialize each component and start it in it's own goroutine, so that the main goroutine is only used as
+			// listener for terminal signals, to initialize the graceful shutdown of the components.
+			// The satelliteServer handles all requests from a kobs hub and serves the configuration, so the hub knows which
+			// clusters and plugins are available via this satellite instance. The metrics server is used to serve the kobs
+			// metrics.
+			satelliteServer, err := satellite.New(debugUsername, debugPassword, satelliteAddress, satelliteToken, cfg.API, clustersClient, pluginsClient)
+			if err != nil {
+				log.Fatal(nil, "Could not create satellite server", zap.Error(err))
+			}
+			go satelliteServer.Start()
+
+			metricsServer := metrics.New(metricsAddress)
+			go metricsServer.Start()
+
+			// All components should be terminated gracefully. For that we are listen for the SIGINT and SIGTERM signals and try
+			// to gracefully shutdown the started kobs components. This ensures that established connections or tasks are not
+			// interrupted.
+			done := make(chan os.Signal, 1)
+			signal.Notify(done, os.Interrupt, syscall.SIGTERM)
+
+			log.Debug(nil, "Start listining for SIGINT and SIGTERM signal")
+			<-done
+			log.Info(nil, "Shutdown kobs satellite...")
+
+			metricsServer.Stop()
+			satelliteServer.Stop()
+
+			log.Info(nil, "Shutdown is done")
+		},
+	}
+
+	satelliteCmd.PersistentFlags().StringVar(&satelliteAddress, "satellite.address", defaultSatelliteAddress, "The address, where the satellite is listen on.")
+	satelliteCmd.PersistentFlags().StringVar(&satelliteConfigFile, "satellite.config", defaultSatelliteConfigFile, "Path to the configuration file for the satellite.")
+	satelliteCmd.PersistentFlags().StringVar(&satelliteToken, "satellite.token", defaultSatelliteToken, "A token to protect the kobs satellite.")
+	satelliteCmd.PersistentFlags().StringVar(&metricsAddress, "metrics.address", defaultMetricsAddress, "The address, where the metrics server is listen on.")
+
+	return satelliteCmd
 }

--- a/cmd/kobs/version/version.go
+++ b/cmd/kobs/version/version.go
@@ -11,23 +11,26 @@ import (
 	"go.uber.org/zap"
 )
 
-// Cmd is the cobra command to print the version information of kobs.
-var Cmd = &cobra.Command{
-	Use:   "version",
-	Short: "Version information about kobs.",
-	Long:  "Version information about kobs.",
-	Run: func(cmd *cobra.Command, args []string) {
-		// Get our global flags for kobs and use them to setup our logging configuration. After our logging is
-		// configured we print the version information and build context of kobs.
-		logLevel, _ := cmd.Flags().GetString("log.level")
-		logFormat, _ := cmd.Flags().GetString("log.format")
-		log.Setup(logLevel, logFormat)
+// Command returns the cobra command for the "version" command. This command can be used to print the version
+// information, like the version, revision and branch for the builded binary.
+func Command() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Version information about kobs.",
+		Long:  "Version information about kobs.",
+		Run: func(cmd *cobra.Command, args []string) {
+			// Get our global flags for kobs and use them to setup our logging configuration. After our logging is
+			// configured we print the version information and build context of kobs.
+			logLevel, _ := cmd.Flags().GetString("log.level")
+			logFormat, _ := cmd.Flags().GetString("log.format")
+			log.Setup(logLevel, logFormat)
 
-		v, err := version.Print("kobs")
-		if err != nil {
-			log.Fatal(nil, "Failed to print version information", zap.Error(err))
-		}
+			v, err := version.Print("kobs")
+			if err != nil {
+				log.Fatal(nil, "Failed to print version information", zap.Error(err))
+			}
 
-		fmt.Fprintln(os.Stdout, v)
-	},
+			fmt.Fprintln(os.Stdout, v)
+		},
+	}
 }

--- a/docs/getting-started/configuration/satellite.md
+++ b/docs/getting-started/configuration/satellite.md
@@ -18,7 +18,6 @@ The following command-line arguments and environment variables are available.
 | `--trace.address` | `KOBS_TRACE_ADDRESS` | The service name which should be used for tracing.  | `http://localhost:14268/api/traces` |
 | `--satellite.address` | `KOBS_SATELLITE_ADDRESS` | The address, where the satellite is listen on. | `:15221` |
 | `--satellite.config` | `KOBS_SATELLITE_CONFIG` | Path to the configuration file for the hub. | `config.yaml` |
-| `--satellite.plugins` | `KOBS_SATELLITE_PLUGINS` |The directory which contains the plugin files. | `plugins` |
 | `--satellite.token` | `KOBS_SATELLITE_TOKEN` | A token to protect the kobs satellite. | |
 | `--metrics.address` | `KOBS_METRICS_ADDRESS` | The address, where the Prometheus metrics are served. | `:15221` |
 

--- a/pkg/satellite/plugins/plugin/plugin.go
+++ b/pkg/satellite/plugins/plugin/plugin.go
@@ -1,5 +1,11 @@
 package plugin
 
+import (
+	"github.com/kobsio/kobs/pkg/kube/clusters"
+
+	"github.com/go-chi/chi/v5"
+)
+
 // Instance is the structure of the configuration for a single plugin instance. Each plugin must contain a name and a
 // type and an optionsl description. It can also contains a map with additional options. The options can be used to
 // specify the addess, username, password, etc. to access an service within the plugin.
@@ -13,3 +19,9 @@ type Instance struct {
 	FrontendOptions map[string]interface{} `json:"frontendOptions"`
 	UpdatedAt       int64                  `json:"updatedAt"`
 }
+
+// MountFn is the type of the mount function, which must be implemented by all plugins, so that the can be used within
+// kobs.
+// We pass the instances for the corresponding plugin type and the clusters client to the mount function. The function
+// must return a chi router or an error, if the mounting of the plugin fails.
+type MountFn func(instances []Instance, clustersClient clusters.Client) (chi.Router, error)

--- a/plugins/plugin-azure/cmd/azure.go
+++ b/plugins/plugin-azure/cmd/azure.go
@@ -1,4 +1,4 @@
-package main
+package azure
 
 import (
 	"github.com/kobsio/kobs/pkg/kube/clusters"
@@ -7,6 +7,9 @@ import (
 
 	"github.com/go-chi/chi/v5"
 )
+
+// PluginType is the type which must be used for the Azure plugin.
+const PluginType = "azure"
 
 // Router implements the router for the Azure plugin, which can be registered in the router for our rest api. It contains
 // the api routes for the Azure plugin and it's configuration.

--- a/plugins/plugin-azure/cmd/azure_test.go
+++ b/plugins/plugin-azure/cmd/azure_test.go
@@ -1,4 +1,4 @@
-package main
+package azure
 
 import (
 	"testing"

--- a/plugins/plugin-azure/cmd/containerinstances.go
+++ b/plugins/plugin-azure/cmd/containerinstances.go
@@ -1,4 +1,4 @@
-package main
+package azure
 
 import (
 	"net/http"

--- a/plugins/plugin-azure/cmd/containerinstances_test.go
+++ b/plugins/plugin-azure/cmd/containerinstances_test.go
@@ -1,4 +1,4 @@
-package main
+package azure
 
 import (
 	"context"

--- a/plugins/plugin-azure/cmd/costmanagement.go
+++ b/plugins/plugin-azure/cmd/costmanagement.go
@@ -1,4 +1,4 @@
-package main
+package azure
 
 import (
 	"net/http"

--- a/plugins/plugin-azure/cmd/costmanagement_test.go
+++ b/plugins/plugin-azure/cmd/costmanagement_test.go
@@ -1,4 +1,4 @@
-package main
+package azure
 
 import (
 	"fmt"

--- a/plugins/plugin-azure/cmd/kubernetesservices.go
+++ b/plugins/plugin-azure/cmd/kubernetesservices.go
@@ -1,4 +1,4 @@
-package main
+package azure
 
 import (
 	"net/http"

--- a/plugins/plugin-azure/cmd/kubernetesservices_test.go
+++ b/plugins/plugin-azure/cmd/kubernetesservices_test.go
@@ -1,4 +1,4 @@
-package main
+package azure
 
 import (
 	"context"

--- a/plugins/plugin-azure/cmd/monitor.go
+++ b/plugins/plugin-azure/cmd/monitor.go
@@ -1,4 +1,4 @@
-package main
+package azure
 
 import (
 	"net/http"

--- a/plugins/plugin-azure/cmd/monitor_test.go
+++ b/plugins/plugin-azure/cmd/monitor_test.go
@@ -1,4 +1,4 @@
-package main
+package azure
 
 import (
 	"context"

--- a/plugins/plugin-azure/cmd/resourcegroups.go
+++ b/plugins/plugin-azure/cmd/resourcegroups.go
@@ -1,4 +1,4 @@
-package main
+package azure
 
 import (
 	"net/http"

--- a/plugins/plugin-azure/cmd/resourcegroups_test.go
+++ b/plugins/plugin-azure/cmd/resourcegroups_test.go
@@ -1,4 +1,4 @@
-package main
+package azure
 
 import (
 	"context"

--- a/plugins/plugin-azure/cmd/virtualmachinescalesets.go
+++ b/plugins/plugin-azure/cmd/virtualmachinescalesets.go
@@ -1,4 +1,4 @@
-package main
+package azure
 
 import (
 	"net/http"

--- a/plugins/plugin-azure/cmd/virtualmachinescalesets_test.go
+++ b/plugins/plugin-azure/cmd/virtualmachinescalesets_test.go
@@ -1,4 +1,4 @@
-package main
+package azure
 
 import (
 	"context"

--- a/plugins/plugin-elasticsearch/cmd/elasticsearch.go
+++ b/plugins/plugin-elasticsearch/cmd/elasticsearch.go
@@ -1,4 +1,4 @@
-package main
+package elasticsearch
 
 import (
 	"net/http"
@@ -14,6 +14,9 @@ import (
 	"github.com/go-chi/render"
 	"go.uber.org/zap"
 )
+
+// PluginType is the type which must be used for the Elasticsearch plugin.
+const PluginType = "elasticsearch"
 
 // Router implements the router for the Elasticsearch plugin, which can be registered in the router for our rest api. It contains
 // the api routes for the Elasticsearch plugin and it's configuration.

--- a/plugins/plugin-elasticsearch/cmd/elasticsearch_test.go
+++ b/plugins/plugin-elasticsearch/cmd/elasticsearch_test.go
@@ -1,4 +1,4 @@
-package main
+package elasticsearch
 
 import (
 	"context"

--- a/plugins/plugin-flux/cmd/flux.go
+++ b/plugins/plugin-flux/cmd/flux.go
@@ -1,4 +1,4 @@
-package main
+package flux
 
 import (
 	"fmt"
@@ -14,6 +14,9 @@ import (
 	"github.com/go-chi/render"
 	"go.uber.org/zap"
 )
+
+// PluginType is the type which must be used for the Flux plugin.
+const PluginType = "flux"
 
 // Router implements the router for the Helm plugin, which can be registered in the router for our rest api. It contains
 // the api routes for the Helm plugin and it's configuration.

--- a/plugins/plugin-flux/cmd/flux_test.go
+++ b/plugins/plugin-flux/cmd/flux_test.go
@@ -1,4 +1,4 @@
-package main
+package flux
 
 import (
 	"testing"

--- a/plugins/plugin-grafana/cmd/grafana.go
+++ b/plugins/plugin-grafana/cmd/grafana.go
@@ -1,4 +1,4 @@
-package main
+package grafana
 
 import (
 	"net/http"
@@ -13,6 +13,9 @@ import (
 	"github.com/go-chi/render"
 	"go.uber.org/zap"
 )
+
+// PluginType is the type which must be used for the Grafana plugin.
+const PluginType = "grafana"
 
 // Router implements the router for the Grafana plugin, which can be registered in the router for our rest api. It contains
 // the api routes for the Grafana plugin and it's configuration.

--- a/plugins/plugin-grafana/cmd/grafana_test.go
+++ b/plugins/plugin-grafana/cmd/grafana_test.go
@@ -1,4 +1,4 @@
-package main
+package grafana
 
 import (
 	"context"

--- a/plugins/plugin-harbor/cmd/harbor.go
+++ b/plugins/plugin-harbor/cmd/harbor.go
@@ -1,4 +1,4 @@
-package main
+package harbor
 
 import (
 	"net/http"
@@ -13,6 +13,9 @@ import (
 	"github.com/go-chi/render"
 	"go.uber.org/zap"
 )
+
+// PluginType is the type which must be used for the Harbor plugin.
+const PluginType = "harbor"
 
 // Router implements the router for the Harbor plugin, which can be registered in the router for our rest api. It contains
 // the api routes for the Harbor plugin and it's configuration.

--- a/plugins/plugin-harbor/cmd/harbor_test.go
+++ b/plugins/plugin-harbor/cmd/harbor_test.go
@@ -1,4 +1,4 @@
-package main
+package harbor
 
 import (
 	"testing"

--- a/plugins/plugin-helm/cmd/helm.go
+++ b/plugins/plugin-helm/cmd/helm.go
@@ -1,4 +1,4 @@
-package main
+package helm
 
 import (
 	"fmt"
@@ -17,6 +17,9 @@ import (
 	"github.com/go-chi/render"
 	"go.uber.org/zap"
 )
+
+// PluginType is the type which must be used for the Helm plugin.
+const PluginType = "helm"
 
 // Router implements the router for the Helm plugin, which can be registered in the router for our rest api. It contains
 // the api routes for the Helm plugin and it's configuration.

--- a/plugins/plugin-helm/cmd/helm_test.go
+++ b/plugins/plugin-helm/cmd/helm_test.go
@@ -1,4 +1,4 @@
-package main
+package helm
 
 import (
 	"context"

--- a/plugins/plugin-istio/cmd/istio.go
+++ b/plugins/plugin-istio/cmd/istio.go
@@ -1,9 +1,10 @@
-package main
+package istio
 
 import (
-	"go.uber.org/zap"
 	"net/http"
 	"strconv"
+
+	"go.uber.org/zap"
 
 	"github.com/kobsio/kobs/pkg/kube/clusters"
 	"github.com/kobsio/kobs/pkg/log"
@@ -14,6 +15,9 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 )
+
+// PluginType is the type which must be used for the Istio plugin.
+const PluginType = "istio"
 
 // Router implements the router for the Istio plugin, which can be registered in the router for our rest api. It contains
 // the api routes for the Istio plugin and it's configuration.

--- a/plugins/plugin-istio/cmd/istio_test.go
+++ b/plugins/plugin-istio/cmd/istio_test.go
@@ -1,4 +1,4 @@
-package main
+package istio
 
 import (
 	"testing"

--- a/plugins/plugin-jaeger/cmd/jaeger.go
+++ b/plugins/plugin-jaeger/cmd/jaeger.go
@@ -1,4 +1,4 @@
-package main
+package jaeger
 
 import (
 	"net/http"
@@ -14,6 +14,9 @@ import (
 	"github.com/go-chi/render"
 	"go.uber.org/zap"
 )
+
+// PluginType is the type which must be used for the Jaeger plugin.
+const PluginType = "jaeger"
 
 // Router implements the router for the Jaeger plugin, which can be registered in the router for our rest api. It contains
 // the api routes for the Jaeger plugin and it's configuration.

--- a/plugins/plugin-jaeger/cmd/jaeger_test.go
+++ b/plugins/plugin-jaeger/cmd/jaeger_test.go
@@ -1,4 +1,4 @@
-package main
+package jaeger
 
 import (
 	"testing"

--- a/plugins/plugin-kiali/cmd/kiali.go
+++ b/plugins/plugin-kiali/cmd/kiali.go
@@ -1,4 +1,4 @@
-package main
+package kiali
 
 import (
 	"net/http"
@@ -14,6 +14,9 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 )
+
+// PluginType is the type which must be used for the Kiali plugin.
+const PluginType = "kiali"
 
 // Router implements the router for the Kiali plugin, which can be registered in the router for our rest api. It contains
 // the api routes for the Kiali plugin and it's configuration.

--- a/plugins/plugin-kiali/cmd/kiali_test.go
+++ b/plugins/plugin-kiali/cmd/kiali_test.go
@@ -1,4 +1,4 @@
-package main
+package kiali
 
 import (
 	"testing"

--- a/plugins/plugin-klogs/cmd/klogs.go
+++ b/plugins/plugin-klogs/cmd/klogs.go
@@ -1,4 +1,4 @@
-package main
+package klogs
 
 import (
 	"encoding/json"
@@ -16,6 +16,9 @@ import (
 	"github.com/go-chi/render"
 	"go.uber.org/zap"
 )
+
+// PluginType is the type which must be used for the klogs plugin.
+const PluginType = "klogs"
 
 // Router implements the router for the klogs plugin, which can be registered in the router for our rest api. It contains
 // the api routes for the klogs plugin and it's configuration.

--- a/plugins/plugin-klogs/cmd/klogs_test.go
+++ b/plugins/plugin-klogs/cmd/klogs_test.go
@@ -1,4 +1,4 @@
-package main
+package klogs
 
 import (
 	"testing"

--- a/plugins/plugin-opsgenie/cmd/opsgenie.go
+++ b/plugins/plugin-opsgenie/cmd/opsgenie.go
@@ -1,4 +1,4 @@
-package main
+package opsgenie
 
 import (
 	"net/http"
@@ -15,6 +15,9 @@ import (
 	"github.com/go-chi/render"
 	"go.uber.org/zap"
 )
+
+// PluginType is the type which must be used for the Opsgenie plugin.
+const PluginType = "opsgenie"
 
 // Router implements the router for the Opsgenie plugin, which can be registered in the router for our rest api.
 type Router struct {

--- a/plugins/plugin-opsgenie/cmd/opsgenie_test.go
+++ b/plugins/plugin-opsgenie/cmd/opsgenie_test.go
@@ -1,4 +1,4 @@
-package main
+package opsgenie
 
 import (
 	"context"

--- a/plugins/plugin-prometheus/cmd/prometheus.go
+++ b/plugins/plugin-prometheus/cmd/prometheus.go
@@ -1,4 +1,4 @@
-package main
+package prometheus
 
 import (
 	"encoding/json"
@@ -15,6 +15,9 @@ import (
 	"github.com/go-chi/render"
 	"go.uber.org/zap"
 )
+
+// PluginType is the type which must be used for the Prometheus plugin.
+const PluginType = "prometheus"
 
 // Router implements the router for the Prometheus plugin, which can be registered in the router for our rest api.
 type Router struct {

--- a/plugins/plugin-rss/cmd/rss.go
+++ b/plugins/plugin-rss/cmd/rss.go
@@ -1,4 +1,4 @@
-package main
+package rss
 
 import (
 	"net/http"
@@ -18,6 +18,9 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.uber.org/zap"
 )
+
+// PluginType is the type which must be used for the RSS plugin.
+const PluginType = "rss"
 
 // Router implements the router for the rss plugin, which can be registered in the router for our rest api. It contains
 // the api routes for the rss plugin and it's configuration.

--- a/plugins/plugin-rss/cmd/rss_test.go
+++ b/plugins/plugin-rss/cmd/rss_test.go
@@ -1,4 +1,4 @@
-package main
+package rss
 
 import (
 	"net/http"

--- a/plugins/plugin-sonarqube/cmd/sonarqube.go
+++ b/plugins/plugin-sonarqube/cmd/sonarqube.go
@@ -1,4 +1,4 @@
-package main
+package sonarqube
 
 import (
 	"net/http"
@@ -13,6 +13,9 @@ import (
 	"github.com/go-chi/render"
 	"go.uber.org/zap"
 )
+
+// PluginType is the type which must be used for the SonarQube plugin.
+const PluginType = "sonarqube"
 
 // Router implements the router for the SonarQube plugin, which can be registered in the router for our rest api.
 type Router struct {

--- a/plugins/plugin-sonarqube/cmd/sonarqube_test.go
+++ b/plugins/plugin-sonarqube/cmd/sonarqube_test.go
@@ -1,4 +1,4 @@
-package main
+package sonarqube
 
 import (
 	"testing"

--- a/plugins/plugin-sql/cmd/sql.go
+++ b/plugins/plugin-sql/cmd/sql.go
@@ -1,4 +1,4 @@
-package main
+package sql
 
 import (
 	"net/http"
@@ -13,6 +13,9 @@ import (
 	"github.com/go-chi/render"
 	"go.uber.org/zap"
 )
+
+// PluginType is the type which must be used for the SQL plugin.
+const PluginType = "sql"
 
 // Router implements the router for the SQL plugin, which can be registered in the router for our rest api. It contains
 // the api routes for the SQL plugin and it's configuration.

--- a/plugins/plugin-sql/cmd/sql_test.go
+++ b/plugins/plugin-sql/cmd/sql_test.go
@@ -1,4 +1,4 @@
-package main
+package sql
 
 import (
 	"testing"

--- a/plugins/plugin-techdocs/cmd/techdocs.go
+++ b/plugins/plugin-techdocs/cmd/techdocs.go
@@ -1,4 +1,4 @@
-package main
+package techdocs
 
 import (
 	"mime"
@@ -15,6 +15,9 @@ import (
 	"github.com/go-chi/render"
 	"go.uber.org/zap"
 )
+
+// PluginType is the type which must be used for the TechDocs plugin.
+const PluginType = "techdocs"
 
 // Router implements the router for the TechDocs plugin, which can be registered in the router for our rest api.
 type Router struct {

--- a/plugins/plugin-techdocs/cmd/techdocs_test.go
+++ b/plugins/plugin-techdocs/cmd/techdocs_test.go
@@ -1,4 +1,4 @@
-package main
+package techdocs
 
 import (
 	"testing"


### PR DESCRIPTION
We used the "plugin" mode for building the Go plugins. The idea was to
make it easy for users to use their own plugins within kobs.
Unfortunately this didn't work well, so that we decided to build the
plugins within the kobs binary. For this a user can now register his
plugins within the "cmd/kobs/main.go" file.

We also adjusted the Docker image to use Alpine as base image again and
to disable CGO in the build.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
