### PR TITLE
[helm] Reload list of Helm releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#405](https://github.com/kobsio/kobs/pull/405): [app] Imporove federated module core
 - [#408](https://github.com/kobsio/kobs/pull/408): [app] Improve usablility for end users, by showing a hint when the `own` filter does not return any applications and by sorting the returned resource tabs alphabetically.
 - [#409](https://github.com/kobsio/kobs/pull/409): [app] Improve toolbar for plugin instances page and reflect selected filter in the url.
+- [#412](https://github.com/kobsio/kobs/pull/412): [helm] Reload list of Helm releases, when user clicks the search button again.
 
 ## [v0.9.1](https://github.com/kobsio/kobs/releases/tag/v0.9.1) (2022-07-08)
 

--- a/plugins/plugin-helm/src/components/page/PageToolbar.tsx
+++ b/plugins/plugin-helm/src/components/page/PageToolbar.tsx
@@ -1,8 +1,6 @@
-import { Button, ButtonVariant } from '@patternfly/react-core';
 import React, { useState } from 'react';
-import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
-import { IPluginInstance, Toolbar, ToolbarItem } from '@kobsio/shared';
+import { IOptionsAdditionalFields, IPluginInstance, ITimes, Options, Toolbar, ToolbarItem } from '@kobsio/shared';
 import { IOptions } from '../../utils/interfaces';
 import PageToolbarItemClusters from './PageToolbarItemClusters';
 import PageToolbarItemNamespaces from './PageToolbarItemNamespaces';
@@ -44,8 +42,8 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({
     }
   };
 
-  const changeOptions = (): void => {
-    setOptions(state);
+  const changeOptions = (times: ITimes, additionalFields: IOptionsAdditionalFields[] | undefined): void => {
+    setOptions({ clusters: state.clusters, namespaces: state.namespaces, times: times });
   };
 
   return (
@@ -61,11 +59,8 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({
           selectNamespace={selectNamespace}
         />
       </ToolbarItem>
-      <ToolbarItem alignRight={true}>
-        <Button variant={ButtonVariant.primary} icon={<SearchIcon />} onClick={changeOptions}>
-          Search
-        </Button>
-      </ToolbarItem>
+
+      <Options times={options.times} showOptions={false} showSearchButton={true} setOptions={changeOptions} />
     </Toolbar>
   );
 };


### PR DESCRIPTION
Reload list of Helm releases, when the user clicks the search button
again. Before this change the list was only reloaded when the cluster or
namespace was changed, now it is always reloaded.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
