### PR TITLE
[app] Display Kubernetes Resources in Notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#389](https://github.com/kobsio/kobs/pull/#389): [app] Add notifications. In the first step notifications are only supported by the Opsgenie plugin.
 - [#390](https://github.com/kobsio/kobs/pull/#390): [app] Improve instrumentation middleware.
 - [#392](https://github.com/kobsio/kobs/pull/#392): [rss] Display RSS feeds within the notifications.
+- [#393](https://github.com/kobsio/kobs/pull/#393): [app] Display Kubernetes Resources within notifications.
 
 ### Fixed
 

--- a/docs/getting-started/configuration/notifications.md
+++ b/docs/getting-started/configuration/notifications.md
@@ -32,6 +32,20 @@ api:
           options:
             urls:
               - https://www.githubstatus.com/history.rss
+      - title: Unhealthy Workloads
+        plugin:
+          name: resources
+          type: app
+          options:
+            satellites:
+              - dev-de1
+            clusters:
+              - dev-de1
+            namespaces:
+              - ""
+            resources:
+              - pods
+            filter: $.status.containerStatuses[?(@.state.waiting || @.state.terminated && @.state.terminated.reason!='Completed')]
 ```
 
 ![Opsgenie](./assets/notifications-opsgenie.png)
@@ -39,6 +53,19 @@ api:
 ## Plugins
 
 Notifications are configured via plugins. To identify a plugin you have to specify the `satellite`, plugin `name` and plugin `type`. The each plugin can be customized using `options`. These options can be found in the following.
+
+### Resources
+
+| Field | Type | Description | Required |
+| ----- | ---- | ----------- | -------- |
+| satellites | []string | A list of satellites for which the resources should be shown. | Yes |
+| clusters | []string | A list of clusters for which the resources should be shown. | Yes |
+| namespaces | []string | A list of namespaces for which the resources should be shown. | Yes |
+| resources | []string | A list of resources for which the resources should be shown. The following strings can be used as resource: `cronjobs`, `daemonsets`, `deployments`, `jobs`, `pods`, `replicasets`, `statefulsets`, `endpoints`, `horizontalpodautoscalers`, `ingresses`, `networkpolicies`, `services`, `configmaps`, `persistentvolumeclaims`, `persistentvolumes`, `poddisruptionbudgets`, `secrets`, `serviceaccounts`, `storageclasses`, `clusterrolebindings`, `clusterroles`, `rolebindings`, `roles`, `events`, `nodes`, `podsecuritypolicies`. A Custom Resource can be used as follows `<name>.<group>/<version>` (e.g. `vaultsecrets.ricoberger.de/v1alpha1`). | Yes |
+| selector | string | A label selector for the resources. | No |
+| columns | [[]Column](#column) | An optional list of columns to customize the shown fields for a resource. | No |
+| filter | string | An optional filter using [JSONPath](https://goessner.net/articles/JsonPath/) to filter the list of resources. | No |
+
 
 ### Opsgenie
 

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -237,6 +237,7 @@ The `resources` plugin can be used to display Kubernetes resources within a dash
 | resources | []string | A list of resources for which the resources should be shown. The following strings can be used as resource: `cronjobs`, `daemonsets`, `deployments`, `jobs`, `pods`, `replicasets`, `statefulsets`, `endpoints`, `horizontalpodautoscalers`, `ingresses`, `networkpolicies`, `services`, `configmaps`, `persistentvolumeclaims`, `persistentvolumes`, `poddisruptionbudgets`, `secrets`, `serviceaccounts`, `storageclasses`, `clusterrolebindings`, `clusterroles`, `rolebindings`, `roles`, `events`, `nodes`, `podsecuritypolicies`. A Custom Resource can be used as follows `<name>.<group>/<version>` (e.g. `vaultsecrets.ricoberger.de/v1alpha1`). | Yes |
 | selector | string | A label selector for the resources. | No |
 | columns | [[]Column](#column) | An optional list of columns to customize the shown fields for a resource. | No |
+| filter | string | An optional filter using [JSONPath](https://goessner.net/articles/JsonPath/) to filter the list of resources. | No |
 
 #### Column
 

--- a/plugins/app/src/components/header/AppNotifications.tsx
+++ b/plugins/app/src/components/header/AppNotifications.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import { ITimes } from '@kobsio/shared';
+import ResourcesNotifications from '../resources/ResourcesNotifications';
+
+interface IAppNotificationsProps {
+  name: string;
+  title: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  options: any;
+  times: ITimes;
+}
+
+const AppNotifications: React.FunctionComponent<IAppNotificationsProps> = ({
+  name,
+  title,
+  options,
+  times,
+}: IAppNotificationsProps) => {
+  if (name === 'resources') {
+    if (options.satellites && options.clusters && options.resources && times) {
+      const clusterIDs: string[] = options.satellites
+        .map((satellite: string) =>
+          options.clusters.map((cluster: string) => `/satellite/${satellite}/cluster/${cluster}`),
+        )
+        .flat();
+
+      return (
+        <ResourcesNotifications
+          title={title}
+          options={{
+            clusterIDs: clusterIDs,
+            columns: options.columns,
+            filter: options.filter,
+            namespaces: options.namespaces || [],
+            param: options.selector || '',
+            paramName: options.selectorType === 'fieldSelector' ? 'fieldSelector' : 'labelSelector',
+            resourceIDs: options.resources || [],
+            times: times,
+          }}
+        />
+      );
+    }
+  }
+
+  return <div></div>;
+};
+
+export default AppNotifications;

--- a/plugins/app/src/components/header/NotificationsGroup.tsx
+++ b/plugins/app/src/components/header/NotificationsGroup.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 
 import { IPluginsContext, PluginsContext } from '../../context/PluginsContext';
+import AppNotifications from './AppNotifications';
 import { IGroup } from '../../context/NotificationsContext';
 import { ITimes } from '@kobsio/shared';
 import Module from '../module/Module';
@@ -17,6 +18,12 @@ const NotificationsGroup: React.FunctionComponent<INotificationsGroupProps> = ({
   const pluginsContext = useContext<IPluginsContext>(PluginsContext);
   const instance = pluginsContext.getInstance(group.plugin.satellite, group.plugin.type, group.plugin.name);
 
+  if (!instance || group.plugin.type === 'app') {
+    return (
+      <AppNotifications name={group.plugin.name} title={group.title} options={group.plugin.options} times={times} />
+    );
+  }
+
   const loadingContent = (): React.ReactElement => {
     return <div></div>;
   };
@@ -24,10 +31,6 @@ const NotificationsGroup: React.FunctionComponent<INotificationsGroupProps> = ({
   const errorContent = (props: { title: string; children: React.ReactElement }): React.ReactElement => {
     return <div></div>;
   };
-
-  if (!instance) {
-    return <div></div>;
-  }
 
   return (
     <Module

--- a/plugins/app/src/components/resources/ResourcesNotifications.tsx
+++ b/plugins/app/src/components/resources/ResourcesNotifications.tsx
@@ -1,0 +1,101 @@
+import { NotificationDrawerGroup, NotificationDrawerList } from '@patternfly/react-core';
+import React, { useState } from 'react';
+import { useQuery } from 'react-query';
+
+import { IOptions, IResourceResponse } from './utils/interfaces';
+import { customResourceDefinitionTableData, resourcesTableData } from './utils/tabledata';
+import ResourcesNotificationsGroup from './ResourcesNotificationsGroup';
+
+const getCount = (data: IResourceResponse[], filter: string | undefined): number => {
+  let sum = 0;
+
+  for (const resourceResponse of data) {
+    if (
+      resourceResponse.resourceLists.filter(
+        (resourceList) => resourceList.list && resourceList.list.items && resourceList.list.items.length > 0,
+      ).length > 0
+    ) {
+      const tableData =
+        resourceResponse.resource.id in resourcesTableData
+          ? resourcesTableData[resourceResponse.resource.id]
+          : customResourceDefinitionTableData(resourceResponse.resource);
+      sum = sum + tableData.rows(resourceResponse, undefined, filter).length;
+    }
+  }
+
+  return sum;
+};
+
+interface IResourcesNotificationsProps {
+  title: string;
+  options: IOptions;
+}
+
+const ResourcesNotifications: React.FunctionComponent<IResourcesNotificationsProps> = ({
+  title,
+  options,
+}: IResourcesNotificationsProps) => {
+  const [isExpanded, setIsExpanded] = useState<boolean>(false);
+
+  const { data } = useQuery<IResourceResponse[], Error>(['app/resources/resources/_', options], async () => {
+    const c = options.clusterIDs.map((clusterID) => `&clusterID=${encodeURIComponent(clusterID)}`);
+    const n = options.clusterIDs
+      .map((clusterID) =>
+        options.namespaces.map(
+          (namespace) => `&namespaceID=${encodeURIComponent(`${clusterID}/namespace/${namespace}`)}`,
+        ),
+      )
+      .flat();
+    const r = options.resourceIDs.map((resourceID) => `&resourceID=${encodeURIComponent(resourceID)}`);
+
+    const response = await fetch(
+      `/api/resources/_?paramName=${options.paramName}&param=${options.param}${c.length > 0 ? c.join('') : ''}${
+        n.length > 0 ? n.join('') : ''
+      }${r.length > 0 ? r.join('') : ''}`,
+      {
+        method: 'get',
+      },
+    );
+    const json = await response.json();
+
+    if (response.status >= 200 && response.status < 300) {
+      return json;
+    } else {
+      if (json.error) {
+        throw new Error(json.error);
+      } else {
+        throw new Error('An unknown error occured');
+      }
+    }
+  });
+
+  if (!data || data.length === 0) {
+    return (
+      <NotificationDrawerGroup title={title} isExpanded={false} count={0}>
+        <NotificationDrawerList isHidden={true} />
+      </NotificationDrawerGroup>
+    );
+  }
+
+  return (
+    <NotificationDrawerGroup
+      title={title}
+      isExpanded={isExpanded}
+      count={getCount(data, options.filter)}
+      onExpand={(): void => setIsExpanded(!isExpanded)}
+    >
+      <NotificationDrawerList isHidden={!isExpanded}>
+        {data.map((resourceResponse) => (
+          <ResourcesNotificationsGroup
+            key={resourceResponse.resource.id}
+            resourceResponse={resourceResponse}
+            columns={options.columns?.filter((column) => column.resource === resourceResponse.resource.id)}
+            filter={options.filter}
+          />
+        ))}
+      </NotificationDrawerList>
+    </NotificationDrawerGroup>
+  );
+};
+
+export default ResourcesNotifications;

--- a/plugins/app/src/components/resources/ResourcesNotificationsGroup.tsx
+++ b/plugins/app/src/components/resources/ResourcesNotificationsGroup.tsx
@@ -1,0 +1,85 @@
+import {
+  Button,
+  ButtonVariant,
+  NotificationDrawerListItem,
+  NotificationDrawerListItemBody,
+  NotificationDrawerListItemHeader,
+} from '@patternfly/react-core';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+import { Link } from 'react-router-dom';
+import React from 'react';
+
+import { IColumn, IResourceResponse } from './utils/interfaces';
+import { customResourceDefinitionTableData, resourcesTableData } from './utils/tabledata';
+
+interface IResourcesNotificationsGroupProps {
+  resourceResponse: IResourceResponse;
+  columns?: IColumn[];
+  filter?: string;
+}
+
+const ResourcesNotificationsGroup: React.FunctionComponent<IResourcesNotificationsGroupProps> = ({
+  resourceResponse,
+  columns,
+  filter,
+}: IResourcesNotificationsGroupProps) => {
+  if (
+    resourceResponse.resourceLists.filter(
+      (resourceList) => resourceList.list && resourceList.list.items && resourceList.list.items.length > 0,
+    ).length === 0
+  ) {
+    return null;
+  }
+
+  const tableData =
+    resourceResponse.resource.id in resourcesTableData
+      ? resourcesTableData[resourceResponse.resource.id]
+      : customResourceDefinitionTableData(resourceResponse.resource);
+
+  return (
+    <React.Fragment>
+      {tableData.rows(resourceResponse, columns, filter).map((row, rowIndex) => (
+        <NotificationDrawerListItem key={rowIndex} variant="info" isRead={false}>
+          <NotificationDrawerListItemHeader
+            variant="info"
+            title={row.namespace ? `${row.namespace}/${row.name}` : row.name}
+          >
+            <Link
+              to={`/resources?clusterID=${encodeURIComponent(`/satellite/${row.satellite}/cluster/${row.cluster}`)}${
+                row.namespace ? `&namespace=${encodeURIComponent(row.namespace)}` : ''
+              }&resourceID=${encodeURIComponent(resourceResponse.resource.id)}&param=metadata.name=${encodeURIComponent(
+                row.name,
+              )}&paramName=fieldSelector`}
+            >
+              <Button variant={ButtonVariant.plain}>
+                <ExternalLinkAltIcon />
+              </Button>
+            </Link>
+          </NotificationDrawerListItemHeader>
+          <NotificationDrawerListItemBody>
+            {columns ? (
+              <React.Fragment>
+                <div>Cluster: {row.cluster}</div>
+                {columns.map((column, columnIndex) => (
+                  <div key={columnIndex}>
+                    {column.title}: {row.cells[columnIndex]}
+                  </div>
+                ))}
+              </React.Fragment>
+            ) : (
+              tableData.columns.map((column, columnIndex) =>
+                column && column !== 'Name' && column !== 'Namespace' ? (
+                  <div key={columnIndex}>
+                    {column}: {row.cells[columnIndex]}
+                  </div>
+                ) : null,
+              )
+            )}
+          </NotificationDrawerListItemBody>
+        </NotificationDrawerListItem>
+      ))}
+    </React.Fragment>
+  );
+};
+
+export default ResourcesNotificationsGroup;

--- a/plugins/app/src/components/resources/ResourcesPanel.tsx
+++ b/plugins/app/src/components/resources/ResourcesPanel.tsx
@@ -137,6 +137,7 @@ const ResourcesPanel: React.FunctionComponent<IResourcesPanelProps> = ({
           <ResourcesPanelTable
             resourceResponse={resourceResponse}
             columns={options.columns?.filter((column) => column.resource === resourceResponse.resource.id)}
+            filter={options.filter}
             selectedRow={state.selectedRow}
             selectRow={
               setDetails

--- a/plugins/app/src/components/resources/ResourcesPanelTable.tsx
+++ b/plugins/app/src/components/resources/ResourcesPanelTable.tsx
@@ -10,6 +10,7 @@ import { IResource } from '../../resources/clusters';
 interface IResourcesPanelTableProps {
   resourceResponse: IResourceResponse;
   columns?: IColumn[];
+  filter?: string;
   selectedRow: number;
   selectRow?: (rowIndex: number, resource: IResource, resourceData: IResourceRow) => void;
 }
@@ -17,6 +18,7 @@ interface IResourcesPanelTableProps {
 const ResourcesPanelTable: React.FunctionComponent<IResourcesPanelTableProps> = ({
   resourceResponse,
   columns,
+  filter,
   selectedRow,
   selectRow,
 }: IResourcesPanelTableProps) => {
@@ -74,7 +76,7 @@ const ResourcesPanelTable: React.FunctionComponent<IResourcesPanelTableProps> = 
             </Td>
           </Tr>
         ) : (
-          tableData.rows(resourceResponse, columns).map((row, rowIndex) => (
+          tableData.rows(resourceResponse, columns, filter).map((row, rowIndex) => (
             <Tr
               key={rowIndex}
               isHoverable={selectRow ? true : false}

--- a/plugins/app/src/components/resources/ResourcesPanelWrapper.tsx
+++ b/plugins/app/src/components/resources/ResourcesPanelWrapper.tsx
@@ -27,6 +27,7 @@ const ResourcesPanelWrapper: React.FunctionComponent<IResourcesPanelWrapperProps
         options={{
           clusterIDs: clusterIDs,
           columns: options.columns,
+          filter: options.filter,
           namespaces: options.namespaces || [],
           param: options.selector || '',
           paramName: options.selectorType === 'fieldSelector' ? 'fieldSelector' : 'labelSelector',

--- a/plugins/app/src/components/resources/utils/interfaces.ts
+++ b/plugins/app/src/components/resources/utils/interfaces.ts
@@ -10,6 +10,7 @@ export interface IOptions {
   param: string;
   paramName: string;
   columns?: IColumn[];
+  filter?: string;
   times: ITimes;
 }
 


### PR DESCRIPTION
It is now possible to display Kubernetes Resources within the
notifications. For this the existing "resources" plugin with type "app"
can be used. It allows the same options as when the plugin is used
within a panel.

We also added a new "filter" option for the resources plugin, which
allows users to filter the retrieved list of resources via JSONPath.
With this new option it is possible to only display unhealthy Pods in
the notifications.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
