### PR TITLE
[app] Improve instrumentation middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 - [#388](https://github.com/kobsio/kobs/pull/#388): [app] Customize navigation sidebar.
 - [#389](https://github.com/kobsio/kobs/pull/#389): [app] Add notifications. In the first step notifications are only supported by the Opsgenie plugin.
+- [#390](https://github.com/kobsio/kobs/pull/#390): [app] Improve instrumentation middleware.
 
 ### Fixed
 

--- a/pkg/hub/hub.go
+++ b/pkg/hub/hub.go
@@ -21,8 +21,8 @@ import (
 	"github.com/kobsio/kobs/pkg/log"
 	"github.com/kobsio/kobs/pkg/middleware/debug"
 	"github.com/kobsio/kobs/pkg/middleware/httplog"
+	"github.com/kobsio/kobs/pkg/middleware/httpmetrics"
 	"github.com/kobsio/kobs/pkg/middleware/httptracer"
-	"github.com/kobsio/kobs/pkg/middleware/metrics"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -93,8 +93,8 @@ func New(config api.Config, debugUsername, debugPassword, hubAddress string, aut
 		r.Use(middleware.URLFormat)
 		r.Use(userauth.Handler(authEnabled, authHeaderUser, authHeaderTeams, authSessionToken, authSessionInterval, storeClient))
 		r.Use(httptracer.Handler("hub"))
-		r.Use(metrics.Metrics)
-		r.Use(httplog.Logger)
+		r.Use(httpmetrics.Handler)
+		r.Use(httplog.Handler)
 		r.Use(render.SetContentType(render.ContentTypeJSON))
 
 		r.Mount("/auth", userauth.Mount(authLogoutRedirect))

--- a/pkg/middleware/httpmetrics/httpmetrics.go
+++ b/pkg/middleware/httpmetrics/httpmetrics.go
@@ -1,4 +1,4 @@
-package metrics
+package httpmetrics
 
 import (
 	"net/http"
@@ -27,8 +27,8 @@ var (
 	}, []string{"response_code", "request_method", "request_path"})
 )
 
-// Metrics is a middleware that handles the Prometheus metrics for kobs and chi.
-func Metrics(next http.Handler) http.Handler {
+// Handler is a middleware that handles the Prometheus metrics for kobs and chi.
+func Handler(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		wrw := middleware.NewWrapResponseWriter(w, r.ProtoMajor)

--- a/pkg/middleware/httptracer/httptracer.go
+++ b/pkg/middleware/httptracer/httptracer.go
@@ -3,6 +3,7 @@ package httptracer
 import (
 	"fmt"
 	"net/http"
+	"runtime/debug"
 	"strings"
 
 	authContext "github.com/kobsio/kobs/pkg/hub/middleware/userauth/context"
@@ -43,30 +44,49 @@ func (tw traceware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx, span := tw.tracer.Start(ctx, "http.request", oteltrace.WithSpanKind(oteltrace.SpanKindServer))
 	defer span.End()
 
+	defer func() {
+		// In go-chi/chi, full route pattern could only be extracted once the request is executed
+		// See: https://github.com/go-chi/chi/issues/150#issuecomment-278850733
+		routeStr := strings.Join(chi.RouteContext(r.Context()).RoutePatterns, "")
+		span.SetAttributes(semconv.HTTPServerAttributesFromHTTPRequest(tw.serverName, routeStr, r)...)
+		span.SetAttributes(semconv.NetAttributesFromHTTPRequest("tcp", r)...)
+		span.SetAttributes(semconv.EndUserAttributesFromHTTPRequest(r)...)
+		span.SetAttributes(otelhttp.ReadBytesKey.Int64(r.ContentLength))
+
+		if requestID := middleware.GetReqID(ctx); requestID != "" {
+			span.SetAttributes(attribute.Key("request.id").String(requestID))
+		}
+
+		if user, _ := authContext.GetUser(ctx); user != nil {
+			span.SetAttributes(attribute.Key("user.email").String(user.Email))
+		}
+
+		span.SetName(fmt.Sprintf("%s:%s", r.Method, routeStr))
+
+		if err := recover(); err != nil {
+			span.SetAttributes(semconv.HTTPAttributesFromHTTPStatusCode(500)...)
+			span.SetStatus(semconv.SpanStatusFromHTTPStatusCode(500))
+			span.AddEvent("panic", oteltrace.WithAttributes(
+				attribute.String("kind", "panic"),
+				attribute.String("message", fmt.Sprintf("%v", err)),
+				attribute.String("stack", string(debug.Stack())),
+			))
+			span.End()
+
+			panic(err)
+		}
+	}()
+
 	r = r.WithContext(ctx)
 	wrw := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 	tw.handler.ServeHTTP(wrw, r)
 
-	// In go-chi/chi, full route pattern could only be extracted once the request is executed
-	// See: https://github.com/go-chi/chi/issues/150#issuecomment-278850733
-	routeStr := strings.Join(chi.RouteContext(r.Context()).RoutePatterns, "")
-	attrs := semconv.HTTPAttributesFromHTTPStatusCode(wrw.Status())
-	attrs = append(attrs, semconv.NetAttributesFromHTTPRequest("tcp", r)...)
-	attrs = append(attrs, semconv.EndUserAttributesFromHTTPRequest(r)...)
-	attrs = append(attrs, semconv.HTTPServerAttributesFromHTTPRequest(tw.serverName, routeStr, r)...)
-	attrs = append(attrs, otelhttp.WroteBytesKey.Int(wrw.BytesWritten()))
-	attrs = append(attrs, otelhttp.ReadBytesKey.Int64(r.ContentLength))
-
-	if requestID := middleware.GetReqID(ctx); requestID != "" {
-		attrs = append(attrs, attribute.Key("request.id").String(requestID))
-	}
-	if user, _ := authContext.GetUser(ctx); user != nil {
-		attrs = append(attrs, attribute.Key("user.email").String(user.Email))
+	status := wrw.Status()
+	if status == 0 {
+		status = http.StatusOK
 	}
 
-	span.SetAttributes(attrs...)
-	span.SetName(fmt.Sprintf("%s:%s", r.Method, routeStr))
-
-	spanStatus, spanMessage := semconv.SpanStatusFromHTTPStatusCode(wrw.Status())
-	span.SetStatus(spanStatus, spanMessage)
+	span.SetAttributes(otelhttp.WroteBytesKey.Int(wrw.BytesWritten()))
+	span.SetAttributes(semconv.HTTPAttributesFromHTTPStatusCode(status)...)
+	span.SetStatus(semconv.SpanStatusFromHTTPStatusCode(status))
 }

--- a/pkg/satellite/satellite.go
+++ b/pkg/satellite/satellite.go
@@ -9,8 +9,8 @@ import (
 	"github.com/kobsio/kobs/pkg/log"
 	"github.com/kobsio/kobs/pkg/middleware/debug"
 	"github.com/kobsio/kobs/pkg/middleware/httplog"
+	"github.com/kobsio/kobs/pkg/middleware/httpmetrics"
 	"github.com/kobsio/kobs/pkg/middleware/httptracer"
-	"github.com/kobsio/kobs/pkg/middleware/metrics"
 	"github.com/kobsio/kobs/pkg/satellite/api"
 	"github.com/kobsio/kobs/pkg/satellite/api/applications"
 	apiClusters "github.com/kobsio/kobs/pkg/satellite/api/clusters"
@@ -93,8 +93,8 @@ func New(debugUsername, debugPassword, satelliteAddress, satelliteToken string, 
 		r.Use(tokenauth.Handler(satelliteToken))
 		r.Use(user.Handler())
 		r.Use(httptracer.Handler("satellite"))
-		r.Use(metrics.Metrics)
-		r.Use(httplog.Logger)
+		r.Use(httpmetrics.Handler)
+		r.Use(httplog.Handler)
 		r.Use(render.SetContentType(render.ContentTypeJSON))
 
 		r.Mount("/clusters", apiClusters.Mount(apiConfig.Clusters, clustersClient))

--- a/plugins/app/src/assets/index.css
+++ b/plugins/app/src/assets/index.css
@@ -16,3 +16,16 @@ html, body, #root {
 .kobsio-hide-scrollbar::-webkit-scrollbar {
   display: none;
 }
+
+/* .pf-c-drawer > .pf-c-drawer__main > .pf-c-drawer__content > .pf-c-drawer__body
+ * This is a hack to get the drawer component inside the PageSectionComponent from the @kobsio/shared package working.
+ * When we are using the notification drawer component the drawer inside the PageSectionComponent doesn't use the full
+ * height anymore. With the following snippet this is fixed and the drawer is using the full height again.
+ * See also https://github.com/patternfly/patternfly-react/issues/7423 */
+.pf-c-drawer > .pf-c-drawer__main > .pf-c-drawer__content > .pf-c-drawer__body {
+  display: flex;
+  flex-direction: column;
+  flex-basis: 0%;
+  flex-grow: 1;
+  flex-shrink: 1;
+}


### PR DESCRIPTION
We unified the exported function name across the httpmetrics, httplog
and httptracer middleware. They all export a Handler function which can
be used in the router.

The logging and tracing middleware also catchs panics now to write a log
line / create a span.

Besides that we also fixed a small bug caused by the notification
drawer, introduced in #389. Because of the notification drawer the
drawer in the PageSectionContent component wasn't using it's full height
anymore, which caused problems for the select boxes in the toolbar and
the pages showing graphs via cytoscape. This should be fixed now.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
