### PR TITLE
[grafana] Add support for variables in dashboards

### DIFF
--- a/docs/plugins/grafana.md
+++ b/docs/plugins/grafana.md
@@ -48,7 +48,7 @@ The following options can be used for a panel with the Grafana plugin:
 | Field | Type | Description | Required |
 | ----- | ---- | ----------- | -------- |
 | type | string | The panel type. This could be `dashboards` or `panel`. | No |
-| dashboards | []string | A list of dashboard ids to show, when the type is `dashboards`. | Yes |
+| dashboards | []string | A list of dashboard ids to show, when the type is `dashboards`. To pass variables to a dashboard the following can be used: `<dashboard-id>?myvar=myvarvalue` | Yes |
 | panel | [Panel](#panel) | The panel which should be displayed, when the type is `panel`. | Yes |
 
 ### Panel

--- a/plugins/plugin-grafana/src/components/panel/Dashboards.tsx
+++ b/plugins/plugin-grafana/src/components/panel/Dashboards.tsx
@@ -6,6 +6,16 @@ import DashboardsItem from './DashboardsItem';
 import { IDashboard } from '../../utils/interfaces';
 import { IPluginInstance } from '@kobsio/shared';
 
+const getVars = (dashboardID: string, dashboardIDs: string[]): string => {
+  for (const id of dashboardIDs) {
+    if (id.startsWith(dashboardID)) {
+      return id.replace(dashboardID, '');
+    }
+  }
+
+  return '';
+};
+
 interface IDashboardsProps {
   instance: IPluginInstance;
   dashboardIDs: string[];
@@ -16,7 +26,9 @@ const Dashboards: React.FunctionComponent<IDashboardsProps> = ({ instance, dashb
     ['grafana/dashboards', instance, dashboardIDs],
     async () => {
       try {
-        const uidParams = dashboardIDs.map((dashboardID) => `uid=${dashboardID}`).join('&');
+        const uidParams = dashboardIDs
+          .map((dashboardID) => `uid=${dashboardID.substring(0, dashboardID.lastIndexOf('?'))}`)
+          .join('&');
 
         const response = await fetch(`/api/plugins/grafana/dashboards?${uidParams}`, {
           headers: {
@@ -79,7 +91,12 @@ const Dashboards: React.FunctionComponent<IDashboardsProps> = ({ instance, dashb
       {data
         .filter((dashboard) => dashboard.type !== 'dash-folder')
         .map((dashboard, index) => (
-          <DashboardsItem key={dashboard.id} instance={instance} dashboard={dashboard} />
+          <DashboardsItem
+            key={dashboard.id}
+            instance={instance}
+            dashboard={dashboard}
+            vars={getVars(dashboard.uid, dashboardIDs)}
+          />
         ))}
     </DataList>
   );

--- a/plugins/plugin-grafana/src/components/panel/DashboardsItem.tsx
+++ b/plugins/plugin-grafana/src/components/panel/DashboardsItem.tsx
@@ -15,13 +15,18 @@ import { IPluginInstance } from '@kobsio/shared';
 interface IDashboardItemProps {
   instance: IPluginInstance;
   dashboard: IDashboard;
+  vars: string;
 }
 
-const DashboardItem: React.FunctionComponent<IDashboardItemProps> = ({ instance, dashboard }: IDashboardItemProps) => {
+const DashboardItem: React.FunctionComponent<IDashboardItemProps> = ({
+  instance,
+  dashboard,
+  vars,
+}: IDashboardItemProps) => {
   return (
     <a
       style={{ color: 'inherit', textDecoration: 'inherit' }}
-      href={`${instance.options?.address}${dashboard.url}`}
+      href={`${instance.options?.address}${dashboard.url}${vars}`}
       target="_blank"
       rel="noreferrer"
     >


### PR DESCRIPTION
It is now possible to set variables for a dashboard in the dashboards panel. The variables can be added behind the provided dashboard id, e.g. "<dashboard-id>?myvar=myvarvalue".

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [app] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
