### PR TITLE
[app] App reduce bundle size of React app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#355](https://github.com/kobsio/kobs/pull/#355): [app] Add profile page for authenticated users, which can be customized via dashboards.
 - [#361](https://github.com/kobsio/kobs/pull/#361): [app] Add tracing support for kobs via Jaeger or Zipkin.
 - [#363](https://github.com/kobsio/kobs/pull/#363): [app] Re-add topology chart, which is generated based on the dependencies of an Application.
+- [#374](https://github.com/kobsio/kobs/pull/#374): [app] Reduce bundle size by using code splitting for React Router and optimizing the import of icons.
 
 ### Fixed
 

--- a/plugins/app/src/App.tsx
+++ b/plugins/app/src/App.tsx
@@ -2,30 +2,32 @@ import '@patternfly/react-core/dist/styles/base.css';
 import '@patternfly/patternfly/patternfly.css';
 import '@patternfly/patternfly/patternfly-addons.css';
 
+import { Alert, AlertVariant, Page, Spinner } from '@patternfly/react-core';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { Page } from '@patternfly/react-core';
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import ReactDOM from 'react-dom/client';
 
-import Application from './components/applications/Application';
-import Applications from './components/applications/Applications';
-import ApplicationsTopology from './components/topology/Applications';
 import { AuthContextProvider } from './context/AuthContext';
-import DashboardPage from './components/dashboards/DashboardPage';
 import Header from './components/header/Header';
-import PluginInstances from './components/plugins/PluginInstances';
-import PluginPage from './components/plugins/PluginPage';
 import { PluginsContextProvider } from './context/PluginsContext';
-import Profile from './components/profile/Profile';
-import Resources from './components/resources/Resources';
-import Settings from './components/settings/Settings';
-import Sidebar from './components/sidebar/Sidebar';
-import Team from './components/teams/Team';
-import Teams from './components/teams/Teams';
 
 import 'xterm/css/xterm.css';
 import './assets/index.css';
+
+const Application = lazy(() => import('./components/applications/Application'));
+const Applications = lazy(() => import('./components/applications/Applications'));
+const ApplicationsTopology = lazy(() => import('./components/topology/Applications'));
+const DashboardPage = lazy(() => import('./components/dashboards/DashboardPage'));
+const PluginInstances = lazy(() => import('./components/plugins/PluginInstances'));
+const PluginPage = lazy(() => import('./components/plugins/PluginPage'));
+const Profile = lazy(() => import('./components/profile/Profile'));
+const Resources = lazy(() => import('./components/resources/Resources'));
+const Settings = lazy(() => import('./components/settings/Settings'));
+const Sidebar = lazy(() => import('./components/sidebar/Sidebar'));
+const Team = lazy(() => import('./components/teams/Team'));
+const Teams = lazy(() => import('./components/teams/Teams'));
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -46,26 +48,46 @@ const App: React.FunctionComponent = () => {
         <PluginsContextProvider>
           <BrowserRouter>
             <Page isManagedSidebar={true} header={<Header />} sidebar={<Sidebar />}>
-              <Routes>
-                <Route path="/" element={<Navigate to="/applications" replace={true} />} />
-                <Route path="/applications" element={<Applications />} />
-                <Route
-                  path="/applications/satellite/:satellite/cluster/:cluster/namespace/:namespace/name/:name"
-                  element={<Application />}
-                />
-                <Route
-                  path="/dashboards/satellite/:satellite/cluster/:cluster/namespace/:namespace/name/:name"
-                  element={<DashboardPage />}
-                />
-                <Route path="/topology" element={<ApplicationsTopology />} />
-                <Route path="/teams" element={<Teams />} />
-                <Route path="/teams/:team" element={<Team />} />
-                <Route path="/resources" element={<Resources />} />
-                <Route path="/plugins" element={<PluginInstances />} />
-                <Route path="/plugins/:satellite/:type/:name/*" element={<PluginPage />} />
-                <Route path="/profile" element={<Profile />} />
-                <Route path="/settings" element={<Settings />} />
-              </Routes>
+              <ErrorBoundary
+                fallbackRender={({ error }): React.ReactElement => (
+                  <Alert
+                    style={{ left: '50%', position: 'fixed', top: '50%', transform: 'translate(-50%, -50%)' }}
+                    variant={AlertVariant.danger}
+                    title="An error occured"
+                  >
+                    <p>{error?.message}</p>
+                  </Alert>
+                )}
+              >
+                <Suspense
+                  fallback={
+                    <Spinner
+                      style={{ left: '50%', position: 'fixed', top: '50%', transform: 'translate(-50%, -50%)' }}
+                    />
+                  }
+                >
+                  <Routes>
+                    <Route path="/" element={<Navigate to="/applications" replace={true} />} />
+                    <Route path="/applications" element={<Applications />} />
+                    <Route
+                      path="/applications/satellite/:satellite/cluster/:cluster/namespace/:namespace/name/:name"
+                      element={<Application />}
+                    />
+                    <Route
+                      path="/dashboards/satellite/:satellite/cluster/:cluster/namespace/:namespace/name/:name"
+                      element={<DashboardPage />}
+                    />
+                    <Route path="/topology" element={<ApplicationsTopology />} />
+                    <Route path="/teams" element={<Teams />} />
+                    <Route path="/teams/:team" element={<Team />} />
+                    <Route path="/resources" element={<Resources />} />
+                    <Route path="/plugins" element={<PluginInstances />} />
+                    <Route path="/plugins/:satellite/:type/:name/*" element={<PluginPage />} />
+                    <Route path="/profile" element={<Profile />} />
+                    <Route path="/settings" element={<Settings />} />
+                  </Routes>
+                </Suspense>
+              </ErrorBoundary>
             </Page>
           </BrowserRouter>
         </PluginsContextProvider>

--- a/plugins/app/src/components/applications/ApplicationDetails.tsx
+++ b/plugins/app/src/components/applications/ApplicationDetails.tsx
@@ -11,7 +11,7 @@ import {
   FlexItem,
   Title,
 } from '@patternfly/react-core';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import { Link } from 'react-router-dom';
 import React from 'react';
 

--- a/plugins/app/src/components/applications/ApplicationDetailsLabels.tsx
+++ b/plugins/app/src/components/applications/ApplicationDetailsLabels.tsx
@@ -1,7 +1,9 @@
-import { ExternalLinkAltIcon, TopologyIcon, UsersIcon } from '@patternfly/react-icons';
 import { Flex, FlexItem, Label } from '@patternfly/react-core';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import { Link } from 'react-router-dom';
 import React from 'react';
+import TopologyIcon from '@patternfly/react-icons/dist/esm/icons/topology-icon';
+import UsersIcon from '@patternfly/react-icons/dist/esm/icons/users-icon';
 
 import { IApplication } from '../../crds/application';
 

--- a/plugins/app/src/components/applications/ApplicationsListItem.tsx
+++ b/plugins/app/src/components/applications/ApplicationsListItem.tsx
@@ -10,9 +10,10 @@ import {
   FlexItem,
   Label,
 } from '@patternfly/react-core';
-import { TopologyIcon, UsersIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
 import React from 'react';
+import TopologyIcon from '@patternfly/react-icons/dist/esm/icons/topology-icon';
+import UsersIcon from '@patternfly/react-icons/dist/esm/icons/users-icon';
 
 import { IApplication } from '../../crds/application';
 

--- a/plugins/app/src/components/applications/ApplicationsToolbar.tsx
+++ b/plugins/app/src/components/applications/ApplicationsToolbar.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonVariant, SearchInput, ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
 import React, { useState } from 'react';
-import { SearchIcon } from '@patternfly/react-icons';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
 import { Toolbar, ToolbarItem } from '@kobsio/shared';
 import ApplicationsToolbarTags from './ApplicationsToolbarTags';

--- a/plugins/app/src/components/header/Header.tsx
+++ b/plugins/app/src/components/header/Header.tsx
@@ -7,7 +7,7 @@ import {
   MastheadToggle,
   PageToggleButton,
 } from '@patternfly/react-core';
-import { BarsIcon } from '@patternfly/react-icons';
+import BarsIcon from '@patternfly/react-icons/dist/esm/icons/bars-icon';
 import React from 'react';
 
 import HeaderToolbar from './HeaderToolbar';

--- a/plugins/app/src/components/header/HeaderToolbar.tsx
+++ b/plugins/app/src/components/header/HeaderToolbar.tsx
@@ -13,9 +13,10 @@ import {
   ToolbarGroupVariant,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { CogIcon, QuestionCircleIcon } from '@patternfly/react-icons';
 import React, { useContext, useState } from 'react';
+import CogIcon from '@patternfly/react-icons/dist/esm/icons/cog-icon';
 import { Link } from 'react-router-dom';
+import { QuestionCircleIcon } from '@patternfly/react-icons/dist/esm/icons/question-circle-icon';
 import md5 from 'md5';
 
 import { AuthContext, IAuthContext } from '../../context/AuthContext';

--- a/plugins/app/src/components/profile/UserTeams.tsx
+++ b/plugins/app/src/components/profile/UserTeams.tsx
@@ -14,10 +14,10 @@ import {
 } from '@patternfly/react-core';
 import { QueryObserverResult, useQuery } from 'react-query';
 import React from 'react';
+import UserIcon from '@patternfly/react-icons/dist/esm/icons/user-icon';
 
 import { ITeam } from '../../crds/team';
 import { LinkWrapper } from '@kobsio/shared';
-import { UserIcon } from '@patternfly/react-icons';
 
 export interface IUserTeamsProps {
   setDetails?: (details: React.ReactNode) => void;

--- a/plugins/app/src/components/resources/ResourcesPanel.tsx
+++ b/plugins/app/src/components/resources/ResourcesPanel.tsx
@@ -14,7 +14,7 @@ import {
 } from '@patternfly/react-core';
 import { QueryObserverResult, useQuery } from 'react-query';
 import React, { useEffect, useState } from 'react';
-import { SearchIcon } from '@patternfly/react-icons';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
 import { IOptions, IResourceResponse } from './utils/interfaces';
 import Details from './details/Details';

--- a/plugins/app/src/components/resources/ResourcesPanelTable.tsx
+++ b/plugins/app/src/components/resources/ResourcesPanelTable.tsx
@@ -1,7 +1,7 @@
 import { Bullseye, EmptyState, EmptyStateBody, EmptyStateIcon, EmptyStateVariant, Title } from '@patternfly/react-core';
 import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import React from 'react';
-import { SearchIcon } from '@patternfly/react-icons';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
 import { IColumn, IResourceResponse } from './utils/interfaces';
 import { IResourceRow, customResourceDefinitionTableData, resourcesTableData } from './utils/tabledata';

--- a/plugins/app/src/components/resources/ResourcesToolbar.tsx
+++ b/plugins/app/src/components/resources/ResourcesToolbar.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import React, { useEffect, useState } from 'react';
-import { SearchIcon } from '@patternfly/react-icons';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
 import { Toolbar, ToolbarItem } from '@kobsio/shared';
 import { IOptions } from './utils/interfaces';

--- a/plugins/app/src/components/resources/utils/tabledata.tsx
+++ b/plugins/app/src/components/resources/utils/tabledata.tsx
@@ -29,7 +29,7 @@ import {
 } from '@kubernetes/client-node';
 import { JSONPath } from 'jsonpath-plus';
 import React from 'react';
-import { SquareIcon } from '@patternfly/react-icons';
+import SquareIcon from '@patternfly/react-icons/dist/esm/icons/square-icon';
 
 import { IColumn, IResourceList, IResourceResponse } from './interfaces';
 import { formatTime, timeDifference } from '@kobsio/shared';

--- a/plugins/app/src/components/teams/Team.tsx
+++ b/plugins/app/src/components/teams/Team.tsx
@@ -11,7 +11,7 @@ import {
 } from '@patternfly/react-core';
 import { QueryObserverResult, useQuery } from 'react-query';
 import { useNavigate, useParams } from 'react-router-dom';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import React from 'react';
 
 import { PageContentSection, PageHeaderSection } from '@kobsio/shared';

--- a/plugins/app/src/components/teams/TeamsItem.tsx
+++ b/plugins/app/src/components/teams/TeamsItem.tsx
@@ -8,7 +8,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import React from 'react';
-import { UsersIcon } from '@patternfly/react-icons';
+import UsersIcon from '@patternfly/react-icons/dist/esm/icons/users-icon';
 import { useNavigate } from 'react-router-dom';
 
 import { ITeam } from '../../crds/team';

--- a/plugins/app/src/components/topology/ApplicationDetailsWrapper.tsx
+++ b/plugins/app/src/components/topology/ApplicationDetailsWrapper.tsx
@@ -14,7 +14,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { QueryObserverResult, useQuery } from 'react-query';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import { Link } from 'react-router-dom';
 import React from 'react';
 

--- a/plugins/plugin-azure/src/components/kubernetesservices/DetailsNodePoolsItem.tsx
+++ b/plugins/plugin-azure/src/components/kubernetesservices/DetailsNodePoolsItem.tsx
@@ -7,7 +7,7 @@ import {
 } from '@patternfly/react-core';
 import { ExpandableRowContent, Tbody, Td, Tr } from '@patternfly/react-table';
 import React, { useState } from 'react';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import { Link } from 'react-router-dom';
 
 import { IPluginInstance, pluginBasePath } from '@kobsio/shared';

--- a/plugins/plugin-azure/src/components/page/Page.tsx
+++ b/plugins/plugin-azure/src/components/page/Page.tsx
@@ -1,14 +1,15 @@
 import { Alert, AlertActionLink, AlertVariant, Spinner } from '@patternfly/react-core';
 import { QueryObserverResult, useQuery } from 'react-query';
+import React, { Suspense, lazy } from 'react';
 import { Route, Routes } from 'react-router-dom';
-import React from 'react';
 
-import ContainerInstancesPage from '../containerinstances/Page';
-import CostManagementPage from '../costmanagement/Page';
 import { IPluginPageProps } from '@kobsio/shared';
-import KubernetesServicesPage from '../kubernetesservices/Page';
-import OverviewPage from './OverviewPage';
-import VirtualMachineScaleSetsPage from '../virtualmachinescalesets/Page';
+
+const ContainerInstancesPage = lazy(() => import('../containerinstances/Page'));
+const CostManagementPage = lazy(() => import('../costmanagement/Page'));
+const KubernetesServicesPage = lazy(() => import('../kubernetesservices/Page'));
+const OverviewPage = lazy(() => import('./OverviewPage'));
+const VirtualMachineScaleSetsPage = lazy(() => import('../virtualmachinescalesets/Page'));
 
 // IResourceGroup is the interface for a resource group returned by the Azure API. This interface is only required for
 // the returned data, because we are only passing the name of the resource group to the other components.
@@ -79,22 +80,26 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ instance }: IPluginPa
   }
 
   return (
-    <Routes>
-      <Route path="/" element={<OverviewPage instance={instance} />} />
-      <Route
-        path="/containerinstances"
-        element={<ContainerInstancesPage instance={instance} resourceGroups={data} />}
-      />
-      <Route path="/costmanagement" element={<CostManagementPage instance={instance} resourceGroups={data} />} />
-      <Route
-        path="/kubernetesservices"
-        element={<KubernetesServicesPage instance={instance} resourceGroups={data} />}
-      />
-      <Route
-        path="/virtualmachinescalesets"
-        element={<VirtualMachineScaleSetsPage instance={instance} resourceGroups={data} />}
-      />
-    </Routes>
+    <Suspense
+      fallback={<Spinner style={{ left: '50%', position: 'fixed', top: '50%', transform: 'translate(-50%, -50%)' }} />}
+    >
+      <Routes>
+        <Route path="/" element={<OverviewPage instance={instance} />} />
+        <Route
+          path="/containerinstances"
+          element={<ContainerInstancesPage instance={instance} resourceGroups={data} />}
+        />
+        <Route path="/costmanagement" element={<CostManagementPage instance={instance} resourceGroups={data} />} />
+        <Route
+          path="/kubernetesservices"
+          element={<KubernetesServicesPage instance={instance} resourceGroups={data} />}
+        />
+        <Route
+          path="/virtualmachinescalesets"
+          element={<VirtualMachineScaleSetsPage instance={instance} resourceGroups={data} />}
+        />
+      </Routes>
+    </Suspense>
   );
 };
 

--- a/plugins/plugin-elasticsearch/src/components/panel/Logs.tsx
+++ b/plugins/plugin-elasticsearch/src/components/panel/Logs.tsx
@@ -9,7 +9,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { QueryObserverResult, useQuery } from 'react-query';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
 import React from 'react';
 
 import { ILogsData, IQuery } from '../../utils/interfaces';

--- a/plugins/plugin-elasticsearch/src/components/panel/LogsDocumentDetailsRow.tsx
+++ b/plugins/plugin-elasticsearch/src/components/panel/LogsDocumentDetailsRow.tsx
@@ -1,7 +1,10 @@
 import { Button, Tooltip } from '@patternfly/react-core';
-import { ColumnsIcon, SearchIcon, SearchMinusIcon, SearchPlusIcon } from '@patternfly/react-icons';
 import React, { useState } from 'react';
 import { Td, Tr } from '@patternfly/react-table';
+import ColumnsIcon from '@patternfly/react-icons/dist/esm/icons/columns-icon';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
+import SearchMinusIcon from '@patternfly/react-icons/dist/esm/icons/search-minus-icon';
+import SearchPlusIcon from '@patternfly/react-icons/dist/esm/icons/search-plus-icon';
 
 export interface ILogsDocumentDetailsRowProps {
   documentKey: string;

--- a/plugins/plugin-flux/src/components/page/PageToolbar.tsx
+++ b/plugins/plugin-flux/src/components/page/PageToolbar.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonVariant, ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
 import React, { useState } from 'react';
-import { SearchIcon } from '@patternfly/react-icons';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
 import { IOptions, TType } from '../../utils/interfaces';
 import { IPluginInstance, Toolbar, ToolbarItem } from '@kobsio/shared';

--- a/plugins/plugin-grafana/src/components/page/PageToolbar.tsx
+++ b/plugins/plugin-grafana/src/components/page/PageToolbar.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonVariant, TextInput } from '@patternfly/react-core';
 import React, { useState } from 'react';
-import { SearchIcon } from '@patternfly/react-icons';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
 import { Toolbar, ToolbarItem } from '@kobsio/shared';
 import { IOptions } from '../../utils/interfaces';

--- a/plugins/plugin-harbor/src/components/page/Page.tsx
+++ b/plugins/plugin-harbor/src/components/page/Page.tsx
@@ -1,18 +1,24 @@
+import React, { Suspense, lazy } from 'react';
 import { Route, Routes } from 'react-router-dom';
-import React from 'react';
+import { Spinner } from '@patternfly/react-core';
 
-import ArtifactsPage from './ArtifactsPage';
 import { IPluginPageProps } from '@kobsio/shared';
-import ProjectsPage from './ProjectsPage';
-import RepositoriesPage from './RepositoriesPage';
+
+const ArtifactsPage = lazy(() => import('./ArtifactsPage'));
+const ProjectsPage = lazy(() => import('./ProjectsPage'));
+const RepositoriesPage = lazy(() => import('./RepositoriesPage'));
 
 const Page: React.FunctionComponent<IPluginPageProps> = ({ instance }: IPluginPageProps) => {
   return (
-    <Routes>
-      <Route path="/" element={<ProjectsPage instance={instance} />} />
-      <Route path="/:projectName" element={<RepositoriesPage instance={instance} />} />
-      <Route path="/:projectName/:repositoryName" element={<ArtifactsPage instance={instance} />} />
-    </Routes>
+    <Suspense
+      fallback={<Spinner style={{ left: '50%', position: 'fixed', top: '50%', transform: 'translate(-50%, -50%)' }} />}
+    >
+      <Routes>
+        <Route path="/" element={<ProjectsPage instance={instance} />} />
+        <Route path="/:projectName" element={<RepositoriesPage instance={instance} />} />
+        <Route path="/:projectName/:repositoryName" element={<ArtifactsPage instance={instance} />} />
+      </Routes>
+    </Suspense>
   );
 };
 

--- a/plugins/plugin-harbor/src/components/page/PageToolbar.tsx
+++ b/plugins/plugin-harbor/src/components/page/PageToolbar.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonVariant, SearchInput } from '@patternfly/react-core';
 import React, { useState } from 'react';
-import { SearchIcon } from '@patternfly/react-icons';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
 import { Toolbar, ToolbarItem } from '@kobsio/shared';
 import { IOptions } from '../../utils/interfaces';

--- a/plugins/plugin-harbor/src/components/panel/NoData.tsx
+++ b/plugins/plugin-harbor/src/components/panel/NoData.tsx
@@ -1,5 +1,5 @@
 import { EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
 import React from 'react';
 
 export interface IIncidentProps {

--- a/plugins/plugin-harbor/src/components/panel/details/Details.tsx
+++ b/plugins/plugin-harbor/src/components/panel/details/Details.tsx
@@ -16,7 +16,7 @@ import {
 } from '@patternfly/react-core';
 import React, { useState } from 'react';
 import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { CopyIcon } from '@patternfly/react-icons';
+import CopyIcon from '@patternfly/react-icons/dist/esm/icons/copy-icon';
 
 import BuildHistory from './BuildHistory';
 import { IArtifact } from '../../../utils/interfaces';

--- a/plugins/plugin-helm/src/components/page/PageToolbar.tsx
+++ b/plugins/plugin-helm/src/components/page/PageToolbar.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import React, { useState } from 'react';
-import { SearchIcon } from '@patternfly/react-icons';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
 import { IPluginInstance, Toolbar, ToolbarItem } from '@kobsio/shared';
 import { IOptions } from '../../utils/interfaces';

--- a/plugins/plugin-helm/src/components/panel/History.tsx
+++ b/plugins/plugin-helm/src/components/panel/History.tsx
@@ -13,7 +13,7 @@ import {
 import { QueryObserverResult, useQuery } from 'react-query';
 import React, { useState } from 'react';
 import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { SearchIcon } from '@patternfly/react-icons';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
 import Details from './details/Details';
 import { IPluginInstance } from '@kobsio/shared';

--- a/plugins/plugin-helm/src/components/panel/Releases.tsx
+++ b/plugins/plugin-helm/src/components/panel/Releases.tsx
@@ -13,7 +13,7 @@ import {
 import { QueryObserverResult, useQuery } from 'react-query';
 import React, { useState } from 'react';
 import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { SearchIcon } from '@patternfly/react-icons';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
 import { IPluginInstance, ITimes } from '@kobsio/shared';
 import Details from './details/Details';

--- a/plugins/plugin-istio/src/components/page/ApplicationActions.tsx
+++ b/plugins/plugin-istio/src/components/page/ApplicationActions.tsx
@@ -13,8 +13,9 @@ import {
   Switch,
   TextInput,
 } from '@patternfly/react-core';
-import { FilterIcon, TimesIcon } from '@patternfly/react-icons';
 import React, { useEffect, useState } from 'react';
+import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
+import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 
 import { IFilters } from '../../utils/interfaces';
 

--- a/plugins/plugin-istio/src/components/page/Page.tsx
+++ b/plugins/plugin-istio/src/components/page/Page.tsx
@@ -1,16 +1,22 @@
+import React, { Suspense, lazy } from 'react';
 import { Route, Routes } from 'react-router-dom';
-import React from 'react';
+import { Spinner } from '@patternfly/react-core';
 
-import Application from './Application';
-import Applications from './Applications';
 import { IPluginPageProps } from '@kobsio/shared';
+
+const Application = lazy(() => import('./Application'));
+const Applications = lazy(() => import('./Applications'));
 
 const Page: React.FunctionComponent<IPluginPageProps> = ({ instance }: IPluginPageProps) => {
   return (
-    <Routes>
-      <Route path={`/`} element={<Applications instance={instance} />}></Route>
-      <Route path={`/:namespace/:application`} element={<Application instance={instance} />} />
-    </Routes>
+    <Suspense
+      fallback={<Spinner style={{ left: '50%', position: 'fixed', top: '50%', transform: 'translate(-50%, -50%)' }} />}
+    >
+      <Routes>
+        <Route path={`/`} element={<Applications instance={instance} />}></Route>
+        <Route path={`/:namespace/:application`} element={<Application instance={instance} />} />
+      </Routes>
+    </Suspense>
   );
 };
 

--- a/plugins/plugin-istio/src/components/panel/Top.tsx
+++ b/plugins/plugin-istio/src/components/panel/Top.tsx
@@ -13,7 +13,7 @@ import {
 import { QueryObserverResult, useQuery } from 'react-query';
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { MicroscopeIcon } from '@patternfly/react-icons';
+import MicroscopeIcon from '@patternfly/react-icons/dist/esm/icons/microscope-icon';
 
 import { IPluginInstance, ITimes, pluginBasePath } from '@kobsio/shared';
 import { escapeRegExp, formatNumber, getDirection } from '../../utils/helpers';

--- a/plugins/plugin-jaeger/src/components/page/Page.tsx
+++ b/plugins/plugin-jaeger/src/components/page/Page.tsx
@@ -1,17 +1,23 @@
+import React, { Suspense, lazy } from 'react';
 import { Route, Routes } from 'react-router-dom';
-import React from 'react';
+import { Spinner } from '@patternfly/react-core';
 
 import { IPluginPageProps } from '@kobsio/shared';
-import Trace from './Trace';
-import Traces from './Traces';
+
+const Trace = lazy(() => import('./Trace'));
+const Traces = lazy(() => import('./Traces'));
 
 const Page: React.FunctionComponent<IPluginPageProps> = ({ instance }: IPluginPageProps) => {
   return (
-    <Routes>
-      <Route path="/" element={<Traces instance={instance} />} />
-      <Route path="/trace/" element={<Trace instance={instance} />} />
-      <Route path="/trace/:traceID" element={<Trace instance={instance} />} />
-    </Routes>
+    <Suspense
+      fallback={<Spinner style={{ left: '50%', position: 'fixed', top: '50%', transform: 'translate(-50%, -50%)' }} />}
+    >
+      <Routes>
+        <Route path="/" element={<Traces instance={instance} />} />
+        <Route path="/trace/" element={<Trace instance={instance} />} />
+        <Route path="/trace/:traceID" element={<Trace instance={instance} />} />
+      </Routes>
+    </Suspense>
   );
 };
 

--- a/plugins/plugin-jaeger/src/components/page/TraceSelect.tsx
+++ b/plugins/plugin-jaeger/src/components/page/TraceSelect.tsx
@@ -12,7 +12,7 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import React, { useState } from 'react';
-import { SearchIcon } from '@patternfly/react-icons';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import { useDropzone } from 'react-dropzone';
 
 import { ITrace } from '../../utils/interfaces';

--- a/plugins/plugin-jaeger/src/components/panel/Traces.tsx
+++ b/plugins/plugin-jaeger/src/components/panel/Traces.tsx
@@ -9,7 +9,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { QueryObserverResult, useQuery } from 'react-query';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
 import React from 'react';
 
 import { IPluginInstance, ITimes } from '@kobsio/shared';

--- a/plugins/plugin-jaeger/src/components/panel/TracesListItem.tsx
+++ b/plugins/plugin-jaeger/src/components/panel/TracesListItem.tsx
@@ -9,7 +9,7 @@ import {
   Label,
   LabelProps,
 } from '@patternfly/react-core';
-import { ExclamationIcon } from '@patternfly/react-icons';
+import ExclamationIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-icon';
 import React from 'react';
 
 import { IPluginInstance, LinkWrapper, pluginBasePath } from '@kobsio/shared';

--- a/plugins/plugin-jaeger/src/components/panel/details/Span.tsx
+++ b/plugins/plugin-jaeger/src/components/panel/details/Span.tsx
@@ -1,5 +1,5 @@
 import { AccordionContent, AccordionItem, AccordionToggle } from '@patternfly/react-core';
-import { ExclamationIcon } from '@patternfly/react-icons';
+import ExclamationIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-icon';
 import React from 'react';
 
 import { IProcess, ISpan } from '../../../utils/interfaces';

--- a/plugins/plugin-klogs/src/components/page/LogsFieldsItem.tsx
+++ b/plugins/plugin-klogs/src/components/page/LogsFieldsItem.tsx
@@ -1,6 +1,9 @@
 import { Button, ButtonVariant, SimpleListItem, Tooltip } from '@patternfly/react-core';
-import { CopyIcon, LongArrowAltDownIcon, LongArrowAltUpIcon, TrashIcon } from '@patternfly/react-icons';
 import React, { useState } from 'react';
+import CopyIcon from '@patternfly/react-icons/dist/esm/icons/copy-icon';
+import LongArrowAltDownIcon from '@patternfly/react-icons/dist/esm/icons/long-arrow-alt-down-icon';
+import LongArrowAltUpIcon from '@patternfly/react-icons/dist/esm/icons/long-arrow-alt-up-icon';
+import TrashIcon from '@patternfly/react-icons/dist/esm/icons/trash-icon';
 
 export interface ILogsFieldsItemProps {
   index: number;

--- a/plugins/plugin-klogs/src/components/page/Page.tsx
+++ b/plugins/plugin-klogs/src/components/page/Page.tsx
@@ -1,16 +1,22 @@
+import React, { Suspense, lazy } from 'react';
 import { Route, Routes } from 'react-router-dom';
-import React from 'react';
+import { Spinner } from '@patternfly/react-core';
 
-import AggregationPage from './AggregationPage';
 import { IPluginPageProps } from '@kobsio/shared';
-import LogsPage from './LogsPage';
+
+const AggregationPage = lazy(() => import('./AggregationPage'));
+const LogsPage = lazy(() => import('./LogsPage'));
 
 const Page: React.FunctionComponent<IPluginPageProps> = ({ instance }: IPluginPageProps) => {
   return (
-    <Routes>
-      <Route path="/" element={<LogsPage instance={instance} />} />
-      <Route path="/aggregation" element={<AggregationPage instance={instance} />} />
-    </Routes>
+    <Suspense
+      fallback={<Spinner style={{ left: '50%', position: 'fixed', top: '50%', transform: 'translate(-50%, -50%)' }} />}
+    >
+      <Routes>
+        <Route path="/" element={<LogsPage instance={instance} />} />
+        <Route path="/aggregation" element={<AggregationPage instance={instance} />} />
+      </Routes>
+    </Suspense>
   );
 };
 

--- a/plugins/plugin-klogs/src/components/panel/Aggregation.tsx
+++ b/plugins/plugin-klogs/src/components/panel/Aggregation.tsx
@@ -9,7 +9,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { QueryObserverResult, useQuery } from 'react-query';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
 import React from 'react';
 
 import { IAggregationData, IAggregationOptions } from '../../utils/interfaces';

--- a/plugins/plugin-klogs/src/components/panel/Logs.tsx
+++ b/plugins/plugin-klogs/src/components/panel/Logs.tsx
@@ -9,7 +9,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { QueryObserverResult, useQuery } from 'react-query';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
 import React from 'react';
 
 import { ILogsData, IQuery } from '../../utils/interfaces';

--- a/plugins/plugin-klogs/src/components/panel/LogsDocumentDetailsRow.tsx
+++ b/plugins/plugin-klogs/src/components/panel/LogsDocumentDetailsRow.tsx
@@ -1,7 +1,10 @@
 import { Button, Tooltip } from '@patternfly/react-core';
-import { ColumnsIcon, SearchIcon, SearchMinusIcon, SearchPlusIcon } from '@patternfly/react-icons';
 import React, { useState } from 'react';
 import { Td, Tr } from '@patternfly/react-table';
+import ColumnsIcon from '@patternfly/react-icons/dist/esm/icons/columns-icon';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
+import SearchMinusIcon from '@patternfly/react-icons/dist/esm/icons/search-minus-icon';
+import SearchPlusIcon from '@patternfly/react-icons/dist/esm/icons/search-plus-icon';
 
 export interface ILogsDocumentDetailsRowProps {
   documentKey: string;

--- a/plugins/plugin-opsgenie/src/components/panel/NoData.tsx
+++ b/plugins/plugin-opsgenie/src/components/panel/NoData.tsx
@@ -1,5 +1,5 @@
 import { EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
 import React from 'react';
 
 export interface IIncidentProps {

--- a/plugins/plugin-prometheus/src/components/page/PageChartLegend.tsx
+++ b/plugins/plugin-prometheus/src/components/page/PageChartLegend.tsx
@@ -1,8 +1,9 @@
 import { Button, ButtonVariant } from '@patternfly/react-core';
-import { EyeSlashIcon, SquareIcon } from '@patternfly/react-icons';
 import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import EyeSlashIcon from '@patternfly/react-icons/dist/esm/icons/eye-slash-icon';
 import React from 'react';
 import { Serie } from '@nivo/line';
+import SquareIcon from '@patternfly/react-icons/dist/esm/icons/square-icon';
 
 import { getColor } from '@kobsio/shared';
 import { roundNumber } from '../../utils/helpers';

--- a/plugins/plugin-prometheus/src/components/page/PageToolbar.tsx
+++ b/plugins/plugin-prometheus/src/components/page/PageToolbar.tsx
@@ -1,6 +1,7 @@
 import { Button, ButtonVariant, Flex, FlexItem, InputGroup } from '@patternfly/react-core';
-import { MinusIcon, PlusIcon } from '@patternfly/react-icons';
 import React, { useState } from 'react';
+import MinusIcon from '@patternfly/react-icons/dist/esm/icons/minus-icon';
+import PlusIcon from '@patternfly/react-icons/dist/esm/icons/plus-icon';
 
 import { IOptionsAdditionalFields, IPluginInstance, ITimes, Options, Toolbar, ToolbarItem } from '@kobsio/shared';
 import { IOptions } from '../../utils/interfaces';

--- a/plugins/plugin-prometheus/src/components/page/PageToolbarAutocomplete.tsx
+++ b/plugins/plugin-prometheus/src/components/page/PageToolbarAutocomplete.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonVariant, TextArea } from '@patternfly/react-core';
 import React, { useRef, useState } from 'react';
-import { TimesIcon } from '@patternfly/react-icons';
+import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 import { useQuery } from 'react-query';
 
 import { IPluginInstance, useDebounce } from '@kobsio/shared';

--- a/plugins/plugin-prometheus/src/components/panel/ChartLegend.tsx
+++ b/plugins/plugin-prometheus/src/components/panel/ChartLegend.tsx
@@ -1,8 +1,9 @@
 import { Button, ButtonVariant } from '@patternfly/react-core';
-import { EyeSlashIcon, SquareIcon } from '@patternfly/react-icons';
 import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import EyeSlashIcon from '@patternfly/react-icons/dist/esm/icons/eye-slash-icon';
 import React from 'react';
 import { Serie } from '@nivo/line';
+import SquareIcon from '@patternfly/react-icons/dist/esm/icons/square-icon';
 
 import { getColor } from '@kobsio/shared';
 import { roundNumber } from '../../utils/helpers';

--- a/plugins/plugin-rss/src/components/panel/Feed.tsx
+++ b/plugins/plugin-rss/src/components/panel/Feed.tsx
@@ -9,7 +9,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { QueryObserverResult, useQuery } from 'react-query';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
 import React from 'react';
 
 import FeedList from './FeedList';

--- a/plugins/plugin-sonarqube/src/components/page/PageToolbar.tsx
+++ b/plugins/plugin-sonarqube/src/components/page/PageToolbar.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonVariant, TextInput } from '@patternfly/react-core';
 import React, { useState } from 'react';
-import { SearchIcon } from '@patternfly/react-icons';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
 import { Toolbar, ToolbarItem } from '@kobsio/shared';
 import { IOptions } from '../../utils/interfaces';

--- a/plugins/plugin-sonarqube/src/components/panel/Measure.tsx
+++ b/plugins/plugin-sonarqube/src/components/panel/Measure.tsx
@@ -1,10 +1,8 @@
-import {
-  CheckCircleIcon,
-  ExclamationCircleIcon,
-  ExclamationTriangleIcon,
-  InfoCircleIcon,
-} from '@patternfly/react-icons';
 import { FlexItem, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
+import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
 import React from 'react';
 
 import { IMeasure, IMetric } from '../../utils/interfaces';

--- a/plugins/plugin-sql/src/components/page/PageToolbar.tsx
+++ b/plugins/plugin-sql/src/components/page/PageToolbar.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonVariant, TextArea } from '@patternfly/react-core';
 import React, { useState } from 'react';
-import { SearchIcon } from '@patternfly/react-icons';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
 import { Toolbar, ToolbarItem } from '@kobsio/shared';
 import { IOptions } from '../../utils/interfaces';

--- a/plugins/plugin-sql/src/components/panel/SQLChartLineLegend.tsx
+++ b/plugins/plugin-sql/src/components/panel/SQLChartLineLegend.tsx
@@ -1,7 +1,7 @@
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import React from 'react';
-import { SquareIcon } from '@patternfly/react-icons';
+import SquareIcon from '@patternfly/react-icons/dist/esm/icons/square-icon';
 
 import { ILegend, ISQLData, ISQLDataRow } from '../../utils/interfaces';
 import { getColor } from '@kobsio/shared';

--- a/plugins/plugin-techdocs/src/components/page/Page.tsx
+++ b/plugins/plugin-techdocs/src/components/page/Page.tsx
@@ -1,17 +1,23 @@
+import React, { Suspense, lazy } from 'react';
 import { Route, Routes } from 'react-router-dom';
-import React from 'react';
+import { Spinner } from '@patternfly/react-core';
 
 import { IPluginPageProps } from '@kobsio/shared';
-import ServicePage from './ServicePage';
-import TechDocsPage from './TechDocsPage';
+
+const ServicePage = lazy(() => import('./ServicePage'));
+const TechDocsPage = lazy(() => import('./TechDocsPage'));
 
 const Page: React.FunctionComponent<IPluginPageProps> = ({ instance }: IPluginPageProps) => {
   return (
-    <Routes>
-      <Route path={`/`} element={<TechDocsPage instance={instance} />} />
-      <Route path={`/:service`} element={<ServicePage instance={instance} />} />
-      <Route path={`/:service/:path`} element={<ServicePage instance={instance} />} />
-    </Routes>
+    <Suspense
+      fallback={<Spinner style={{ left: '50%', position: 'fixed', top: '50%', transform: 'translate(-50%, -50%)' }} />}
+    >
+      <Routes>
+        <Route path={`/`} element={<TechDocsPage instance={instance} />} />
+        <Route path={`/:service`} element={<ServicePage instance={instance} />} />
+        <Route path={`/:service/:path`} element={<ServicePage instance={instance} />} />
+      </Routes>
+    </Suspense>
   );
 };
 

--- a/plugins/shared/src/components/chart/ChartTooltip.tsx
+++ b/plugins/shared/src/components/chart/ChartTooltip.tsx
@@ -1,6 +1,6 @@
 import { TooltipAnchor, TooltipWrapper } from '@nivo/tooltip';
 import React from 'react';
-import { SquareIcon } from '@patternfly/react-icons';
+import SquareIcon from '@patternfly/react-icons/dist/esm/icons/square-icon';
 
 interface IChartTooltipProps {
   anchor?: TooltipAnchor;

--- a/plugins/shared/src/components/toolbar/Options.tsx
+++ b/plugins/shared/src/components/toolbar/Options.tsx
@@ -14,7 +14,8 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import React, { useEffect, useState } from 'react';
-import { RedoIcon, SearchIcon } from '@patternfly/react-icons';
+import RedoIcon from '@patternfly/react-icons/dist/esm/icons/redo-icon';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
 import { ITimes, TTime, formatTime, timeOptions } from '../../utils/times';
 import { ToolbarItem } from './ToolbarItem';


### PR DESCRIPTION
To load the React UI faster, we worked on reducing the bundle size. This
is done by using code splitting based on the different routes registered
in the React Router and by changing the import of icons from the
"@patternfly/react-icons" package.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
