### PR TITLE
[sql] Add yAxisGroup Property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#401](https://github.com/kobsio/kobs/pull/401): [app] Add integrations for Kubernetes Resource, which allows administrators to define a set of default dashboards, which are added to each resource.
 - [#402](https://github.com/kobsio/kobs/pull/402): [app] Add `mongodb` driver as alternative to the existing `bolt` driver.
 - [#407](https://github.com/kobsio/kobs/pull/407): [sql] Add `singlestats` chart to render single values returned by a query.
+- [#411](https://github.com/kobsio/kobs/pull/411): [sql] Add `yAxisGroup` property for charts.
 
 ### Fixed
 

--- a/docs/plugins/sql.md
+++ b/docs/plugins/sql.md
@@ -70,6 +70,7 @@ The following options can be used for a panel with the SQL plugin:
 | xAxisUnit | string | The unit which should be used for the x axis. | No |
 | yAxisColumns | []string | A list of columns which should be shown for the y axis. This is required when the type is `line` or `area`. | No |
 | yAxisUnit | string | The unit for the y axis. | No |
+| yAxisGroup | string | The name of the column, which values should be used to group the data. | No |
 | yAxisStacked | boolean | When this is `true` the values of the y axis are stacked. | No |
 | legend | map<string, string> | A map of string pairs, to set the displayed title for a column in the legend. The key is the column name as returned by the query and the value is the shown title. | No |
 | thresholds | map<string, string> | A map of string pairs, to set the background color in a `singlestats` chart. | No |

--- a/plugins/plugin-sql/src/components/page/Page.tsx
+++ b/plugins/plugin-sql/src/components/page/Page.tsx
@@ -16,7 +16,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ instance }: IPluginPa
   // changeOptions is used to change the options for an SQL query. Instead of directly modifying the options state we
   // change the URL parameters.
   const changeOptions = (opts: IOptions): void => {
-    navigate(`${location.pathname}?query=${opts.query}`);
+    navigate(`${location.pathname}?query=${encodeURIComponent(opts.query)}`);
   };
 
   useEffect(() => {

--- a/plugins/plugin-sql/src/components/page/PageToolbar.tsx
+++ b/plugins/plugin-sql/src/components/page/PageToolbar.tsx
@@ -23,6 +23,7 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({ options, setO
   // use "SHIFT" + "ENTER".
   const onEnter = (e: React.KeyboardEvent<HTMLTextAreaElement> | undefined): void => {
     if (e?.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
       setOptions(data);
     }
   };

--- a/plugins/plugin-sql/src/components/panel/Panel.tsx
+++ b/plugins/plugin-sql/src/components/panel/Panel.tsx
@@ -35,6 +35,7 @@ const Panel: React.FunctionComponent<ISQLPluginPanelProps> = ({
         xAxisUnit={options.chart.xAxisUnit}
         yAxisColumns={options.chart.yAxisColumns}
         yAxisUnit={options.chart.yAxisUnit}
+        yAxisGroup={options.chart.yAxisGroup}
         yAxisStacked={options.chart.yAxisStacked}
         legend={options.chart.legend}
         thresholds={options.chart.thresholds}

--- a/plugins/plugin-sql/src/components/panel/SQLChart.tsx
+++ b/plugins/plugin-sql/src/components/panel/SQLChart.tsx
@@ -7,7 +7,6 @@ import { IPluginInstance } from '@kobsio/shared';
 import { PluginPanel } from '@kobsio/shared';
 import SQLChartActions from './SQLChartActions';
 import SQLChartLine from './SQLChartLine';
-import SQLChartLineLegend from './SQLChartLineLegend';
 import SQLChartPie from './SQLChartPie';
 import SQLChartSinglestats from './SQLChartSinglestats';
 
@@ -24,6 +23,7 @@ interface ISQLChartProps {
   xAxisUnit?: string;
   yAxisColumns?: string[];
   yAxisUnit?: string;
+  yAxisGroup?: string;
   yAxisStacked?: boolean;
   legend?: ILegend;
   thresholds?: IThresholds;
@@ -42,6 +42,7 @@ const SQLChart: React.FunctionComponent<ISQLChartProps> = ({
   xAxisUnit,
   yAxisColumns,
   yAxisUnit,
+  yAxisGroup,
   yAxisStacked,
   legend,
   thresholds,
@@ -106,23 +107,18 @@ const SQLChart: React.FunctionComponent<ISQLChartProps> = ({
         </Alert>
       ) : data && (type === 'line' || type === 'area') && xAxisColumn && yAxisColumns ? (
         <React.Fragment>
-          <div style={{ height: 'calc(100% - 80px)' }}>
-            <SQLChartLine
-              data={data}
-              type={type}
-              xAxisColumn={xAxisColumn}
-              xAxisType={xAxisType}
-              xAxisUnit={xAxisUnit}
-              yAxisColumns={yAxisColumns}
-              yAxisUnit={yAxisUnit}
-              yAxisStacked={yAxisStacked}
-              legend={legend}
-            />
-          </div>
-
-          <div className="pf-u-mt-md kobsio-hide-scrollbar" style={{ height: '60px', overflow: 'auto' }}>
-            <SQLChartLineLegend data={data} yAxisColumns={yAxisColumns} yAxisUnit={yAxisUnit} legend={legend} />
-          </div>
+          <SQLChartLine
+            data={data}
+            type={type}
+            xAxisColumn={xAxisColumn}
+            xAxisType={xAxisType}
+            xAxisUnit={xAxisUnit}
+            yAxisColumns={yAxisColumns}
+            yAxisUnit={yAxisUnit}
+            yAxisGroup={yAxisGroup}
+            yAxisStacked={yAxisStacked}
+            legend={legend}
+          />
         </React.Fragment>
       ) : data && type === 'pie' && pieLabelColumn && pieValueColumn ? (
         <React.Fragment>

--- a/plugins/plugin-sql/src/components/panel/SQLChartLine.tsx
+++ b/plugins/plugin-sql/src/components/panel/SQLChartLine.tsx
@@ -1,31 +1,62 @@
-import { Datum, ResponsiveLineCanvas, Serie } from '@nivo/line';
+import { Datum, Serie } from '@nivo/line';
 import React from 'react';
 
-import { CHART_THEME, COLOR_SCALE, ChartTooltip } from '@kobsio/shared';
 import { ILegend, ISQLData, ISQLDataRow } from '../../utils/interfaces';
+import SQLChartLineChart from './SQLChartLineChart';
+import SQLChartLineLegend from './SQLChartLineLegend';
 
 const getSeriesData = (
   rows: ISQLDataRow[],
   xAxisColumn: string,
   xAxisType: string | undefined,
   yAxisColumns: string[],
+  yAxisGroup: string | undefined,
 ): Serie[] => {
+  const groups: string[] = [];
   const series: Serie[] = [];
 
-  for (const yAxisColumn of yAxisColumns) {
-    const data: Datum[] = [];
+  if (yAxisGroup) {
+    for (const value of rows) {
+      if (yAxisGroup in value && !groups.includes(value[yAxisGroup].toString())) {
+        groups.push(value[yAxisGroup].toString());
+      }
+    }
+  }
 
-    for (const row of rows) {
-      data.push({
-        x: xAxisType === 'time' ? new Date(row[xAxisColumn] as string) : (row[xAxisColumn] as number),
-        y: row.hasOwnProperty(yAxisColumn) ? (row[yAxisColumn] as number) : null,
+  for (const yAxisColumn of yAxisColumns) {
+    if (yAxisGroup && groups.length > 0) {
+      for (const group of groups) {
+        const data: Datum[] = [];
+
+        for (const row of rows) {
+          if (row[yAxisGroup] === group) {
+            data.push({
+              x: xAxisType === 'time' ? new Date(row[xAxisColumn] as string) : (row[xAxisColumn] as number),
+              y: row.hasOwnProperty(yAxisColumn) ? (row[yAxisColumn] as number) : null,
+            });
+          }
+        }
+
+        series.push({
+          data: data,
+          id: `${yAxisColumn}-${group}`,
+        });
+      }
+    } else {
+      const data: Datum[] = [];
+
+      for (const row of rows) {
+        data.push({
+          x: xAxisType === 'time' ? new Date(row[xAxisColumn] as string) : (row[xAxisColumn] as number),
+          y: row.hasOwnProperty(yAxisColumn) ? (row[yAxisColumn] as number) : null,
+        });
+      }
+
+      series.push({
+        data: data,
+        id: yAxisColumn,
       });
     }
-
-    series.push({
-      data: data,
-      id: yAxisColumn,
-    });
   }
 
   return series;
@@ -39,6 +70,7 @@ interface ISQLChartLineProps {
   xAxisUnit?: string;
   yAxisColumns: string[];
   yAxisUnit?: string;
+  yAxisGroup?: string;
   yAxisStacked?: boolean;
   legend?: ILegend;
 }
@@ -51,71 +83,29 @@ export const SQLChartLine: React.FunctionComponent<ISQLChartLineProps> = ({
   xAxisUnit,
   yAxisColumns,
   yAxisUnit,
+  yAxisGroup,
   yAxisStacked,
   legend,
 }: ISQLChartLineProps) => {
-  const series = data.rows ? getSeriesData(data.rows, xAxisColumn, xAxisType, yAxisColumns) : [];
+  const series = data.rows ? getSeriesData(data.rows, xAxisColumn, xAxisType, yAxisColumns, yAxisGroup) : [];
 
   return (
-    <ResponsiveLineCanvas
-      axisBottom={{
-        format: xAxisType === 'time' ? '%m-%d %H:%M:%S' : '>-.2f',
-        tickValues:
-          series.length > 0
-            ? series[0].data
-                .filter(
-                  (datum, index) =>
-                    index !== 0 &&
-                    index !== series[0].data.length - 1 &&
-                    (index + 1) %
-                      (Math.floor(series[0].data.length / 10) > 2 ? Math.floor(series[0].data.length / 10) : 2) ===
-                      0,
-                )
-                .map((datum) => datum.x)
-            : undefined,
-      }}
-      axisLeft={{
-        format: '>-.2f',
-        legend: yAxisUnit,
-        legendOffset: -40,
-        legendPosition: 'middle',
-      }}
-      colors={COLOR_SCALE}
-      curve="monotoneX"
-      data={series}
-      enableArea={type === 'area'}
-      enableGridX={false}
-      enableGridY={true}
-      enablePoints={false}
-      xFormat={xAxisType === 'time' ? 'time:%Y-%m-%d %H:%M:%S' : '>-.4f'}
-      lineWidth={1}
-      margin={{ bottom: 25, left: 50, right: 0, top: 0 }}
-      theme={CHART_THEME}
-      // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-      tooltip={(tooltip) => {
-        return (
-          <ChartTooltip
-            anchor="center"
-            color={tooltip.point.color}
-            label={`${
-              legend && legend.hasOwnProperty(tooltip.point.serieId)
-                ? legend[tooltip.point.serieId]
-                : tooltip.point.serieId
-            } ${tooltip.point.data.yFormatted}`}
-            position={[0, 50]}
-            title={tooltip.point.data.xFormatted.toString()}
-          />
-        );
-      }}
-      xScale={{ max: 'auto', min: 'auto', type: xAxisType === 'time' ? 'time' : 'linear' }}
-      yScale={{
-        max: 'auto',
-        min: 'auto',
-        stacked: yAxisStacked ? true : false,
-        type: 'linear',
-      }}
-      yFormat=">-.4f"
-    />
+    <React.Fragment>
+      <div style={{ height: 'calc(100% - 80px)' }}>
+        <SQLChartLineChart
+          series={series}
+          type={type}
+          xAxisType={xAxisType}
+          yAxisUnit={yAxisUnit}
+          yAxisStacked={yAxisStacked}
+          legend={legend}
+        />
+      </div>
+
+      <div className="pf-u-mt-md kobsio-hide-scrollbar" style={{ height: '60px', overflow: 'auto' }}>
+        <SQLChartLineLegend series={series} yAxisUnit={yAxisUnit} legend={legend} />
+      </div>
+    </React.Fragment>
   );
 };
 

--- a/plugins/plugin-sql/src/components/panel/SQLChartLineChart.tsx
+++ b/plugins/plugin-sql/src/components/panel/SQLChartLineChart.tsx
@@ -1,0 +1,87 @@
+import { ResponsiveLineCanvas, Serie } from '@nivo/line';
+import React from 'react';
+
+import { CHART_THEME, COLOR_SCALE, ChartTooltip } from '@kobsio/shared';
+import { ILegend } from '../../utils/interfaces';
+
+interface ISQLChartLineChartProps {
+  series: Serie[];
+  type: string;
+  xAxisType?: string;
+  yAxisUnit?: string;
+  yAxisStacked?: boolean;
+  legend?: ILegend;
+}
+
+export const SQLChartLineChart: React.FunctionComponent<ISQLChartLineChartProps> = ({
+  series,
+  type,
+  xAxisType,
+  yAxisUnit,
+  yAxisStacked,
+  legend,
+}: ISQLChartLineChartProps) => {
+  return (
+    <ResponsiveLineCanvas
+      axisBottom={{
+        format: xAxisType === 'time' ? '%m-%d %H:%M:%S' : '>-.2f',
+        tickValues:
+          series.length > 0
+            ? series[0].data
+                .filter(
+                  (datum, index) =>
+                    index !== 0 &&
+                    index !== series[0].data.length - 1 &&
+                    (index + 1) %
+                      (Math.floor(series[0].data.length / 10) > 2 ? Math.floor(series[0].data.length / 10) : 2) ===
+                      0,
+                )
+                .map((datum) => datum.x)
+            : undefined,
+      }}
+      axisLeft={{
+        format: '>-.2f',
+        legend: yAxisUnit,
+        legendOffset: -40,
+        legendPosition: 'middle',
+      }}
+      colors={COLOR_SCALE}
+      curve="monotoneX"
+      data={series}
+      enableArea={type === 'area'}
+      enableGridX={false}
+      enableGridY={true}
+      enablePoints={false}
+      xFormat={xAxisType === 'time' ? 'time:%Y-%m-%d %H:%M:%S' : '>-.4f'}
+      lineWidth={1}
+      margin={{ bottom: 25, left: 50, right: 0, top: 0 }}
+      theme={CHART_THEME}
+      // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+      tooltip={(tooltip) => {
+        return (
+          <ChartTooltip
+            anchor="center"
+            color={tooltip.point.color}
+            label={`${
+              legend && legend.hasOwnProperty(tooltip.point.serieId)
+                ? legend[tooltip.point.serieId]
+                : tooltip.point.serieId
+            } ${tooltip.point.data.yFormatted}`}
+            position={[0, 50]}
+            title={tooltip.point.data.xFormatted.toString()}
+          />
+        );
+      }}
+      xScale={{ max: 'auto', min: 'auto', type: xAxisType === 'time' ? 'time' : 'linear' }}
+      yScale={{
+        max: 'auto',
+        min: 'auto',
+        stacked: yAxisStacked ? true : false,
+        type: 'linear',
+      }}
+      yFormat=">-.4f"
+    />
+  );
+};
+
+export default SQLChartLineChart;

--- a/plugins/plugin-sql/src/utils/interfaces.ts
+++ b/plugins/plugin-sql/src/utils/interfaces.ts
@@ -35,6 +35,7 @@ export interface IChart {
   xAxisUnit?: string;
   yAxisColumns?: string[];
   yAxisUnit?: string;
+  yAxisGroup?: string;
   yAxisStacked?: boolean;
   legend?: ILegend;
   thresholds?: IThresholds;


### PR DESCRIPTION
The new "yAxisGroup" property in the SQL charts can be used to group the
returned data, based on the values of a column. This means the value of
the property must be a valid column in the returned data.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
