### PR TITLE
[app] Fix Shutdown Logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#387](https://github.com/kobsio/kobs/pull/#387): [app] Fix tooltip in charts.
 - [#391](https://github.com/kobsio/kobs/pull/#391): [app] Fix terminal for Kubernetes Pods.
 - [#395](https://github.com/kobsio/kobs/pull/#395): [app] Fix permission handling for applications and teams.
+- [#396](https://github.com/kobsio/kobs/pull/#396): [app] Fix shutdown logic.
 
 ### Changed
 

--- a/cmd/kobs/hub/hub.go
+++ b/cmd/kobs/hub/hub.go
@@ -147,11 +147,9 @@ func Command() *cobra.Command {
 			traceProvider, _ := cmd.Flags().GetString("trace.provider")
 			traceAddress, _ := cmd.Flags().GetString("trace.address")
 
-			if traceEnabled {
-				err := tracer.Setup(traceServiceName, traceProvider, traceAddress)
-				if err != nil {
-					log.Fatal(nil, "Could not setup tracing", zap.Error(err), zap.String("provider", traceProvider), zap.String("address", traceAddress))
-				}
+			tracerClient, err := tracer.Setup(traceEnabled, traceServiceName, traceProvider, traceAddress)
+			if err != nil {
+				log.Fatal(nil, "Could not setup tracing", zap.Error(err), zap.String("provider", traceProvider), zap.String("address", traceAddress))
 			}
 
 			// Load the configuration for the satellite from the provided configuration file.
@@ -231,6 +229,10 @@ func Command() *cobra.Command {
 			if hubMode == "default" || hubMode == "server" {
 				appServer.Stop()
 				hubSever.Stop()
+			}
+
+			if tracerClient != nil {
+				tracerClient.Shutdown()
 			}
 
 			log.Info(nil, "Shutdown is done")

--- a/cmd/kobs/satellite/satellite.go
+++ b/cmd/kobs/satellite/satellite.go
@@ -70,11 +70,9 @@ func Command(pluginMounts map[string]plugin.MountFn) *cobra.Command {
 			traceProvider, _ := cmd.Flags().GetString("trace.provider")
 			traceAddress, _ := cmd.Flags().GetString("trace.address")
 
-			if traceEnabled {
-				err := tracer.Setup(traceServiceName, traceProvider, traceAddress)
-				if err != nil {
-					log.Fatal(nil, "Could not setup tracing", zap.Error(err), zap.String("provider", traceProvider), zap.String("address", traceAddress))
-				}
+			tracerClient, err := tracer.Setup(traceEnabled, traceServiceName, traceProvider, traceAddress)
+			if err != nil {
+				log.Fatal(nil, "Could not setup tracing", zap.Error(err), zap.String("provider", traceProvider), zap.String("address", traceAddress))
 			}
 
 			// Load the configuration for the satellite from the provided configuration file.
@@ -123,6 +121,10 @@ func Command(pluginMounts map[string]plugin.MountFn) *cobra.Command {
 
 			metricsServer.Stop()
 			satelliteServer.Stop()
+
+			if tracerClient != nil {
+				tracerClient.Shutdown()
+			}
 
 			log.Info(nil, "Shutdown is done")
 		},

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -44,7 +44,7 @@ func (s *server) Start() {
 func (s *server) Stop() {
 	log.Debug(nil, "Start shutdown of the Application server")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	err := s.server.Shutdown(ctx)

--- a/pkg/hub/hub.go
+++ b/pkg/hub/hub.go
@@ -57,7 +57,7 @@ func (s *server) Start() {
 func (s *server) Stop() {
 	log.Debug(nil, "Start shutdown of the hub server")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	err := s.server.Shutdown(ctx)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -39,7 +39,7 @@ func (s *server) Start() {
 func (s *server) Stop() {
 	log.Debug(nil, "Start shutdown of the metrics server")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	err := s.Shutdown(ctx)

--- a/pkg/satellite/satellite.go
+++ b/pkg/satellite/satellite.go
@@ -56,7 +56,7 @@ func (s *server) Start() {
 func (s *server) Stop() {
 	log.Debug(nil, "Start shutdown of the satellite server")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	err := s.server.Shutdown(ctx)

--- a/pkg/tracer/tracer_test.go
+++ b/pkg/tracer/tracer_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2022, Staffbase GmbH and contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShutdown(t *testing.T) {
+	client, err := Setup(true, "kobs", "jaeger", "http://localhost:14268/api/traces")
+	require.NotNil(t, client)
+	require.NoError(t, err)
+	require.NotPanics(t, client.Shutdown)
+}
+
+func TestSetup(t *testing.T) {
+	t.Run("tracing disabled", func(t *testing.T) {
+		client, err := Setup(false, "", "jaeger", "http://localhost:14268/api/traces")
+		require.Nil(t, client)
+		require.NoError(t, err)
+	})
+
+	t.Run("setup failed", func(t *testing.T) {
+		client, err := Setup(true, "", "jaeger", "http://localhost:14268/api/traces")
+		require.Nil(t, client)
+		require.Error(t, err)
+	})
+
+	t.Run("setup succeeded", func(t *testing.T) {
+		client, err := Setup(true, "kobs", "jaeger", "http://localhost:14268/api/traces")
+		require.NotNil(t, client)
+		require.NoError(t, err)
+	})
+}
+
+func TestNewProvider(t *testing.T) {
+	t.Run("no service name", func(t *testing.T) {
+		tp, err := newProvider("", "jaeger", "http://localhost:14268/api/traces")
+		require.Error(t, err)
+		require.Nil(t, tp)
+	})
+
+	t.Run("no provider url", func(t *testing.T) {
+		tp, err := newProvider("myapp", "jaeger", "")
+		require.Error(t, err)
+		require.Nil(t, tp)
+	})
+
+	t.Run("zipkin provider error", func(t *testing.T) {
+		tp, err := newProvider("myapp", "zipkin", "///threeslashes")
+		require.Error(t, err)
+		require.Nil(t, tp)
+	})
+
+	t.Run("zipkin provider created", func(t *testing.T) {
+		tp, err := newProvider("myapp", "zipkin", "http://localhost:14268/api/traces")
+		require.NoError(t, err)
+		require.NotNil(t, tp)
+	})
+
+	t.Run("jaeger provider created", func(t *testing.T) {
+		tp, err := newProvider("myapp", "jaeger", "http://localhost:14268/api/traces")
+		require.NoError(t, err)
+		require.NotNil(t, tp)
+	})
+}


### PR DESCRIPTION
We forgot to shutdown the created tracer provider. This is now
implemented, by returning a client in the tracer setup. This client
exposes a Shutdown method which can be used to gracefully shutdown the
tracer provider.

We also fixed the context timeouts for all http server, so that the hub,
satellite and app server are having a timeout of 30 seconds and the
metrics server has a timeout of 10 seconds as it is also used for the
tracer client.

This way we always stay within the 90 seconds timeout, which was
configured at the Kubernetes deployments for the hub and satellite.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
