### PR TITLE
[app] Fix tooltip in charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 ### Fixed
 
 - [#382](https://github.com/kobsio/kobs/pull/#382): [app] Remove ServiceWorker.
+- [#383](https://github.com/kobsio/kobs/pull/#383): [app] Fix tooltip in charts.
 
 ### Changed
 

--- a/plugins/app/package.json
+++ b/plugins/app/package.json
@@ -7,7 +7,6 @@
     "@kobsio/react-scripts": "5.0.1-1",
     "@kubernetes/client-node": "^0.17.0",
     "@nivo/bar": "^0.79.1",
-    "@nivo/core": "^0.79.0",
     "@patternfly/patternfly": "^4.194.4",
     "@patternfly/react-core": "^4.214.1",
     "@patternfly/react-icons": "^4.65.1",

--- a/plugins/plugin-azure/package.json
+++ b/plugins/plugin-azure/package.json
@@ -8,7 +8,6 @@
     "@azure/arm-containerinstance": "^8.1.0",
     "@azure/arm-containerservice": "^16.1.0",
     "@kobsio/react-scripts": "5.0.1-1",
-    "@nivo/core": "^0.79.0",
     "@nivo/line": "^0.79.1",
     "@nivo/pie": "^0.79.1",
     "@patternfly/patternfly": "^4.194.4",

--- a/plugins/plugin-istio/package.json
+++ b/plugins/plugin-istio/package.json
@@ -5,7 +5,6 @@
   "private": true,
   "dependencies": {
     "@kobsio/react-scripts": "5.0.1-1",
-    "@nivo/core": "^0.79.0",
     "@nivo/line": "^0.79.1",
     "@nivo/scales": "^0.79.0",
     "@patternfly/patternfly": "^4.194.4",

--- a/plugins/plugin-kiali/package.json
+++ b/plugins/plugin-kiali/package.json
@@ -5,7 +5,6 @@
   "private": true,
   "dependencies": {
     "@kobsio/react-scripts": "5.0.1-1",
-    "@nivo/core": "^0.79.0",
     "@nivo/line": "^0.79.1",
     "@patternfly/patternfly": "^4.194.4",
     "@patternfly/react-core": "^4.214.1",

--- a/plugins/plugin-klogs/package.json
+++ b/plugins/plugin-klogs/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "@kobsio/react-scripts": "5.0.1-1",
     "@nivo/bar": "^0.79.1",
-    "@nivo/core": "^0.79.0",
     "@nivo/line": "^0.79.1",
     "@nivo/pie": "^0.79.1",
     "@patternfly/patternfly": "^4.194.4",

--- a/plugins/plugin-prometheus/package.json
+++ b/plugins/plugin-prometheus/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "@kobsio/react-scripts": "5.0.1-1",
     "@nivo/bar": "^0.79.1",
-    "@nivo/core": "^0.79.0",
     "@nivo/line": "^0.79.1",
     "@patternfly/patternfly": "^4.194.4",
     "@patternfly/react-core": "^4.214.1",

--- a/plugins/plugin-sql/package.json
+++ b/plugins/plugin-sql/package.json
@@ -5,7 +5,6 @@
   "private": true,
   "dependencies": {
     "@kobsio/react-scripts": "5.0.1-1",
-    "@nivo/core": "^0.79.0",
     "@nivo/line": "^0.79.1",
     "@nivo/pie": "^0.79.1",
     "@patternfly/patternfly": "^4.194.4",

--- a/plugins/shared/src/components/chart/ChartTooltip.tsx
+++ b/plugins/shared/src/components/chart/ChartTooltip.tsx
@@ -22,25 +22,26 @@ export const ChartTooltip: React.FunctionComponent<IChartTooltipProps> = ({
 
   return (
     <TooltipWrapper anchor={anchorDefault} position={positionDefault}>
-      <div
-        style={{
-          background: '#151515',
-          color: '#f0f0f0',
-          fontFamily: '"RedHatText", "Overpass", overpass, helvetica, arial, sans-serif',
-          fontSize: '14px',
-          // maxWidth: '50vw',
-          // minWidth: '50vw',
-          padding: '8px',
-          whiteSpace: 'nowrap',
-        }}
-      >
-        {title && (
-          <div>
-            <b>{title}</b>
+      <div style={{ minWidth: '25vw' }}>
+        <div
+          style={{
+            background: '#151515',
+            color: '#f0f0f0',
+            fontFamily: '"RedHatText", "Overpass", overpass, helvetica, arial, sans-serif',
+            fontSize: '14px',
+            padding: '8px',
+            whiteSpace: 'nowrap',
+            width: 'fit-content',
+          }}
+        >
+          {title && (
+            <div>
+              <b>{title}</b>
+            </div>
+          )}
+          <div className="pf-u-text-break-word pf-u-text-wrap">
+            <SquareIcon color={color} /> {label}
           </div>
-        )}
-        <div className="pf-u-text-break-word pf-u-text-wrap">
-          <SquareIcon color={color} /> {label}
         </div>
       </div>
     </TooltipWrapper>


### PR DESCRIPTION
The tooltip in charts was not working. The bug was reproducable in the
Azure, Istio, Kiali, klogs, Prometheus and SQL plugin. To fix it we had
to remove the "@nivo/core" dependencie from the package.json file.

We also imrpoved the layout of the tooltip, to look better at different
label sizes.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
