### PR TITLE
[app] Fix token auth

### DIFF
--- a/pkg/satellite/middleware/tokenauth/tokenauth.go
+++ b/pkg/satellite/middleware/tokenauth/tokenauth.go
@@ -14,7 +14,7 @@ func Handler(token string) func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
 			if token != "" {
 				authHeader := r.Header.Get("Authorization")
-				if !strings.HasPrefix(authHeader, "Bearer ") || strings.TrimLeft(authHeader, "Bearer ") != token {
+				if !strings.HasPrefix(authHeader, "Bearer ") || strings.TrimPrefix(authHeader, "Bearer ") != token {
 					errresponse.Render(w, r, fmt.Errorf("authorization token is missing or invalid"), http.StatusUnauthorized, "You are not authorized to access the resource")
 					return
 				}


### PR DESCRIPTION
We used the "strings.TrimLeft" method in the token auth handler, which is not what we want. Instead we should use "strings.TrimPrefix".

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [app] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
