### PR TITLE
[app] Only display columns with priority 0 for CRs

### DIFF
--- a/pkg/kube/clusters/cluster/cluster.go
+++ b/pkg/kube/clusters/cluster/cluster.go
@@ -718,12 +718,14 @@ func (c *client) loadCRDs() {
 				var columns []CRDColumn
 				if version.AdditionalPrinterColumns != nil {
 					for _, column := range version.AdditionalPrinterColumns {
-						columns = append(columns, CRDColumn{
-							Description: column.Description,
-							JSONPath:    column.JSONPath,
-							Name:        column.Name,
-							Type:        column.Type,
-						})
+						if column.Priority == 0 {
+							columns = append(columns, CRDColumn{
+								Description: column.Description,
+								JSONPath:    column.JSONPath,
+								Name:        column.Name,
+								Type:        column.Type,
+							})
+						}
 					}
 				}
 


### PR DESCRIPTION
It is possible to set a priority for the additional print columns in a CRD. We decided to only display columns with a priority set to 0 in kobs.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [app] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
