### PR TITLE
[jaeger] Add Service Performance Monitoring

### DIFF
--- a/plugins/plugin-jaeger/pkg/instance/instance.go
+++ b/plugins/plugin-jaeger/pkg/instance/instance.go
@@ -38,6 +38,7 @@ type Instance interface {
 	GetOperations(ctx context.Context, service string) (map[string]any, error)
 	GetTraces(ctx context.Context, limit, maxDuration, minDuration, operation, service, tags string, timeStart, timeEnd int64) (map[string]any, error)
 	GetTrace(ctx context.Context, traceID string) (map[string]any, error)
+	GetMetrics(ctx context.Context, metric, service, groupByOperation, quantile, ratePer, step string, timeStart, timeEnd int64) (map[string]any, error)
 }
 
 type instance struct {
@@ -109,6 +110,14 @@ func (i *instance) GetTraces(ctx context.Context, limit, maxDuration, minDuratio
 
 func (i *instance) GetTrace(ctx context.Context, traceID string) (map[string]any, error) {
 	return i.doRequest(ctx, fmt.Sprintf("/api/traces/%s", traceID))
+}
+
+func (i *instance) GetMetrics(ctx context.Context, metric, service, groupByOperation, quantile, ratePer, step string, timeStart, timeEnd int64) (map[string]any, error) {
+	timeStart = timeStart * 1000
+	timeEnd = timeEnd * 1000
+	lookback := timeEnd - timeStart
+
+	return i.doRequest(ctx, fmt.Sprintf("/api/metrics/%s?service=%s&endTs=%d&lookback=%d&groupByOperation=%s&quantile=%s&ratePer=%s&step=%s&spanKind=unspecified&spanKind=internal&spanKind=server&spanKind=client&spanKind=producer&spanKind=consumer", metric, service, timeEnd, lookback, groupByOperation, quantile, ratePer, step))
 }
 
 // New returns a new Jaeger instance for the given configuration.

--- a/plugins/plugin-jaeger/pkg/instance/instance_mock.go
+++ b/plugins/plugin-jaeger/pkg/instance/instance_mock.go
@@ -13,6 +13,29 @@ type MockInstance struct {
 	mock.Mock
 }
 
+// GetMetrics provides a mock function with given fields: ctx, metric, service, groupByOperation, quantile, ratePer, step, timeEnd, timeStart
+func (_m *MockInstance) GetMetrics(ctx context.Context, metric string, service string, groupByOperation string, quantile string, ratePer string, step string, timeEnd int64, timeStart int64) (map[string]interface{}, error) {
+	ret := _m.Called(ctx, metric, service, groupByOperation, quantile, ratePer, step, timeEnd, timeStart)
+
+	var r0 map[string]interface{}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string, string, int64, int64) map[string]interface{}); ok {
+		r0 = rf(ctx, metric, service, groupByOperation, quantile, ratePer, step, timeEnd, timeStart)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]interface{})
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, string, string, string, int64, int64) error); ok {
+		r1 = rf(ctx, metric, service, groupByOperation, quantile, ratePer, step, timeEnd, timeStart)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetName provides a mock function with given fields:
 func (_m *MockInstance) GetName() string {
 	ret := _m.Called()

--- a/plugins/plugin-jaeger/src/components/page/Monitor.tsx
+++ b/plugins/plugin-jaeger/src/components/page/Monitor.tsx
@@ -1,0 +1,105 @@
+import { Grid, GridItem } from '@patternfly/react-core';
+import React, { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import { IPluginInstance, PageContentSection, PageHeaderSection, PluginPageTitle } from '@kobsio/shared';
+import { IMonitorOptions } from '../../utils/interfaces';
+import MonitorActions from './MonitorActions';
+import MonitorOperations from '../panel/MonitorOperations';
+import MonitorServiceCalls from '../panel/MonitorServiceCalls';
+import MonitorServiceErrors from '../panel/MonitorServiceErrors';
+import MonitorServiceLatency from '../panel/MonitorServiceLatency';
+import MonitorToolbar from './MonitorToolbar';
+import { defaultDescription } from '../../utils/constants';
+import { getInitialMonitorOptions } from '../../utils/helpers';
+
+interface IMonitorProps {
+  instance: IPluginInstance;
+}
+
+const Monitor: React.FunctionComponent<IMonitorProps> = ({ instance }: IMonitorProps) => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [options, setOptions] = useState<IMonitorOptions>();
+  const [details, setDetails] = useState<React.ReactNode>(undefined);
+
+  const changeOptions = (opts: IMonitorOptions): void => {
+    navigate(
+      `${location.pathname}?service=${encodeURIComponent(opts.service)}&time=${opts.times.time}&timeEnd=${
+        opts.times.timeEnd
+      }&timeStart=${opts.times.timeStart}`,
+    );
+  };
+
+  useEffect(() => {
+    setOptions((prevOptions) => getInitialMonitorOptions(location.search, !prevOptions));
+  }, [location.search]);
+
+  if (!options) {
+    return null;
+  }
+
+  return (
+    <React.Fragment>
+      <PageHeaderSection
+        component={
+          <PluginPageTitle
+            satellite={instance.satellite}
+            name={instance.name}
+            description={instance.description || defaultDescription}
+            actions={<MonitorActions instance={instance} />}
+          />
+        }
+      />
+
+      <PageContentSection
+        hasPadding={true}
+        hasDivider={true}
+        toolbarContent={<MonitorToolbar instance={instance} options={options} setOptions={changeOptions} />}
+        panelContent={details}
+      >
+        {options.service ? (
+          <Grid hasGutter={true}>
+            <GridItem style={{ height: '300px' }} sm={12} md={12} lg={4} xl={4} xl2={4}>
+              <MonitorServiceLatency
+                title="Latency (ms)"
+                instance={instance}
+                service={options.service}
+                times={options.times}
+              />
+            </GridItem>
+            <GridItem style={{ height: '300px' }} sm={12} md={12} lg={4} xl={4} xl2={4}>
+              <MonitorServiceErrors
+                title="Error Rate (%)"
+                instance={instance}
+                service={options.service}
+                times={options.times}
+              />
+            </GridItem>
+            <GridItem style={{ height: '300px' }} sm={12} md={12} lg={4} xl={4} xl2={4}>
+              <MonitorServiceCalls
+                title="Request Rate (req/s)"
+                instance={instance}
+                service={options.service}
+                times={options.times}
+              />
+            </GridItem>
+            <GridItem span={12}>
+              <MonitorOperations
+                title="Operations"
+                instance={instance}
+                service={options.service}
+                times={options.times}
+                setDetails={setDetails}
+              />
+            </GridItem>
+          </Grid>
+        ) : (
+          <div></div>
+        )}
+      </PageContentSection>
+    </React.Fragment>
+  );
+};
+
+export default Monitor;

--- a/plugins/plugin-jaeger/src/components/page/MonitorActions.tsx
+++ b/plugins/plugin-jaeger/src/components/page/MonitorActions.tsx
@@ -4,11 +4,11 @@ import { Link } from 'react-router-dom';
 
 import { IPluginInstance, pluginBasePath } from '@kobsio/shared';
 
-interface ITracesActionsProps {
+interface IMonitorActionsProps {
   instance: IPluginInstance;
 }
 
-export const TracesActions: React.FunctionComponent<ITracesActionsProps> = ({ instance }: ITracesActionsProps) => {
+export const MonitorActions: React.FunctionComponent<IMonitorActionsProps> = ({ instance }: IMonitorActionsProps) => {
   const [show, setShow] = useState<boolean>(false);
 
   return (
@@ -19,11 +19,11 @@ export const TracesActions: React.FunctionComponent<ITracesActionsProps> = ({ in
       isPlain={true}
       position="right"
       dropdownItems={[
-        <DropdownItem key={0} component={<Link to={`${pluginBasePath(instance)}/trace`}>Compare Traces</Link>} />,
-        <DropdownItem key={1} component={<Link to={`${pluginBasePath(instance)}/monitor`}>Monitor</Link>} />,
+        <DropdownItem key={0} component={<Link to={pluginBasePath(instance)}>Traces</Link>} />,
+        <DropdownItem key={1} component={<Link to={`${pluginBasePath(instance)}/trace`}>Compare Traces</Link>} />,
       ]}
     />
   );
 };
 
-export default TracesActions;
+export default MonitorActions;

--- a/plugins/plugin-jaeger/src/components/page/MonitorToolbar.tsx
+++ b/plugins/plugin-jaeger/src/components/page/MonitorToolbar.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+
+import { IOptionsAdditionalFields, IPluginInstance, ITimes, Options, Toolbar, ToolbarItem } from '@kobsio/shared';
+import { IMonitorOptions } from '../../utils/interfaces';
+import TracesToolbarServices from './TracesToolbarServices';
+
+interface IMonitorToolbarProps {
+  instance: IPluginInstance;
+  options: IMonitorOptions;
+  setOptions: (data: IMonitorOptions) => void;
+}
+
+const MonitorToolbar: React.FunctionComponent<IMonitorToolbarProps> = ({
+  instance,
+  options,
+  setOptions,
+}: IMonitorToolbarProps) => {
+  const [service, setService] = useState<string>(options.service);
+
+  const changeOptions = (times: ITimes, additionalFields: IOptionsAdditionalFields[] | undefined): void => {
+    setOptions({
+      service: service,
+      times: times,
+    });
+  };
+
+  return (
+    <Toolbar usePageInsets={true}>
+      <ToolbarItem grow={true}>
+        <TracesToolbarServices instance={instance} service={service} setService={(value): void => setService(value)} />
+      </ToolbarItem>
+
+      <Options times={options.times} showOptions={true} showSearchButton={true} setOptions={changeOptions} />
+    </Toolbar>
+  );
+};
+
+export default MonitorToolbar;

--- a/plugins/plugin-jaeger/src/components/page/Page.tsx
+++ b/plugins/plugin-jaeger/src/components/page/Page.tsx
@@ -6,6 +6,7 @@ import { IPluginPageProps } from '@kobsio/shared';
 
 const Trace = lazy(() => import('./Trace'));
 const Traces = lazy(() => import('./Traces'));
+const Monitor = lazy(() => import('./Monitor'));
 
 const Page: React.FunctionComponent<IPluginPageProps> = ({ instance }: IPluginPageProps) => {
   return (
@@ -16,6 +17,7 @@ const Page: React.FunctionComponent<IPluginPageProps> = ({ instance }: IPluginPa
         <Route path="/" element={<Traces instance={instance} />} />
         <Route path="/trace/" element={<Trace instance={instance} />} />
         <Route path="/trace/:traceID" element={<Trace instance={instance} />} />
+        <Route path="/monitor" element={<Monitor instance={instance} />} />
       </Routes>
     </Suspense>
   );

--- a/plugins/plugin-jaeger/src/components/panel/MonitorChart.tsx
+++ b/plugins/plugin-jaeger/src/components/panel/MonitorChart.tsx
@@ -1,0 +1,79 @@
+import {
+  Chart,
+  ChartAxis,
+  ChartGroup,
+  ChartLegendTooltip,
+  ChartLine,
+  ChartThemeColor,
+  createContainer,
+} from '@patternfly/react-charts';
+import React, { useRef } from 'react';
+
+import { IChartData, IChartDatum } from '../../utils/interfaces';
+import {
+  ITimes,
+  chartAxisStyle,
+  chartFormatLabel,
+  chartTickFormatDate,
+  formatTime,
+  useDimensions,
+} from '@kobsio/shared';
+
+interface IMonitorChartProps {
+  data: IChartData[];
+  unit: string;
+  times: ITimes;
+}
+
+const MonitorChart: React.FunctionComponent<IMonitorChartProps> = ({ data, unit, times }: IMonitorChartProps) => {
+  const refChart = useRef<HTMLDivElement>(null);
+  const chartSize = useDimensions(refChart);
+
+  const legendData = data.map((metric, index) => {
+    return { childName: metric.name, name: metric.name };
+  });
+
+  const CursorVoronoiContainer = createContainer('voronoi', 'cursor');
+
+  return (
+    <div style={{ height: '100%', width: '100%' }} ref={refChart}>
+      <Chart
+        containerComponent={
+          <CursorVoronoiContainer
+            cursorDimension="x"
+            labels={({ datum }: { datum: IChartDatum }): string =>
+              chartFormatLabel(datum.y != null ? `${datum.y} ${unit}` : '')
+            }
+            labelComponent={
+              <ChartLegendTooltip
+                themeColor={ChartThemeColor.multiOrdered}
+                legendData={legendData}
+                title={(datum: IChartDatum): string => formatTime(Math.floor((datum.x as Date).getTime() / 1000))}
+              />
+            }
+            mouseFollowTooltips={true}
+            voronoiDimension="x"
+            voronoiPadding={0}
+          />
+        }
+        height={chartSize.height}
+        padding={{ bottom: 20, left: 50, right: 0, top: 0 }}
+        scale={{ x: 'time', y: 'linear' }}
+        themeColor={ChartThemeColor.multiOrdered}
+        width={chartSize.width}
+        domain={{ x: [new Date(times.timeStart * 1000), new Date(times.timeEnd * 1000)] }}
+      >
+        <ChartAxis dependentAxis={false} tickFormat={chartTickFormatDate} showGrid={true} style={chartAxisStyle} />
+        <ChartAxis dependentAxis={true} showGrid={true} style={chartAxisStyle} />
+
+        <ChartGroup>
+          {data.map((metric) => (
+            <ChartLine key={metric.name} data={metric.data} name={metric.name} interpolation="monotoneX" />
+          ))}
+        </ChartGroup>
+      </Chart>
+    </div>
+  );
+};
+
+export default MonitorChart;

--- a/plugins/plugin-jaeger/src/components/panel/MonitorOperations.tsx
+++ b/plugins/plugin-jaeger/src/components/panel/MonitorOperations.tsx
@@ -1,0 +1,76 @@
+import { Alert, AlertVariant, Spinner } from '@patternfly/react-core';
+import React from 'react';
+
+import { IPluginInstance, ITimes, PluginPanel } from '@kobsio/shared';
+import { operationMetricsToData, useGetOperationMetrics } from '../../utils/helpers';
+import MonitorOperationsTable from './MonitorOperationsTable';
+
+interface IMonitorOperationsProps {
+  title: string;
+  description?: string;
+  instance: IPluginInstance;
+  service: string;
+  times: ITimes;
+  setDetails?: (details: React.ReactNode) => void;
+}
+
+const MonitorOperations: React.FunctionComponent<IMonitorOperationsProps> = ({
+  title,
+  description,
+  instance,
+  times,
+  service,
+  setDetails,
+}: IMonitorOperationsProps) => {
+  const metrics = useGetOperationMetrics(instance, service, times);
+
+  if (
+    metrics[0].isLoading ||
+    metrics[1].isLoading ||
+    metrics[2].isLoading ||
+    metrics[3].isLoading ||
+    metrics[4].isLoading
+  ) {
+    return (
+      <PluginPanel title={title} description={description}>
+        <div className="pf-u-text-align-center">
+          <Spinner />
+        </div>
+      </PluginPanel>
+    );
+  }
+
+  if (metrics[0].isError || metrics[1].isError || metrics[2].isError || metrics[3].isError || metrics[4].isError) {
+    return (
+      <PluginPanel title={title} description={description}>
+        <Alert isInline={true} variant={AlertVariant.danger} title="Could not get metrics">
+          {metrics[0].error?.message && <p>{metrics[0].error?.message}</p>}
+          {metrics[1].error?.message && <p>{metrics[1].error?.message}</p>}
+          {metrics[2].error?.message && <p>{metrics[2].error?.message}</p>}
+          {metrics[3].error?.message && <p>{metrics[3].error?.message}</p>}
+          {metrics[4].error?.message && <p>{metrics[4].error?.message}</p>}
+        </Alert>
+      </PluginPanel>
+    );
+  }
+
+  return (
+    <MonitorOperationsTable
+      title={title}
+      description={description}
+      data={operationMetricsToData([
+        { metrics: metrics[0].data, name: 'P50' },
+        { metrics: metrics[1].data, name: 'P75' },
+        { metrics: metrics[2].data, name: 'P95' },
+        { metrics: metrics[3].data, name: 'Errors' },
+        { metrics: metrics[4].data, name: 'Calls' },
+      ])}
+      instance={instance}
+      service={service}
+      times={times}
+      setDetails={setDetails}
+    />
+  );
+};
+
+export default MonitorOperations;

--- a/plugins/plugin-jaeger/src/components/panel/MonitorOperationsTable.tsx
+++ b/plugins/plugin-jaeger/src/components/panel/MonitorOperationsTable.tsx
@@ -1,0 +1,152 @@
+import { CardActions, CardFooter, Pagination, PaginationVariant, TextInput } from '@patternfly/react-core';
+import React, { useState } from 'react';
+import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+
+import { IPluginInstance, ITimes, PluginPanel } from '@kobsio/shared';
+import { IOperationData } from '../../utils/interfaces';
+import Operation from './details/Operation';
+
+interface IMonitorOperationsTableProps {
+  title: string;
+  description?: string;
+  data: IOperationData[];
+  instance: IPluginInstance;
+  service: string;
+  times: ITimes;
+  setDetails?: (details: React.ReactNode) => void;
+}
+
+const MonitorOperationsTable: React.FunctionComponent<IMonitorOperationsTableProps> = ({
+  title,
+  description,
+  data,
+  instance,
+  service,
+  times,
+  setDetails,
+}: IMonitorOperationsTableProps) => {
+  const [selectedOperation, setSelectedOperation] = useState<IOperationData>();
+  const [options, setOptions] = useState<{ filter: string; page: number; perPage: number }>({
+    filter: '',
+    page: 1,
+    perPage: 20,
+  });
+  const impact = data[0].impact;
+
+  const selectOperation = (operation: IOperationData): void => {
+    if (setDetails) {
+      setSelectedOperation(operation);
+      setDetails(
+        <Operation
+          operation={operation}
+          instance={instance}
+          service={service}
+          times={times}
+          close={(): void => {
+            setSelectedOperation(undefined);
+            setDetails(undefined);
+          }}
+        />,
+      );
+    }
+  };
+
+  return (
+    <PluginPanel
+      title={title}
+      description={description}
+      actions={
+        <CardActions>
+          <TextInput
+            placeholder="Filter"
+            aria-label="Filter"
+            value={options.filter}
+            onChange={(value: string): void => setOptions({ filter: value, page: 1, perPage: options.perPage })}
+          />
+        </CardActions>
+      }
+      footer={
+        <CardFooter>
+          <Pagination
+            style={{ padding: 0 }}
+            itemCount={data.length}
+            perPage={options.perPage}
+            page={options.page}
+            variant={PaginationVariant.bottom}
+            onSetPage={(event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPage: number): void =>
+              setOptions({ ...options, page: newPage })
+            }
+            onPerPageSelect={(event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPerPage: number): void =>
+              setOptions({ ...options, page: 1, perPage: newPerPage })
+            }
+            onFirstClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+              setOptions({ ...options, page: newPage })
+            }
+            onLastClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+              setOptions({ ...options, page: newPage })
+            }
+            onNextClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+              setOptions({ ...options, page: newPage })
+            }
+            onPreviousClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+              setOptions({ ...options, page: newPage })
+            }
+          />
+        </CardFooter>
+      }
+    >
+      <TableComposable aria-label="Events" variant={TableVariant.compact} borders={true}>
+        <Thead>
+          <Tr>
+            <Th>Operation</Th>
+            <Th>P50</Th>
+            <Th>P75</Th>
+            <Th>P95</Th>
+            <Th>Request Rate</Th>
+            <Th>Error Rate</Th>
+            <Th>Impact</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {data
+            .filter((operation) => operation.operation.toLowerCase().includes(options.filter.toLowerCase()))
+            .slice((options.page - 1) * options.perPage, options.page * options.perPage)
+            .map((operation) => (
+              <Tr
+                key={operation.operation}
+                isHoverable={setDetails ? true : false}
+                isRowSelected={selectedOperation?.operation === operation.operation}
+                onClick={(): void => (setDetails ? selectOperation(operation) : undefined)}
+              >
+                <Td dataLabel="Operation">{operation.operation}</Td>
+                <Td dataLabel="P50">{operation.avgs[0] ? `${operation.avgs[0]} ms` : '-'}</Td>
+                <Td dataLabel="P75">{operation.avgs[1] ? `${operation.avgs[1]} ms` : '-'}</Td>
+                <Td dataLabel="P95">{operation.avgs[2] ? `${operation.avgs[2]} ms` : '-'}</Td>
+                <Td dataLabel="Request Rate">{operation.avgs[4] ? `${operation.avgs[4]} req/s` : '-'}</Td>
+                <Td dataLabel="Error Rate">{operation.avgs[3] ? `${operation.avgs[3]} %` : '-'}</Td>
+                <Td dataLabel="Impact">
+                  <div
+                    style={{
+                      backgroundColor: 'rgba(0, 102, 204, 0.2)',
+                      height: '12px',
+                      width: '200px',
+                    }}
+                  >
+                    <div
+                      style={{
+                        backgroundColor: 'rgba(0, 102, 204, 1)',
+                        height: '12px',
+                        width: `${200 * (operation.impact / impact)}px`,
+                      }}
+                    ></div>
+                  </div>
+                </Td>
+              </Tr>
+            ))}
+        </Tbody>
+      </TableComposable>
+    </PluginPanel>
+  );
+};
+
+export default MonitorOperationsTable;

--- a/plugins/plugin-jaeger/src/components/panel/MonitorServiceCalls.tsx
+++ b/plugins/plugin-jaeger/src/components/panel/MonitorServiceCalls.tsx
@@ -1,0 +1,75 @@
+import { Alert, AlertVariant, Spinner } from '@patternfly/react-core';
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { IPluginInstance, ITimes, PluginPanel } from '@kobsio/shared';
+import { IChartData } from '../../utils/interfaces';
+import MonitorChart from './MonitorChart';
+import { serviceMetricsToChartData } from '../../utils/helpers';
+
+interface IMonitorServiceCallsProps {
+  title: string;
+  description?: string;
+  instance: IPluginInstance;
+  service: string;
+  times: ITimes;
+}
+
+const MonitorServiceCalls: React.FunctionComponent<IMonitorServiceCallsProps> = ({
+  title,
+  description,
+  instance,
+  times,
+  service,
+}: IMonitorServiceCallsProps) => {
+  const { isError, isLoading, error, data } = useQuery<IChartData[], Error>(
+    ['jaeger/metrics/calls/service', instance, service, times],
+    async () => {
+      try {
+        const response = await fetch(
+          `/api/plugins/jaeger/metrics?metric=calls&service=${service}&groupByOperation=false&ratePer=600000&step=60000&timeStart=${times.timeStart}&timeEnd=${times.timeEnd}`,
+          {
+            headers: {
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              'x-kobs-plugin': instance.name,
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              'x-kobs-satellite': instance.satellite,
+            },
+            method: 'get',
+          },
+        );
+        const json = await response.json();
+
+        if (response.status >= 200 && response.status < 300) {
+          return serviceMetricsToChartData([{ metrics: json, name: 'Calls' }]);
+        } else {
+          if (json.error) {
+            throw new Error(json.error);
+          } else {
+            throw new Error('An unknown error occured');
+          }
+        }
+      } catch (err) {
+        throw err;
+      }
+    },
+  );
+
+  return (
+    <PluginPanel title={title} description={description}>
+      {isLoading ? (
+        <div className="pf-u-text-align-center">
+          <Spinner />
+        </div>
+      ) : isError ? (
+        <Alert isInline={true} variant={AlertVariant.danger} title="Could not get metrics">
+          <p>{error?.message}</p>
+        </Alert>
+      ) : (
+        <MonitorChart data={data} unit="req/s" times={times} />
+      )}
+    </PluginPanel>
+  );
+};
+
+export default MonitorServiceCalls;

--- a/plugins/plugin-jaeger/src/components/panel/MonitorServiceErrors.tsx
+++ b/plugins/plugin-jaeger/src/components/panel/MonitorServiceErrors.tsx
@@ -1,0 +1,75 @@
+import { Alert, AlertVariant, Spinner } from '@patternfly/react-core';
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { IPluginInstance, ITimes, PluginPanel } from '@kobsio/shared';
+import { IChartData } from '../../utils/interfaces';
+import MonitorChart from './MonitorChart';
+import { serviceMetricsToChartData } from '../../utils/helpers';
+
+interface IMonitorServiceErrorsProps {
+  title: string;
+  description?: string;
+  instance: IPluginInstance;
+  service: string;
+  times: ITimes;
+}
+
+const MonitorServiceErrors: React.FunctionComponent<IMonitorServiceErrorsProps> = ({
+  title,
+  description,
+  instance,
+  times,
+  service,
+}: IMonitorServiceErrorsProps) => {
+  const { isError, isLoading, error, data } = useQuery<IChartData[], Error>(
+    ['jaeger/metrics/errors/service', instance, service, times],
+    async () => {
+      try {
+        const response = await fetch(
+          `/api/plugins/jaeger/metrics?metric=errors&service=${service}&groupByOperation=false&ratePer=600000&step=60000&timeStart=${times.timeStart}&timeEnd=${times.timeEnd}`,
+          {
+            headers: {
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              'x-kobs-plugin': instance.name,
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              'x-kobs-satellite': instance.satellite,
+            },
+            method: 'get',
+          },
+        );
+        const json = await response.json();
+
+        if (response.status >= 200 && response.status < 300) {
+          return serviceMetricsToChartData([{ metrics: json, name: 'Errors' }]);
+        } else {
+          if (json.error) {
+            throw new Error(json.error);
+          } else {
+            throw new Error('An unknown error occured');
+          }
+        }
+      } catch (err) {
+        throw err;
+      }
+    },
+  );
+
+  return (
+    <PluginPanel title={title} description={description}>
+      {isLoading ? (
+        <div className="pf-u-text-align-center">
+          <Spinner />
+        </div>
+      ) : isError ? (
+        <Alert isInline={true} variant={AlertVariant.danger} title="Could not get metrics">
+          <p>{error?.message}</p>
+        </Alert>
+      ) : (
+        <MonitorChart data={data} unit="%" times={times} />
+      )}
+    </PluginPanel>
+  );
+};
+
+export default MonitorServiceErrors;

--- a/plugins/plugin-jaeger/src/components/panel/MonitorServiceLatency.tsx
+++ b/plugins/plugin-jaeger/src/components/panel/MonitorServiceLatency.tsx
@@ -1,0 +1,52 @@
+import { Alert, AlertVariant, Spinner } from '@patternfly/react-core';
+import React from 'react';
+
+import { IPluginInstance, ITimes, PluginPanel } from '@kobsio/shared';
+import { serviceMetricsToChartData, useGetServiceLatency } from '../../utils/helpers';
+import MonitorChart from './MonitorChart';
+
+interface IMonitorServiceLatencyProps {
+  title: string;
+  description?: string;
+  instance: IPluginInstance;
+  service: string;
+  times: ITimes;
+}
+
+const MonitorServiceLatency: React.FunctionComponent<IMonitorServiceLatencyProps> = ({
+  title,
+  description,
+  instance,
+  times,
+  service,
+}: IMonitorServiceLatencyProps) => {
+  const latencies = useGetServiceLatency(instance, service, times);
+
+  return (
+    <PluginPanel title={title} description={description}>
+      {latencies[0].isLoading || latencies[1].isLoading || latencies[2].isLoading ? (
+        <div className="pf-u-text-align-center">
+          <Spinner />
+        </div>
+      ) : latencies[0].isError || latencies[1].isError || latencies[2].isError ? (
+        <Alert isInline={true} variant={AlertVariant.danger} title="Could not get metrics">
+          {latencies[0].error?.message && <p>{latencies[0].error?.message}</p>}
+          {latencies[1].error?.message && <p>{latencies[1].error?.message}</p>}
+          {latencies[2].error?.message && <p>{latencies[2].error?.message}</p>}
+        </Alert>
+      ) : (
+        <MonitorChart
+          data={serviceMetricsToChartData([
+            { metrics: latencies[0].data, name: 'P50' },
+            { metrics: latencies[1].data, name: 'P75' },
+            { metrics: latencies[2].data, name: 'P95' },
+          ])}
+          unit="ms"
+          times={times}
+        />
+      )}
+    </PluginPanel>
+  );
+};
+
+export default MonitorServiceLatency;

--- a/plugins/plugin-jaeger/src/components/panel/details/Operation.tsx
+++ b/plugins/plugin-jaeger/src/components/panel/details/Operation.tsx
@@ -1,0 +1,78 @@
+import {
+  Card,
+  CardBody,
+  DrawerActions,
+  DrawerCloseButton,
+  DrawerHead,
+  DrawerPanelBody,
+  DrawerPanelContent,
+  Title,
+} from '@patternfly/react-core';
+import React from 'react';
+
+import { IPluginInstance, ITimes } from '@kobsio/shared';
+import { IOperationData } from '../../../utils/interfaces';
+import MonitorChart from '../MonitorChart';
+import OperationActions from './OperationActions';
+
+export interface IOperationProps {
+  operation: IOperationData;
+  instance: IPluginInstance;
+  service: string;
+  times: ITimes;
+  close: () => void;
+}
+
+const Operation: React.FunctionComponent<IOperationProps> = ({
+  operation,
+  instance,
+  service,
+  times,
+  close,
+}: IOperationProps) => {
+  return (
+    <DrawerPanelContent minSize="50%">
+      <DrawerHead>
+        <Title headingLevel="h2" size="xl">
+          {operation.operation}
+        </Title>
+        <DrawerActions style={{ padding: 0 }}>
+          <OperationActions instance={instance} service={service} operation={operation.operation} times={times} />
+          <DrawerCloseButton onClose={close} />
+        </DrawerActions>
+      </DrawerHead>
+
+      <DrawerPanelBody>
+        <Card isCompact={true}>
+          <CardBody>
+            <div style={{ height: '300px' }}>
+              <MonitorChart
+                data={[operation.chartData[0], operation.chartData[1], operation.chartData[2]]}
+                unit="ms"
+                times={times}
+              />
+            </div>
+          </CardBody>
+        </Card>
+        <p>&nbsp;</p>
+        <Card isCompact={true}>
+          <CardBody>
+            <div style={{ height: '300px' }}>
+              <MonitorChart data={[operation.chartData[3]]} unit="%" times={times} />
+            </div>
+          </CardBody>
+        </Card>
+        <p>&nbsp;</p>
+        <Card isCompact={true}>
+          <CardBody>
+            <div style={{ height: '300px' }}>
+              <MonitorChart data={[operation.chartData[4]]} unit="req/s" times={times} />
+            </div>
+          </CardBody>
+        </Card>
+      </DrawerPanelBody>
+    </DrawerPanelContent>
+  );
+};
+
+export default Operation;

--- a/plugins/plugin-jaeger/src/components/panel/details/OperationActions.tsx
+++ b/plugins/plugin-jaeger/src/components/panel/details/OperationActions.tsx
@@ -1,0 +1,47 @@
+import { Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import { IPluginInstance, ITimes, pluginBasePath } from '@kobsio/shared';
+
+interface IOperationActionsProps {
+  instance: IPluginInstance;
+  service: string;
+  operation: string;
+  times: ITimes;
+}
+
+const OperationActions: React.FunctionComponent<IOperationActionsProps> = ({
+  instance,
+  service,
+  operation,
+  times,
+}: IOperationActionsProps) => {
+  const [showDropdown, setShowDropdown] = useState<boolean>(false);
+
+  return (
+    <Dropdown
+      className="pf-c-drawer__close"
+      toggle={<KebabToggle onToggle={(): void => setShowDropdown(!showDropdown)} />}
+      isOpen={showDropdown}
+      isPlain={true}
+      position="right"
+      dropdownItems={[
+        <DropdownItem
+          key={0}
+          component={
+            <Link
+              to={`${pluginBasePath(instance)}?service=${service}&operation=${operation}&time=${times.time}&timeStart=${
+                times.timeStart
+              }&timeEnd=${times.timeEnd}`}
+            >
+              Traces
+            </Link>
+          }
+        />,
+      ]}
+    />
+  );
+};
+
+export default OperationActions;

--- a/plugins/plugin-jaeger/src/utils/interfaces.ts
+++ b/plugins/plugin-jaeger/src/utils/interfaces.ts
@@ -119,3 +119,52 @@ export interface IDeduplicateTags {
   tags: IKeyValuePair[];
   warnings: string[];
 }
+
+// IMonitorOptions is the interface for all options, which can be set for Jaeger to get a the metrics for a service.
+export interface IMonitorOptions {
+  service: string;
+  times: ITimes;
+}
+
+// IMetrics is the JSON format which is returned by the Jaeger API for a metrics call.
+export interface IMetrics {
+  name: string;
+  type: string;
+  help: string;
+  metrics: IMetric[];
+}
+
+export interface IMetric {
+  labels: IMetricLabel[];
+  metricPoints: IMetricPoint[];
+}
+
+export interface IMetricLabel {
+  name: string;
+  value: string;
+}
+
+export interface IMetricPoint {
+  gaugeValue: IMetricGaugeValue;
+  timestamp: string;
+}
+export interface IMetricGaugeValue {
+  doubleValue: number | string;
+}
+
+export interface IChartData {
+  name: string;
+  data: IChartDatum[];
+}
+
+export interface IChartDatum {
+  x: Date;
+  y: number | null;
+}
+
+export interface IOperationData {
+  operation: string;
+  avgs: number[];
+  impact: number;
+  chartData: IChartData[];
+}


### PR DESCRIPTION
It is now possible to view the Jaeger Metrics for Service Performance Monitoring within kobs.

Service Performance Monitoring allows users to view the latency, error rate and request rate for all operation of a service. It is also possible to switch from the monitor view directly to the corresponding traces view of a selected operation.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [app] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
