### PR TITLE
[app] Fix error handling in resources table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#403](https://github.com/kobsio/kobs/pull/403): [app] Add missing sort keys to MongoDB queries and fix `go.mongodb.org/mongo-driver/bson/primitive.E composite literal uses unkeyed fields`.
 - [#410](https://github.com/kobsio/kobs/pull/410): [app] Fix 404 error for ACE worker files, by disabling workers.
 - [#413](https://github.com/kobsio/kobs/pull/413): [app] Fix permission handling for applications.
+- [#416](https://github.com/kobsio/kobs/pull/416): [app] Fix error handling in resources table and details handling in notifications.
 
 ### Changed
 

--- a/plugins/app/src/components/resources/ResourcesNotificationsGroup.tsx
+++ b/plugins/app/src/components/resources/ResourcesNotificationsGroup.tsx
@@ -1,13 +1,10 @@
 import {
-  Button,
-  ButtonVariant,
   NotificationDrawerListItem,
   NotificationDrawerListItemBody,
   NotificationDrawerListItemHeader,
 } from '@patternfly/react-core';
-import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
-import { Link } from 'react-router-dom';
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { IColumn, IResourceResponse } from './utils/interfaces';
 import { customResourceDefinitionTableData, resourcesTableData } from './utils/tabledata';
@@ -23,6 +20,8 @@ const ResourcesNotificationsGroup: React.FunctionComponent<IResourcesNotificatio
   columns,
   filter,
 }: IResourcesNotificationsGroupProps) => {
+  const navigate = useNavigate();
+
   if (
     resourceResponse.resourceLists.filter(
       (resourceList) => resourceList.list && resourceList.list.items && resourceList.list.items.length > 0,
@@ -39,23 +38,24 @@ const ResourcesNotificationsGroup: React.FunctionComponent<IResourcesNotificatio
   return (
     <React.Fragment>
       {tableData.rows(resourceResponse, columns, filter).map((row, rowIndex) => (
-        <NotificationDrawerListItem key={rowIndex} variant="info" isRead={false}>
-          <NotificationDrawerListItemHeader
-            variant="info"
-            title={row.namespace ? `${row.namespace}/${row.name}` : row.name}
-          >
-            <Link
-              to={`/resources?clusterID=${encodeURIComponent(`/satellite/${row.satellite}/cluster/${row.cluster}`)}${
+        <NotificationDrawerListItem
+          key={rowIndex}
+          variant="info"
+          isRead={false}
+          onClick={(): void =>
+            navigate(
+              `/resources?clusterID=${encodeURIComponent(`/satellite/${row.satellite}/cluster/${row.cluster}`)}${
                 row.namespace ? `&namespace=${encodeURIComponent(row.namespace)}` : ''
               }&resourceID=${encodeURIComponent(resourceResponse.resource.id)}&param=metadata.name=${encodeURIComponent(
                 row.name,
-              )}&paramName=fieldSelector`}
-            >
-              <Button variant={ButtonVariant.plain}>
-                <ExternalLinkAltIcon />
-              </Button>
-            </Link>
-          </NotificationDrawerListItemHeader>
+              )}&paramName=fieldSelector`,
+            )
+          }
+        >
+          <NotificationDrawerListItemHeader
+            variant="info"
+            title={row.namespace ? `${row.namespace}/${row.name}` : row.name}
+          />
           <NotificationDrawerListItemBody>
             {columns ? (
               <React.Fragment>

--- a/plugins/app/src/components/resources/ResourcesPanelTable.tsx
+++ b/plugins/app/src/components/resources/ResourcesPanelTable.tsx
@@ -52,12 +52,12 @@ const ResourcesPanelTable: React.FunctionComponent<IResourcesPanelTableProps> = 
         )}
       </Thead>
       <Tbody>
-        {resourceResponse.errors ||
-        !resourceResponse.resourceLists ||
-        resourceResponse.resourceLists.length === 0 ||
-        resourceResponse.resourceLists.filter(
-          (resourceList) => resourceList.list && resourceList.list.items && resourceList.list.items.length > 0,
-        ).length === 0 ? (
+        {resourceResponse.errors &&
+        (!resourceResponse.resourceLists ||
+          resourceResponse.resourceLists.length === 0 ||
+          resourceResponse.resourceLists.filter(
+            (resourceList) => resourceList.list && resourceList.list.items && resourceList.list.items.length > 0,
+          ).length === 0) ? (
           <Tr>
             <Td colSpan={columns ? 3 + columns.length : tableData.columns.length}>
               <Bullseye>

--- a/plugins/app/src/components/resources/ResourcesPanelWrapper.tsx
+++ b/plugins/app/src/components/resources/ResourcesPanelWrapper.tsx
@@ -17,9 +17,11 @@ const ResourcesPanelWrapper: React.FunctionComponent<IResourcesPanelWrapperProps
   setDetails,
 }: IResourcesPanelWrapperProps) => {
   if (options.satellites && options.clusters && options.resources && times) {
-    const clusterIDs: string[] = options.satellites.map((satellite: string) =>
-      options.clusters.map((cluster: string) => `/satellite/${satellite}/cluster/${cluster}`),
-    );
+    const clusterIDs: string[] = options.satellites
+      .map((satellite: string) =>
+        options.clusters.map((cluster: string) => `/satellite/${satellite}/cluster/${cluster}`),
+      )
+      .flat();
 
     return (
       <ResourcesPanel

--- a/plugins/plugin-github/src/components/notifications/UserNotification.tsx
+++ b/plugins/plugin-github/src/components/notifications/UserNotification.tsx
@@ -1,12 +1,9 @@
 import {
-  Button,
-  ButtonVariant,
   NotificationDrawerListItem,
   NotificationDrawerListItemBody,
   NotificationDrawerListItemHeader,
 } from '@patternfly/react-core';
 import React, { useContext } from 'react';
-import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 
 import { AuthContext, IAuthContext } from '../../context/AuthContext';
 import { formatTime } from '@kobsio/shared';
@@ -41,11 +38,7 @@ const UserNotification: React.FunctionComponent<IAlertProps> = ({
 
   return (
     <NotificationDrawerListItem variant="info" isRead={!unread}>
-      <NotificationDrawerListItemHeader variant="info" title={title}>
-        <Button variant={ButtonVariant.plain} onClick={selectNotification}>
-          <ExternalLinkAltIcon />
-        </Button>
-      </NotificationDrawerListItemHeader>
+      <NotificationDrawerListItemHeader variant="info" title={title} onClick={selectNotification} />
       <NotificationDrawerListItemBody timestamp={formatTime(Math.floor(new Date(updatedAt).getTime() / 1000))}>
         {repo}
       </NotificationDrawerListItemBody>

--- a/plugins/plugin-github/src/components/notifications/UserPullRequest.tsx
+++ b/plugins/plugin-github/src/components/notifications/UserPullRequest.tsx
@@ -1,11 +1,8 @@
 import {
-  Button,
-  ButtonVariant,
   NotificationDrawerListItem,
   NotificationDrawerListItemBody,
   NotificationDrawerListItemHeader,
 } from '@patternfly/react-core';
-import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import React from 'react';
 
 import { formatTime } from '@kobsio/shared';
@@ -34,15 +31,13 @@ const UserPullRequest: React.FunctionComponent<IAlertProps> = ({
   closedAt,
   mergedAt,
 }: IAlertProps) => {
+  const open = (): void => {
+    window.open(url, '_blank');
+  };
+
   return (
     <NotificationDrawerListItem variant="info" isRead={mergedAt ? true : false}>
-      <NotificationDrawerListItemHeader variant="info" title={title}>
-        <a href={url} target="_blank" rel="noreferrer">
-          <Button variant={ButtonVariant.plain}>
-            <ExternalLinkAltIcon />
-          </Button>
-        </a>
-      </NotificationDrawerListItemHeader>
+      <NotificationDrawerListItemHeader variant="info" title={title} onClick={open} />
       <NotificationDrawerListItemBody timestamp={formatTime(Math.floor(new Date(updatedAt).getTime() / 1000))}>
         {getPRSubTitle(number, user, state, createdAt, closedAt, mergedAt)}
       </NotificationDrawerListItemBody>

--- a/plugins/plugin-github/src/components/panel/Panel.tsx
+++ b/plugins/plugin-github/src/components/panel/Panel.tsx
@@ -129,7 +129,7 @@ const Panel: React.FunctionComponent<IGitHubPluginPanelProps> = ({
     );
   }
 
-  if (options && options.type && options.type === 'userpullrequests' && options.repository) {
+  if (options && options.type && options.type === 'userpullrequests') {
     return (
       <AuthContextProvider title={title} isNotification={false} instance={instance}>
         <UserPullRequests title={title} description={description} instance={instance} />
@@ -137,7 +137,7 @@ const Panel: React.FunctionComponent<IGitHubPluginPanelProps> = ({
     );
   }
 
-  if (options && options.type && options.type === 'usernotifications' && options.repository) {
+  if (options && options.type && options.type === 'usernotifications') {
     return (
       <AuthContextProvider title={title} isNotification={false} instance={instance}>
         <UserNotifications title={title} description={description} instance={instance} />


### PR DESCRIPTION
This commit fixes the error handling in the resources table. When an
error was returned and a valid list of resources, we did not show the
list, but instead we only show the errors.

Now we are checking if there is a valid list of resources. If this is
the case we render the table and ignore the errors.

We also fixed the handling of links in notification. Until now we always
displayed an external link icon which was used to redirect a user to the
details. Now the user can directly click on the notification to get
redirected to the details for a notification.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
