### PR TITLE
[app] Delete all cookies on signout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#417](https://github.com/kobsio/kobs/pull/417): [jira] Adjust notification style based on the issue status.
 - [#418](https://github.com/kobsio/kobs/pull/418): [app] Go to details page when a user selects an application.
 - [#420](https://github.com/kobsio/kobs/pull/420): [app] Use generics for `jwt` package and reuse the package for the GitHub and Jira plugin, to make the generated cookies more secure.
+- [#421](https://github.com/kobsio/kobs/pull/421): [app] Delete all cookies on signout.
 
 ## [v0.9.1](https://github.com/kobsio/kobs/releases/tag/v0.9.1) (2022-07-08)
 

--- a/pkg/hub/auth/auth.go
+++ b/pkg/hub/auth/auth.go
@@ -209,14 +209,20 @@ func (c *client) signinHandler(w http.ResponseWriter, r *http.Request) {
 // signoutHandler handles the logout for an user. For this we are setting the value of the auth cookie to an empty
 // string and we adjust the expiration date of the cookie.
 func (c *client) signoutHandler(w http.ResponseWriter, r *http.Request) {
-	http.SetCookie(w, &http.Cookie{
-		Name:     "kobs",
-		Value:    "",
-		Path:     "/",
-		Secure:   true,
-		HttpOnly: true,
-		Expires:  time.Unix(0, 0),
-	})
+	cookies := r.Cookies()
+
+	for _, cookie := range cookies {
+		if strings.HasPrefix(cookie.Name, "kobs") {
+			http.SetCookie(w, &http.Cookie{
+				Name:     cookie.Name,
+				Value:    "",
+				Path:     "/",
+				Secure:   true,
+				HttpOnly: true,
+				Expires:  time.Unix(0, 0),
+			})
+		}
+	}
 
 	render.JSON(w, r, nil)
 }

--- a/pkg/hub/auth/auth_test.go
+++ b/pkg/hub/auth/auth_test.go
@@ -307,6 +307,14 @@ func TestSignoutHandler(t *testing.T) {
 	}
 
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{
+		Name:     "kobs",
+		Value:    "1234",
+		Path:     "/",
+		Secure:   true,
+		HttpOnly: true,
+		Expires:  time.Unix(0, 0),
+	})
 	w := httptest.NewRecorder()
 	c.signoutHandler(w, req)
 	require.Equal(t, http.StatusOK, w.Code)


### PR DESCRIPTION
Until now we only deleted the main cookie when the user clicks the
signout button. This is now changed so that all cookies are deleted.
This means that also the cookies generated by plugins are deleted when
they are starting with "kobs".

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
