### PR TITLE
Add PodDisruptionBudget to Helm Charts

### DIFF
--- a/deploy/helm/hub/Chart.yaml
+++ b/deploy/helm/hub/Chart.yaml
@@ -4,5 +4,5 @@ description: Kubernetes Observability Platform
 type: application
 home: https://kobs.io
 icon: https://kobs.io/assets/images/logo.svg
-version: 0.20.1
+version: 0.21.0
 appVersion: v0.10.0

--- a/deploy/helm/hub/templates/deployment.yaml
+++ b/deploy/helm/hub/templates/deployment.yaml
@@ -61,6 +61,7 @@ spec:
             httpGet:
               path: /api/health
               port: http-api
+            failureThreshold: 10
           readinessProbe:
             httpGet:
               path: /api/health

--- a/deploy/helm/hub/templates/pdb.yaml
+++ b/deploy/helm/hub/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.podDisruptionBudget }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "hub.fullname" . }}
+  labels:
+    {{- include "hub.labels" . | nindent 4 }}
+spec:
+  {{- toYaml .Values.podDisruptionBudget | nindent 2 }}
+  selector:
+    matchLabels:
+      {{- include "hub.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/hub/values.yaml
+++ b/deploy/helm/hub/values.yaml
@@ -24,6 +24,12 @@ image:
   tag: v0.10.0
   pullPolicy: IfNotPresent
 
+## Specifies if PodDisruptionBudget should be enabled
+## See: https://kubernetes.io/docs/tasks/run-application/configure-pdb
+##
+podDisruptionBudget: {}
+  # maxUnavailable: 1
+
 ## Specify security settings for the created Pods. To set the security settings for the kobs or envoy Container use the
 ## corresponding "securityContext" field.
 ## See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod

--- a/deploy/helm/satellite/Chart.yaml
+++ b/deploy/helm/satellite/Chart.yaml
@@ -4,5 +4,5 @@ description: Kubernetes Observability Platform
 type: application
 home: https://kobs.io
 icon: https://kobs.io/assets/images/logo.svg
-version: 0.20.1
+version: 0.21.0
 appVersion: v0.10.0

--- a/deploy/helm/satellite/templates/deployment.yaml
+++ b/deploy/helm/satellite/templates/deployment.yaml
@@ -54,6 +54,7 @@ spec:
             httpGet:
               path: /api/health
               port: http-api
+            failureThreshold: 10
           readinessProbe:
             httpGet:
               path: /api/health

--- a/deploy/helm/satellite/templates/pdb.yaml
+++ b/deploy/helm/satellite/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.podDisruptionBudget }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "satellite.fullname" . }}
+  labels:
+    {{- include "satellite.labels" . | nindent 4 }}
+spec:
+  {{- toYaml .Values.podDisruptionBudget | nindent 2 }}
+  selector:
+    matchLabels:
+      {{- include "satellite.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/satellite/values.yaml
+++ b/deploy/helm/satellite/values.yaml
@@ -24,6 +24,12 @@ image:
   tag: v0.10.0
   pullPolicy: IfNotPresent
 
+## Specifies if PodDisruptionBudget should be enabled
+## See: https://kubernetes.io/docs/tasks/run-application/configure-pdb
+##
+podDisruptionBudget: {}
+  # maxUnavailable: 1
+
 ## Specify security settings for the created Pods. To set the security settings for the kobs or envoy Container use the
 ## corresponding "securityContext" field.
 ## See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod


### PR DESCRIPTION
Signed-off-by: André Bauer <andre.bauer@staffbase.com>

* add pdb to helm charts
* set failureThreshold to 10 for livenessprobe so probes are not the same
<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [app] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.


-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [x] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/installation/helm.md).
