### PR TITLE
[jira] Convert description to markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#408](https://github.com/kobsio/kobs/pull/408): [app] Improve usablility for end users, by showing a hint when the `own` filter does not return any applications and by sorting the returned resource tabs alphabetically.
 - [#409](https://github.com/kobsio/kobs/pull/409): [app] Improve toolbar for plugin instances page and reflect selected filter in the url.
 - [#412](https://github.com/kobsio/kobs/pull/412): [helm] Reload list of Helm releases, when user clicks the search button again.
+- [#415](https://github.com/kobsio/kobs/pull/415): [jira] Convert the description of issues to markdown before the description is rendered. Adjust the colors of the rendered status label. Show fields in details only when they have a value.
 
 ## [v0.9.1](https://github.com/kobsio/kobs/releases/tag/v0.9.1) (2022-07-08)
 

--- a/plugins/plugin-jira/src/components/jira/Issue.tsx
+++ b/plugins/plugin-jira/src/components/jira/Issue.tsx
@@ -49,7 +49,7 @@ const Issue: React.FunctionComponent<IIssueProps> = ({ issue }: IIssueProps) => 
           <Tooltip content={issue.fields?.priority?.name}>
             <Avatar style={{ height: '14px', width: '14px' }} src={issue.fields?.priority?.iconUrl} alt="" />
           </Tooltip>
-          <Label style={{ fontSize: '10px' }} color={getStatusColor(issue.fields?.status?.statusCategory.colorName)}>
+          <Label style={{ fontSize: '10px' }} color={getStatusColor(issue.fields?.status?.statusCategory.name)}>
             {issue.fields?.status?.name.toUpperCase()}
           </Label>
           {issue.fields?.assignee?.avatarUrls?.['24x24'] && (

--- a/plugins/plugin-jira/src/components/jira/IssueDetails.tsx
+++ b/plugins/plugin-jira/src/components/jira/IssueDetails.tsx
@@ -21,11 +21,11 @@ import React from 'react';
 import ReactMarkdown from 'react-markdown';
 
 import { IPluginInstance, LinkWrapper, pluginBasePath } from '@kobsio/shared';
+import { getStatusColor, jiraToMarkdown } from '../../utils/helpers';
 import { AuthContextProvider } from '../../context/AuthContext';
 import { IIssue } from '../../utils/issue';
 import Issue from './Issue';
 import IssueDetailsLink from './IssueDetailsLink';
-import { getStatusColor } from '../../utils/helpers';
 
 interface IIssueDetailsProps {
   instance: IPluginInstance;
@@ -51,96 +51,106 @@ const IssueDetails: React.FunctionComponent<IIssueDetailsProps> = ({ instance, i
       </DrawerHead>
       <DrawerPanelBody>
         <DescriptionList className="pf-u-text-break-word">
-          <DescriptionListGroup>
-            <DescriptionListTerm className="pf-u-text-nowrap">Issue Type</DescriptionListTerm>
-            <DescriptionListDescription>
-              <Flex direction={{ default: 'row' }}>
-                <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
-                  {issue.fields?.issuetype?.iconUrl && (
-                    <Avatar style={{ height: '24px', width: '24px' }} src={issue.fields?.issuetype?.iconUrl} alt="" />
-                  )}
-                </FlexItem>
-                <FlexItem>{issue.fields?.issuetype?.name || ''}</FlexItem>
-              </Flex>
-            </DescriptionListDescription>
-          </DescriptionListGroup>
+          {issue.fields?.issuetype?.name && (
+            <DescriptionListGroup>
+              <DescriptionListTerm className="pf-u-text-nowrap">Issue Type</DescriptionListTerm>
+              <DescriptionListDescription>
+                <Flex direction={{ default: 'row' }}>
+                  <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
+                    {issue.fields?.issuetype?.iconUrl && (
+                      <Avatar style={{ height: '24px', width: '24px' }} src={issue.fields?.issuetype?.iconUrl} alt="" />
+                    )}
+                  </FlexItem>
+                  <FlexItem>{issue.fields?.issuetype?.name || ''}</FlexItem>
+                </Flex>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
 
-          <DescriptionListGroup>
-            <DescriptionListTerm className="pf-u-text-nowrap">Assignee</DescriptionListTerm>
-            <DescriptionListDescription>
-              <Flex direction={{ default: 'row' }}>
-                <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
-                  {issue.fields?.assignee?.avatarUrls?.['24x24'] && (
-                    <Avatar
-                      style={{ height: '24px', width: '24px' }}
-                      src={issue.fields?.assignee?.avatarUrls?.['24x24']}
-                      alt=""
-                    />
-                  )}
-                </FlexItem>
-                <FlexItem>{issue.fields?.assignee?.displayName || ''}</FlexItem>
-              </Flex>
-            </DescriptionListDescription>
-          </DescriptionListGroup>
+          {issue.fields?.assignee?.displayName && (
+            <DescriptionListGroup>
+              <DescriptionListTerm className="pf-u-text-nowrap">Assignee</DescriptionListTerm>
+              <DescriptionListDescription>
+                <Flex direction={{ default: 'row' }}>
+                  <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
+                    {issue.fields?.assignee?.avatarUrls?.['24x24'] && (
+                      <Avatar
+                        style={{ height: '24px', width: '24px' }}
+                        src={issue.fields?.assignee?.avatarUrls?.['24x24']}
+                        alt=""
+                      />
+                    )}
+                  </FlexItem>
+                  <FlexItem>{issue.fields?.assignee?.displayName || ''}</FlexItem>
+                </Flex>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
 
-          <DescriptionListGroup>
-            <DescriptionListTerm className="pf-u-text-nowrap">Reporter</DescriptionListTerm>
-            <DescriptionListDescription>
-              <Flex direction={{ default: 'row' }}>
-                <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
-                  {issue.fields?.reporter?.avatarUrls?.['24x24'] && (
-                    <Avatar
-                      style={{ height: '24px', width: '24px' }}
-                      src={issue.fields?.reporter?.avatarUrls?.['24x24']}
-                      alt=""
-                    />
-                  )}
-                </FlexItem>
-                <FlexItem>{issue.fields?.reporter?.displayName || ''}</FlexItem>
-              </Flex>
-            </DescriptionListDescription>
-          </DescriptionListGroup>
+          {issue.fields?.reporter?.displayName && (
+            <DescriptionListGroup>
+              <DescriptionListTerm className="pf-u-text-nowrap">Reporter</DescriptionListTerm>
+              <DescriptionListDescription>
+                <Flex direction={{ default: 'row' }}>
+                  <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
+                    {issue.fields?.reporter?.avatarUrls?.['24x24'] && (
+                      <Avatar
+                        style={{ height: '24px', width: '24px' }}
+                        src={issue.fields?.reporter?.avatarUrls?.['24x24']}
+                        alt=""
+                      />
+                    )}
+                  </FlexItem>
+                  <FlexItem>{issue.fields?.reporter?.displayName || ''}</FlexItem>
+                </Flex>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
 
-          <DescriptionListGroup>
-            <DescriptionListTerm className="pf-u-text-nowrap">Reporter</DescriptionListTerm>
-            <DescriptionListDescription>
-              <Flex direction={{ default: 'row' }}>
-                <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
-                  {issue.fields?.reporter?.avatarUrls?.['24x24'] && (
-                    <Avatar
-                      style={{ height: '24px', width: '24px' }}
-                      src={issue.fields?.reporter?.avatarUrls?.['24x24']}
-                      alt=""
-                    />
-                  )}
-                </FlexItem>
-                <FlexItem>{issue.fields?.reporter?.displayName || ''}</FlexItem>
-              </Flex>
-            </DescriptionListDescription>
-          </DescriptionListGroup>
+          {issue.fields?.status?.name && (
+            <DescriptionListGroup>
+              <DescriptionListTerm className="pf-u-text-nowrap">Status</DescriptionListTerm>
+              <DescriptionListDescription>
+                <Label color={getStatusColor(issue.fields?.status?.statusCategory.name)}>
+                  {issue.fields?.status?.name.toUpperCase()}
+                </Label>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
 
-          <DescriptionListGroup>
-            <DescriptionListTerm className="pf-u-text-nowrap">Status</DescriptionListTerm>
-            <DescriptionListDescription>
-              <Label color={getStatusColor(issue.fields?.status?.statusCategory.colorName)}>
-                {issue.fields?.status?.name.toUpperCase()}
-              </Label>
-            </DescriptionListDescription>
-          </DescriptionListGroup>
+          {issue.fields?.labels && issue.fields?.labels.length > 0 && (
+            <DescriptionListGroup>
+              <DescriptionListTerm className="pf-u-text-nowrap">Labels</DescriptionListTerm>
+              <DescriptionListDescription>
+                {issue.fields?.labels.map((label) => (
+                  <Link
+                    key={label}
+                    to={`${pluginBasePath(instance)}/search?jql=${encodeURIComponent(`labels = "${label}"`)}`}
+                  >
+                    <Label className="pf-u-mr-sm" color="grey">
+                      {label}
+                    </Label>
+                  </Link>
+                ))}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
 
-          <DescriptionListGroup>
-            <DescriptionListTerm className="pf-u-text-nowrap">Description</DescriptionListTerm>
-            <DescriptionListDescription>
-              <TextContent>
-                <ReactMarkdown linkTarget="_blank">{issue.fields?.description || ''}</ReactMarkdown>
-              </TextContent>
-            </DescriptionListDescription>
-          </DescriptionListGroup>
+          {issue.fields?.description && (
+            <DescriptionListGroup>
+              <DescriptionListTerm className="pf-u-text-nowrap">Description</DescriptionListTerm>
+              <DescriptionListDescription>
+                <TextContent>
+                  <ReactMarkdown linkTarget="_blank">{jiraToMarkdown(issue.fields?.description)}</ReactMarkdown>
+                </TextContent>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
 
-          <DescriptionListGroup>
-            <DescriptionListTerm className="pf-u-text-nowrap">Parent</DescriptionListTerm>
-            <DescriptionListDescription>
-              {issue.fields?.parent && issue.fields?.parent.key ? (
+          {issue.fields?.parent?.key && (
+            <DescriptionListGroup>
+              <DescriptionListTerm className="pf-u-text-nowrap">Parent</DescriptionListTerm>
+              <DescriptionListDescription>
                 <Link
                   to={`${pluginBasePath(instance)}/search?jql=${encodeURIComponent(
                     `key = ${issue.fields?.parent.key}`,
@@ -148,14 +158,14 @@ const IssueDetails: React.FunctionComponent<IIssueDetailsProps> = ({ instance, i
                 >
                   <div>{issue.fields?.parent.key}</div>
                 </Link>
-              ) : null}
-            </DescriptionListDescription>
-          </DescriptionListGroup>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
 
-          <DescriptionListGroup>
-            <DescriptionListTerm className="pf-u-text-nowrap">Subtasks</DescriptionListTerm>
-            <DescriptionListDescription>
-              {issue.fields?.subtasks && issue.fields?.subtasks.length > 0 ? (
+          {issue.fields?.subtasks && issue.fields?.subtasks.length > 0 && (
+            <DescriptionListGroup>
+              <DescriptionListTerm className="pf-u-text-nowrap">Subtasks</DescriptionListTerm>
+              <DescriptionListDescription>
                 <DataList aria-label="subtasks" isCompact={true}>
                   {issue.fields?.subtasks?.map((issue) => (
                     <LinkWrapper
@@ -166,14 +176,14 @@ const IssueDetails: React.FunctionComponent<IIssueDetailsProps> = ({ instance, i
                     </LinkWrapper>
                   ))}
                 </DataList>
-              ) : null}
-            </DescriptionListDescription>
-          </DescriptionListGroup>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
 
-          <DescriptionListGroup>
-            <DescriptionListTerm className="pf-u-text-nowrap">Linked Issues</DescriptionListTerm>
-            <DescriptionListDescription>
-              {issue.fields?.issuelinks && issue.fields?.issuelinks.length > 0 ? (
+          {issue.fields?.issuelinks && issue.fields?.issuelinks.length > 0 && (
+            <DescriptionListGroup>
+              <DescriptionListTerm className="pf-u-text-nowrap">Linked Issues</DescriptionListTerm>
+              <DescriptionListDescription>
                 <DataList aria-label="subtasks" isCompact={true}>
                   {issue.fields?.issuelinks?.map((issue) => (
                     <LinkWrapper
@@ -198,9 +208,9 @@ const IssueDetails: React.FunctionComponent<IIssueDetailsProps> = ({ instance, i
                     </LinkWrapper>
                   ))}
                 </DataList>
-              ) : null}
-            </DescriptionListDescription>
-          </DescriptionListGroup>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
         </DescriptionList>
       </DrawerPanelBody>
     </DrawerPanelContent>

--- a/plugins/plugin-jira/src/utils/helpers.ts
+++ b/plugins/plugin-jira/src/utils/helpers.ts
@@ -15,25 +15,123 @@ export const getInitialOptions = (search: string, isInitial: boolean): IOptions 
   };
 };
 
-export const getStatusColor = (
-  color?: string,
-): 'blue' | 'cyan' | 'green' | 'orange' | 'purple' | 'red' | 'grey' | 'gold' | undefined => {
-  if (
-    color === 'blue' ||
-    color === 'cyan' ||
-    color === 'green' ||
-    color === 'orange' ||
-    color === 'purple' ||
-    color === 'red' ||
-    color === 'grey' ||
-    color === 'gold'
-  ) {
-    return color;
+export const getStatusColor = (name?: string): 'blue' | 'green' | 'grey' => {
+  if (name === 'Done') {
+    return 'green';
   }
 
-  if ((color = 'yellow')) {
-    return 'orange';
+  if (name === 'In Progress') {
+    return 'blue';
   }
 
-  return undefined;
+  return 'grey';
+};
+
+// The jiraToMarkdown and markdownToJira functions are used to convert the provided description for an issue into
+// markdown, so that we can render it using react markdown. For that we are using a modified version of the functions
+// provided by https://github.com/kylefarris/J2M
+export const jiraToMarkdown = (str: string): string => {
+  return str
+    .replace(/^[ \t]*(\*+)\s+/gm, (match, stars) => {
+      return Array(stars.length).join('  ') + '* ';
+    })
+    .replace(/^[ \t]*(#+)\s+/gm, (match, nums) => {
+      return Array(nums.length).join('  ') + '1. ';
+    })
+    .replace(/^h([0-6])\.(.*)$/gm, (match, level, content) => {
+      return Array(parseInt(level) + 1).join('#') + content;
+    })
+    .replace(/\*(\S.*)\*/g, '**$1**')
+    .replace(/_(\S.*)_/g, '*$1*')
+    .replace(/\{\{([^}]+)\}\}/g, '`$1`')
+    .replace(/\+([^+]*)\+/g, '<ins>$1</ins>')
+    .replace(/\^([^^]*)\^/g, '<sup>$1</sup>')
+    .replace(/~([^~]*)~/g, '<sub>$1</sub>')
+    .replace(/(\s+)-(\S+.*?\S)-(\s+)/g, '$1~~$2~~$3')
+    .replace(
+      /\{code(:([a-z]+))?([:|]?(title|borderStyle|borderColor|borderWidth|bgColor|titleBGColor)=.+?)*\}([^]*?)\n?\{code\}/gm,
+      '```$2$5\n```',
+    )
+    .replace(/{noformat}/g, '```')
+    .replace(/\[([^|]+?)\]/g, '<$1>')
+    .replace(/!(.+)!/g, '![]($1)')
+    .replace(/\[(.+?)\|(.+?)\]/g, '[$1]($2)')
+    .replace(/^bq\.\s+/gm, '> ')
+    .replace(/\{color:[^}]+\}([^]*)\{color\}/gm, '$1')
+    .replace(/\{panel:title=([^}]*)\}\n?([^]*?)\n?\{panel\}/gm, '\n| $1 |\n| --- |\n| $2 |')
+    .replace(/^[ \t]*((?:\|\|.*?)+\|\|)[ \t]*$/gm, (match, headers) => {
+      const singleBarred = headers.replace(/\|\|/g, '|');
+      return '\n' + singleBarred + '\n' + singleBarred.replace(/\|[^|]+/g, '| --- ');
+    })
+    .replace(/^[ \t]*\|/gm, '|');
+};
+
+export const markdownToJira = (str: string): string => {
+  const map: Record<string, string> = {
+    del: '-',
+    ins: '+',
+    sub: '~',
+    sup: '^',
+  };
+
+  return str
+    .replace(
+      /^\n((?:\|.*?)+\|)[ \t]*\n((?:\|\s*?-{3,}\s*?)+\|)[ \t]*\n((?:(?:\|.*?)+\|[ \t]*\n)*)$/gm,
+      (match, headerLine, separatorLine, rowstr) => {
+        const headers = headerLine.match(/[^|]+(?=\|)/g);
+        const separators = separatorLine.match(/[^|]+(?=\|)/g);
+        if (headers.length !== separators.length) {
+          return match;
+        }
+        const rows = rowstr.split('\n');
+        if (rows.length === 1 + 1 && headers.length === 1) {
+          return (
+            '{panel:title=' + headers[0].trim() + '}\n' + rowstr.replace(/^\|(.*)[ \t]*\|/, '$1').trim() + '\n{panel}\n'
+          );
+        } else {
+          return '||' + headers.join('||') + '||\n' + rowstr;
+        }
+      },
+    )
+    .replace(/([*_]+)(\S.*?)\1/g, (match, wrapper, content) => {
+      switch (wrapper.length) {
+        case 1:
+          return '_' + content + '_';
+        case 2:
+          return '*' + content + '*';
+        case 3:
+          return '_*' + content + '*_';
+        default:
+          return wrapper + content * wrapper;
+      }
+    })
+    .replace(/^([#]+)(.*?)$/gm, (match, level, content) => {
+      return 'h' + level.length + '.' + content;
+    })
+    .replace(/^(.*?)\n([=-]+)$/gm, (match, content, level) => {
+      return 'h' + (level[0] === '=' ? 1 : 2) + '. ' + content;
+    })
+    .replace(/^([ \t]*)\d+\.\s+/gm, (match, spaces) => {
+      return Array(Math.floor(spaces.length / 2 + 1)).join('#') + '# ';
+    })
+    .replace(/^([ \t]*)\*\s+/gm, (match, spaces) => {
+      return Array(Math.floor(spaces.length / 2 + 1)).join('*') + '* ';
+    })
+    .replace(new RegExp('<(' + Object.keys(map).join('|') + ')>(.*?)</\\1>', 'g'), (match, from, content) => {
+      const to = map[from];
+      return to + content + to;
+    })
+    .replace(/(\s+)~~(.*?)~~(\s+)/g, '$1-$2-$3')
+    .replace(/```(.+\n)?((?:.|\n)*?)```/g, (match, synt, content) => {
+      let code = '{code}';
+      if (synt) {
+        code = '{code:' + synt.replace(/\n/g, '') + '}\n';
+      }
+      return code + content + '{code}';
+    })
+    .replace(/`([^`]+)`/g, '{{$1}}')
+    .replace(/!\[[^\]]*\]\(([^)]+)\)/g, '!$1!')
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '[$1|$2]')
+    .replace(/<([^>]+)>/g, '[$1]')
+    .replace(/^>/gm, 'bq.');
 };


### PR DESCRIPTION
The description of an issue is now converted to markdown before we
render the description. This is necessary because Jira returns the
description in a wiki markup format, which doesn't look good when it is
directly passed to the ReactMarkdown component for rendering.

We also changed the logic to display the details of an issue, so that
only the fields which are relly available are displayed in the details.
This means if for example an issue doesn't have subtasks we do not
display the subtasks section anymore.

We also changed the color of the status label, so that the label matches
the color in Jira. The previously used color field seems to be
deprecated and Jira only allows 3 status categories. For these
categories we set the color: "Done" -> "green", "In Progress" -> "blue"
and "Open" -> "grey".

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
