### PR TITLE
[app] Fix Permission Handling for Applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#397](https://github.com/kobsio/kobs/pull/397): [demo] Update elastic setup version to work with recent kubernetes api.
 - [#403](https://github.com/kobsio/kobs/pull/403): [app] Add missing sort keys to MongoDB queries and fix `go.mongodb.org/mongo-driver/bson/primitive.E composite literal uses unkeyed fields`.
 - [#410](https://github.com/kobsio/kobs/pull/410): [app] Fix 404 error for ACE worker files, by disabling workers.
+- [#413](https://github.com/kobsio/kobs/pull/413): [app] Fix permission handling for applications.
 
 ### Changed
 

--- a/pkg/hub/api/applications/applications.go
+++ b/pkg/hub/api/applications/applications.go
@@ -77,8 +77,11 @@ func (router *Router) getApplications(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check if the user requested to see all applications, if this is the case we have to check if he is alowed to do
+	// so. If a team isn't part of any teams "user.Teams" is "nil" we handle it the same ways as he wants to see all
+	// applications.
 	parsedAll, _ := strconv.ParseBool(all)
-	if parsedAll == true {
+	if parsedAll == true || teams == nil {
 		if !user.HasApplicationAccess("", "", "", []string{""}) {
 			log.Warn(ctx, "The user is not authorized to view all applications")
 			span.RecordError(fmt.Errorf("user is not authorized to view all applications"))
@@ -131,8 +134,11 @@ func (router *Router) getApplicationsCount(w http.ResponseWriter, r *http.Reques
 	span.SetAttributes(attribute.Key("searchTerm").String(searchTerm))
 	span.SetAttributes(attribute.Key("external").String(external))
 
+	// Check if the user requested to see all applications, if this is the case we have to check if he is alowed to do
+	// so. If a team isn't part of any teams "user.Teams" is "nil" we handle it the same ways as he wants to see all
+	// applications.
 	parsedAll, _ := strconv.ParseBool(all)
-	if parsedAll == true {
+	if parsedAll == true || teams == nil {
 		if !user.HasApplicationAccess("", "", "", []string{""}) {
 			log.Warn(ctx, "The user is not authorized to view all applications")
 			span.RecordError(fmt.Errorf("user is not authorized to view all applications"))

--- a/pkg/hub/api/applications/topology.go
+++ b/pkg/hub/api/applications/topology.go
@@ -161,8 +161,11 @@ func (router *Router) getApplicationsTopology(w http.ResponseWriter, r *http.Req
 	span.SetAttributes(attribute.Key("searchTerm").String(searchTerm))
 	span.SetAttributes(attribute.Key("external").String(external))
 
+	// Check if the user requested to see all applications, if this is the case we have to check if he is alowed to do
+	// so. If a team isn't part of any teams "user.Teams" is "nil" we handle it the same ways as he wants to see all
+	// applications.
 	parsedAll, _ := strconv.ParseBool(all)
-	if parsedAll == true {
+	if parsedAll == true || teams == nil {
 		if !user.HasApplicationAccess("", "", "", []string{""}) {
 			log.Warn(ctx, "The user is not authorized to view all applications")
 			span.RecordError(fmt.Errorf("user is not authorized to view all applications"))

--- a/plugins/app/src/components/profile/UserTeams.tsx
+++ b/plugins/app/src/components/profile/UserTeams.tsx
@@ -8,9 +8,14 @@ import {
   DataListItem,
   DataListItemCells,
   DataListItemRow,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateVariant,
   Flex,
   FlexItem,
   Spinner,
+  Title,
 } from '@patternfly/react-core';
 import { QueryObserverResult, useQuery } from '@tanstack/react-query';
 import React from 'react';
@@ -69,7 +74,15 @@ const UserTeams: React.FunctionComponent<IUserTeamsProps> = ({ setDetails }: IUs
   }
 
   if (!data || data.length === 0) {
-    return null;
+    return (
+      <EmptyState variant={EmptyStateVariant.small}>
+        <EmptyStateIcon icon={UserIcon} />
+        <Title headingLevel="h2" size="lg">
+          No teams found
+        </Title>
+        <EmptyStateBody>We could not found any teams you are part of.</EmptyStateBody>
+      </EmptyState>
+    );
   }
 
   return (


### PR DESCRIPTION
This commit fixes the permission handling for applications, when
authentication is enabled, but the user is not part of any teams. In
this case a user was still able to see all applications. We changed the
implementation to handle such cases like the user wants to see all
applications so that the access check is executed.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
