### PR TITLE
[sql] Fix query encoding in panel actions

### DIFF
--- a/plugins/plugin-sql/src/components/panel/SQLActions.tsx
+++ b/plugins/plugin-sql/src/components/panel/SQLActions.tsx
@@ -31,7 +31,11 @@ export const SQLActions: React.FunctionComponent<ISQLActionsProps> = ({
           dropdownItems={queries.map((query, index) => (
             <DropdownItem
               key={index}
-              component={<Link to={`${pluginBasePath(instance)}?query=${query.query}`}>{query.name}</Link>}
+              component={
+                <Link to={`${pluginBasePath(instance)}?query=${encodeURIComponent(query.query || '')}`}>
+                  {query.name}
+                </Link>
+              }
             />
           ))}
         />

--- a/plugins/plugin-sql/src/components/panel/SQLChartActions.tsx
+++ b/plugins/plugin-sql/src/components/panel/SQLChartActions.tsx
@@ -28,7 +28,10 @@ export const SQLChartActions: React.FunctionComponent<ISQLChartActionsProps> = (
           isPlain={true}
           position="right"
           dropdownItems={[
-            <DropdownItem key={0} component={<Link to={`${pluginBasePath(instance)}?query=${query}`}>Explore</Link>} />,
+            <DropdownItem
+              key={0}
+              component={<Link to={`${pluginBasePath(instance)}?query=${encodeURIComponent(query)}`}>Explore</Link>}
+            />,
           ]}
         />
       )}


### PR DESCRIPTION
The query parameter was not encoded in the panel actions, so that the
a users query broke, when he selected a query in the action and was
redirected to the raw view of his data.

This is now fixed by using "encodeURIComponent" for the query parameter
in the actions of an sql panel.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [app] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
