### PR TITLE
[app] Show empty integer colums as 0 in CRs

### DIFF
--- a/plugins/app/src/components/resources/utils/tabledata.tsx
+++ b/plugins/app/src/components/resources/utils/tabledata.tsx
@@ -1747,7 +1747,9 @@ export const customResourceDefinitionTableData = (crd: IResource): ITableDatum =
               crd.columns && crd.columns.length > 0
                 ? crd.columns.map((column) => {
                     const value = JSONPath<string | string[]>({ json: cr, path: `$.${column.jsonPath}` })[0];
-                    if (!value) {
+                    if (column.type === 'integer' && !value) {
+                      return 0;
+                    } else if (!value) {
                       return '';
                     } else if (column.type === 'date') {
                       return timeDifference(new Date().getTime(), new Date(value).getTime());


### PR DESCRIPTION
When a CR is displayed in the resource table and a column of type integer is empty it didn't show anything. This is fixed now and a 0 is displayed for empty columns of type integer.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [app] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
