### PR TITLE
[app] Improve Plugin Instaces Toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#400](https://github.com/kobsio/kobs/pull/400): [app] Add recover handler for `httpmetrics` middleware and rename metrics to `kobs_requests_total`, `kobs_request_duration_seconds` and `kobs_request_size_bytes`.
 - [#405](https://github.com/kobsio/kobs/pull/405): [app] Imporove federated module core
 - [#408](https://github.com/kobsio/kobs/pull/408): [app] Improve usablility for end users, by showing a hint when the `own` filter does not return any applications and by sorting the returned resource tabs alphabetically.
+- [#409](https://github.com/kobsio/kobs/pull/409): [app] Improve toolbar for plugin instances page and reflect selected filter in the url.
 
 ## [v0.9.1](https://github.com/kobsio/kobs/releases/tag/v0.9.1) (2022-07-08)
 

--- a/plugins/app/src/components/plugins/PluginInstancesToolbar.tsx
+++ b/plugins/app/src/components/plugins/PluginInstancesToolbar.tsx
@@ -1,0 +1,78 @@
+import React, { useContext, useState } from 'react';
+import { SearchInput, Select, SelectOption, SelectOptionObject, SelectVariant } from '@patternfly/react-core';
+
+import { IPluginsContext, PluginsContext } from '../../context/PluginsContext';
+import { Toolbar, ToolbarItem } from '@kobsio/shared';
+import { IOptions } from './utils/interfaces';
+
+interface IPluginInstancesToolbarProps {
+  options: IOptions;
+  setOptions: (opts: IOptions) => void;
+}
+
+const PluginInstancesToolbar: React.FunctionComponent<IPluginInstancesToolbarProps> = ({
+  options,
+  setOptions,
+}: IPluginInstancesToolbarProps) => {
+  const [pluginSatelliteIsOpen, setPluginSatelliteIsOpen] = useState<boolean>(false);
+  const [pluginTypeIsOpen, setPluginTypeIsOpen] = useState<boolean>(false);
+
+  const pluginsContext = useContext<IPluginsContext>(PluginsContext);
+
+  return (
+    <Toolbar usePageInsets={true}>
+      <ToolbarItem width="200px">
+        <Select
+          variant={SelectVariant.typeahead}
+          aria-label="Select satellite input"
+          placeholderText="Satellite"
+          onToggle={(): void => setPluginSatelliteIsOpen(!pluginSatelliteIsOpen)}
+          onSelect={(
+            event: React.MouseEvent<Element, MouseEvent> | React.ChangeEvent<Element>,
+            value: string | SelectOptionObject,
+          ): void => setOptions({ ...options, page: 1, pluginSatellite: value.toString() })}
+          onClear={(): void => setOptions({ ...options, page: 1, pluginSatellite: '' })}
+          selections={options.pluginSatellite}
+          isOpen={pluginSatelliteIsOpen}
+          maxHeight="50vh"
+        >
+          {pluginsContext.getPluginSatellites().map((option) => (
+            <SelectOption key={option} value={option} />
+          ))}
+        </Select>
+      </ToolbarItem>
+
+      <ToolbarItem width="200px">
+        <Select
+          variant={SelectVariant.typeahead}
+          aria-label="Select plugin type input"
+          placeholderText="Plugin Type"
+          onToggle={(): void => setPluginTypeIsOpen(!pluginTypeIsOpen)}
+          onSelect={(
+            event: React.MouseEvent<Element, MouseEvent> | React.ChangeEvent<Element>,
+            value: string | SelectOptionObject,
+          ): void => setOptions({ ...options, page: 1, pluginType: value.toString() })}
+          onClear={(): void => setOptions({ ...options, page: 1, pluginType: '' })}
+          selections={options.pluginType}
+          isOpen={pluginTypeIsOpen}
+          maxHeight="50vh"
+        >
+          {pluginsContext.getPluginTypes().map((option) => (
+            <SelectOption key={option} value={option} />
+          ))}
+        </Select>
+      </ToolbarItem>
+
+      <ToolbarItem grow={true}>
+        <SearchInput
+          aria-label="Search plugin input"
+          onChange={(value: string): void => setOptions({ ...options, page: 1, searchTerm: value })}
+          value={options.searchTerm}
+          onClear={(): void => setOptions({ ...options, page: 1, searchTerm: '' })}
+        />
+      </ToolbarItem>
+    </Toolbar>
+  );
+};
+
+export default PluginInstancesToolbar;

--- a/plugins/app/src/components/plugins/utils/helpers.ts
+++ b/plugins/app/src/components/plugins/utils/helpers.ts
@@ -1,0 +1,18 @@
+import { IOptions } from './interfaces';
+
+export const getInitialOptions = (search: string): IOptions => {
+  const params = new URLSearchParams(search);
+  const page = params.get('page');
+  const perPage = params.get('perPage');
+  const pluginSatellite = params.get('pluginSatellite');
+  const pluginType = params.get('pluginType');
+  const searchTerm = params.get('searchTerm');
+
+  return {
+    page: page ? parseInt(page) : 1,
+    perPage: perPage ? parseInt(perPage) : 10,
+    pluginSatellite: pluginSatellite || '',
+    pluginType: pluginType || '',
+    searchTerm: searchTerm || '',
+  };
+};

--- a/plugins/app/src/components/plugins/utils/interfaces.ts
+++ b/plugins/app/src/components/plugins/utils/interfaces.ts
@@ -1,0 +1,7 @@
+export interface IOptions {
+  page: number;
+  perPage: number;
+  pluginSatellite: string;
+  pluginType: string;
+  searchTerm: string;
+}


### PR DESCRIPTION
This commit improves the toolbar for the plugin instaces page, by moving
the toolbar to a seperate component and by relecting the selected
filters in the url, so that the filter is the same if a user selects a
plugin and then goaes back to the plugin instances page.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
