### PR TITLE
[mongodb] Fix render performance

### DIFF
--- a/plugins/plugin-mongodb/src/components/page/DocumentPage.tsx
+++ b/plugins/plugin-mongodb/src/components/page/DocumentPage.tsx
@@ -1,4 +1,4 @@
-import { Alert, AlertActionLink, AlertVariant, Card, Spinner } from '@patternfly/react-core';
+import { Alert, AlertActionLink, AlertVariant, Card, Flex, FlexItem, Spinner } from '@patternfly/react-core';
 import { Document, EJSON } from 'bson';
 import { QueryObserverResult, useQuery } from '@tanstack/react-query';
 import { TableComposable, TableVariant, Th, Thead, Tr } from '@patternfly/react-table';
@@ -73,42 +73,46 @@ const DocumentPage: React.FunctionComponent<IDocumentPageProps> = ({ instance }:
         }
       />
       <PageContentSection hasPadding={true} hasDivider={true} toolbarContent={undefined} panelContent={undefined}>
-        {isLoading ? (
-          <div className="pf-u-text-align-center">
-            <Spinner />
-          </div>
-        ) : isError ? (
-          <Alert
-            variant={AlertVariant.danger}
-            isInline={false}
-            title="Could not get document"
-            actionLinks={
-              <React.Fragment>
-                <AlertActionLink onClick={(): Promise<QueryObserverResult<Document[], Error>> => refetch()}>
-                  Retry
-                </AlertActionLink>
-              </React.Fragment>
-            }
-          >
-            <p>{error?.message}</p>
-          </Alert>
-        ) : data ? (
-          <Card>
-            <TableComposable aria-label="Documents" variant={TableVariant.compact} borders={true}>
-              <Thead>
-                <Tr>
-                  <Th />
-                  <Th>ID</Th>
-                  <Th>Document</Th>
-                  <Th />
-                </Tr>
-              </Thead>
-              <FindDocument instance={instance} collectionName={params.collectionName ?? ''} document={data} />
-            </TableComposable>
-          </Card>
-        ) : (
-          <div></div>
-        )}
+        <Flex direction={{ default: 'column' }}>
+          <FlexItem>
+            {isLoading ? (
+              <div className="pf-u-text-align-center">
+                <Spinner />
+              </div>
+            ) : isError ? (
+              <Alert
+                variant={AlertVariant.danger}
+                isInline={false}
+                title="Could not get document"
+                actionLinks={
+                  <React.Fragment>
+                    <AlertActionLink onClick={(): Promise<QueryObserverResult<Document[], Error>> => refetch()}>
+                      Retry
+                    </AlertActionLink>
+                  </React.Fragment>
+                }
+              >
+                <p>{error?.message}</p>
+              </Alert>
+            ) : data ? (
+              <Card>
+                <TableComposable aria-label="Documents" variant={TableVariant.compact} borders={true}>
+                  <Thead>
+                    <Tr>
+                      <Th />
+                      <Th>ID</Th>
+                      <Th>Document</Th>
+                      <Th />
+                    </Tr>
+                  </Thead>
+                  <FindDocument instance={instance} collectionName={params.collectionName ?? ''} document={data} />
+                </TableComposable>
+              </Card>
+            ) : (
+              <div></div>
+            )}
+          </FlexItem>
+        </Flex>
       </PageContentSection>
     </React.Fragment>
   );

--- a/plugins/plugin-mongodb/src/components/page/OverviewPage.tsx
+++ b/plugins/plugin-mongodb/src/components/page/OverviewPage.tsx
@@ -1,4 +1,4 @@
-import { Grid, GridItem } from '@patternfly/react-core';
+import { Flex, FlexItem, Grid, GridItem } from '@patternfly/react-core';
 import React from 'react';
 
 import { IPluginInstance, PageContentSection, PageHeaderSection, PluginPageTitle } from '@kobsio/shared';
@@ -25,10 +25,18 @@ const OverviewPage: React.FunctionComponent<IOverviewPageProps> = ({ instance }:
       <PageContentSection hasPadding={true} hasDivider={true} toolbarContent={<div />} panelContent={undefined}>
         <Grid hasGutter={true}>
           <GridItem sm={12} md={12} lg={7} xl={9} xl2={9}>
-            <Collections instance={instance} title="Collections" />
+            <Flex direction={{ default: 'column' }}>
+              <FlexItem>
+                <Collections instance={instance} title="Collections" />
+              </FlexItem>
+            </Flex>
           </GridItem>
           <GridItem sm={12} md={12} lg={5} xl={3} xl2={3}>
-            <DBStats instance={instance} title="Database Statistics" />
+            <Flex direction={{ default: 'column' }}>
+              <FlexItem>
+                <DBStats instance={instance} title="Database Statistics" />
+              </FlexItem>
+            </Flex>
           </GridItem>
         </Grid>
       </PageContentSection>

--- a/plugins/plugin-mongodb/src/components/page/QueryPage.tsx
+++ b/plugins/plugin-mongodb/src/components/page/QueryPage.tsx
@@ -1,3 +1,4 @@
+import { Flex, FlexItem } from '@patternfly/react-core';
 import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
@@ -57,20 +58,24 @@ const QueryPage: React.FunctionComponent<IQueryPageProps> = ({ instance }: IQuer
         toolbarContent={<QueryPageToolbar options={options} setOptions={changeOptions} />}
         panelContent={undefined}
       >
-        {options.operation === 'find' ? (
-          <Find
-            instance={instance}
-            title="Results"
-            collectionName={params.collectionName}
-            query={options.query}
-            limit={options.limit}
-            sort={options.sort}
-          />
-        ) : options.operation === 'count' ? (
-          <Count instance={instance} title="Results" collectionName={params.collectionName} query={options.query} />
-        ) : (
-          <div></div>
-        )}
+        <Flex direction={{ default: 'column' }}>
+          <FlexItem>
+            {options.operation === 'find' ? (
+              <Find
+                instance={instance}
+                title="Results"
+                collectionName={params.collectionName}
+                query={options.query}
+                limit={options.limit}
+                sort={options.sort}
+              />
+            ) : options.operation === 'count' ? (
+              <Count instance={instance} title="Results" collectionName={params.collectionName} query={options.query} />
+            ) : (
+              <div></div>
+            )}
+          </FlexItem>
+        </Flex>
       </PageContentSection>
     </React.Fragment>
   );

--- a/plugins/plugin-mongodb/src/components/panel/Collections.tsx
+++ b/plugins/plugin-mongodb/src/components/panel/Collections.tsx
@@ -4,6 +4,9 @@ import {
   AlertActionLink,
   AlertVariant,
   CardActions,
+  CardFooter,
+  Pagination,
+  PaginationVariant,
   Spinner,
   TextInput,
 } from '@patternfly/react-core';
@@ -25,6 +28,7 @@ const Collections: React.FunctionComponent<ICollectionsProps> = ({
   description,
 }: ICollectionsProps) => {
   const [filter, setFilter] = useState<string>('');
+  const [page, setPage] = useState<{ page: number; perPage: number }>({ page: 1, perPage: 20 });
 
   const { isError, isLoading, data, error, refetch } = useQuery<string[], Error>(
     ['mongodb/collections', instance],
@@ -112,10 +116,41 @@ const Collections: React.FunctionComponent<ICollectionsProps> = ({
           />
         </CardActions>
       }
+      footer={
+        <CardFooter>
+          <Pagination
+            style={{ padding: 0 }}
+            isCompact={true}
+            itemCount={data.length}
+            perPage={page.perPage}
+            page={page.page}
+            variant={PaginationVariant.bottom}
+            onSetPage={(event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPage: number): void =>
+              setPage({ ...page, page: newPage })
+            }
+            onPerPageSelect={(event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPerPage: number): void =>
+              setPage({ ...page, page: 1, perPage: newPerPage })
+            }
+            onFirstClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+              setPage({ ...page, page: newPage })
+            }
+            onLastClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+              setPage({ ...page, page: newPage })
+            }
+            onNextClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+              setPage({ ...page, page: newPage })
+            }
+            onPreviousClick={(event: React.SyntheticEvent<HTMLButtonElement>, newPage: number): void =>
+              setPage({ ...page, page: newPage })
+            }
+          />
+        </CardFooter>
+      }
     >
       <Accordion asDefinitionList={true}>
         {data
           .filter((name) => name.toLowerCase().includes(filter.toLowerCase()))
+          .slice((page.page - 1) * page.perPage, page.page * page.perPage)
           .map((name) => (
             <Collection key={name} instance={instance} collectionName={name} />
           ))}

--- a/plugins/plugin-mongodb/src/components/panel/FindDocumentDetails.tsx
+++ b/plugins/plugin-mongodb/src/components/panel/FindDocumentDetails.tsx
@@ -21,6 +21,7 @@ const FindDocumentDetails: React.FunctionComponent<IFindDocumentDetailsProps> = 
       onSelect={(event, tabIndex): void => setActiveTab(tabIndex.toString())}
       isFilled={true}
       mountOnEnter={true}
+      unmountOnExit={true}
     >
       <Tab eventKey="tree" title={<TabTitleText>Tree</TabTitleText>}>
         <div style={{ maxWidth: '100%', overflowX: 'scroll', padding: '24px 0px' }}>
@@ -50,12 +51,13 @@ const FindDocumentDetails: React.FunctionComponent<IFindDocumentDetailsProps> = 
             value={JSON.stringify(EJSON.serialize(document, { relaxed: true }), null, 2)}
             mode="json"
             readOnly={true}
+            maxLines={50}
           />
         </div>
       </Tab>
       <Tab eventKey="json" title={<TabTitleText>JSON</TabTitleText>}>
         <div style={{ maxWidth: '100%', overflowX: 'scroll', padding: '24px 0px' }}>
-          <Editor value={JSON.stringify(document, null, 2)} mode="json" readOnly={true} />
+          <Editor value={JSON.stringify(document, null, 2)} mode="json" readOnly={true} maxLines={50} />
         </div>
       </Tab>
     </Tabs>

--- a/plugins/plugin-mongodb/src/components/panel/FindDocumentDetailsTree.tsx
+++ b/plugins/plugin-mongodb/src/components/panel/FindDocumentDetailsTree.tsx
@@ -156,7 +156,7 @@ const FindDocumentDetailsTree: React.FunctionComponent<IFindDocumentDetailsTreeP
       </Tr>
       <Tr isExpanded={isExpanded}>
         <Td />
-        <Td colSpan={2}>{formatDetails(documentValue)}</Td>
+        <Td colSpan={2}>{isExpanded && formatDetails(documentValue)}</Td>
       </Tr>
     </Tbody>
   );

--- a/plugins/shared/src/components/misc/Editor.tsx
+++ b/plugins/shared/src/components/misc/Editor.tsx
@@ -18,11 +18,18 @@ interface IEditorProps {
   value: string;
   mode: string;
   readOnly: boolean;
+  maxLines?: number;
   onChange?: (newValue: string) => void;
 }
 
 // Editor is the editor component, which can be used to show for example the yaml representation of a resource.
-export const Editor: React.FunctionComponent<IEditorProps> = ({ value, mode, readOnly, onChange }: IEditorProps) => {
+export const Editor: React.FunctionComponent<IEditorProps> = ({
+  value,
+  mode,
+  readOnly,
+  maxLines,
+  onChange,
+}: IEditorProps) => {
   const editor = useRef<AceEditor>(null);
 
   const changeValue = (newValue: string): void => {
@@ -34,7 +41,7 @@ export const Editor: React.FunctionComponent<IEditorProps> = ({ value, mode, rea
   return (
     <AceEditor
       height="100%"
-      maxLines={Infinity}
+      maxLines={maxLines || Infinity}
       mode={mode}
       name="yaml-editor"
       onChange={changeValue}


### PR DESCRIPTION
The MongoDB plugin had some performance issues when it rendered a large list of collection or large documents. The performance issues for the collections lists are fixed by adding pagination to the collections panel. The performance issues for large documents are fixed by limiting the number of lines for the editor view to 50 and by only rendering the document parts which are expanded.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [app] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
