### PR TITLE
[app] Replace interface{} with any

### DIFF
--- a/pkg/hub/middleware/userauth/jwt/jwt.go
+++ b/pkg/hub/middleware/userauth/jwt/jwt.go
@@ -17,7 +17,7 @@ type CustomClaims struct {
 
 // ValidateToken validates a given jwt token and returns the user from the claims or an error when the validation fails.
 func ValidateToken(tokenString, sessionToken string) (*authContext.User, error) {
-	token, err := goJWT.ParseWithClaims(tokenString, &CustomClaims{}, func(token *goJWT.Token) (interface{}, error) {
+	token, err := goJWT.ParseWithClaims(tokenString, &CustomClaims{}, func(token *goJWT.Token) (any, error) {
 		if _, ok := token.Method.(*goJWT.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
 		}

--- a/pkg/hub/middleware/userauth/router_test.go
+++ b/pkg/hub/middleware/userauth/router_test.go
@@ -14,7 +14,7 @@ import (
 func TestUserAuthHandler(t *testing.T) {
 	for _, tt := range []struct {
 		name               string
-		user               interface{}
+		user               any
 		expectedStatusCode int
 		expectedBody       string
 	}{

--- a/pkg/satellite/plugins/plugin/plugin.go
+++ b/pkg/satellite/plugins/plugin/plugin.go
@@ -10,14 +10,14 @@ import (
 // type and an optionsl description. It can also contains a map with additional options. The options can be used to
 // specify the addess, username, password, etc. to access an service within the plugin.
 type Instance struct {
-	ID              string                 `json:"id"`
-	Satellite       string                 `json:"satellite"`
-	Name            string                 `json:"name"`
-	Description     string                 `json:"description"`
-	Type            string                 `json:"type"`
-	Options         map[string]interface{} `json:"options"`
-	FrontendOptions map[string]interface{} `json:"frontendOptions"`
-	UpdatedAt       int64                  `json:"updatedAt"`
+	ID              string         `json:"id"`
+	Satellite       string         `json:"satellite"`
+	Name            string         `json:"name"`
+	Description     string         `json:"description"`
+	Type            string         `json:"type"`
+	Options         map[string]any `json:"options"`
+	FrontendOptions map[string]any `json:"frontendOptions"`
+	UpdatedAt       int64          `json:"updatedAt"`
 }
 
 // MountFn is the type of the mount function, which must be implemented by all plugins, so that the can be used within

--- a/plugins/plugin-azure/cmd/azure_test.go
+++ b/plugins/plugin-azure/cmd/azure_test.go
@@ -26,7 +26,7 @@ func TestGetInstance(t *testing.T) {
 }
 
 func TestMount(t *testing.T) {
-	router1, err := Mount([]plugin.Instance{{Name: "azure", Options: map[string]interface{}{}}}, nil)
+	router1, err := Mount([]plugin.Instance{{Name: "azure", Options: map[string]any{}}}, nil)
 	require.Error(t, err)
 	require.Nil(t, router1)
 }

--- a/plugins/plugin-azure/pkg/instance/instance.go
+++ b/plugins/plugin-azure/pkg/instance/instance.go
@@ -80,7 +80,7 @@ func (i *instance) MonitorClient() monitor.Client {
 }
 
 // New returns a new Azure instance for the given configuration.
-func New(name string, options map[string]interface{}) (Instance, error) {
+func New(name string, options map[string]any) (Instance, error) {
 	var config Config
 	err := mapstructure.Decode(options, &config)
 	if err != nil {

--- a/plugins/plugin-azure/pkg/instance/instance_test.go
+++ b/plugins/plugin-azure/pkg/instance/instance_test.go
@@ -9,12 +9,12 @@ import (
 func TestNew(t *testing.T) {
 	for _, tt := range []struct {
 		name    string
-		options map[string]interface{}
+		options map[string]any
 		isError bool
 	}{
 		{
 			name:    "instance without credentials",
-			options: map[string]interface{}{},
+			options: map[string]any{},
 			isError: true,
 		},
 	} {

--- a/plugins/plugin-elasticsearch/cmd/elasticsearch_test.go
+++ b/plugins/plugin-elasticsearch/cmd/elasticsearch_test.go
@@ -119,11 +119,11 @@ func TestGetLogs(t *testing.T) {
 }
 
 func TestMount(t *testing.T) {
-	router1, err := Mount([]plugin.Instance{{Name: "elasticsearch", Options: map[string]interface{}{}}}, nil)
+	router1, err := Mount([]plugin.Instance{{Name: "elasticsearch", Options: map[string]any{}}}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, router1)
 
-	router2, err := Mount([]plugin.Instance{{Name: "elasticsearch", Options: map[string]interface{}{"token": []string{"token"}}}}, nil)
+	router2, err := Mount([]plugin.Instance{{Name: "elasticsearch", Options: map[string]any{"token": []string{"token"}}}}, nil)
 	require.Error(t, err)
 	require.Nil(t, router2)
 }

--- a/plugins/plugin-elasticsearch/pkg/instance/instance.go
+++ b/plugins/plugin-elasticsearch/pkg/instance/instance.go
@@ -110,7 +110,7 @@ func (i *instance) GetLogs(ctx context.Context, query string, timeStart, timeEnd
 // New returns a new Elasticsearch instance for the given configuration. If the configuration contains a username and
 // password we will add a basic auth header to each request against the Elasticsearch api. If the config contains a
 // token we are adding an authentication header with the token.
-func New(name string, options map[string]interface{}) (Instance, error) {
+func New(name string, options map[string]any) (Instance, error) {
 	var config Config
 	err := mapstructure.Decode(options, &config)
 	if err != nil {

--- a/plugins/plugin-elasticsearch/pkg/instance/instance_test.go
+++ b/plugins/plugin-elasticsearch/pkg/instance/instance_test.go
@@ -68,7 +68,7 @@ func TestGetLogs(t *testing.T) {
 				w.Write([]byte(`{"took": 100, "hits": {"total": {"value": 1000}, "hits": [{"test": "test"}]}, "aggregations": {"logcount": {"buckets": [{"key_as_string": "123", "key": 123, "doc_count": 1000}]}}}`))
 			},
 			expectedError: false,
-			expectedData:  &Data{Took: 100, Hits: 1000, Documents: []map[string]interface{}{{"test": "test"}}, Buckets: []Bucket{{KeyAsString: "123", Key: 123, DocCount: 1000}}},
+			expectedData:  &Data{Took: 100, Hits: 1000, Documents: []map[string]any{{"test": "test"}}, Buckets: []Bucket{{KeyAsString: "123", Key: 123, DocCount: 1000}}},
 		},
 		{
 			name: "success request with invalid json data",
@@ -109,27 +109,27 @@ func TestGetLogs(t *testing.T) {
 func TestNew(t *testing.T) {
 	for _, tt := range []struct {
 		name    string
-		options map[string]interface{}
+		options map[string]any
 		isError bool
 	}{
 		{
 			name:    "instance without auth",
-			options: map[string]interface{}{},
+			options: map[string]any{},
 			isError: false,
 		},
 		{
 			name:    "instance with basic auth",
-			options: map[string]interface{}{"username": "admin", "password": "admin"},
+			options: map[string]any{"username": "admin", "password": "admin"},
 			isError: false,
 		},
 		{
 			name:    "instance with token auth",
-			options: map[string]interface{}{"token": "token"},
+			options: map[string]any{"token": "token"},
 			isError: false,
 		},
 		{
 			name:    "fail to parse options",
-			options: map[string]interface{}{"token": []string{"token"}},
+			options: map[string]any{"token": []string{"token"}},
 			isError: true,
 		},
 	} {

--- a/plugins/plugin-elasticsearch/pkg/instance/structs.go
+++ b/plugins/plugin-elasticsearch/pkg/instance/structs.go
@@ -16,7 +16,7 @@ type Response struct {
 			Value    int64  `json:"value"`
 			Relation string `json:"relation"`
 		} `json:"total"`
-		Hits []map[string]interface{} `json:"hits"`
+		Hits []map[string]any `json:"hits"`
 	} `json:"hits"`
 	Aggregations struct {
 		LogCount struct {
@@ -52,8 +52,8 @@ type ResponseError struct {
 // Data is the transformed Response result, which is passed to the React UI. It contains only the important fields, like
 // the time a request took, the number of hits, the documents and the buckets.
 type Data struct {
-	Took      int64                    `json:"took"`
-	Hits      int64                    `json:"hits"`
-	Documents []map[string]interface{} `json:"documents"`
-	Buckets   []Bucket                 `json:"buckets"`
+	Took      int64            `json:"took"`
+	Hits      int64            `json:"hits"`
+	Documents []map[string]any `json:"documents"`
+	Buckets   []Bucket         `json:"buckets"`
 }

--- a/plugins/plugin-grafana/cmd/grafana_test.go
+++ b/plugins/plugin-grafana/cmd/grafana_test.go
@@ -133,11 +133,11 @@ func TestGetDashboards(t *testing.T) {
 }
 
 func TestMount(t *testing.T) {
-	router1, err := Mount([]plugin.Instance{{Name: "grafana", Options: map[string]interface{}{}}}, nil)
+	router1, err := Mount([]plugin.Instance{{Name: "grafana", Options: map[string]any{}}}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, router1)
 
-	router2, err := Mount([]plugin.Instance{{Name: "grafana", Options: map[string]interface{}{"token": []string{"token"}}}}, nil)
+	router2, err := Mount([]plugin.Instance{{Name: "grafana", Options: map[string]any{"token": []string{"token"}}}}, nil)
 	require.Error(t, err)
 	require.Nil(t, router2)
 }

--- a/plugins/plugin-grafana/pkg/instance/instance.go
+++ b/plugins/plugin-grafana/pkg/instance/instance.go
@@ -63,7 +63,7 @@ func (i *instance) GetDashboard(ctx context.Context, uid string) (*Dashboard, er
 }
 
 // New returns a new Grafana instance for the given configuration.
-func New(name string, options map[string]interface{}) (Instance, error) {
+func New(name string, options map[string]any) (Instance, error) {
 	var config Config
 	err := mapstructure.Decode(options, &config)
 	if err != nil {

--- a/plugins/plugin-grafana/pkg/instance/instance_test.go
+++ b/plugins/plugin-grafana/pkg/instance/instance_test.go
@@ -149,27 +149,27 @@ func TestGetDashboard(t *testing.T) {
 func TestNew(t *testing.T) {
 	for _, tt := range []struct {
 		name    string
-		options map[string]interface{}
+		options map[string]any
 		isError bool
 	}{
 		{
 			name:    "instance without auth",
-			options: map[string]interface{}{},
+			options: map[string]any{},
 			isError: false,
 		},
 		{
 			name:    "instance with basic auth",
-			options: map[string]interface{}{"username": "admin", "password": "admin"},
+			options: map[string]any{"username": "admin", "password": "admin"},
 			isError: false,
 		},
 		{
 			name:    "instance with token auth",
-			options: map[string]interface{}{"token": "token"},
+			options: map[string]any{"token": "token"},
 			isError: false,
 		},
 		{
 			name:    "fail to parse options",
-			options: map[string]interface{}{"token": []string{"token"}},
+			options: map[string]any{"token": []string{"token"}},
 			isError: true,
 		},
 	} {

--- a/plugins/plugin-harbor/cmd/harbor_test.go
+++ b/plugins/plugin-harbor/cmd/harbor_test.go
@@ -26,11 +26,11 @@ func TestGetInstance(t *testing.T) {
 }
 
 func TestMount(t *testing.T) {
-	router1, err := Mount([]plugin.Instance{{Name: "harbor", Options: map[string]interface{}{}}}, nil)
+	router1, err := Mount([]plugin.Instance{{Name: "harbor", Options: map[string]any{}}}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, router1)
 
-	router2, err := Mount([]plugin.Instance{{Name: "harbor", Options: map[string]interface{}{"token": []string{"token"}}}}, nil)
+	router2, err := Mount([]plugin.Instance{{Name: "harbor", Options: map[string]any{"token": []string{"token"}}}}, nil)
 	require.Error(t, err)
 	require.Nil(t, router2)
 }

--- a/plugins/plugin-harbor/pkg/instance/instance.go
+++ b/plugins/plugin-harbor/pkg/instance/instance.go
@@ -126,7 +126,7 @@ func (i *instance) GetBuildHistory(ctx context.Context, projectName, repositoryN
 }
 
 // New returns a new Harbor instance for the given configuration.
-func New(name string, options map[string]interface{}) (Instance, error) {
+func New(name string, options map[string]any) (Instance, error) {
 	var config Config
 	err := mapstructure.Decode(options, &config)
 	if err != nil {

--- a/plugins/plugin-harbor/pkg/instance/structs.go
+++ b/plugins/plugin-harbor/pkg/instance/structs.go
@@ -67,13 +67,13 @@ type Artifact struct {
 		Architecture string `json:"architecture"`
 		Author       string `json:"author"`
 		Config       struct {
-			Cmd          []string               `json:"Cmd"`
-			Entrypoint   []string               `json:"Entrypoint"`
-			Env          []string               `json:"Env"`
-			ExposedPorts map[string]interface{} `json:"ExposedPorts"`
-			Labels       map[string]string      `json:"Labels"`
-			User         string                 `json:"User"`
-			WorkingDir   string                 `json:"WorkingDir"`
+			Cmd          []string          `json:"Cmd"`
+			Entrypoint   []string          `json:"Entrypoint"`
+			Env          []string          `json:"Env"`
+			ExposedPorts map[string]any    `json:"ExposedPorts"`
+			Labels       map[string]string `json:"Labels"`
+			User         string            `json:"User"`
+			WorkingDir   string            `json:"WorkingDir"`
 		} `json:"config"`
 		Created time.Time `json:"created"`
 		Os      string    `json:"os"`

--- a/plugins/plugin-helm/cmd/helm_test.go
+++ b/plugins/plugin-helm/cmd/helm_test.go
@@ -364,7 +364,7 @@ func TestGetReleaseHistory(t *testing.T) {
 }
 
 func TestMount(t *testing.T) {
-	router1, err := Mount([]plugin.Instance{{Name: "helm", Options: map[string]interface{}{"permissionsEnabled": true}}}, nil)
+	router1, err := Mount([]plugin.Instance{{Name: "helm", Options: map[string]any{"permissionsEnabled": true}}}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, router1)
 

--- a/plugins/plugin-helm/pkg/client/types.go
+++ b/plugins/plugin-helm/pkg/client/types.go
@@ -12,7 +12,7 @@ type Release struct {
 	Chart *Chart `json:"chart,omitempty"`
 	// Config is the set of extra Values added to the chart.
 	// These values override the default values inside of the chart.
-	Config map[string]interface{} `json:"config,omitempty"`
+	Config map[string]any `json:"config,omitempty"`
 	// Manifest is the string representation of the rendered template.
 	Manifest string `json:"manifest,omitempty"`
 	// Hooks are all of the hooks declared for this release.
@@ -80,7 +80,7 @@ type Chart struct {
 	// Templates for this chart.
 	Templates []*File `json:"templates"`
 	// Values are default config for this chart.
-	Values map[string]interface{} `json:"values"`
+	Values map[string]any `json:"values"`
 	// Schema is an optional JSON schema for imposing structure on Values
 	Schema []byte `json:"schema"`
 	// Files are miscellaneous files in a chart archive,
@@ -174,7 +174,7 @@ type Dependency struct {
 	Enabled bool `json:"enabled,omitempty"`
 	// ImportValues holds the mapping of source values to parent key to be imported. Each item can be a
 	// string or pair of child/parent sublist items.
-	ImportValues []interface{} `json:"import-values,omitempty"`
+	ImportValues []any `json:"import-values,omitempty"`
 	// Alias usable alias to be used for the chart
 	Alias string `json:"alias,omitempty"`
 }

--- a/plugins/plugin-istio/cmd/istio_test.go
+++ b/plugins/plugin-istio/cmd/istio_test.go
@@ -26,11 +26,11 @@ func TestGetInstance(t *testing.T) {
 }
 
 func TestMount(t *testing.T) {
-	router1, err := Mount([]plugin.Instance{{Name: "istio", Options: map[string]interface{}{}}}, nil)
+	router1, err := Mount([]plugin.Instance{{Name: "istio", Options: map[string]any{}}}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, router1)
 
-	router2, err := Mount([]plugin.Instance{{Name: "istio", Options: map[string]interface{}{"prometheus": map[string]interface{}{"enabled": "true"}}}}, nil)
+	router2, err := Mount([]plugin.Instance{{Name: "istio", Options: map[string]any{"prometheus": map[string]any{"enabled": "true"}}}}, nil)
 	require.Error(t, err)
 	require.Nil(t, router2)
 }

--- a/plugins/plugin-istio/pkg/instance/instance.go
+++ b/plugins/plugin-istio/pkg/instance/instance.go
@@ -21,15 +21,15 @@ type Config struct {
 // ConfigPrometheus is the structure of the configuration, which is required to enabled the Prometheus integration for
 // the Istio plugin.
 type ConfigPrometheus struct {
-	Enabled bool                   `json:"enabled"`
-	Options map[string]interface{} `json:"options"`
+	Enabled bool           `json:"enabled"`
+	Options map[string]any `json:"options"`
 }
 
 // ConfigKlogs is the structure of the configuration, which is required to enabled the klogs integration for the Istio
 // plugin.
 type ConfigKlogs struct {
-	Enabled bool                   `json:"enabled"`
-	Options map[string]interface{} `json:"options"`
+	Enabled bool           `json:"enabled"`
+	Options map[string]any `json:"options"`
 }
 
 type Instance interface {
@@ -39,9 +39,9 @@ type Instance interface {
 	GetMetricsDetails(ctx context.Context, metric, reporter, destinationWorkload, destinationWorkloadNamespace, destinationVersion, destinationService, sourceWorkload, sourceWorkloadNamespace, pod string, timeStart int64, timeEnd int64) (*prometheusInstance.Metrics, error)
 	GetMetricsPod(ctx context.Context, metric, namespace, pod string, timeStart int64, timeEnd int64) (*prometheusInstance.Metrics, error)
 	GetTopology(ctx context.Context, namespace, application string, timeStart int64, timeEnd int64) ([]Edge, []Node, error)
-	Tap(ctx context.Context, namespace, application, filterUpstreamCluster, filterMethod, filterPath string, timeStart int64, timeEnd int64) ([]map[string]interface{}, error)
-	Top(ctx context.Context, namespace, application, filterUpstreamCluster, filterMethod, filterPath, sortBy, sortDirection string, timeStart int64, timeEnd int64) ([][]interface{}, error)
-	TopDetails(ctx context.Context, namespace, application, upstreamCluster, method, path string, timeStart int64, timeEnd int64) ([][]interface{}, error)
+	Tap(ctx context.Context, namespace, application, filterUpstreamCluster, filterMethod, filterPath string, timeStart int64, timeEnd int64) ([]map[string]any, error)
+	Top(ctx context.Context, namespace, application, filterUpstreamCluster, filterMethod, filterPath, sortBy, sortDirection string, timeStart int64, timeEnd int64) ([][]any, error)
+	TopDetails(ctx context.Context, namespace, application, upstreamCluster, method, path string, timeStart int64, timeEnd int64) ([][]any, error)
 }
 
 type instance struct {
@@ -312,7 +312,7 @@ func (i *instance) GetTopology(ctx context.Context, namespace, application strin
 }
 
 // Tap returns the logs for the specified Istio application.
-func (i *instance) Tap(ctx context.Context, namespace, application, filterUpstreamCluster, filterMethod, filterPath string, timeStart int64, timeEnd int64) ([]map[string]interface{}, error) {
+func (i *instance) Tap(ctx context.Context, namespace, application, filterUpstreamCluster, filterMethod, filterPath string, timeStart int64, timeEnd int64) ([]map[string]any, error) {
 	var filters string
 	if filterUpstreamCluster != "" {
 		filters = filters + fmt.Sprintf(" _and_ content.upstream_cluster~'%s'", filterUpstreamCluster)
@@ -333,7 +333,7 @@ func (i *instance) Tap(ctx context.Context, namespace, application, filterUpstre
 }
 
 // Top returns the aggregated logs for the specified Istio application.
-func (i *instance) Top(ctx context.Context, namespace, application, filterUpstreamCluster, filterMethod, filterPath, sortBy, sortDirection string, timeStart int64, timeEnd int64) ([][]interface{}, error) {
+func (i *instance) Top(ctx context.Context, namespace, application, filterUpstreamCluster, filterMethod, filterPath, sortBy, sortDirection string, timeStart int64, timeEnd int64) ([][]any, error) {
 	var filters string
 	if filterUpstreamCluster != "" {
 		filters = filters + fmt.Sprintf(" AND match(fields_string.value[indexOf(fields_string.key, 'content.upstream_cluster')], '%s')", filterUpstreamCluster)
@@ -372,7 +372,7 @@ SETTINGS skip_unavailable_shards = 1`, timeStart, timeEnd, namespace, applicatio
 }
 
 // TopDetails returns the success rate and latency for the specified upstream cluster, method and path.
-func (i *instance) TopDetails(ctx context.Context, namespace, application, upstreamCluster, method, path string, timeStart int64, timeEnd int64) ([][]interface{}, error) {
+func (i *instance) TopDetails(ctx context.Context, namespace, application, upstreamCluster, method, path string, timeStart int64, timeEnd int64) ([][]any, error) {
 	interval := (timeEnd - timeStart) / 30
 	filters := fmt.Sprintf(" AND namespace = '%s' AND app = '%s' AND container_name = 'istio-proxy'", namespace, application)
 
@@ -407,7 +407,7 @@ SETTINGS skip_unavailable_shards = 1`, interval, timeStart, timeEnd, filters, ti
 }
 
 // New returns a new Elasticsearch instance for the given configuration.
-func New(name string, options map[string]interface{}) (Instance, error) {
+func New(name string, options map[string]any) (Instance, error) {
 	var config Config
 	err := mapstructure.Decode(options, &config)
 	if err != nil {

--- a/plugins/plugin-jaeger/cmd/jaeger_test.go
+++ b/plugins/plugin-jaeger/cmd/jaeger_test.go
@@ -26,11 +26,11 @@ func TestGetInstance(t *testing.T) {
 }
 
 func TestMount(t *testing.T) {
-	router1, err := Mount([]plugin.Instance{{Name: "jaeger", Options: map[string]interface{}{}}}, nil)
+	router1, err := Mount([]plugin.Instance{{Name: "jaeger", Options: map[string]any{}}}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, router1)
 
-	router2, err := Mount([]plugin.Instance{{Name: "jaeger", Options: map[string]interface{}{"token": []string{"token"}}}}, nil)
+	router2, err := Mount([]plugin.Instance{{Name: "jaeger", Options: map[string]any{"token": []string{"token"}}}}, nil)
 	require.Error(t, err)
 	require.Nil(t, router2)
 }

--- a/plugins/plugin-kiali/cmd/kiali_test.go
+++ b/plugins/plugin-kiali/cmd/kiali_test.go
@@ -26,11 +26,11 @@ func TestGetInstance(t *testing.T) {
 }
 
 func TestMount(t *testing.T) {
-	router1, err := Mount([]plugin.Instance{{Name: "kiali", Options: map[string]interface{}{}}}, nil)
+	router1, err := Mount([]plugin.Instance{{Name: "kiali", Options: map[string]any{}}}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, router1)
 
-	router2, err := Mount([]plugin.Instance{{Name: "kiali", Options: map[string]interface{}{"token": []string{"token"}}}}, nil)
+	router2, err := Mount([]plugin.Instance{{Name: "kiali", Options: map[string]any{"token": []string{"token"}}}}, nil)
 	require.Error(t, err)
 	require.Nil(t, router2)
 }

--- a/plugins/plugin-kiali/pkg/instance/instance.go
+++ b/plugins/plugin-kiali/pkg/instance/instance.go
@@ -26,7 +26,7 @@ type Instance interface {
 	GetName() string
 	GetNamespaces(ctx context.Context) ([]models.Namespace, error)
 	GetGraph(ctx context.Context, duration int64, graphType, groupBy string, injectServiceNodes bool, appenders, namespaces []string) (*Graph, error)
-	GetMetrics(ctx context.Context, url string) (*map[string]interface{}, error)
+	GetMetrics(ctx context.Context, url string) (*map[string]any, error)
 }
 
 type instance struct {
@@ -153,8 +153,8 @@ func (i *instance) GetGraph(ctx context.Context, duration int64, graphType, grou
 }
 
 // GetMetrics returns the metrics for an edge or node in the Kiali topology graph.
-func (i *instance) GetMetrics(ctx context.Context, url string) (*map[string]interface{}, error) {
-	metrics, err := doRequest[map[string]interface{}](ctx, i.client, i.address+url)
+func (i *instance) GetMetrics(ctx context.Context, url string) (*map[string]any, error) {
+	metrics, err := doRequest[map[string]any](ctx, i.client, i.address+url)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func (i *instance) GetMetrics(ctx context.Context, url string) (*map[string]inte
 }
 
 // New returns a new Kiali instance for the given configuration.
-func New(name string, options map[string]interface{}) (Instance, error) {
+func New(name string, options map[string]any) (Instance, error) {
 	var config Config
 	err := mapstructure.Decode(options, &config)
 	if err != nil {

--- a/plugins/plugin-klogs/cmd/klogs.go
+++ b/plugins/plugin-klogs/cmd/klogs.go
@@ -138,11 +138,11 @@ func (router *Router) getLogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := struct {
-		Documents []map[string]interface{} `json:"documents"`
-		Fields    []string                 `json:"fields"`
-		Count     int64                    `json:"count"`
-		Took      int64                    `json:"took"`
-		Buckets   []instance.Bucket        `json:"buckets"`
+		Documents []map[string]any  `json:"documents"`
+		Fields    []string          `json:"fields"`
+		Count     int64             `json:"count"`
+		Took      int64             `json:"took"`
+		Buckets   []instance.Bucket `json:"buckets"`
 	}{
 		documents,
 		fields,
@@ -209,8 +209,8 @@ func (router *Router) getAggregation(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := struct {
-		Rows    []map[string]interface{} `json:"rows"`
-		Columns []string                 `json:"columns"`
+		Rows    []map[string]any `json:"rows"`
+		Columns []string         `json:"columns"`
 	}{
 		rows,
 		columns,

--- a/plugins/plugin-klogs/cmd/klogs_test.go
+++ b/plugins/plugin-klogs/cmd/klogs_test.go
@@ -26,11 +26,11 @@ func TestGetInstance(t *testing.T) {
 }
 
 func TestMount(t *testing.T) {
-	router1, err := Mount([]plugin.Instance{{Name: "klogs", Options: map[string]interface{}{}}}, nil)
+	router1, err := Mount([]plugin.Instance{{Name: "klogs", Options: map[string]any{}}}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, router1)
 
-	router2, err := Mount([]plugin.Instance{{Name: "klogs", Options: map[string]interface{}{"username": []string{"token"}}}}, nil)
+	router2, err := Mount([]plugin.Instance{{Name: "klogs", Options: map[string]any{"username": []string{"token"}}}}, nil)
 	require.Error(t, err)
 	require.Nil(t, router2)
 }

--- a/plugins/plugin-klogs/pkg/instance/aggregation.go
+++ b/plugins/plugin-klogs/pkg/instance/aggregation.go
@@ -273,7 +273,7 @@ func buildAggregationQuery(chart string, options AggregationOptions, materialize
 // GetAggregation returns the data for the given aggregation. To get the data we have to build the aggregation query.
 // Then we can reuse the parseLogsQuery function from getting the logs, to build the WHERE statement. Finally we are
 // running the query and parsing all rows into a map with the column names as keys and the value of each row.
-func (i *instance) GetAggregation(ctx context.Context, aggregation Aggregation) ([]map[string]interface{}, []string, error) {
+func (i *instance) GetAggregation(ctx context.Context, aggregation Aggregation) ([]map[string]any, []string, error) {
 	log.Debug(ctx, "Aggregation data", zap.String("aggregation", fmt.Sprintf("%#v", aggregation)))
 
 	// Build the SELECT, GROUP BY, ORDER BY and LIMIT statement for the SQL query. When the function returns an error
@@ -320,11 +320,11 @@ func (i *instance) GetAggregation(ctx context.Context, aggregation Aggregation) 
 		return nil, nil, err
 	}
 
-	var result []map[string]interface{}
+	var result []map[string]any
 
 	for rows.Next() {
-		values := make([]interface{}, len(columns))
-		pointers := make([]interface{}, len(columns))
+		values := make([]any, len(columns))
+		pointers := make([]any, len(columns))
 
 		for i := range values {
 			pointers[i] = &values[i]
@@ -336,7 +336,7 @@ func (i *instance) GetAggregation(ctx context.Context, aggregation Aggregation) 
 
 		// When we assign the correct value to an row, we also have to check if the returned value is of type float and
 		// if the value is NaN or Inf, because then the json encoding would fail if we add the value.
-		resultMap := make(map[string]interface{})
+		resultMap := make(map[string]any)
 		for i, val := range values {
 			switch v := val.(type) {
 			case float64:

--- a/plugins/plugin-opsgenie/cmd/opsgenie_test.go
+++ b/plugins/plugin-opsgenie/cmd/opsgenie_test.go
@@ -804,7 +804,7 @@ func TestMount(t *testing.T) {
 		{
 			Name:        "opsgenie",
 			Description: "On-call and alert management to keep services always on.",
-			Options: map[string]interface{}{
+			Options: map[string]any{
 				"apiKey": "test",
 				"apiUrl": "api.eu.opsgenie.com",
 			},
@@ -817,7 +817,7 @@ func TestMount(t *testing.T) {
 		{
 			Name:        "opsgenie",
 			Description: "On-call and alert management to keep services always on.",
-			Options: map[string]interface{}{
+			Options: map[string]any{
 				"apiKey": "",
 				"apiUrl": "api.eu.opsgenie.com",
 			},

--- a/plugins/plugin-opsgenie/pkg/instance/instance.go
+++ b/plugins/plugin-opsgenie/pkg/instance/instance.go
@@ -213,7 +213,7 @@ func (i *instance) CloseIncident(ctx context.Context, id, user string) error {
 }
 
 // New returns a new Elasticsearch instance for the given configuration.
-func New(name string, options map[string]interface{}) (Instance, error) {
+func New(name string, options map[string]any) (Instance, error) {
 	var config Config
 	err := mapstructure.Decode(options, &config)
 	if err != nil {

--- a/plugins/plugin-prometheus/pkg/instance/instance.go
+++ b/plugins/plugin-prometheus/pkg/instance/instance.go
@@ -296,7 +296,7 @@ func (i *instance) GetLabelValues(ctx context.Context, searchTerm string) ([]str
 }
 
 // New returns a new Prometheus instance for the given configuration.
-func New(name string, options map[string]interface{}) (Instance, error) {
+func New(name string, options map[string]any) (Instance, error) {
 	var config Config
 	err := mapstructure.Decode(options, &config)
 	if err != nil {

--- a/plugins/plugin-sonarqube/pkg/instance/instance.go
+++ b/plugins/plugin-sonarqube/pkg/instance/instance.go
@@ -65,7 +65,7 @@ func (i *instance) GetProjectMeasures(ctx context.Context, project string, metri
 }
 
 // New returns a new Elasticsearch instance for the given configuration.
-func New(name string, options map[string]interface{}) (Instance, error) {
+func New(name string, options map[string]any) (Instance, error) {
 	var config Config
 	err := mapstructure.Decode(options, &config)
 	if err != nil {

--- a/plugins/plugin-sql/cmd/sql.go
+++ b/plugins/plugin-sql/cmd/sql.go
@@ -62,8 +62,8 @@ func (router *Router) getQueryResults(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := struct {
-		Rows    []map[string]interface{} `json:"rows"`
-		Columns []string                 `json:"columns"`
+		Rows    []map[string]any `json:"rows"`
+		Columns []string         `json:"columns"`
 	}{
 		rows,
 		columns,

--- a/plugins/plugin-sql/cmd/sql_test.go
+++ b/plugins/plugin-sql/cmd/sql_test.go
@@ -26,11 +26,11 @@ func TestGetInstance(t *testing.T) {
 }
 
 func TestMount(t *testing.T) {
-	router1, err := Mount([]plugin.Instance{{Name: "sql", Options: map[string]interface{}{"driver": "mysql"}}}, nil)
+	router1, err := Mount([]plugin.Instance{{Name: "sql", Options: map[string]any{"driver": "mysql"}}}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, router1)
 
-	router2, err := Mount([]plugin.Instance{{Name: "sql", Options: map[string]interface{}{"driver": "bigquery"}}}, nil)
+	router2, err := Mount([]plugin.Instance{{Name: "sql", Options: map[string]any{"driver": "bigquery"}}}, nil)
 	require.Error(t, err)
 	require.Nil(t, router2)
 }

--- a/plugins/plugin-sql/pkg/instance/instance.go
+++ b/plugins/plugin-sql/pkg/instance/instance.go
@@ -20,7 +20,7 @@ type Config struct {
 
 type Instance interface {
 	GetName() string
-	GetQueryResults(ctx context.Context, query string) ([]map[string]interface{}, []string, error)
+	GetQueryResults(ctx context.Context, query string) ([]map[string]any, []string, error)
 }
 
 type instance struct {
@@ -33,7 +33,7 @@ func (i *instance) GetName() string {
 }
 
 // GetQueryResults returns all rows for the user provided SQL query.
-func (i *instance) GetQueryResults(ctx context.Context, query string) ([]map[string]interface{}, []string, error) {
+func (i *instance) GetQueryResults(ctx context.Context, query string) ([]map[string]any, []string, error) {
 	rows, err := i.client.QueryContext(ctx, query)
 	if err != nil {
 		return nil, nil, err
@@ -45,11 +45,11 @@ func (i *instance) GetQueryResults(ctx context.Context, query string) ([]map[str
 		return nil, nil, err
 	}
 
-	var result []map[string]interface{}
+	var result []map[string]any
 
 	for rows.Next() {
-		values := make([]interface{}, len(columns))
-		pointers := make([]interface{}, len(columns))
+		values := make([]any, len(columns))
+		pointers := make([]any, len(columns))
 
 		for i := range values {
 			pointers[i] = &values[i]
@@ -61,7 +61,7 @@ func (i *instance) GetQueryResults(ctx context.Context, query string) ([]map[str
 
 		// When we assign the correct value to an row, we also have to check if the returned value is of type float and
 		// if the value is NaN or Inf, because then the json encoding would fail if we add the value.
-		resultMap := make(map[string]interface{})
+		resultMap := make(map[string]any)
 		for i, val := range values {
 			switch v := val.(type) {
 			case float64:
@@ -84,7 +84,7 @@ func (i *instance) GetQueryResults(ctx context.Context, query string) ([]map[str
 }
 
 // New returns a new Elasticsearch instance for the given configuration.
-func New(name string, options map[string]interface{}) (Instance, error) {
+func New(name string, options map[string]any) (Instance, error) {
 	var config Config
 	err := mapstructure.Decode(options, &config)
 	if err != nil {

--- a/plugins/plugin-techdocs/cmd/techdocs_test.go
+++ b/plugins/plugin-techdocs/cmd/techdocs_test.go
@@ -26,11 +26,11 @@ func TestGetInstance(t *testing.T) {
 }
 
 func TestMount(t *testing.T) {
-	router1, err := Mount([]plugin.Instance{{Name: "techdocs", Options: map[string]interface{}{"provider": map[string]interface{}{"type": "local"}}}}, nil)
+	router1, err := Mount([]plugin.Instance{{Name: "techdocs", Options: map[string]any{"provider": map[string]any{"type": "local"}}}}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, router1)
 
-	router2, err := Mount([]plugin.Instance{{Name: "techdocs", Options: map[string]interface{}{"provider": map[string]interface{}{"type": "fake"}}}}, nil)
+	router2, err := Mount([]plugin.Instance{{Name: "techdocs", Options: map[string]any{"provider": map[string]any{"type": "fake"}}}}, nil)
 	require.Error(t, err)
 	require.Nil(t, router2)
 }

--- a/plugins/plugin-techdocs/pkg/instance/instance.go
+++ b/plugins/plugin-techdocs/pkg/instance/instance.go
@@ -63,7 +63,7 @@ func (i *instance) GetFile(ctx context.Context, service, path string) ([]byte, e
 }
 
 // New returns a new TechDocs instance for the given configuration.
-func New(name string, options map[string]interface{}) (Instance, error) {
+func New(name string, options map[string]any) (Instance, error) {
 	var config Config
 	err := mapstructure.Decode(options, &config)
 	if err != nil {

--- a/plugins/plugin-techdocs/pkg/shared/shared.go
+++ b/plugins/plugin-techdocs/pkg/shared/shared.go
@@ -14,11 +14,11 @@ var (
 
 // Index is the structure of the index file required in the root directory for each TechDoc.
 type Index struct {
-	Key         string                   `json:"key"`
-	Name        string                   `json:"name"`
-	Description string                   `json:"description"`
-	Home        string                   `json:"home"`
-	TOC         []map[string]interface{} `json:"toc"`
+	Key         string           `json:"key"`
+	Name        string           `json:"name"`
+	Description string           `json:"description"`
+	Home        string           `json:"home"`
+	TOC         []map[string]any `json:"toc"`
 }
 
 // Markdown is the structure for returning a markdown file.


### PR DESCRIPTION
We decided to replace "interface{}" with "any". This was done using the
following command: "gofmt -w -r 'interface{} -> any' ."

We did not replace "interface{}" with "any" for all generated code, this
means the created mocks still use "interface{}" and the created Go
clients for our Custom Resource Definitions are also unsing "interface{}".

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
