### PR TITLE
[demo] Upgrade Istio version to 1.15.0 ⬆️ 

### DIFF
--- a/deploy/demo/istio-operator/istio-operator.yaml
+++ b/deploy/demo/istio-operator/istio-operator.yaml
@@ -157,7 +157,7 @@ spec:
       serviceAccountName: istio-operator
       containers:
         - name: istio-operator
-          image: docker.io/istio/operator:1.13.4
+          image: docker.io/istio/operator:1.15.0
           command:
           - operator
           - server

--- a/deploy/demo/istio-system/istio.yaml
+++ b/deploy/demo/istio-system/istio.yaml
@@ -83,7 +83,7 @@ spec:
     accessLogFile: /dev/stdout
     accessLogEncoding: JSON
   profile: default
-  tag: 1.13.4
+  tag: 1.15.0
   values:
     base:
       enableCRDTemplates: false


### PR DESCRIPTION
<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [app] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->
This PR bumps the version of istio-operator used in the demo environment, because v1.13.4 is incompatible with kubernetes 1.25 (used by kind)