### PR TITLE
[app] Rework "useDimensions" hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - [#418](https://github.com/kobsio/kobs/pull/418): [app] Go to details page when a user selects an application.
 - [#420](https://github.com/kobsio/kobs/pull/420): [app] Use generics for `jwt` package and reuse the package for the GitHub and Jira plugin, to make the generated cookies more secure.
 - [#421](https://github.com/kobsio/kobs/pull/421): [app] Delete all cookies on signout.
+- [#422](https://github.com/kobsio/kobs/pull/422): [app] Rework `useDimensions` hook.
 
 ## [v0.9.1](https://github.com/kobsio/kobs/releases/tag/v0.9.1) (2022-07-08)
 

--- a/plugins/app/src/components/dashboards/DashboardsWrapper.tsx
+++ b/plugins/app/src/components/dashboards/DashboardsWrapper.tsx
@@ -21,12 +21,14 @@ export const DashboardsWrapper: React.FunctionComponent<IDashboardsWrapperProps>
 
   return (
     <div style={{ minHeight: '100%' }} ref={refTabs}>
-      <Dashboards
-        manifest={manifest}
-        references={references}
-        forceDefaultSpan={tabsSize.width < 1200}
-        useDrawer={useDrawer}
-      />
+      {tabsSize.height !== 0 && tabsSize.width !== 0 && (
+        <Dashboards
+          manifest={manifest}
+          references={references}
+          forceDefaultSpan={tabsSize.width < 1200}
+          useDrawer={useDrawer}
+        />
+      )}
     </div>
   );
 };

--- a/plugins/plugin-klogs/src/components/panel/AggregationChart.tsx
+++ b/plugins/plugin-klogs/src/components/panel/AggregationChart.tsx
@@ -23,23 +23,25 @@ const AggregationChart: React.FunctionComponent<IAggregationChartProps> = ({
 
   return (
     <div ref={refChartContainer} style={{ height: '100%', minHeight: `${minHeight}px`, width: '100%' }}>
-      <div style={{ height: `${chartContainerSize.height}px`, width: '100%' }}>
-        {options.chart === 'pie' ? (
-          <AggregationChartPie data={data} />
-        ) : options.chart === 'bar' && options.options.horizontalAxisOperation === 'top' ? (
-          <AggregationChartBarTop filters={options.options.breakDownByFilters} data={data} />
-        ) : options.chart === 'bar' && options.options.horizontalAxisOperation === 'time' ? (
-          <AggregationChartBarTime filters={options.options.breakDownByFilters} data={data} />
-        ) : options.chart === 'line' || options.chart === 'area' ? (
-          <AggregationChartLine
-            isArea={options.chart === 'area'}
-            startTime={options.times.timeStart}
-            endTime={options.times.timeEnd}
-            filters={options.options.breakDownByFilters}
-            data={data}
-          />
-        ) : null}
-      </div>
+      {chartContainerSize.height !== 0 && chartContainerSize.width !== 0 && (
+        <div style={{ height: `${chartContainerSize.height}px`, width: '100%' }}>
+          {options.chart === 'pie' ? (
+            <AggregationChartPie data={data} />
+          ) : options.chart === 'bar' && options.options.horizontalAxisOperation === 'top' ? (
+            <AggregationChartBarTop filters={options.options.breakDownByFilters} data={data} />
+          ) : options.chart === 'bar' && options.options.horizontalAxisOperation === 'time' ? (
+            <AggregationChartBarTime filters={options.options.breakDownByFilters} data={data} />
+          ) : options.chart === 'line' || options.chart === 'area' ? (
+            <AggregationChartLine
+              isArea={options.chart === 'area'}
+              startTime={options.times.timeStart}
+              endTime={options.times.timeEnd}
+              filters={options.options.breakDownByFilters}
+              data={data}
+            />
+          ) : null}
+        </div>
+      )}
     </div>
   );
 };

--- a/plugins/shared/src/hooks/useDimensions.ts
+++ b/plugins/shared/src/hooks/useDimensions.ts
@@ -1,32 +1,43 @@
-import { useEffect, useLayoutEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import { getResizeObserver } from '@patternfly/react-charts';
 
 export interface IDimensions {
   height: number;
   width: number;
 }
 
-export const useDimensions = (targetRef: React.RefObject<HTMLDivElement>, defaults?: IDimensions): IDimensions => {
-  const getDimensions = (): IDimensions => {
-    return {
-      height: targetRef.current ? targetRef.current.offsetHeight : defaults ? defaults.height : 0,
-      width: targetRef.current ? targetRef.current.offsetWidth : defaults ? defaults.width : 0,
-    };
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const debounce = (func: (...args: any[]) => any, wait: number): ((...args: any[]) => any) => {
+  let timeout: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (...args: any[]) => {
+    clearTimeout(timeout);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    timeout = setTimeout(() => func.apply(this, args), wait) as any;
   };
+};
 
-  const [dimensions, setDimensions] = useState(getDimensions);
-
-  const handleResize = (): void => {
-    setDimensions(getDimensions());
-  };
+export const useDimensions = (
+  targetRef: React.RefObject<HTMLDivElement>,
+  defaults: IDimensions = { height: 0, width: 0 },
+  delay = 500,
+): IDimensions => {
+  const [dimensions, setDimensions] = useState({
+    height: targetRef.current ? targetRef.current.offsetHeight : defaults.height,
+    width: targetRef.current ? targetRef.current.offsetWidth : defaults.width,
+  });
 
   useEffect(() => {
-    window.addEventListener('resize', handleResize);
-    return (): void => window.removeEventListener('resize', handleResize);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useLayoutEffect(() => {
-    handleResize();
+    if (targetRef.current) {
+      getResizeObserver(
+        targetRef.current,
+        debounce(() => {
+          if (targetRef.current && targetRef.current.clientHeight && targetRef.current.clientWidth) {
+            setDimensions({ height: targetRef.current.clientHeight, width: targetRef.current.clientWidth });
+          }
+        }, delay),
+      );
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
We changed the "useDimensions" hook, so that the hook now also takes
into account when the sidebar is toggled. Before the rework the returned
height and width of the "useDimensions" hook was not changed when a user
opens/closes the sidebar, so that some components where not correctly
adjusted. This is now fixed by using the "getResizeObserver" from the
"@patternfly/react-charts" package within the hook.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I added a [CHANGELOG](https://github.com/kobsio/kobs/blob/master/CHANGELOG.md) entry for this change.
- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
