### PR TITLE
[app] Fix Permission Handling for Apps and Teams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 ### Added
 
 - [#388](https://github.com/kobsio/kobs/pull/#388): [app] Customize navigation sidebar.
-- [#389](https://github.com/kobsio/kobs/pull/#389): [app] Add notifications. In the first step notifications are only supported by the Opsgenie plugin.
+- [#389](https://github.com/kobsio/kobs/pull/#389): [app] Add notifications. In the first iteration notifications are only supported by the Opsgenie plugin.
 - [#390](https://github.com/kobsio/kobs/pull/#390): [app] Improve instrumentation middleware.
 - [#392](https://github.com/kobsio/kobs/pull/#392): [rss] Display RSS feeds within the notifications.
 - [#393](https://github.com/kobsio/kobs/pull/#393): [app] Display Kubernetes Resources within notifications.
@@ -21,6 +21,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 - [#387](https://github.com/kobsio/kobs/pull/#387): [app] Fix tooltip in charts.
 - [#391](https://github.com/kobsio/kobs/pull/#391): [app] Fix terminal for Kubernetes Pods.
+- [#395](https://github.com/kobsio/kobs/pull/#395): [app] Fix permission handling for applications and teams.
 
 ### Changed
 

--- a/pkg/hub/api/applications/applications.go
+++ b/pkg/hub/api/applications/applications.go
@@ -76,7 +76,7 @@ func (router *Router) getApplications(w http.ResponseWriter, r *http.Request) {
 	}
 
 	parsedAll, _ := strconv.ParseBool(all)
-	if parsedAll == true || (len(user.Permissions.Teams) == 1 && user.Permissions.Teams[0] == "*") {
+	if parsedAll == true {
 		if !user.HasApplicationAccess("", "", "", []string{""}) {
 			log.Warn(ctx, "The user is not authorized to view all applications")
 			span.RecordError(fmt.Errorf("user is not authorized to view all applications"))
@@ -130,7 +130,7 @@ func (router *Router) getApplicationsCount(w http.ResponseWriter, r *http.Reques
 	span.SetAttributes(attribute.Key("external").String(external))
 
 	parsedAll, _ := strconv.ParseBool(all)
-	if parsedAll == true || (len(user.Permissions.Teams) == 1 && user.Permissions.Teams[0] == "*") {
+	if parsedAll == true {
 		if !user.HasApplicationAccess("", "", "", []string{""}) {
 			log.Warn(ctx, "The user is not authorized to view all applications")
 			span.RecordError(fmt.Errorf("user is not authorized to view all applications"))

--- a/pkg/hub/api/applications/topology.go
+++ b/pkg/hub/api/applications/topology.go
@@ -162,7 +162,7 @@ func (router *Router) getApplicationsTopology(w http.ResponseWriter, r *http.Req
 	span.SetAttributes(attribute.Key("external").String(external))
 
 	parsedAll, _ := strconv.ParseBool(all)
-	if parsedAll == true || (len(user.Permissions.Teams) == 1 && user.Permissions.Teams[0] == "*") {
+	if parsedAll == true {
 		if !user.HasApplicationAccess("", "", "", []string{""}) {
 			log.Warn(ctx, "The user is not authorized to view all applications")
 			span.RecordError(fmt.Errorf("user is not authorized to view all applications"))

--- a/pkg/hub/api/teams/teams.go
+++ b/pkg/hub/api/teams/teams.go
@@ -32,7 +32,7 @@ func (router *Router) getTeams(w http.ResponseWriter, r *http.Request) {
 	all := r.URL.Query().Get("all")
 
 	parsedAll, _ := strconv.ParseBool(all)
-	if parsedAll == true || (len(user.Permissions.Teams) == 1 && user.Permissions.Teams[0] == "*") {
+	if parsedAll == true {
 		if !user.HasTeamAccess("*") {
 			log.Warn(r.Context(), "The user is not authorized to view all teams", zap.Error(err))
 			errresponse.Render(w, r, nil, http.StatusForbidden, "You are not allowed to view all teams")


### PR DESCRIPTION
This commit fixes a bug in the permission handling for applications and
teams. Because we not only checked the "all" query parameter in the
corresponding routes, it could happen that we return all applications /
teams, when a user just wants to see his own applications / teams.

We are now just checking if the "all" query parameter is true to set the
teams to "nil". For all other use cases we are directly using the teams
form the authenticated user object.

When authentication is disabled or when no team header is present the
teams for the user are automatically set to "nil" so that the other
checks are not necessary anymore.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
