### PR TITLE
[mongodb] Fix pagination for collections

### DIFF
--- a/plugins/plugin-mongodb/src/components/page/DocumentPage.tsx
+++ b/plugins/plugin-mongodb/src/components/page/DocumentPage.tsx
@@ -66,8 +66,8 @@ const DocumentPage: React.FunctionComponent<IDocumentPageProps> = ({ instance }:
       <PageHeaderSection
         component={
           <PluginPageTitle
-            satellite={instance.satellite}
-            name={instance.name}
+            satellite={`${instance.name} / ${instance.satellite}`}
+            name={params.collectionName || ''}
             description={instance.description || defaultDescription}
           />
         }

--- a/plugins/plugin-mongodb/src/components/page/QueryPage.tsx
+++ b/plugins/plugin-mongodb/src/components/page/QueryPage.tsx
@@ -46,8 +46,8 @@ const QueryPage: React.FunctionComponent<IQueryPageProps> = ({ instance }: IQuer
       <PageHeaderSection
         component={
           <PluginPageTitle
-            satellite={instance.satellite}
-            name={instance.name}
+            satellite={`${instance.name} / ${instance.satellite}`}
+            name={params.collectionName || ''}
             description={instance.description || defaultDescription}
           />
         }

--- a/plugins/plugin-mongodb/src/components/panel/Collections.tsx
+++ b/plugins/plugin-mongodb/src/components/panel/Collections.tsx
@@ -112,7 +112,10 @@ const Collections: React.FunctionComponent<ICollectionsProps> = ({
             placeholder="Filter"
             aria-label="Filter"
             value={filter}
-            onChange={(value: string): void => setFilter(value)}
+            onChange={(value: string): void => {
+              setPage({ page: 1, perPage: 20 });
+              setFilter(value);
+            }}
           />
         </CardActions>
       }
@@ -121,7 +124,7 @@ const Collections: React.FunctionComponent<ICollectionsProps> = ({
           <Pagination
             style={{ padding: 0 }}
             isCompact={true}
-            itemCount={data.length}
+            itemCount={data.filter((name) => name.toLowerCase().includes(filter.toLowerCase())).length}
             perPage={page.perPage}
             page={page.page}
             variant={PaginationVariant.bottom}


### PR DESCRIPTION
There was a small bug in the pagination logic for the collections overview. Instead of the count of the filtered collections we always used the complete count of the collections in the pagination logic. This is now fixed.

We also changed the logic to reset the users selected page, when he changed the filter.

Last but not least we now show the collection name on the queries and document page besides the plugin name and satellite name.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [app] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
