### PR TITLE
[app] Add recover handler for metrics middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 ### Changed
 
+- [#400](https://github.com/kobsio/kobs/pull/#400): [app] Add recover handler for `httpmetrics` middleware and rename metrics to `kobs_requests_total`, `kobs_request_duration_seconds` and `kobs_request_size_bytes`.
+
 ## [v0.9.1](https://github.com/kobsio/kobs/releases/tag/v0.9.1) (2022-07-08)
 
 ### Fixed

--- a/pkg/middleware/httpmetrics/httpmetrics.go
+++ b/pkg/middleware/httpmetrics/httpmetrics.go
@@ -13,15 +13,22 @@ import (
 )
 
 var (
-	reqMetric = promauto.NewCounterVec(prometheus.CounterOpts{
+	requestsTotalMetric = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "kobs",
-		Name:      "chi_requests_total",
+		Name:      "requests_total",
 		Help:      "Number of HTTP requests processed, partitioned by status code, method and path.",
 	}, []string{"response_code", "request_method", "request_path"})
 
-	sumMetric = promauto.NewSummaryVec(prometheus.SummaryOpts{
+	requestDurationMetric = promauto.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace:  "kobs",
-		Name:       "chi_request_duration_milliseconds",
+		Name:       "request_duration_seconds",
+		Help:       "Latency of HTTP requests processed, partitioned by status code, method and path.",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.95: 0.005, 0.99: 0.001},
+	}, []string{"response_code", "request_method", "request_path"})
+
+	requestSizeMetric = promauto.NewSummaryVec(prometheus.SummaryOpts{
+		Namespace:  "kobs",
+		Name:       "request_size_bytes",
 		Help:       "Latency of HTTP requests processed, partitioned by status code, method and path.",
 		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.95: 0.005, 0.99: 0.001},
 	}, []string{"response_code", "request_method", "request_path"})
@@ -31,15 +38,25 @@ var (
 func Handler(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
+
+		defer func() {
+			if err := recover(); err != nil {
+				routeStr := strings.Join(chi.RouteContext(r.Context()).RoutePatterns, "")
+				requestsTotalMetric.WithLabelValues(strconv.Itoa(http.StatusInternalServerError), r.Method, routeStr).Inc()
+				requestDurationMetric.WithLabelValues(strconv.Itoa(http.StatusInternalServerError), r.Method, routeStr).Observe(time.Since(start).Seconds())
+				requestSizeMetric.WithLabelValues(strconv.Itoa(http.StatusInternalServerError), r.Method, routeStr).Observe(0)
+
+				panic(err)
+			}
+		}()
+
 		wrw := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 		next.ServeHTTP(wrw, r)
 
-		// In go-chi/chi, full route pattern could only be extracted once the request is executed
-		// See: https://github.com/go-chi/chi/issues/150#issuecomment-278850733
 		routeStr := strings.Join(chi.RouteContext(r.Context()).RoutePatterns, "")
-
-		reqMetric.WithLabelValues(strconv.Itoa(wrw.Status()), r.Method, routeStr).Inc()
-		sumMetric.WithLabelValues(strconv.Itoa(wrw.Status()), r.Method, routeStr).Observe(float64(time.Since(start).Nanoseconds()) / 1000000)
+		requestsTotalMetric.WithLabelValues(strconv.Itoa(wrw.Status()), r.Method, routeStr).Inc()
+		requestDurationMetric.WithLabelValues(strconv.Itoa(wrw.Status()), r.Method, routeStr).Observe(time.Since(start).Seconds())
+		requestSizeMetric.WithLabelValues(strconv.Itoa(wrw.Status()), r.Method, routeStr).Observe(float64(wrw.BytesWritten()))
 	}
 
 	return http.HandlerFunc(fn)


### PR DESCRIPTION
We now have a recover handler for the "httpmetrics" middleware. We also
renamed the metrics to "kobs_requests_total",
"kobs_request_duration_seconds" and "kobs_request_size_bytes".

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
