### PR TITLE
[app] Change drawer panel behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#369](https://github.com/kobsio/kobs/pull/#369): [app] Add `insights` panel, to display the insights of an application within a dashboard.
 - [#371](https://github.com/kobsio/kobs/pull/#371): [app] Change toolbar handling by replacing the Patternfly `Toolbar` and `ToolbarItem` components with a custom `Toolbar` and `ToolbarItem` component.
 - [#372](https://github.com/kobsio/kobs/pull/#372): [app] Change `hasDivider` property to `PageContentSection` component to explicit enable / disable the diver.
+- [#373](https://github.com/kobsio/kobs/pull/#373): [app] Change behaviour of drawer panels on pages with dashboards.
 
 ## [v0.8.0](https://github.com/kobsio/kobs/releases/tag/v0.8.0) (2022-03-24)
 

--- a/plugins/app/src/components/applications/Application.tsx
+++ b/plugins/app/src/components/applications/Application.tsx
@@ -9,8 +9,8 @@ import {
   TextContent,
 } from '@patternfly/react-core';
 import { QueryObserverResult, useQuery } from 'react-query';
-import React, { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import React from 'react';
 
 import { PageContentSection, PageHeaderSection } from '@kobsio/shared';
 import ApplicationDetailsLabels from './ApplicationDetailsLabels';
@@ -27,7 +27,6 @@ interface IApplicationParams extends Record<string, string | undefined> {
 const Application: React.FunctionComponent = () => {
   const navigate = useNavigate();
   const params = useParams<IApplicationParams>();
-  const [details, setDetails] = useState<React.ReactNode>(undefined);
 
   const { isError, isLoading, error, data, refetch } = useQuery<IApplication, Error>(
     ['app/applications/application', params.satellite, params.cluster, params.namespace, params.name],
@@ -104,9 +103,14 @@ const Application: React.FunctionComponent = () => {
         }
       />
 
-      <PageContentSection hasPadding={false} hasDivider={false} toolbarContent={undefined} panelContent={details}>
+      <PageContentSection
+        hasPadding={false}
+        hasDivider={data.dashboards ? false : true}
+        toolbarContent={undefined}
+        panelContent={undefined}
+      >
         {data.dashboards ? (
-          <DashboardsWrapper manifest={data} references={data.dashboards} setDetails={setDetails} />
+          <DashboardsWrapper manifest={data} references={data.dashboards} useDrawer={true} />
         ) : (
           <div></div>
         )}

--- a/plugins/app/src/components/dashboards/Dashboards.tsx
+++ b/plugins/app/src/components/dashboards/Dashboards.tsx
@@ -2,6 +2,9 @@ import {
   Alert,
   AlertActionLink,
   AlertVariant,
+  Drawer,
+  DrawerContent,
+  DrawerContentBody,
   PageSection,
   PageSectionVariants,
   Spinner,
@@ -24,27 +27,28 @@ interface IDashboardsProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   manifest: any;
   references: IReference[];
-  setDetails?: (details: React.ReactNode) => void;
+  useDrawer: boolean;
   forceDefaultSpan: boolean;
 }
 
 const Dashboards: React.FunctionComponent<IDashboardsProps> = ({
   manifest,
   references,
+  useDrawer,
   forceDefaultSpan,
-  setDetails,
 }: IDashboardsProps) => {
   const location = useLocation();
   const navigate = useNavigate();
   const [options, setOptions] = useState<IOptions>();
+  const [details, setDetails] = useState<React.ReactNode>(undefined);
 
   const changeOptions = (opts: IOptions): void => {
     navigate(`${location.pathname}?dashboard=${opts.dashboard}`);
   };
 
   useEffect(() => {
-    setOptions(getInitialOptions(location.search, references, setDetails !== undefined));
-  }, [location.search, references, setDetails]);
+    setOptions(getInitialOptions(location.search, references, useDrawer));
+  }, [location.search, references, useDrawer]);
 
   const { isError, isLoading, error, data, refetch } = useQuery<IDashboard[], Error>(
     ['app/dashboards/dashboards', references],
@@ -124,15 +128,21 @@ const Dashboards: React.FunctionComponent<IDashboardsProps> = ({
       mountOnEnter={true}
       unmountOnExit={false}
       onSelect={(event, tabIndex): void =>
-        setDetails
+        useDrawer
           ? changeOptions({ ...options, dashboard: tabIndex.toString() })
           : setOptions({ ...options, dashboard: tabIndex.toString() })
       }
     >
       {data.map((dashboard) => (
         <Tab key={dashboard.title} eventKey={dashboard.title} title={<TabTitleText>{dashboard.title}</TabTitleText>}>
-          <TabContentBody hasPadding={true}>
-            <Dashboard dashboard={dashboard} forceDefaultSpan={forceDefaultSpan} setDetails={setDetails} />
+          <TabContentBody hasPadding={false}>
+            <Drawer isExpanded={details !== undefined}>
+              <DrawerContent className="pf-m-no-background" panelContent={details}>
+                <DrawerContentBody hasPadding={true}>
+                  <Dashboard dashboard={dashboard} forceDefaultSpan={forceDefaultSpan} setDetails={setDetails} />
+                </DrawerContentBody>
+              </DrawerContent>
+            </Drawer>
           </TabContentBody>
         </Tab>
       ))}

--- a/plugins/app/src/components/dashboards/DashboardsWrapper.tsx
+++ b/plugins/app/src/components/dashboards/DashboardsWrapper.tsx
@@ -8,13 +8,13 @@ interface IDashboardsWrapperProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   manifest: any;
   references: IReference[];
-  setDetails?: (details: React.ReactNode) => void;
+  useDrawer: boolean;
 }
 
 export const DashboardsWrapper: React.FunctionComponent<IDashboardsWrapperProps> = ({
   manifest,
   references,
-  setDetails,
+  useDrawer,
 }: IDashboardsWrapperProps) => {
   const refTabs = useRef<HTMLDivElement>(null);
   const tabsSize = useDimensions(refTabs);
@@ -25,7 +25,7 @@ export const DashboardsWrapper: React.FunctionComponent<IDashboardsWrapperProps>
         manifest={manifest}
         references={references}
         forceDefaultSpan={tabsSize.width < 1200}
-        setDetails={setDetails}
+        useDrawer={useDrawer}
       />
     </div>
   );

--- a/plugins/app/src/components/profile/Profile.tsx
+++ b/plugins/app/src/components/profile/Profile.tsx
@@ -1,12 +1,11 @@
 import { Alert, AlertVariant, PageSection } from '@patternfly/react-core';
-import React, { useContext, useState } from 'react';
+import React, { useContext } from 'react';
 
 import { AuthContext, IAuthContext } from '../../context/AuthContext';
 import { PageContentSection, PageHeaderSection } from '@kobsio/shared';
 import ProfileWrapper from './ProfileWrapper';
 
 const Profile: React.FunctionComponent = () => {
-  const [details, setDetails] = useState<React.ReactNode>(undefined);
   const authContext = useContext<IAuthContext>(AuthContext);
 
   if (authContext.user.email === '') {
@@ -23,8 +22,8 @@ const Profile: React.FunctionComponent = () => {
     <React.Fragment>
       <PageHeaderSection title={authContext.user.email} description="" />
 
-      <PageContentSection hasPadding={false} hasDivider={false} toolbarContent={undefined} panelContent={details}>
-        <ProfileWrapper email={authContext.user.email} setDetails={setDetails} />
+      <PageContentSection hasPadding={false} hasDivider={false} toolbarContent={undefined} panelContent={undefined}>
+        <ProfileWrapper email={authContext.user.email} />
       </PageContentSection>
     </React.Fragment>
   );

--- a/plugins/app/src/components/profile/ProfileWrapper.tsx
+++ b/plugins/app/src/components/profile/ProfileWrapper.tsx
@@ -8,10 +8,9 @@ import { IUser } from '../../crds/user';
 
 interface IProfileWrapperProps {
   email: string;
-  setDetails?: (details: React.ReactNode) => void;
 }
 
-const ProfileWrapper: React.FunctionComponent<IProfileWrapperProps> = ({ email, setDetails }: IProfileWrapperProps) => {
+const ProfileWrapper: React.FunctionComponent<IProfileWrapperProps> = ({ email }: IProfileWrapperProps) => {
   const navigate = useNavigate();
 
   const { isError, isLoading, error, data, refetch } = useQuery<IUser, Error>(['app/users/user', email], async () => {
@@ -59,7 +58,7 @@ const ProfileWrapper: React.FunctionComponent<IProfileWrapperProps> = ({ email, 
     return null;
   }
 
-  return <DashboardsWrapper manifest={data} references={data.dashboards} setDetails={setDetails} />;
+  return <DashboardsWrapper manifest={data} references={data.dashboards} useDrawer={true} />;
 };
 
 export default ProfileWrapper;

--- a/plugins/app/src/components/resources/details/Dashboards.tsx
+++ b/plugins/app/src/components/resources/details/Dashboards.tsx
@@ -71,7 +71,7 @@ const Dashboards: React.FunctionComponent<IDashboardsProps> = ({ resource, resou
     );
   }
 
-  return <DashboardsWrapper manifest={resourceData.props} references={references} />;
+  return <DashboardsWrapper manifest={resourceData.props} references={references} useDrawer={false} />;
 };
 
 export default Dashboards;

--- a/plugins/app/src/components/teams/Team.tsx
+++ b/plugins/app/src/components/teams/Team.tsx
@@ -10,9 +10,9 @@ import {
   TextContent,
 } from '@patternfly/react-core';
 import { QueryObserverResult, useQuery } from 'react-query';
-import React, { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import React from 'react';
 
 import { PageContentSection, PageHeaderSection } from '@kobsio/shared';
 import { DashboardsWrapper } from '../dashboards/DashboardsWrapper';
@@ -25,7 +25,6 @@ interface ITeamParams extends Record<string, string | undefined> {
 const Team: React.FunctionComponent = () => {
   const navigate = useNavigate();
   const params = useParams<ITeamParams>();
-  const [details, setDetails] = useState<React.ReactNode>(undefined);
 
   const { isError, isLoading, error, data, refetch } = useQuery<ITeam, Error>(
     ['app/teams/team', params.team],
@@ -108,9 +107,14 @@ const Team: React.FunctionComponent = () => {
         }
       />
 
-      <PageContentSection hasPadding={false} hasDivider={false} toolbarContent={undefined} panelContent={details}>
+      <PageContentSection
+        hasPadding={false}
+        hasDivider={data.dashboards ? false : true}
+        toolbarContent={undefined}
+        panelContent={undefined}
+      >
         {data.dashboards ? (
-          <DashboardsWrapper manifest={data} references={data.dashboards} setDetails={setDetails} />
+          <DashboardsWrapper manifest={data} references={data.dashboards} useDrawer={true} />
         ) : (
           <div></div>
         )}

--- a/plugins/plugin-jaeger/src/components/page/Traces.tsx
+++ b/plugins/plugin-jaeger/src/components/page/Traces.tsx
@@ -25,9 +25,11 @@ const Traces: React.FunctionComponent<ITracesProps> = ({ instance }: ITracesProp
     navigate(
       `${location.pathname}?limit=${opts.limit}&maxDuration=${opts.maxDuration}&minDuration=${
         opts.minDuration
-      }&operation=${opts.operation === 'All Operations' ? '' : opts.operation}&service=${opts.service}&tags=${
-        opts.tags
-      }&time=${opts.times.time}&timeEnd=${opts.times.timeEnd}&timeStart=${opts.times.timeStart}`,
+      }&operation=${
+        opts.operation === 'All Operations' ? '' : encodeURIComponent(opts.operation)
+      }&service=${encodeURIComponent(opts.service)}&tags=${encodeURIComponent(opts.tags)}&time=${
+        opts.times.time
+      }&timeEnd=${opts.times.timeEnd}&timeStart=${opts.times.timeStart}`,
     );
   };
 

--- a/plugins/shared/src/components/toolbar/Options.tsx
+++ b/plugins/shared/src/components/toolbar/Options.tsx
@@ -152,6 +152,15 @@ export const Options: React.FunctionComponent<IOptionsProps> = ({
         },
         additionalFields,
       );
+    } else {
+      setOptions(
+        {
+          time: times.time,
+          timeEnd: times.timeEnd,
+          timeStart: times.timeStart,
+        },
+        additionalFields,
+      );
     }
   };
 


### PR DESCRIPTION
This commit changes the behaviour of the drawer panel on pages where we
show dashboards (application, team and profile page), so that the drawer
does not overlap with the dashboards tab bar. Instead it is now shown
below the tab bar with the dashboards.

We also changed the behaviour of the search button in the Options
component, so that the onClick event is also triggered when the user
selected a custom time range.

Last but not least we are also encoding the parameters (service,
operation, tags) in the Jaeger plugin now.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
