### PR TITLE
[github] Add Notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#393](https://github.com/kobsio/kobs/pull/#393): [app] Display Kubernetes Resources within notifications.
 - [#394](https://github.com/kobsio/kobs/pull/#394): [app] Allow users and teams to customize their notification settings.
 - [#398](https://github.com/kobsio/kobs/pull/#398): [github] Add GitHub plugin to access issues, pull requests, teams and members of an organization.
+- [#399](https://github.com/kobsio/kobs/pull/#399): [github] Add new `usernotifications` panel and allow users to use the plugin within the Notifications.
 
 ### Fixed
 

--- a/docs/getting-started/configuration/notifications.md
+++ b/docs/getting-started/configuration/notifications.md
@@ -50,6 +50,25 @@ api:
             resources:
               - pods
             filter: $.status.containerStatuses[?(@.state.waiting || @.state.terminated && @.state.terminated.reason!='Completed')]
+      - title: GitHub Notifications
+        plugin:
+          satellite: global
+          name: github
+          type: github
+          options:
+            type: usernotifications
+            usernotifications:
+              all: true
+              participating: false
+      - title: GitHub Pull Requests
+        plugin:
+          satellite: global
+          name: github
+          type: github
+          options:
+            type: userpullrequests
+            userpullrequests:
+              query: created
 ```
 
 Each plugin is identified by a `satellite`, `name` and `type`. The options for each plugin can be found in the **Notification Options** section of the corresponding plugin documentation.

--- a/docs/plugins/github.md
+++ b/docs/plugins/github.md
@@ -45,14 +45,30 @@ The following options can be used for a panel with the GitHub plugin:
 
 | Field | Type | Description | Required |
 | ----- | ---- | ----------- | -------- |
-| type | string | The type of the panel which should be shown. This could be `orgmemebers`, `orgpullrequests`, `orgrepositories`, `orgteams`, `team`, `teammembers`, `teamrepositories`, `repository`, `repositoryissues`, `repositorypullrequests`, `repositoryworkflowruns` or `userpullrequests`. | Yes |
+| type | string | The type of the panel which should be shown. This could be `orgmemebers`, `orgpullrequests`, `orgrepositories`, `orgteams`, `team`, `teammembers`, `teamrepositories`, `repository`, `repositoryissues`, `repositorypullrequests`, `repositoryworkflowruns`, `userpullrequests` or `usernotifications`. | Yes |
 | team | string | The name of the GitHub team from your organization. This is required if the type is `team`, `teammembers` or `teamrepositories`. | No |
 | repository | string | The name of the GitHub repository from your organization. This is required if the type is `repository`, `repositoryissues`, `repositorypullrequests` or `repositoryworkflowruns`. | No |
 
 ## Notification Options
 
-!!! note
-    The GitHub plugin can not be used to get a list of notifications.
+| Field | Type | Description | Required |
+| ----- | ---- | ----------- | -------- |
+| type | string | The type of the panel which should be shown. This could be `userpullrequests` or `usernotifications`. | Yes |
+| userpullrequests | [User Pull Requests](#user-pull-requests) | Options for the `userpullrequests` type. | No |
+| usernotifications | [User Notifications](#user-notifications) | Options for the `usernotifications` type. | No |
+
+### User Pull Requests
+
+| Field | Type | Description | Required |
+| ----- | ---- | ----------- | -------- |
+| query | string | The query which should be used to get the users pull requests. Must be `created`, `assigned`, `mentioned` or `reviewRequests`. | Yes |
+
+### User Notifications
+
+| Field | Type | Description | Required |
+| ----- | ---- | ----------- | -------- |
+| all | boolean | If `true`, show notifications marked as read. | No |
+| participating | boolean | If `true`, only shows notifications in which the user is directly participating or mentioned. | No |
 
 ## Usage
 

--- a/plugins/plugin-github/cmd/github.go
+++ b/plugins/plugin-github/cmd/github.go
@@ -7,7 +7,6 @@ import (
 	"github.com/kobsio/kobs/pkg/log"
 	"github.com/kobsio/kobs/pkg/middleware/errresponse"
 	"github.com/kobsio/kobs/pkg/satellite/plugins/plugin"
-	"github.com/kobsio/kobs/plugins/plugin-github/pkg/helpers"
 	"github.com/kobsio/kobs/plugins/plugin-github/pkg/instance"
 
 	"github.com/go-chi/chi/v5"
@@ -88,7 +87,7 @@ func (router *Router) oauthCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cookie, err := helpers.TokenToCookie(token)
+	cookie, err := i.TokenToCookie(token)
 	if err != nil {
 		log.Error(r.Context(), "Could not create authentication cookie", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusUnauthorized, "Could not create authentication cookie")
@@ -113,7 +112,7 @@ func (router *Router) oauthToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := helpers.TokenFromCookie(r)
+	token, err := i.TokenFromCookie(r)
 	if err != nil {
 		log.Error(r.Context(), "Could not get authentication token from cookie", zap.Error(err))
 		errresponse.Render(w, r, err, http.StatusUnauthorized, "Could not get authentication token from cookie")

--- a/plugins/plugin-github/pkg/instance/helpers.go
+++ b/plugins/plugin-github/pkg/instance/helpers.go
@@ -1,9 +1,8 @@
-package helpers
+package instance
 
 import (
 	"encoding/base64"
 	"encoding/json"
-	"net/http"
 
 	"golang.org/x/oauth2"
 )
@@ -32,30 +31,4 @@ func tokenFromBase64(tokenStr string) (*oauth2.Token, error) {
 	}
 
 	return &token, nil
-}
-
-// TokenToCookie returns a cookie for the given oauth token.
-func TokenToCookie(token *oauth2.Token) (*http.Cookie, error) {
-	cookieValue, err := tokenToBase64(token)
-	if err != nil {
-		return nil, err
-	}
-
-	return &http.Cookie{
-		Name:     "kobs-oauth-github",
-		Value:    cookieValue,
-		Secure:   false,
-		HttpOnly: false,
-		Path:     "/",
-	}, nil
-}
-
-// TokenFromCookie returns the token from the "kobs-oauth-github" cookie in the given request.
-func TokenFromCookie(r *http.Request) (*oauth2.Token, error) {
-	cookie, err := r.Cookie("kobs-oauth-github")
-	if err != nil {
-		return nil, err
-	}
-
-	return tokenFromBase64(cookie.Value)
 }

--- a/plugins/plugin-github/pkg/instance/helpers_test.go
+++ b/plugins/plugin-github/pkg/instance/helpers_test.go
@@ -1,0 +1,37 @@
+package instance
+
+import (
+	"testing"
+
+	"golang.org/x/oauth2"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenToBase64(t *testing.T) {
+	t.Run("token to base64 without error", func(t *testing.T) {
+		tokenStr, err := tokenToBase64(&oauth2.Token{AccessToken: "1234"})
+		require.NoError(t, err)
+		require.Equal(t, "eyJhY2Nlc3NfdG9rZW4iOiIxMjM0IiwiZXhwaXJ5IjoiMDAwMS0wMS0wMVQwMDowMDowMFoifQ==", tokenStr)
+	})
+}
+
+func TestTokenFromBase64(t *testing.T) {
+	t.Run("token from base64 without error", func(t *testing.T) {
+		token, err := tokenFromBase64("eyJhY2Nlc3NfdG9rZW4iOiIxMjM0IiwiZXhwaXJ5IjoiMDAwMS0wMS0wMVQwMDowMDowMFoifQ==")
+		require.NoError(t, err)
+		require.Equal(t, &oauth2.Token{AccessToken: "1234"}, token)
+	})
+
+	t.Run("token from base64 without error (not a base64 string)", func(t *testing.T) {
+		token, err := tokenFromBase64("eyJhY2Nlc3NfdG9rZW4iOiIxMjM0IiwiZXhwaXJ5IjoiMDAwMS0wMS0wMVQwMDowMDowMFoifQ")
+		require.Error(t, err)
+		require.Nil(t, token)
+	})
+
+	t.Run("token from base64 without error (invalid json)", func(t *testing.T) {
+		token, err := tokenFromBase64("eyJhY2Nlc3NfdG9rZW4iOlsiMTIzNCJdfQ==")
+		require.Error(t, err)
+		require.Nil(t, token)
+	})
+}

--- a/plugins/plugin-github/pkg/instance/instance_mock.go
+++ b/plugins/plugin-github/pkg/instance/instance_mock.go
@@ -4,8 +4,10 @@ package instance
 
 import (
 	context "context"
+	http "net/http"
 
 	github "github.com/google/go-github/github"
+
 	mock "github.com/stretchr/testify/mock"
 
 	oauth2 "golang.org/x/oauth2"
@@ -111,6 +113,52 @@ func (_m *MockInstance) OAuthLoginURL() string {
 	}
 
 	return r0
+}
+
+// TokenFromCookie provides a mock function with given fields: r
+func (_m *MockInstance) TokenFromCookie(r *http.Request) (*oauth2.Token, error) {
+	ret := _m.Called(r)
+
+	var r0 *oauth2.Token
+	if rf, ok := ret.Get(0).(func(*http.Request) *oauth2.Token); ok {
+		r0 = rf(r)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*oauth2.Token)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*http.Request) error); ok {
+		r1 = rf(r)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// TokenToCookie provides a mock function with given fields: token
+func (_m *MockInstance) TokenToCookie(token *oauth2.Token) (*http.Cookie, error) {
+	ret := _m.Called(token)
+
+	var r0 *http.Cookie
+	if rf, ok := ret.Get(0).(func(*oauth2.Token) *http.Cookie); ok {
+		r0 = rf(token)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*http.Cookie)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*oauth2.Token) error); ok {
+		r1 = rf(token)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 type NewMockInstanceT interface {

--- a/plugins/plugin-github/pkg/instance/instance_test.go
+++ b/plugins/plugin-github/pkg/instance/instance_test.go
@@ -1,0 +1,80 @@
+package instance
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+	githuboauth "golang.org/x/oauth2/github"
+)
+
+func TestGetName(t *testing.T) {
+	i := instance{name: "github"}
+	require.Equal(t, "github", i.GetName())
+}
+
+func TestGetOrganization(t *testing.T) {
+	i := instance{name: "github", config: Config{Organization: "kobsio"}}
+	require.Equal(t, "kobsio", i.GetOrganization())
+}
+
+func TestTokenToCookie(t *testing.T) {
+	i := instance{name: "github", config: Config{Organization: "kobsio"}}
+
+	t.Run("no error", func(t *testing.T) {
+		cookie, err := i.TokenToCookie(&oauth2.Token{AccessToken: "1234"})
+		require.NoError(t, err)
+		require.Equal(t, &http.Cookie{Name: "kobs-oauth-github-kobsio", Value: "eyJhY2Nlc3NfdG9rZW4iOiIxMjM0IiwiZXhwaXJ5IjoiMDAwMS0wMS0wMVQwMDowMDowMFoifQ==", Path: "/", Secure: false, HttpOnly: false}, cookie)
+	})
+}
+
+func TestTokenFromCookie(t *testing.T) {
+	i := instance{name: "github", config: Config{Organization: "kobsio"}}
+
+	t.Run("no error", func(t *testing.T) {
+		r, _ := http.NewRequest(http.MethodGet, "", nil)
+		r.AddCookie(&http.Cookie{Name: "kobs-oauth-github-kobsio", Value: "eyJhY2Nlc3NfdG9rZW4iOiIxMjM0IiwiZXhwaXJ5IjoiMDAwMS0wMS0wMVQwMDowMDowMFoifQ==", Path: "/", Secure: false, HttpOnly: false})
+
+		token, err := i.TokenFromCookie(r)
+		require.NoError(t, err)
+		require.Equal(t, &oauth2.Token{AccessToken: "1234"}, token)
+	})
+
+	t.Run("with error invalid cookie value", func(t *testing.T) {
+		r, _ := http.NewRequest(http.MethodGet, "", nil)
+		r.AddCookie(&http.Cookie{Name: "kobs-oauth-github-kobsio", Value: "eyJhY2Nlc3NfdG9rZW4iOiIxMjM0IiwiZXhwaXJ5IjoiMDAwMS0wMS0wMVQwMDowMDowMFoifQ", Path: "/", Secure: false, HttpOnly: false})
+
+		token, err := i.TokenFromCookie(r)
+		require.Error(t, err)
+		require.Nil(t, token)
+	})
+
+	t.Run("with error invalid cookie name", func(t *testing.T) {
+		r, _ := http.NewRequest(http.MethodGet, "", nil)
+		r.AddCookie(&http.Cookie{Name: "kobs-oauth-github", Value: "eyJhY2Nlc3NfdG9rZW4iOiIxMjM0IiwiZXhwaXJ5IjoiMDAwMS0wMS0wMVQwMDowMDowMFoifQ==", Path: "/", Secure: false, HttpOnly: false})
+
+		token, err := i.TokenFromCookie(r)
+		require.Error(t, err)
+		require.Nil(t, token)
+	})
+}
+
+func TestOAuthLoginURL(t *testing.T) {
+	i := instance{name: "github", config: Config{Organization: "kobsio", OAuth: OAuthConfig{State: "test"}}, oauthConfig: &oauth2.Config{ClientID: "clientID", ClientSecret: "clientSecret", Scopes: []string{"user", "repo", "notifications", "project"}, Endpoint: githuboauth.Endpoint}}
+	require.Equal(t, "https://github.com/login/oauth/authorize?access_type=online&client_id=clientID&response_type=code&scope=user+repo+notifications+project&state=test", i.OAuthLoginURL())
+}
+
+func TestNew(t *testing.T) {
+	t.Run("no error", func(t *testing.T) {
+		i, err := New("github", map[string]any{"organization": "kobsio"})
+		require.NoError(t, err)
+		require.NotNil(t, i)
+	})
+
+	t.Run("with error", func(t *testing.T) {
+		i, err := New("github", map[string]any{"organization": []string{"kobsio"}})
+		require.Error(t, err)
+		require.Nil(t, i)
+	})
+}

--- a/plugins/plugin-github/src/components/github/Details.tsx
+++ b/plugins/plugin-github/src/components/github/Details.tsx
@@ -44,7 +44,7 @@ const Details: React.FunctionComponent<IDetailsProps> = ({ title, link, instance
         </DrawerActions>
       </DrawerHead>
       <DrawerPanelBody>
-        <AuthContextProvider title="" instance={instance}>
+        <AuthContextProvider title="" isNotification={false} instance={instance}>
           {children}
         </AuthContextProvider>
       </DrawerPanelBody>

--- a/plugins/plugin-github/src/components/github/repos/RepositoryIssues.tsx
+++ b/plugins/plugin-github/src/components/github/repos/RepositoryIssues.tsx
@@ -76,19 +76,19 @@ const RepositoryIssues: React.FunctionComponent<IRepositoryIssuesProps> = ({
           <ToggleGroup aria-label="Type">
             <ToggleGroupItem
               className="pf-u-text-nowrap"
-              text="open"
+              text="Open"
               isSelected={state === 'open'}
               onChange={(): void => setState('open')}
             />
             <ToggleGroupItem
               className="pf-u-text-nowrap"
-              text="closed"
+              text="Closed"
               isSelected={state === 'closed'}
               onChange={(): void => setState('closed')}
             />
             <ToggleGroupItem
               className="pf-u-text-nowrap"
-              text="all"
+              text="All"
               isSelected={state === 'all'}
               onChange={(): void => setState('all')}
             />

--- a/plugins/plugin-github/src/components/github/repos/RepositoryPullRequests.tsx
+++ b/plugins/plugin-github/src/components/github/repos/RepositoryPullRequests.tsx
@@ -64,19 +64,19 @@ const RepositoryPullRequests: React.FunctionComponent<IRepositoryPullRequestsPro
           <ToggleGroup aria-label="Type">
             <ToggleGroupItem
               className="pf-u-text-nowrap"
-              text="open"
+              text="Open"
               isSelected={state === 'open'}
               onChange={(): void => setState('open')}
             />
             <ToggleGroupItem
               className="pf-u-text-nowrap"
-              text="closed"
+              text="Closed"
               isSelected={state === 'closed'}
               onChange={(): void => setState('closed')}
             />
             <ToggleGroupItem
               className="pf-u-text-nowrap"
-              text="all"
+              text="All"
               isSelected={state === 'all'}
               onChange={(): void => setState('all')}
             />

--- a/plugins/plugin-github/src/components/github/users/UserNotifications.tsx
+++ b/plugins/plugin-github/src/components/github/users/UserNotifications.tsx
@@ -1,0 +1,156 @@
+import {
+  Alert,
+  AlertActionLink,
+  AlertVariant,
+  CardActions,
+  DataList,
+  DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+  Flex,
+  FlexItem,
+  Spinner,
+  Switch,
+} from '@patternfly/react-core';
+import { QueryObserverResult, useQuery } from 'react-query';
+import React, { useContext, useState } from 'react';
+
+import { AuthContext, IAuthContext } from '../../../context/AuthContext';
+import GitHubPagination, { IPage } from '../GitHubPagination';
+import { IPluginInstance, PluginPanel } from '@kobsio/shared';
+import { TUserNotifications } from '../../../utils/interfaces';
+
+interface IUserNotificationsProps {
+  title: string;
+  description?: string;
+  instance: IPluginInstance;
+}
+
+const UserNotifications: React.FunctionComponent<IUserNotificationsProps> = ({
+  title,
+  description,
+  instance,
+}: IUserNotificationsProps) => {
+  const authContext = useContext<IAuthContext>(AuthContext);
+  const [page, setPage] = useState<IPage>({ page: 1, perPage: 20 });
+  const [all, setAll] = useState<boolean>(false);
+  const [participating, setParticipating] = useState<boolean>(false);
+
+  const { isError, isLoading, error, data, refetch } = useQuery<TUserNotifications, Error>(
+    ['github/users/notifications', authContext.organization, all, participating, instance],
+    async () => {
+      try {
+        const octokit = authContext.getOctokitClient();
+        const notifications = await octokit.activity.listNotificationsForAuthenticatedUser({
+          all: all,
+          page: 1,
+          participating: participating,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          per_page: 100,
+        });
+        return notifications.data;
+      } catch (err) {
+        throw err;
+      }
+    },
+  );
+
+  const selectNotification = async (id: string): Promise<void> => {
+    try {
+      const notification = data?.filter((notification) => notification.id === id);
+      if (notification && notification.length === 1) {
+        const octokit = authContext.getOctokitClient();
+        const response = await octokit.request(`GET ${notification[0].subject.url}`);
+
+        if (response && response.data && response.data.html_url) {
+          window.open(response.data.html_url, '_blank');
+        }
+      }
+    } catch (err) {}
+  };
+
+  return (
+    <PluginPanel
+      title={title}
+      description={description}
+      actions={
+        <CardActions>
+          <span>
+            <Switch
+              id="all"
+              label="All"
+              labelOff="All"
+              isReversed={true}
+              isChecked={all}
+              onChange={(isChecked: boolean): void => setAll(isChecked)}
+            />
+          </span>
+          <span className="pf-u-pl-xl">
+            <Switch
+              id="participating"
+              label="Participating"
+              labelOff="Participating"
+              isReversed={true}
+              isChecked={participating}
+              onChange={(isChecked: boolean): void => setParticipating(isChecked)}
+            />
+          </span>
+        </CardActions>
+      }
+      footer={<GitHubPagination itemCount={data?.length || 0} page={page} setPage={setPage} />}
+    >
+      {isLoading ? (
+        <div className="pf-u-text-align-center">
+          <Spinner />
+        </div>
+      ) : isError ? (
+        <Alert
+          variant={AlertVariant.danger}
+          isInline={true}
+          title="Could not get notifications"
+          actionLinks={
+            <React.Fragment>
+              <AlertActionLink onClick={(): Promise<QueryObserverResult<TUserNotifications, Error>> => refetch()}>
+                Retry
+              </AlertActionLink>
+            </React.Fragment>
+          }
+        >
+          <p>{error?.message}</p>
+        </Alert>
+      ) : data ? (
+        <DataList aria-label="notifications" isCompact={true} onSelectDataListItem={selectNotification}>
+          {data.slice((page.page - 1) * page.perPage, page.page * page.perPage).map((notification) => (
+            <DataListItem
+              key={notification.id}
+              id={notification.id}
+              aria-labelledby={notification.subject.title}
+              style={{ cursor: 'pointer' }}
+              isExpanded={notification.unread}
+            >
+              <DataListItemRow>
+                <DataListItemCells
+                  dataListCells={[
+                    <DataListCell key="main">
+                      <Flex direction={{ default: 'column' }}>
+                        <FlexItem>
+                          <p>{notification.subject.title}</p>
+                          <small>{notification.repository.full_name}</small>
+                        </FlexItem>
+                      </Flex>
+                    </DataListCell>,
+                  ]}
+                />
+              </DataListItemRow>
+            </DataListItem>
+          ))}
+        </DataList>
+      ) : (
+        <div></div>
+      )}
+    </PluginPanel>
+  );
+};
+
+export default UserNotifications;

--- a/plugins/plugin-github/src/components/github/users/UserPullRequests.tsx
+++ b/plugins/plugin-github/src/components/github/users/UserPullRequests.tsx
@@ -101,7 +101,7 @@ const UserPullRequests: React.FunctionComponent<IUserPullRequestsProps> = ({
         <Alert
           variant={AlertVariant.danger}
           isInline={true}
-          title="Could not get organization pull requests"
+          title="Could not get pull requests"
           actionLinks={
             <React.Fragment>
               <AlertActionLink onClick={(): Promise<QueryObserverResult<TUserPullRequests, Error>> => refetch()}>

--- a/plugins/plugin-github/src/components/notifications/Notifications.tsx
+++ b/plugins/plugin-github/src/components/notifications/Notifications.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import { AuthContextProvider } from '../../context/AuthContext';
+import { INotificationProps } from '../../utils/interfaces';
+import UserNotifications from './UserNotifications';
+import UserPullRequests from './UserPullRequests';
+
+const Notifications: React.FunctionComponent<INotificationProps> = ({
+  title,
+  options,
+  instance,
+  times,
+}: INotificationProps) => {
+  if (options && options.type === 'userpullrequests') {
+    return (
+      <AuthContextProvider title={title} isNotification={true} instance={instance}>
+        <UserPullRequests title={title} options={options} instance={instance} times={times} />
+      </AuthContextProvider>
+    );
+  }
+
+  if (options && options.type === 'usernotifications') {
+    return (
+      <AuthContextProvider title={title} isNotification={true} instance={instance}>
+        <UserNotifications title={title} options={options} instance={instance} times={times} />
+      </AuthContextProvider>
+    );
+  }
+
+  return <div></div>;
+};
+
+export default Notifications;

--- a/plugins/plugin-github/src/components/notifications/UserNotification.tsx
+++ b/plugins/plugin-github/src/components/notifications/UserNotification.tsx
@@ -1,0 +1,56 @@
+import {
+  Button,
+  ButtonVariant,
+  NotificationDrawerListItem,
+  NotificationDrawerListItemBody,
+  NotificationDrawerListItemHeader,
+} from '@patternfly/react-core';
+import React, { useContext } from 'react';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+
+import { AuthContext, IAuthContext } from '../../context/AuthContext';
+import { formatTime } from '@kobsio/shared';
+
+interface IAlertProps {
+  url: string;
+  unread: boolean;
+  title: string;
+  repo: string;
+  updatedAt: string;
+}
+
+const UserNotification: React.FunctionComponent<IAlertProps> = ({
+  url,
+  unread,
+  title,
+  repo,
+  updatedAt,
+}: IAlertProps) => {
+  const authContext = useContext<IAuthContext>(AuthContext);
+
+  const selectNotification = async (): Promise<void> => {
+    try {
+      const octokit = authContext.getOctokitClient();
+      const response = await octokit.request(`GET ${url}`);
+
+      if (response && response.data && response.data.html_url) {
+        window.open(response.data.html_url, '_blank');
+      }
+    } catch (err) {}
+  };
+
+  return (
+    <NotificationDrawerListItem variant="info" isRead={!unread}>
+      <NotificationDrawerListItemHeader variant="info" title={title}>
+        <Button variant={ButtonVariant.plain} onClick={selectNotification}>
+          <ExternalLinkAltIcon />
+        </Button>
+      </NotificationDrawerListItemHeader>
+      <NotificationDrawerListItemBody timestamp={formatTime(Math.floor(new Date(updatedAt).getTime() / 1000))}>
+        {repo}
+      </NotificationDrawerListItemBody>
+    </NotificationDrawerListItem>
+  );
+};
+
+export default UserNotification;

--- a/plugins/plugin-github/src/components/notifications/UserNotifications.tsx
+++ b/plugins/plugin-github/src/components/notifications/UserNotifications.tsx
@@ -1,0 +1,68 @@
+import { NotificationDrawerGroup, NotificationDrawerList } from '@patternfly/react-core';
+import React, { useContext, useState } from 'react';
+import { useQuery } from 'react-query';
+
+import { AuthContext, IAuthContext } from '../../context/AuthContext';
+import { INotificationProps, TUserNotifications } from '../../utils/interfaces';
+import UserNotification from './UserNotification';
+
+const UserNotifications: React.FunctionComponent<INotificationProps> = ({
+  title,
+  options,
+  instance,
+}: INotificationProps) => {
+  const authContext = useContext<IAuthContext>(AuthContext);
+  const [isExpanded, setIsExpanded] = useState<boolean>(false);
+
+  const { data } = useQuery<TUserNotifications, Error>(
+    ['github/users/notifications', authContext.organization, options, instance],
+    async () => {
+      try {
+        const octokit = authContext.getOctokitClient();
+        const notifications = await octokit.activity.listNotificationsForAuthenticatedUser({
+          all: options && options.usernotifications.all ? options.usernotifications.all : false,
+          page: 1,
+          participating:
+            options && options.usernotifications.participating ? options.usernotifications.participating : false,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          per_page: 100,
+        });
+        return notifications.data;
+      } catch (err) {
+        throw err;
+      }
+    },
+  );
+
+  if (!data || data.length === 0) {
+    return (
+      <NotificationDrawerGroup title={title} isExpanded={false} count={0}>
+        <NotificationDrawerList isHidden={true} />
+      </NotificationDrawerGroup>
+    );
+  }
+
+  return (
+    <NotificationDrawerGroup
+      title={title}
+      isExpanded={isExpanded}
+      count={data.length}
+      onExpand={(): void => setIsExpanded(!isExpanded)}
+    >
+      <NotificationDrawerList isHidden={!isExpanded}>
+        {data.map((notification) => (
+          <UserNotification
+            key={notification.id}
+            url={notification.subject.url}
+            unread={notification.unread}
+            title={notification.subject.title}
+            repo={notification.repository.full_name}
+            updatedAt={notification.updated_at}
+          />
+        ))}
+      </NotificationDrawerList>
+    </NotificationDrawerGroup>
+  );
+};
+
+export default UserNotifications;

--- a/plugins/plugin-github/src/components/notifications/UserPullRequest.tsx
+++ b/plugins/plugin-github/src/components/notifications/UserPullRequest.tsx
@@ -1,0 +1,53 @@
+import {
+  Button,
+  ButtonVariant,
+  NotificationDrawerListItem,
+  NotificationDrawerListItemBody,
+  NotificationDrawerListItemHeader,
+} from '@patternfly/react-core';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+import React from 'react';
+
+import { formatTime } from '@kobsio/shared';
+import { getPRSubTitle } from '../../utils/helpers';
+
+interface IAlertProps {
+  url: string;
+  title: string;
+  updatedAt: string;
+  number: number;
+  user: string | undefined;
+  state: string;
+  createdAt: string;
+  closedAt: string | null;
+  mergedAt: string | null | undefined;
+}
+
+const UserPullRequest: React.FunctionComponent<IAlertProps> = ({
+  url,
+  title,
+  updatedAt,
+  number,
+  user,
+  state,
+  createdAt,
+  closedAt,
+  mergedAt,
+}: IAlertProps) => {
+  return (
+    <NotificationDrawerListItem variant="info" isRead={mergedAt ? true : false}>
+      <NotificationDrawerListItemHeader variant="info" title={title}>
+        <a href={url} target="_blank" rel="noreferrer">
+          <Button variant={ButtonVariant.plain}>
+            <ExternalLinkAltIcon />
+          </Button>
+        </a>
+      </NotificationDrawerListItemHeader>
+      <NotificationDrawerListItemBody timestamp={formatTime(Math.floor(new Date(updatedAt).getTime() / 1000))}>
+        {getPRSubTitle(number, user, state, createdAt, closedAt, mergedAt)}
+      </NotificationDrawerListItemBody>
+    </NotificationDrawerListItem>
+  );
+};
+
+export default UserPullRequest;

--- a/plugins/plugin-github/src/components/notifications/UserPullRequests.tsx
+++ b/plugins/plugin-github/src/components/notifications/UserPullRequests.tsx
@@ -1,0 +1,85 @@
+import { NotificationDrawerGroup, NotificationDrawerList } from '@patternfly/react-core';
+import React, { useContext, useState } from 'react';
+import { useQuery } from 'react-query';
+
+import { AuthContext, IAuthContext } from '../../context/AuthContext';
+import { INotificationProps, TUserPullRequests } from '../../utils/interfaces';
+import UserPullRequest from './UserPullRequest';
+
+const UserPullRequests: React.FunctionComponent<INotificationProps> = ({
+  title,
+  options,
+  instance,
+}: INotificationProps) => {
+  const authContext = useContext<IAuthContext>(AuthContext);
+  const [isExpanded, setIsExpanded] = useState<boolean>(false);
+
+  const { data } = useQuery<TUserPullRequests, Error>(
+    ['github/users/pullrequests', authContext.organization, options, instance],
+    async () => {
+      try {
+        let query = '';
+        if (options.userpullrequests.query === 'created') {
+          query = 'is:pull-request author:';
+        } else if (options.userpullrequests.query === 'assigned') {
+          query = 'is:pull-request assignee:';
+        } else if (options.userpullrequests.query === 'mentioned') {
+          query = 'is:pull-request mentions:';
+        } else if (options.userpullrequests.query === 'reviewRequests') {
+          query = 'is:pull-request review-requested:';
+        } else {
+          throw new Error('invalid query');
+        }
+
+        const octokit = authContext.getOctokitClient();
+        const pullRequests = await octokit.search.issuesAndPullRequests({
+          order: 'desc',
+          page: 1,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          per_page: 100,
+          q: query + authContext.username,
+          sort: 'updated',
+        });
+        return pullRequests.data;
+      } catch (err) {
+        throw err;
+      }
+    },
+  );
+
+  if (!data || data.items.length === 0) {
+    return (
+      <NotificationDrawerGroup title={title} isExpanded={false} count={0}>
+        <NotificationDrawerList isHidden={true} />
+      </NotificationDrawerGroup>
+    );
+  }
+
+  return (
+    <NotificationDrawerGroup
+      title={title}
+      isExpanded={isExpanded}
+      count={data.items.length}
+      onExpand={(): void => setIsExpanded(!isExpanded)}
+    >
+      <NotificationDrawerList isHidden={!isExpanded}>
+        {data.items.map((pr) => (
+          <UserPullRequest
+            key={pr.id}
+            url={pr.html_url}
+            title={pr.title}
+            updatedAt={pr.updated_at}
+            number={pr.number}
+            user={pr.user?.login}
+            state={pr.state}
+            createdAt={pr.created_at}
+            closedAt={pr.closed_at}
+            mergedAt={pr.pull_request?.merged_at}
+          />
+        ))}
+      </NotificationDrawerList>
+    </NotificationDrawerGroup>
+  );
+};
+
+export default UserPullRequests;

--- a/plugins/plugin-github/src/components/page/Overview.tsx
+++ b/plugins/plugin-github/src/components/page/Overview.tsx
@@ -29,7 +29,7 @@ const Overview: React.FunctionComponent<IOverviewProps> = ({ instance }: IOvervi
       />
 
       <PageContentSection hasPadding={true} hasDivider={true} toolbarContent={undefined} panelContent={details}>
-        <AuthContextProvider title="" instance={instance}>
+        <AuthContextProvider title="" isNotification={false} instance={instance}>
           <Grid hasGutter={true}>
             <GridItem span={9}>
               <Flex direction={{ default: 'column' }}>

--- a/plugins/plugin-github/src/components/panel/Panel.tsx
+++ b/plugins/plugin-github/src/components/panel/Panel.tsx
@@ -14,6 +14,7 @@ import RepositoryWorkflowRuns from '../github/repos/RepositoryWorkflowRuns';
 import Team from '../github/teams/Team';
 import TeamMembers from '../github/teams/TeamMembers';
 import TeamRepos from '../github/teams/TeamRepos';
+import UserNotifications from '../github/users/UserNotifications';
 import UserPullRequests from '../github/users/UserPullRequests';
 
 interface IGitHubPluginPanelProps extends IPluginPanelProps {
@@ -30,7 +31,7 @@ const Panel: React.FunctionComponent<IGitHubPluginPanelProps> = ({
 }: IGitHubPluginPanelProps) => {
   if (options && options.type && options.type === 'orgmemebers') {
     return (
-      <AuthContextProvider title={title} instance={instance}>
+      <AuthContextProvider title={title} isNotification={false} instance={instance}>
         <OrgMembers title={title} description={description} instance={instance} />
       </AuthContextProvider>
     );
@@ -38,7 +39,7 @@ const Panel: React.FunctionComponent<IGitHubPluginPanelProps> = ({
 
   if (options && options.type && options.type === 'orgpullrequests') {
     return (
-      <AuthContextProvider title={title} instance={instance}>
+      <AuthContextProvider title={title} isNotification={false} instance={instance}>
         <OrgPullRequests title={title} description={description} instance={instance} />
       </AuthContextProvider>
     );
@@ -46,7 +47,7 @@ const Panel: React.FunctionComponent<IGitHubPluginPanelProps> = ({
 
   if (options && options.type && options.type === 'orgrepositories') {
     return (
-      <AuthContextProvider title={title} instance={instance}>
+      <AuthContextProvider title={title} isNotification={false} instance={instance}>
         <OrgRepos title={title} description={description} instance={instance} setDetails={setDetails} />
       </AuthContextProvider>
     );
@@ -54,7 +55,7 @@ const Panel: React.FunctionComponent<IGitHubPluginPanelProps> = ({
 
   if (options && options.type && options.type === 'orgteams') {
     return (
-      <AuthContextProvider title={title} instance={instance}>
+      <AuthContextProvider title={title} isNotification={false} instance={instance}>
         <OrgTeams title={title} description={description} instance={instance} setDetails={setDetails} />
       </AuthContextProvider>
     );
@@ -62,7 +63,7 @@ const Panel: React.FunctionComponent<IGitHubPluginPanelProps> = ({
 
   if (options && options.type && options.type === 'team' && options.team) {
     return (
-      <AuthContextProvider title={title} instance={instance}>
+      <AuthContextProvider title={title} isNotification={false} instance={instance}>
         <Team title={title} description={description} slug={options.team} instance={instance} />
       </AuthContextProvider>
     );
@@ -70,7 +71,7 @@ const Panel: React.FunctionComponent<IGitHubPluginPanelProps> = ({
 
   if (options && options.type && options.type === 'teammembers' && options.team) {
     return (
-      <AuthContextProvider title={title} instance={instance}>
+      <AuthContextProvider title={title} isNotification={false} instance={instance}>
         <TeamMembers title={title} description={description} slug={options.team} instance={instance} />
       </AuthContextProvider>
     );
@@ -78,7 +79,7 @@ const Panel: React.FunctionComponent<IGitHubPluginPanelProps> = ({
 
   if (options && options.type && options.type === 'teamrepositories' && options.team) {
     return (
-      <AuthContextProvider title={title} instance={instance}>
+      <AuthContextProvider title={title} isNotification={false} instance={instance}>
         <TeamRepos
           title={title}
           description={description}
@@ -92,7 +93,7 @@ const Panel: React.FunctionComponent<IGitHubPluginPanelProps> = ({
 
   if (options && options.type && options.type === 'repository' && options.repository) {
     return (
-      <AuthContextProvider title={title} instance={instance}>
+      <AuthContextProvider title={title} isNotification={false} instance={instance}>
         <Repository title={title} description={description} repo={options.repository} instance={instance} />
       </AuthContextProvider>
     );
@@ -100,7 +101,7 @@ const Panel: React.FunctionComponent<IGitHubPluginPanelProps> = ({
 
   if (options && options.type && options.type === 'repositoryissues' && options.repository) {
     return (
-      <AuthContextProvider title={title} instance={instance}>
+      <AuthContextProvider title={title} isNotification={false} instance={instance}>
         <RepositoryIssues title={title} description={description} repo={options.repository} instance={instance} />
       </AuthContextProvider>
     );
@@ -108,7 +109,7 @@ const Panel: React.FunctionComponent<IGitHubPluginPanelProps> = ({
 
   if (options && options.type && options.type === 'repositorypullrequests' && options.repository) {
     return (
-      <AuthContextProvider title={title} instance={instance}>
+      <AuthContextProvider title={title} isNotification={false} instance={instance}>
         <RepositoryPullRequests title={title} description={description} repo={options.repository} instance={instance} />
       </AuthContextProvider>
     );
@@ -116,7 +117,7 @@ const Panel: React.FunctionComponent<IGitHubPluginPanelProps> = ({
 
   if (options && options.type && options.type === 'repositoryworkflowruns' && options.repository) {
     return (
-      <AuthContextProvider title={title} instance={instance}>
+      <AuthContextProvider title={title} isNotification={false} instance={instance}>
         <RepositoryWorkflowRuns
           title={title}
           description={description}
@@ -130,8 +131,16 @@ const Panel: React.FunctionComponent<IGitHubPluginPanelProps> = ({
 
   if (options && options.type && options.type === 'userpullrequests' && options.repository) {
     return (
-      <AuthContextProvider title={title} instance={instance}>
+      <AuthContextProvider title={title} isNotification={false} instance={instance}>
         <UserPullRequests title={title} description={description} instance={instance} />
+      </AuthContextProvider>
+    );
+  }
+
+  if (options && options.type && options.type === 'usernotifications' && options.repository) {
+    return (
+      <AuthContextProvider title={title} isNotification={false} instance={instance}>
+        <UserNotifications title={title} description={description} instance={instance} />
       </AuthContextProvider>
     );
   }

--- a/plugins/plugin-github/src/context/AuthContext.tsx
+++ b/plugins/plugin-github/src/context/AuthContext.tsx
@@ -30,6 +30,7 @@ export const AuthContextConsumer = AuthContext.Consumer;
 // properties are child components of the type ReactElement.
 interface IAuthContextProviderProps {
   title: string;
+  isNotification: boolean;
   instance: IPluginInstance;
   children: React.ReactElement;
 }
@@ -38,6 +39,7 @@ interface IAuthContextProviderProps {
 // changes.
 export const AuthContextProvider: React.FunctionComponent<IAuthContextProviderProps> = ({
   title,
+  isNotification,
   instance,
   children,
 }: IAuthContextProviderProps) => {
@@ -74,6 +76,10 @@ export const AuthContextProvider: React.FunctionComponent<IAuthContextProviderPr
   };
 
   if (isLoading) {
+    if (isNotification) {
+      return <div></div>;
+    }
+
     const loadingContent = (
       <div className="pf-u-text-align-center">
         <Spinner />
@@ -86,6 +92,10 @@ export const AuthContextProvider: React.FunctionComponent<IAuthContextProviderPr
   // If an error occured during the fetch of the plugins, we are showing the error message in the cernter of the screen
   // within an Alert component. The Alert component contains a Retry button to call the fetchData function again.
   if (isError) {
+    if (isNotification) {
+      return <div></div>;
+    }
+
     const alertContent = (
       <Alert
         variant={AlertVariant.danger}

--- a/plugins/plugin-github/src/setupModuleFederation.js
+++ b/plugins/plugin-github/src/setupModuleFederation.js
@@ -9,6 +9,7 @@ module.exports = {
     './Instance': './src/components/instance/Instance.tsx',
     './Panel': './src/components/panel/Panel.tsx',
     './Page': './src/components/page/Page.tsx',
+    './Notifications': './src/components/notifications/Notifications.tsx',
   },
   shared: {
     ...deps,

--- a/plugins/plugin-github/src/utils/interfaces.ts
+++ b/plugins/plugin-github/src/utils/interfaces.ts
@@ -1,10 +1,20 @@
 import { GetResponseDataTypeFromEndpointMethod } from '@octokit/types';
 import { Octokit } from '@octokit/rest';
 
+import { IPluginNotificationsProps } from '@kobsio/shared';
+
 export interface IPanelOptions {
   type?: string;
   team?: string;
   repository?: string;
+}
+
+export interface INotificationProps extends IPluginNotificationsProps {
+  options: {
+    type: string;
+    usernotifications: { all?: boolean; participating?: boolean };
+    userpullrequests: { query?: string };
+  };
 }
 
 const octokit = new Octokit();
@@ -25,3 +35,6 @@ export type TRepositoryWorkflowRunsJobs = GetResponseDataTypeFromEndpointMethod<
   typeof octokit.actions.listJobsForWorkflowRunAttempt
 >;
 export type TUserPullRequests = GetResponseDataTypeFromEndpointMethod<typeof octokit.search.issuesAndPullRequests>;
+export type TUserNotifications = GetResponseDataTypeFromEndpointMethod<
+  typeof octokit.activity.listNotificationsForAuthenticatedUser
+>;


### PR DESCRIPTION
It is now possible to use the GitHub plugin for notifications. This
means it is possible to show a users notifications or a users created,
mentioned, assigned or review requested pull requests in the
notification drawer.

We also added a new panel "usernotifications" to show the users GitHub
notifications within a dashboard (e.g. on his profile page).

Last but not least we renamed the cookie used for authentication against
the GitHub API. This was necessary, because until now the cookie always
had the same name which doesn't allow multiple instances of the GitHub
plugin. Now we add the configured organization name to the cookie name,
so that multiple instances of the plugin can be used.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
