### PR TITLE
[flux] Add action to suspend / resume resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#363](https://github.com/kobsio/kobs/pull/#363): [app] Re-add topology chart, which is generated based on the dependencies of an Application.
 - [#374](https://github.com/kobsio/kobs/pull/#374): [app] Reduce bundle size by using code splitting for React Router and optimizing the import of icons.
 - [#375](https://github.com/kobsio/kobs/pull/#375): [app] Add ServiceWorker and version parameter for `remoteEntry.js` file.
+- [#376](https://github.com/kobsio/kobs/pull/#376): [flux] Add action to suspend / resume resources.
 
 ### Fixed
 

--- a/plugins/plugin-azure/src/components/costmanagement/CostPieChartLegend.tsx
+++ b/plugins/plugin-azure/src/components/costmanagement/CostPieChartLegend.tsx
@@ -37,10 +37,10 @@ const CostPieChartLegend: React.FunctionComponent<ICostPieChartLegendProps> = ({
       <Tbody>
         {tableData.map((row, index) => (
           <Tr key={index}>
-            <Td style={{ fontSize: '12px', padding: 0 }} dataLabel="Min">
+            <Td style={{ fontSize: '12px', padding: 0 }} dataLabel="Scope">
               <SquareIcon color={getColor(index)} /> {row.label}
             </Td>
-            <Td style={{ fontSize: '12px', padding: 0 }} dataLabel="Max">
+            <Td style={{ fontSize: '12px', padding: 0 }} dataLabel="Value">
               {roundNumber(row.value)} {getCurrency(data, row.label.toString())}
             </Td>
           </Tr>

--- a/plugins/plugin-flux/src/components/page/Page.tsx
+++ b/plugins/plugin-flux/src/components/page/Page.tsx
@@ -60,6 +60,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ instance }: IPluginPa
               type={options.type}
               cluster={options.cluster}
               namespace={options.namespace}
+              times={options.times}
               setDetails={setDetails}
             />
           )}

--- a/plugins/plugin-flux/src/components/page/PageToolbar.tsx
+++ b/plugins/plugin-flux/src/components/page/PageToolbar.tsx
@@ -1,9 +1,8 @@
-import { Button, ButtonVariant, ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
 import React, { useState } from 'react';
-import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
+import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
 
 import { IOptions, TType } from '../../utils/interfaces';
-import { IPluginInstance, Toolbar, ToolbarItem } from '@kobsio/shared';
+import { IOptionsAdditionalFields, IPluginInstance, ITimes, Options, Toolbar, ToolbarItem } from '@kobsio/shared';
 import PageToolbarItemClusters from './PageToolbarItemClusters';
 import PageToolbarItemNamespaces from './PageToolbarItemNamespaces';
 import { resources } from '../../utils/constants';
@@ -33,8 +32,8 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({
     setState({ ...state, type: type });
   };
 
-  const changeOptions = (): void => {
-    setOptions(state);
+  const changeOptions = (times: ITimes, additionalFields: IOptionsAdditionalFields[] | undefined): void => {
+    setOptions({ ...state, times: times });
   };
 
   return (
@@ -87,11 +86,7 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({
         </ToggleGroup>
       </ToolbarItem>
 
-      <ToolbarItem alignRight={true}>
-        <Button variant={ButtonVariant.primary} icon={<SearchIcon />} onClick={changeOptions}>
-          Search
-        </Button>
-      </ToolbarItem>
+      <Options times={options.times} showOptions={false} showSearchButton={true} setOptions={changeOptions} />
     </Toolbar>
   );
 };

--- a/plugins/plugin-flux/src/components/panel/details/Actions.tsx
+++ b/plugins/plugin-flux/src/components/panel/details/Actions.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 
 import { IAlert, TType } from '../../../utils/interfaces';
 import { IPluginInstance } from '@kobsio/shared';
+import SuspendResume from './actions/SuspendResume';
 import Sync from './actions/Sync';
 
 interface IActionProps {
@@ -18,6 +19,8 @@ const Actions: React.FunctionComponent<IActionProps> = ({ instance, cluster, typ
   const [showDropdown, setShowDropdown] = useState<boolean>(false);
   const [alerts, setAlerts] = useState<IAlert[]>([]);
   const [showSync, setShowSync] = useState<boolean>(false);
+  const [showSuspend, setShowSuspend] = useState<boolean>(false);
+  const [showResume, setShowResume] = useState<boolean>(false);
 
   // removeAlert is used to remove an alert from the list of alerts, when the user clicks the close button.
   const removeAlert = (index: number): void => {
@@ -25,6 +28,46 @@ const Actions: React.FunctionComponent<IActionProps> = ({ instance, cluster, typ
     tmpAlerts.splice(index, 1);
     setAlerts(tmpAlerts);
   };
+
+  const dropdownItems: React.ReactNode[] = [];
+
+  if (type === 'kustomizations' || type === 'helmreleases') {
+    dropdownItems.push(
+      <DropdownItem
+        key="sync"
+        onClick={(): void => {
+          setShowDropdown(false);
+          setShowSync(true);
+        }}
+      >
+        Sync
+      </DropdownItem>,
+    );
+  }
+
+  dropdownItems.push(
+    <DropdownItem
+      key="suspend"
+      onClick={(): void => {
+        setShowDropdown(false);
+        setShowSuspend(true);
+      }}
+    >
+      Suspend
+    </DropdownItem>,
+  );
+
+  dropdownItems.push(
+    <DropdownItem
+      key="resume"
+      onClick={(): void => {
+        setShowDropdown(false);
+        setShowResume(true);
+      }}
+    >
+      Resume
+    </DropdownItem>,
+  );
 
   return (
     <React.Fragment>
@@ -34,17 +77,7 @@ const Actions: React.FunctionComponent<IActionProps> = ({ instance, cluster, typ
         isOpen={showDropdown}
         isPlain={true}
         position="right"
-        dropdownItems={[
-          <DropdownItem
-            key="sync"
-            onClick={(): void => {
-              setShowDropdown(false);
-              setShowSync(true);
-            }}
-          >
-            Sync
-          </DropdownItem>,
-        ]}
+        dropdownItems={dropdownItems}
       />
 
       <AlertGroup isToast={true}>
@@ -66,6 +99,30 @@ const Actions: React.FunctionComponent<IActionProps> = ({ instance, cluster, typ
         item={item}
         show={showSync}
         setShow={setShowSync}
+        setAlert={(alert: IAlert): void => setAlerts([...alerts, alert])}
+        refetch={refetch}
+      />
+
+      <SuspendResume
+        instance={instance}
+        cluster={cluster}
+        type={type}
+        item={item}
+        suspendResume="suspend"
+        show={showSuspend}
+        setShow={setShowSuspend}
+        setAlert={(alert: IAlert): void => setAlerts([...alerts, alert])}
+        refetch={refetch}
+      />
+
+      <SuspendResume
+        instance={instance}
+        cluster={cluster}
+        type={type}
+        item={item}
+        suspendResume="resume"
+        show={showResume}
+        setShow={setShowResume}
         setAlert={(alert: IAlert): void => setAlerts([...alerts, alert])}
         refetch={refetch}
       />

--- a/plugins/plugin-flux/src/components/panel/details/Details.tsx
+++ b/plugins/plugin-flux/src/components/panel/details/Details.tsx
@@ -45,16 +45,14 @@ const Details: React.FunctionComponent<IDetailsProps> = ({
           <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">{item.metadata.namespace}</span>
         </Title>
         <DrawerActions style={{ padding: 0 }}>
-          {type === 'kustomizations' || type === 'helmreleases' ? (
-            <Actions instance={instance} cluster={cluster} type={type} item={item} refetch={refetch} />
-          ) : null}
+          <Actions instance={instance} cluster={cluster} type={type} item={item} refetch={refetch} />
           <DrawerCloseButton onClose={close} />
         </DrawerActions>
       </DrawerHead>
 
       <DrawerPanelBody>
         {type === 'gitrepositories' || type === 'buckets' || type === 'helmrepositories' ? (
-          <SourceInfo type={type} url={item?.spec?.url} timeout={item?.spec?.timeout} />
+          <SourceInfo type={type} url={item?.spec?.url} timeout={item?.spec?.timeout} suspend={item?.spec?.suspend} />
         ) : null}
         {type === 'kustomizations' ? (
           <KustomizationInfo
@@ -65,6 +63,7 @@ const Details: React.FunctionComponent<IDetailsProps> = ({
             path={item?.spec?.path}
             interval={item?.spec?.interval}
             prune={item?.spec?.prune}
+            suspend={item?.spec?.suspend}
             appliedRevision={item?.status?.lastAppliedRevision}
           />
         ) : null}
@@ -73,6 +72,7 @@ const Details: React.FunctionComponent<IDetailsProps> = ({
             interval={item?.spec?.interval}
             chart={item?.spec?.chart?.spec?.chart}
             version={item?.spec?.chart?.spec?.version}
+            suspend={item?.spec?.suspend}
           />
         ) : null}
         {type === 'helmreleases' &&

--- a/plugins/plugin-flux/src/components/panel/details/HelmInfo.tsx
+++ b/plugins/plugin-flux/src/components/panel/details/HelmInfo.tsx
@@ -13,9 +13,10 @@ interface IHelmInfoProps {
   interval?: string;
   chart?: string;
   version?: string;
+  suspend?: boolean;
 }
 
-const HelmInfo: React.FunctionComponent<IHelmInfoProps> = ({ interval, chart, version }: IHelmInfoProps) => {
+const HelmInfo: React.FunctionComponent<IHelmInfoProps> = ({ interval, chart, version, suspend }: IHelmInfoProps) => {
   return (
     <Card className="pf-u-mb-lg" isCompact={true}>
       <CardTitle>Info</CardTitle>
@@ -32,6 +33,10 @@ const HelmInfo: React.FunctionComponent<IHelmInfoProps> = ({ interval, chart, ve
           <DescriptionListGroup>
             <DescriptionListTerm>Version</DescriptionListTerm>
             <DescriptionListDescription>{version ? version : '-'}</DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Suspended</DescriptionListTerm>
+            <DescriptionListDescription>{suspend ? 'True' : 'False'}</DescriptionListDescription>
           </DescriptionListGroup>
         </DescriptionList>
       </CardBody>

--- a/plugins/plugin-flux/src/components/panel/details/KustomizationInfo.tsx
+++ b/plugins/plugin-flux/src/components/panel/details/KustomizationInfo.tsx
@@ -22,6 +22,7 @@ interface IKustomizationInfoProps {
   path?: string;
   interval?: string;
   prune?: string;
+  suspend?: boolean;
   appliedRevision?: string;
 }
 
@@ -33,6 +34,7 @@ const KustomizationInfo: React.FunctionComponent<IKustomizationInfoProps> = ({
   path,
   interval,
   prune,
+  suspend,
   appliedRevision,
 }: IKustomizationInfoProps) => {
   return (
@@ -71,8 +73,12 @@ const KustomizationInfo: React.FunctionComponent<IKustomizationInfoProps> = ({
           <DescriptionListGroup>
             <DescriptionListTerm>Prune</DescriptionListTerm>
             <DescriptionListDescription>
-              {prune !== undefined ? (prune ? 'true' : 'false') : '-'}
+              {prune !== undefined ? (prune ? 'True' : 'False') : '-'}
             </DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Suspended</DescriptionListTerm>
+            <DescriptionListDescription>{suspend ? 'True' : 'False'}</DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>
             <DescriptionListTerm>Applied Revision</DescriptionListTerm>

--- a/plugins/plugin-flux/src/components/panel/details/SourceInfo.tsx
+++ b/plugins/plugin-flux/src/components/panel/details/SourceInfo.tsx
@@ -15,9 +15,10 @@ interface ISourceInfoProps {
   type: TType;
   url?: string;
   timeout?: string;
+  suspend?: boolean;
 }
 
-const SourceInfo: React.FunctionComponent<ISourceInfoProps> = ({ type, url, timeout }: ISourceInfoProps) => {
+const SourceInfo: React.FunctionComponent<ISourceInfoProps> = ({ type, url, timeout, suspend }: ISourceInfoProps) => {
   return (
     <Card className="pf-u-mb-lg" isCompact={true}>
       <CardTitle>Info</CardTitle>
@@ -42,6 +43,10 @@ const SourceInfo: React.FunctionComponent<ISourceInfoProps> = ({ type, url, time
           <DescriptionListGroup>
             <DescriptionListTerm>Timeout</DescriptionListTerm>
             <DescriptionListDescription>{timeout ? timeout : '-'}</DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Suspended</DescriptionListTerm>
+            <DescriptionListDescription>{suspend ? 'True' : 'False'}</DescriptionListDescription>
           </DescriptionListGroup>
         </DescriptionList>
       </CardBody>

--- a/plugins/plugin-flux/src/components/panel/details/actions/SuspendResume.tsx
+++ b/plugins/plugin-flux/src/components/panel/details/actions/SuspendResume.tsx
@@ -1,0 +1,99 @@
+import { AlertVariant, Button, ButtonVariant, Modal, ModalVariant } from '@patternfly/react-core';
+import React from 'react';
+
+import { IAlert, TType } from '../../../../utils/interfaces';
+import { IPluginInstance } from '@kobsio/shared';
+import { resources } from '../../../../utils/constants';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getJSONPatch = (item: any, suspendResume: 'suspend' | 'resume'): string => {
+  if (suspendResume === 'suspend') {
+    if (item?.suspend) {
+      return JSON.stringify([{ op: 'replace', path: '/spec/suspend', value: true }]);
+    }
+
+    return JSON.stringify([{ op: 'add', path: '/spec/suspend', value: true }]);
+  } else {
+    if (item?.suspend) {
+      return JSON.stringify([{ op: 'replace', path: '/spec/suspend', value: false }]);
+    }
+
+    return JSON.stringify([{ op: 'add', path: '/spec/suspend', value: false }]);
+  }
+};
+
+interface ISuspendResumeProps {
+  instance: IPluginInstance;
+  cluster: string;
+  type: TType;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  item: any;
+  suspendResume: 'suspend' | 'resume';
+  show: boolean;
+  setShow: (value: boolean) => void;
+  setAlert: (alert: IAlert) => void;
+  refetch: () => void;
+}
+
+const SuspendResume: React.FunctionComponent<ISuspendResumeProps> = ({
+  instance,
+  cluster,
+  type,
+  item,
+  suspendResume,
+  show,
+  setShow,
+  setAlert,
+  refetch,
+}: ISuspendResumeProps) => {
+  const handleAction = async (): Promise<void> => {
+    try {
+      const response = await fetch(
+        `/api/resources?satellite=${instance.satellite}&cluster=${cluster}&namespace=${item.metadata.namespace}&name=${item.metadata.name}&resource=${resources[type].resource}&path=${resources[type].path}`,
+        {
+          body: getJSONPatch(item, suspendResume),
+          method: 'put',
+        },
+      );
+      const json = await response.json();
+
+      if (response.status >= 200 && response.status < 300) {
+        setShow(false);
+        setAlert({ title: `${item.metadata.name} was ${suspendResume}ed`, variant: AlertVariant.success });
+        refetch();
+      } else {
+        if (json.error) {
+          throw new Error(json.error);
+        } else {
+          throw new Error('An unknown error occured');
+        }
+      }
+    } catch (err) {
+      setShow(false);
+      setAlert({ title: err.message, variant: AlertVariant.danger });
+    }
+  };
+
+  return (
+    <Modal
+      variant={ModalVariant.small}
+      title={suspendResume === 'suspend' ? `Suspend ${item.metadata.name}` : `Resume ${item.metadata.name}`}
+      isOpen={show}
+      onClose={(): void => setShow(false)}
+      actions={[
+        <Button key="action" variant={ButtonVariant.primary} onClick={handleAction}>
+          {suspendResume === 'suspend' ? 'Suspend' : 'Resume'}
+        </Button>,
+        <Button key="cancel" variant={ButtonVariant.link} onClick={(): void => setShow(false)}>
+          Cancel
+        </Button>,
+      ]}
+    >
+      <p>
+        Do you really want to {suspendResume} <b>{item.metadata.name}</b> ({item.metadata.namespace})?
+      </p>
+    </Modal>
+  );
+};
+
+export default SuspendResume;

--- a/plugins/plugin-flux/src/utils/constants.ts
+++ b/plugins/plugin-flux/src/utils/constants.ts
@@ -17,6 +17,11 @@ export const resources: TResource = {
         type: 'string',
       },
       {
+        jsonPath: '$.spec.suspend',
+        title: 'Suspended',
+        type: 'boolean',
+      },
+      {
         jsonPath: '$.status.conditions[?(@.type=="Ready")].message',
         title: 'Status',
         type: 'string',
@@ -44,6 +49,11 @@ export const resources: TResource = {
         type: 'string',
       },
       {
+        jsonPath: '$.spec.suspend',
+        title: 'Suspended',
+        type: 'boolean',
+      },
+      {
         jsonPath: '$.status.conditions[?(@.type=="Ready")].message',
         title: 'Status',
         type: 'string',
@@ -64,6 +74,11 @@ export const resources: TResource = {
         jsonPath: '$.status.conditions[?(@.type=="Ready")].status',
         title: 'Ready',
         type: 'string',
+      },
+      {
+        jsonPath: '$.spec.suspend',
+        title: 'Suspended',
+        type: 'boolean',
       },
       {
         jsonPath: '$.status.conditions[?(@.type=="Ready")].message',
@@ -93,6 +108,11 @@ export const resources: TResource = {
         type: 'string',
       },
       {
+        jsonPath: '$.spec.suspend',
+        title: 'Suspended',
+        type: 'boolean',
+      },
+      {
         jsonPath: '$.status.conditions[?(@.type=="Ready")].message',
         title: 'Status',
         type: 'string',
@@ -114,6 +134,11 @@ export const resources: TResource = {
         jsonPath: '$.status.conditions[?(@.type=="Ready")].status',
         title: 'Ready',
         type: 'string',
+      },
+      {
+        jsonPath: '$.spec.suspend',
+        title: 'Suspended',
+        type: 'boolean',
       },
       {
         jsonPath: '$.status.conditions[?(@.type=="Ready")].message',

--- a/plugins/plugin-flux/src/utils/helpers.ts
+++ b/plugins/plugin-flux/src/utils/helpers.ts
@@ -26,7 +26,10 @@ export const getInitialOptions = (search: string, isInitial: boolean): IOptions 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const getValue = (manifest: any, jsonPath: string, type: string): string => {
   const value = JSONPath<string | string[]>({ json: manifest, path: jsonPath })[0];
-  if (!value) {
+
+  if (type === 'boolean') {
+    return (value as unknown as boolean) === true ? 'True' : 'False';
+  } else if (!value) {
     return '';
   } else if (type === 'date') {
     return timeDifference(new Date().getTime(), new Date(value).getTime());


### PR DESCRIPTION
It is now possible to suspend / resume a resource via the details
actions.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
