### PR TITLE
[app] Fix 404 error for ACE worker files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#396](https://github.com/kobsio/kobs/pull/396): [app] Fix shutdown logic.
 - [#397](https://github.com/kobsio/kobs/pull/397): [demo] Update elastic setup version to work with recent kubernetes api.
 - [#403](https://github.com/kobsio/kobs/pull/403): [app] Add missing sort keys to MongoDB queries and fix `go.mongodb.org/mongo-driver/bson/primitive.E composite literal uses unkeyed fields`.
+- [#410](https://github.com/kobsio/kobs/pull/410): [app] Fix 404 error for ACE worker files, by disabling workers.
 
 ### Changed
 

--- a/plugins/shared/src/components/misc/Editor.tsx
+++ b/plugins/shared/src/components/misc/Editor.tsx
@@ -1,6 +1,12 @@
 import React, { useRef } from 'react';
 import AceEditor from 'react-ace';
 
+// At the moment we are using "useWorker: false" to fix a 404 error for loading worker files. We can also set
+// "useWorker: true" and import the "ace-builds/webpack-resolver" file to enable syntax checking.
+//
+// See https://github.com/securingsincity/react-ace/issues/725
+//
+// import 'ace-builds/webpack-resolver';
 import 'ace-builds/src-noconflict/mode-json';
 import 'ace-builds/src-noconflict/mode-yaml';
 import 'ace-builds/src-noconflict/theme-nord_dark';
@@ -36,6 +42,7 @@ export const Editor: React.FunctionComponent<IEditorProps> = ({ value, mode, rea
       ref={editor}
       setOptions={{
         useSoftTabs: true,
+        useWorker: false,
       }}
       showPrintMargin={false}
       tabSize={2}


### PR DESCRIPTION
When a user opens a page with an Editor component a 404 error was thrown
in the console, because the worker files for ACE (the underlying editor)
could not be found. This is fixed by disabling workers using the
"useWorker: false" in the "setOptions" property.

This also disables syntax checking in ACE. If we want to use syntax
checking in the future, we can set "useWorker: true" and import the
"ace-builds/webpack-resolver" file.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
