### PR TITLE
[app] Extend Placeholders for Dashboards

### DIFF
--- a/deploy/helm/hub/Chart.yaml
+++ b/deploy/helm/hub/Chart.yaml
@@ -4,5 +4,5 @@ description: Kubernetes Observability Platform
 type: application
 home: https://kobs.io
 icon: https://kobs.io/assets/images/logo.svg
-version: 0.20.0
+version: 0.20.1
 appVersion: v0.10.0

--- a/deploy/helm/satellite/Chart.yaml
+++ b/deploy/helm/satellite/Chart.yaml
@@ -4,5 +4,5 @@ description: Kubernetes Observability Platform
 type: application
 home: https://kobs.io
 icon: https://kobs.io/assets/images/logo.svg
-version: 0.20.0
+version: 0.20.1
 appVersion: v0.10.0

--- a/deploy/helm/satellite/crds/kobs.io_dashboards.yaml
+++ b/deploy/helm/satellite/crds/kobs.io_dashboards.yaml
@@ -53,9 +53,13 @@ spec:
               placeholders:
                 items:
                   properties:
+                    default:
+                      type: string
                     description:
                       type: string
                     name:
+                      type: string
+                    type:
                       type: string
                   required:
                   - name

--- a/deploy/kustomize/crds/kobs.io_dashboards.yaml
+++ b/deploy/kustomize/crds/kobs.io_dashboards.yaml
@@ -53,9 +53,13 @@ spec:
               placeholders:
                 items:
                   properties:
+                    default:
+                      type: string
                     description:
                       type: string
                     name:
+                      type: string
+                    type:
                       type: string
                   required:
                   - name

--- a/docs/resources/dashboards.md
+++ b/docs/resources/dashboards.md
@@ -9,7 +9,7 @@ Dashboards are defined via the [Dashboard Custom Resource Definition](https://gi
 | description | string | Provide a descriptions for the dashboard with additional details. | No |
 | hideToolbar | boolean | If this is `true` the toolbar will be hidden in the dashboard. | No |
 | placeholders | [[]Placeholder](#placeholder) | A list of placeholders, which can be directly set by the user. | No |
-| variables | [[]Variable](#Variable) | A list of variables, where the values are loaded by the specified plugin. | No |
+| variables | [[]Variable](#variable) | A list of variables, where the values are loaded by the specified plugin. | No |
 | rows | [[]Row](#row) | A list of rows for the dashboard. | Yes |
 
 ### Placeholder
@@ -18,6 +18,8 @@ Dashboards are defined via the [Dashboard Custom Resource Definition](https://gi
 | ----- | ---- | ----------- | -------- |
 | name | string | The name for the placeholder, which can be used in the dashboard via `{% .<placeholder-name> %}`. | Yes |
 | description | string | An optional description, to provide more information how the placeholder is used. | No |
+| default | string | A default value for the placeholder, when it is not provided in a dashboard reference. | No |
+| type | string | The type of the placeholder value. This could be `string`, `number` or `object`. The default value is `string`. | No |
 
 ### Variable
 
@@ -235,3 +237,45 @@ spec:
 ```
 
 ![Dashboard - Resource Usage](assets/dashboards-resource-usage.png)
+
+The following example shows how complex types for placeholders can be used. In the example the `grafana-dashboards` dashboard requires a list of dashboards via the `dashboards` placeholder:
+
+```yaml
+---
+apiVersion: kobs.io/v1
+kind: Application
+metadata:
+  name: kobs
+  namespace: kobs
+spec:
+  dashboards:
+    - namespace: kobs
+      name: test
+      title: Grafana Dashboards
+      placeholders:
+        dashboards: |
+          - "vErzsZIVk"
+          - "Tf1skG8Mz"
+          - "iyJszGUMk"
+
+---
+apiVersion: kobs.io/v1
+kind: Dashboard
+metadata:
+  name: grafana-dashboards
+  namespace: kobs
+spec:
+  placeholders:
+    - name: dashboards
+      type: object
+  rows:
+    - size: -1
+      panels:
+        - title: Grafana Dashboards
+          plugin:
+            name: grafana
+            type: grafana
+            options:
+              type: dashboards
+              dashboards: '{% .dashboards %}'
+```

--- a/pkg/hub/api/dashboards/dashboards.go
+++ b/pkg/hub/api/dashboards/dashboards.go
@@ -44,7 +44,7 @@ func (router *Router) getDashboardsFromReferences(w http.ResponseWriter, r *http
 				Title:       reference.Title,
 				Description: reference.Description,
 				HideToolbar: reference.Inline.HideToolbar,
-				Variables:   addPlaceholdersAsVariables(reference.Inline.Variables, reference.Placeholders),
+				Variables:   addPlaceholdersAsVariables(nil, reference.Inline.Variables, reference.Placeholders),
 				Rows:        reference.Inline.Rows,
 			})
 		} else {
@@ -56,7 +56,7 @@ func (router *Router) getDashboardsFromReferences(w http.ResponseWriter, r *http
 			}
 
 			dashboard.Title = reference.Title
-			dashboard.Variables = addPlaceholdersAsVariables(dashboard.Variables, reference.Placeholders)
+			dashboard.Variables = addPlaceholdersAsVariables(dashboard.Placeholders, dashboard.Variables, reference.Placeholders)
 			dashboards = append(dashboards, dashboard)
 		}
 	}
@@ -84,7 +84,7 @@ func (router *Router) getDashboard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dashboard.Variables = addPlaceholdersAsVariables(dashboard.Variables, placeholders)
+	dashboard.Variables = addPlaceholdersAsVariables(dashboard.Placeholders, dashboard.Variables, placeholders)
 	render.JSON(w, r, dashboard)
 }
 

--- a/pkg/hub/api/dashboards/dashboards_test.go
+++ b/pkg/hub/api/dashboards/dashboards_test.go
@@ -77,12 +77,12 @@ func TestGetDashboard(t *testing.T) {
 			name:               "get dashboards",
 			url:                "/dashboard?id=/satellite/satellite2/cluster/cluster1/namespace/namespace1/name/name1&key1=value1",
 			expectedStatusCode: http.StatusOK,
-			expectedBody:       "{\"variables\":[{\"name\":\"key1\",\"label\":\"key1\",\"hide\":true,\"plugin\":{\"type\":\"app\",\"name\":\"static\",\"options\":[\"value1\"]}}],\"rows\":null}\n",
+			expectedBody:       "{\"placeholders\":[{\"name\":\"key1\"}],\"variables\":[{\"name\":\"key1\",\"label\":\"key1\",\"hide\":true,\"plugin\":{\"type\":\"app\",\"name\":\"placeholder\",\"options\":{\"type\":\"string\",\"value\":\"value1\"}}}],\"rows\":null}\n",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			mockStoreClient := &store.MockClient{}
-			mockStoreClient.On("GetDashboardByID", mock.Anything, "/satellite/satellite2/cluster/cluster1/namespace/namespace1/name/name1").Return(&dashboardv1.DashboardSpec{}, nil)
+			mockStoreClient.On("GetDashboardByID", mock.Anything, "/satellite/satellite2/cluster/cluster1/namespace/namespace1/name/name1").Return(&dashboardv1.DashboardSpec{Placeholders: []dashboardv1.Placeholder{{Name: "key1"}}}, nil)
 			mockStoreClient.On("GetDashboardByID", mock.Anything, "/satellite/satellite1/cluster/cluster1/namespace/namespace1/name/name1").Return(nil, fmt.Errorf("could not get dashboard"))
 
 			router := Router{chi.NewRouter(), mockStoreClient}

--- a/pkg/hub/api/dashboards/variables_test.go
+++ b/pkg/hub/api/dashboards/variables_test.go
@@ -17,12 +17,16 @@ func TestAddPlaceholdersAsVariables(t *testing.T) {
 				Label: "placeholder1",
 				Hide:  true,
 				Plugin: dashboardv1.Plugin{
-					Name:    "static",
+					Name:    "placeholder",
 					Type:    "app",
-					Options: &apiextensionsv1.JSON{Raw: []byte(`["value1"]`)},
+					Options: &apiextensionsv1.JSON{Raw: []byte(`{"type":"string","value":"value1"}`)},
 				},
 			},
-		}, addPlaceholdersAsVariables(nil, map[string]string{"placeholder1": "value1"}))
+		}, addPlaceholdersAsVariables([]dashboardv1.Placeholder{
+			{
+				Name: "placeholder1",
+			},
+		}, nil, map[string]string{"placeholder1": "value1"}))
 	})
 
 	t.Run("placeholders are nil", func(t *testing.T) {
@@ -37,7 +41,7 @@ func TestAddPlaceholdersAsVariables(t *testing.T) {
 					Options: &apiextensionsv1.JSON{Raw: []byte(`["value1"]`)},
 				},
 			},
-		}, addPlaceholdersAsVariables([]dashboardv1.Variable{
+		}, addPlaceholdersAsVariables(nil, []dashboardv1.Variable{
 			{
 				Name:  "variable1",
 				Label: "Variable 1",
@@ -58,9 +62,9 @@ func TestAddPlaceholdersAsVariables(t *testing.T) {
 				Label: "placeholder1",
 				Hide:  true,
 				Plugin: dashboardv1.Plugin{
-					Name:    "static",
+					Name:    "placeholder",
 					Type:    "app",
-					Options: &apiextensionsv1.JSON{Raw: []byte(`["value1"]`)},
+					Options: &apiextensionsv1.JSON{Raw: []byte(`{"type":"string","value":"value1"}`)},
 				},
 			},
 			{
@@ -73,7 +77,11 @@ func TestAddPlaceholdersAsVariables(t *testing.T) {
 					Options: &apiextensionsv1.JSON{Raw: []byte(`["value1"]`)},
 				},
 			},
-		}, addPlaceholdersAsVariables([]dashboardv1.Variable{
+		}, addPlaceholdersAsVariables([]dashboardv1.Placeholder{
+			{
+				Name: "placeholder1",
+			},
+		}, []dashboardv1.Variable{
 			{
 				Name:  "variable1",
 				Label: "Variable 1",
@@ -85,5 +93,25 @@ func TestAddPlaceholdersAsVariables(t *testing.T) {
 				},
 			},
 		}, map[string]string{"placeholder1": "value1"}))
+	})
+
+	t.Run("placeholder values are nil", func(t *testing.T) {
+		require.Equal(t, []dashboardv1.Variable{
+			{
+				Name:  "placeholder1",
+				Label: "placeholder1",
+				Hide:  true,
+				Plugin: dashboardv1.Plugin{
+					Name:    "placeholder",
+					Type:    "app",
+					Options: &apiextensionsv1.JSON{Raw: []byte(`{"type":"string","value":"default1"}`)},
+				},
+			},
+		}, addPlaceholdersAsVariables([]dashboardv1.Placeholder{
+			{
+				Name:    "placeholder1",
+				Default: "default1",
+			},
+		}, nil, nil))
 	})
 }

--- a/pkg/kube/apis/dashboard/v1/types.go
+++ b/pkg/kube/apis/dashboard/v1/types.go
@@ -46,6 +46,8 @@ type DashboardSpec struct {
 type Placeholder struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
+	Default     string `json:"default,omitempty"`
+	Type        string `json:"type,omitempty"`
 }
 
 type Variable struct {

--- a/plugins/app/src/components/dashboards/Dashboard.tsx
+++ b/plugins/app/src/components/dashboards/Dashboard.tsx
@@ -56,6 +56,13 @@ const Dashboard: React.FunctionComponent<IDashboardProps> = ({
                 tmpVariables[i].value = tmpVariables[i].value || tmpVariables[i].plugin.options[0];
               }
             }
+
+            if (tmpVariables[i].plugin.name === 'placeholder') {
+              if (tmpVariables[i].plugin.options) {
+                tmpVariables[i].values = [tmpVariables[i].plugin.options.value || ''];
+                tmpVariables[i].value = tmpVariables[i].plugin.options.value || '';
+              }
+            }
           } else {
             tmpVariables[i] = await getVariableViaPlugin(tmpVariables[i], tmpVariables, times);
           }

--- a/plugins/app/src/crds/dashboard.ts
+++ b/plugins/app/src/crds/dashboard.ts
@@ -16,6 +16,8 @@ export interface IDashboard {
 export interface IPlaceholder {
   name: string;
   description?: string;
+  default?: string;
+  type?: string;
 }
 
 export interface IVariable {


### PR DESCRIPTION
It is now possible to set a default value for a placeholder in a dashboard and it is possible to set a type for the placeholder.

Until now, it was only possible to use string values for placeholders. This is now changed so that also "numbers" and "objects" can be used.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [app] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
