### PR TITLE
[app] Go to details when application is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#412](https://github.com/kobsio/kobs/pull/412): [helm] Reload list of Helm releases, when user clicks the search button again.
 - [#415](https://github.com/kobsio/kobs/pull/415): [jira] Convert the description of issues to markdown before the description is rendered. Adjust the colors of the rendered status label. Show fields in details only when they have a value.
 - [#417](https://github.com/kobsio/kobs/pull/417): [jira] Adjust notification style based on the issue status.
+- [#418](https://github.com/kobsio/kobs/pull/418): [app] Go to details page when a user selects an application.
 
 ## [v0.9.1](https://github.com/kobsio/kobs/releases/tag/v0.9.1) (2022-07-08)
 

--- a/plugins/app/src/components/applications/ApplicationsList.tsx
+++ b/plugins/app/src/components/applications/ApplicationsList.tsx
@@ -19,13 +19,6 @@ const ApplicationsList: React.FunctionComponent<IApplicationsListProps> = ({
   selectedApplication,
   setSelectedApplication,
 }: IApplicationsListProps) => {
-  const selectApplicationID = (id: string): void => {
-    const selectedApplications = data?.filter((application) => application.id === id);
-    if (selectedApplications?.length === 1) {
-      setSelectedApplication(selectedApplications[0]);
-    }
-  };
-
   const { isError, isLoading, error, data, refetch } = useQuery<IApplication[], Error>(
     ['app/applications/applications', options],
     async () => {
@@ -118,10 +111,13 @@ const ApplicationsList: React.FunctionComponent<IApplicationsListProps> = ({
     <DataList
       aria-label="applications list"
       selectedDataListItemId={selectedApplication ? selectedApplication.id : undefined}
-      onSelectDataListItem={selectApplicationID}
     >
       {data.map((application) => (
-        <ApplicationsListItem key={application.id} application={application} />
+        <ApplicationsListItem
+          key={application.id}
+          application={application}
+          selectApplication={setSelectedApplication}
+        />
       ))}
     </DataList>
   );

--- a/plugins/app/src/components/applications/ApplicationsListItem.tsx
+++ b/plugins/app/src/components/applications/ApplicationsListItem.tsx
@@ -10,19 +10,21 @@ import {
   FlexItem,
   Label,
 } from '@patternfly/react-core';
-import { Link } from 'react-router-dom';
 import React from 'react';
 import TopologyIcon from '@patternfly/react-icons/dist/esm/icons/topology-icon';
 import UsersIcon from '@patternfly/react-icons/dist/esm/icons/users-icon';
 
 import { IApplication } from '../../crds/application';
+import { LinkWrapper } from '@kobsio/shared';
 
 interface IApplicationsListItemProps {
   application: IApplication;
+  selectApplication: (application: IApplication) => void;
 }
 
 const ApplicationsListItem: React.FunctionComponent<IApplicationsListItemProps> = ({
   application,
+  selectApplication,
 }: IApplicationsListItemProps) => {
   return (
     <DataListItem id={application.id} aria-labelledby={application.id}>
@@ -30,64 +32,64 @@ const ApplicationsListItem: React.FunctionComponent<IApplicationsListItemProps> 
         <DataListItemCells
           dataListCells={[
             <DataListCell key="main">
-              <Flex direction={{ default: 'column' }}>
-                <FlexItem>
-                  <p>
-                    {application.name}
-                    <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">
-                      {application.topology && application.topology.external === true
-                        ? ''
-                        : `(${application.namespace} / ${application.cluster})`}
-                    </span>
-                  </p>
-                  <small>{application.description}</small>
-                </FlexItem>
-                <Flex>
-                  {application.tags && application.tags.length > 0 && (
-                    <FlexItem>
-                      {application.tags.map((tag) => (
-                        <Label key={tag} className="pf-u-mr-sm" color="blue">
-                          {tag}
-                        </Label>
-                      ))}
-                    </FlexItem>
-                  )}
-                  {application.teams && application.teams.length > 0 && (
-                    <FlexItem>
-                      <Label color="grey" icon={<UsersIcon />}>
-                        {application.teams.length === 1 ? '1 Team' : `${application.teams.length} Teams`}
-                      </Label>
-                    </FlexItem>
-                  )}
-                  {application.topology &&
-                    application.topology.dependencies &&
-                    application.topology.dependencies.length > 0 && (
+              <LinkWrapper to={`/applications${application.id}`}>
+                <Flex direction={{ default: 'column' }}>
+                  <FlexItem>
+                    <p>
+                      {application.name}
+                      <span className="pf-u-pl-sm pf-u-font-size-sm pf-u-color-400">
+                        {application.topology && application.topology.external === true
+                          ? ''
+                          : `(${application.namespace} / ${application.cluster})`}
+                      </span>
+                    </p>
+                    <small>{application.description}</small>
+                  </FlexItem>
+                  <Flex>
+                    {application.tags && application.tags.length > 0 && (
                       <FlexItem>
-                        <Label color="grey" icon={<TopologyIcon />}>
-                          {application.topology.dependencies.length === 1
-                            ? '1 Dependency'
-                            : `${application.topology.dependencies.length} Dependencies`}
+                        {application.tags.map((tag) => (
+                          <Label key={tag} className="pf-u-mr-sm" color="blue">
+                            {tag}
+                          </Label>
+                        ))}
+                      </FlexItem>
+                    )}
+                    {application.teams && application.teams.length > 0 && (
+                      <FlexItem>
+                        <Label color="grey" icon={<UsersIcon />}>
+                          {application.teams.length === 1 ? '1 Team' : `${application.teams.length} Teams`}
                         </Label>
                       </FlexItem>
                     )}
-                  {application.topology && application.topology.external && application.topology.external === true && (
-                    <FlexItem>
-                      <Label color="grey" icon={<TopologyIcon />}>
-                        External Application
-                      </Label>
-                    </FlexItem>
-                  )}
+                    {application.topology &&
+                      application.topology.dependencies &&
+                      application.topology.dependencies.length > 0 && (
+                        <FlexItem>
+                          <Label color="grey" icon={<TopologyIcon />}>
+                            {application.topology.dependencies.length === 1
+                              ? '1 Dependency'
+                              : `${application.topology.dependencies.length} Dependencies`}
+                          </Label>
+                        </FlexItem>
+                      )}
+                    {application.topology && application.topology.external && application.topology.external === true && (
+                      <FlexItem>
+                        <Label color="grey" icon={<TopologyIcon />}>
+                          External Application
+                        </Label>
+                      </FlexItem>
+                    )}
+                  </Flex>
                 </Flex>
-              </Flex>
+              </LinkWrapper>
             </DataListCell>,
           ]}
         />
+
         <DataListAction aria-labelledby={application.id} id={application.id} aria-label="Actions">
-          <Button
-            variant={ButtonVariant.link}
-            component={(props): React.ReactElement => <Link {...props} to={`/applications${application.id}`} />}
-          >
-            View Details
+          <Button variant={ButtonVariant.link} onClick={(): void => selectApplication(application)}>
+            Preview
           </Button>
         </DataListAction>
       </DataListItemRow>

--- a/plugins/app/src/components/applications/ApplicationsPanelList.tsx
+++ b/plugins/app/src/components/applications/ApplicationsPanelList.tsx
@@ -31,12 +31,9 @@ const ApplicationsPanelList: React.FunctionComponent<IApplicationsPanelListProps
 }: IApplicationsPanelListProps) => {
   const [options, setOptions] = useState<{ page: number; perPage: number }>({ page: 1, perPage: 10 });
 
-  const selectApplicationID = (id: string): void => {
-    const selectedApplications = data?.applications?.filter((application) => application.id === id);
-    if (selectedApplications?.length === 1 && setDetails) {
-      setDetails(
-        <ApplicationDetails application={selectedApplications[0]} close={(): void => setDetails(undefined)} />,
-      );
+  const selectApplication = (application: IApplication): void => {
+    if (setDetails) {
+      setDetails(<ApplicationDetails application={application} close={(): void => setDetails(undefined)} />);
     }
   };
 
@@ -122,13 +119,13 @@ const ApplicationsPanelList: React.FunctionComponent<IApplicationsPanelListProps
           <p>{error?.message}</p>
         </Alert>
       ) : data && data.applications && data.applications.length > 0 ? (
-        <DataList
-          aria-label={`applications list ${team}`}
-          selectedDataListItemId={undefined}
-          onSelectDataListItem={selectApplicationID}
-        >
+        <DataList aria-label={`applications list ${team}`} selectedDataListItemId={undefined}>
           {data.applications.map((application) => (
-            <ApplicationsListItem key={application.id} application={application} />
+            <ApplicationsListItem
+              key={application.id}
+              application={application}
+              selectApplication={selectApplication}
+            />
           ))}
         </DataList>
       ) : null}

--- a/plugins/app/src/components/profile/UserApplications.tsx
+++ b/plugins/app/src/components/profile/UserApplications.tsx
@@ -21,12 +21,9 @@ const UserApplications: React.FunctionComponent<IUserApplicationsProps> = ({
 }: IUserApplicationsProps) => {
   const [options, setOptions] = useState<{ page: number; perPage: number }>({ page: 1, perPage: 10 });
 
-  const selectApplicationID = (id: string): void => {
-    const selectedApplications = data?.filter((application) => application.id === id);
-    if (selectedApplications?.length === 1 && setDetails) {
-      setDetails(
-        <ApplicationDetails application={selectedApplications[0]} close={(): void => setDetails(undefined)} />,
-      );
+  const selectApplication = (application: IApplication): void => {
+    if (setDetails) {
+      setDetails(<ApplicationDetails application={application} close={(): void => setDetails(undefined)} />);
     }
   };
 
@@ -84,13 +81,13 @@ const UserApplications: React.FunctionComponent<IUserApplicationsProps> = ({
           <p>{error?.message}</p>
         </Alert>
       ) : data && data.length > 0 ? (
-        <DataList
-          aria-label="applications list"
-          selectedDataListItemId={undefined}
-          onSelectDataListItem={selectApplicationID}
-        >
+        <DataList aria-label="applications list" selectedDataListItemId={undefined}>
           {data.map((application) => (
-            <ApplicationsListItem key={application.id} application={application} />
+            <ApplicationsListItem
+              key={application.id}
+              application={application}
+              selectApplication={selectApplication}
+            />
           ))}
         </DataList>
       ) : null}


### PR DESCRIPTION
Instead of showing the preview of an application, we now open the
details page of the application, when the user clicks on the
application. The preview panel can be opened by clicking the new
"Preview" button.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
