### PR TITLE
`klogs-plugin`: add links integration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,9 +8,10 @@
       "mode": "debug",
       "program": "${workspaceFolder}/cmd/kobs",
       "args": [
+        "hub",
         "--log.level=debug",
         "--hub.config=../../deploy/docker/kobs/hub.yaml",
-        "--app.assets=''"
+        "--app.assets="
       ]
     },
     {
@@ -20,6 +21,7 @@
       "mode": "debug",
       "program": "${workspaceFolder}/cmd/kobs",
       "args": [
+        "satellite",
         "--log.level=debug",
         "--satellite.config=../../deploy/docker/kobs/satellite.yaml",
         "--satellite.token=unsecuretoken"

--- a/docs/plugins/klogs.md
+++ b/docs/plugins/klogs.md
@@ -21,6 +21,7 @@ To use the klogs plugin the following configuration is needed in the satellites 
 | options.maxIdleConns | number | ClickHouse maximum number of idle connections. The default value is `5`. | No |
 | options.maxOpenConns | number | ClickHouse maximum number of open connections. The default value is `10`. | No |
 | options.materializedColumns | []string | A list of materialized columns. See [kobsio/klogs](https://github.com/kobsio/klogs#configuration) for more information. | No |
+| options.integrations | []object | A list of integrations. See [Integrations](#integrations) for more information. | No |
 
 ```yaml
 plugins:
@@ -36,6 +37,7 @@ plugins:
       maxIdleConns:
       maxOpenConns:
       materializedColumns:
+      integrations:
 ```
 
 ## Insight Options
@@ -57,6 +59,35 @@ The following options can be used for a panel with the klogs plugin:
 | type | string | Set the type which should be used to visualize your logs. This can be `logs` or `aggregation`. | Yes |
 | queries | [[]Query](#query) | A list of queries, which can be selected by the user. This is only required for type `logs`. | Yes |
 | aggregation | [Aggregation](#aggregation) | Options for the aggregation. This is only required for type `aggregation`. | Yes |
+
+## Integrations
+
+Integrations enhance the experience of the klogs plugin. The integrations are differentiated by the `type` property on the integration config. Integrations share the following properties:
+
+| Field | Type | Description | Required |
+| ----- | ---- | ----------- | -------- |
+| name  | string | Sets the name of the integration | No |
+| type  | string | Sets the integration type. | Yes |
+
+The following integrations are available:
+
+### Integration - Autolinks (`type: autolinks`)
+
+The autolinks integration converts a value of a specific column to a link. This could be a link to a different kobs plugin. It's possible to use relative or absolute paths. 
+The options for this integration type are specified under the property `autolinks` and use the following configuration values:
+
+| Field | Type | Description | Required |
+| ----- | ---- | ----------- | -------- |
+| columnName | string | The column name for which the autolinks should be applied | Yes |
+| path | string | The path for the autolink (can be absolute or relative) | Yes |
+
+The path property can contain placeholders for the document value and time frame values:
+
+| Placeholder | Description |
+| ----- | ---- |
+| `<<value>>` | placeholder for the document value |
+| `<<timeStart>>` | placeholder for the klogs start time (unix timestamp) |
+| `<<timeEnd>>` | placeholder for the klogs end time (unix timestamp) |
 
 ### Query
 

--- a/plugins/plugin-klogs/cmd/klogs.go
+++ b/plugins/plugin-klogs/cmd/klogs.go
@@ -139,7 +139,7 @@ func (router *Router) getLogs(w http.ResponseWriter, r *http.Request) {
 
 	data := struct {
 		Documents []map[string]any  `json:"documents"`
-		Fields    []string          `json:"fields"`
+		Fields    []instance.Field  `json:"fields"`
 		Count     int64             `json:"count"`
 		Took      int64             `json:"took"`
 		Buckets   []instance.Bucket `json:"buckets"`

--- a/plugins/plugin-klogs/pkg/instance/aggregation.go
+++ b/plugins/plugin-klogs/pkg/instance/aggregation.go
@@ -52,7 +52,7 @@ type AggregationTimes struct {
 // We can also directly say that the passed in field must be a number field, e.g. aggregation with the min, max, sum or
 // avg operation can only run against number fields.
 func generateFieldName(fieldName string, materializedColumns []string, customFields Fields, mustNumber bool) string {
-	if contains(defaultFields, fieldName) || contains(materializedColumns, fieldName) {
+	if containsField(defaultFields, Field{fieldName}) || contains(materializedColumns, fieldName) {
 		return fieldName
 	}
 
@@ -61,7 +61,7 @@ func generateFieldName(fieldName string, materializedColumns []string, customFie
 	}
 
 	for _, field := range customFields.Number {
-		if field == fieldName {
+		if field.Name == fieldName {
 			return fmt.Sprintf("fields_number['%s']", fieldName)
 		}
 	}

--- a/plugins/plugin-klogs/pkg/instance/aggregation.go
+++ b/plugins/plugin-klogs/pkg/instance/aggregation.go
@@ -52,7 +52,7 @@ type AggregationTimes struct {
 // We can also directly say that the passed in field must be a number field, e.g. aggregation with the min, max, sum or
 // avg operation can only run against number fields.
 func generateFieldName(fieldName string, materializedColumns []string, customFields Fields, mustNumber bool) string {
-	if containsField(defaultFields, Field{fieldName}) || contains(materializedColumns, fieldName) {
+	if containsField(defaultFields, Field{Name: fieldName}) || contains(materializedColumns, fieldName) {
 		return fieldName
 	}
 

--- a/plugins/plugin-klogs/pkg/instance/aggregation_test.go
+++ b/plugins/plugin-klogs/pkg/instance/aggregation_test.go
@@ -19,7 +19,7 @@ func TestGenerateFieldName(t *testing.T) {
 		{field: "content_duration", mustNumber: false, expect: "fields_number['content_duration']"},
 	} {
 		t.Run(tt.field, func(t *testing.T) {
-			actual := generateFieldName(tt.field, nil, Fields{String: nil, Number: []Field{{"content_duration"}}}, tt.mustNumber)
+			actual := generateFieldName(tt.field, nil, Fields{String: nil, Number: []Field{{Name: "content_duration"}}}, tt.mustNumber)
 			require.Equal(t, tt.expect, actual)
 		})
 	}

--- a/plugins/plugin-klogs/pkg/instance/aggregation_test.go
+++ b/plugins/plugin-klogs/pkg/instance/aggregation_test.go
@@ -19,7 +19,7 @@ func TestGenerateFieldName(t *testing.T) {
 		{field: "content_duration", mustNumber: false, expect: "fields_number['content_duration']"},
 	} {
 		t.Run(tt.field, func(t *testing.T) {
-			actual := generateFieldName(tt.field, nil, Fields{String: nil, Number: []string{"content_duration"}}, tt.mustNumber)
+			actual := generateFieldName(tt.field, nil, Fields{String: nil, Number: []Field{{"content_duration"}}}, tt.mustNumber)
 			require.Equal(t, tt.expect, actual)
 		})
 	}

--- a/plugins/plugin-klogs/pkg/instance/helpers.go
+++ b/plugins/plugin-klogs/pkg/instance/helpers.go
@@ -9,7 +9,8 @@ import (
 )
 
 type Field struct {
-	Name string `json:"name"`
+	Name         string `json:"name"`
+	AutolinkPath string `json:"autolinkPath,omitempty"`
 }
 
 func fieldsFromNames(names ...string) []Field {
@@ -151,7 +152,7 @@ func handleConditionParts(key, value, operator string, materializedColumns []str
 	// ALTER TABLE logs.logs ON CLUSTER '{cluster}' ADD COLUMN <FIELD> Float64 DEFAULT fields_number['<FIELD>'];
 	fieldsMetric.WithLabelValues(key).Inc()
 
-	if containsField(defaultFields, Field{key}) || contains(materializedColumns, key) {
+	if containsField(defaultFields, Field{Name: key}) || contains(materializedColumns, key) {
 		if operator == "=~" {
 			return fmt.Sprintf("%s ILIKE %s", key, value), nil
 		}
@@ -199,7 +200,7 @@ func handleConditionParts(key, value, operator string, materializedColumns []str
 }
 
 func handleExistsCondition(key string, materializedColumns []string) string {
-	if containsField(defaultFields, Field{key}) || contains(materializedColumns, key) {
+	if containsField(defaultFields, Field{Name: key}) || contains(materializedColumns, key) {
 		return fmt.Sprintf("%s IS NOT NULL", key)
 	}
 
@@ -218,7 +219,7 @@ func parseOrder(order, orderBy string, materializedColumns []string) string {
 	}
 
 	orderBy = strings.TrimSpace(orderBy)
-	if containsField(defaultFields, Field{orderBy}) || contains(materializedColumns, orderBy) {
+	if containsField(defaultFields, Field{Name: orderBy}) || contains(materializedColumns, orderBy) {
 		return fmt.Sprintf("%s %s", orderBy, order)
 	}
 

--- a/plugins/plugin-klogs/pkg/instance/helpers.go
+++ b/plugins/plugin-klogs/pkg/instance/helpers.go
@@ -240,7 +240,7 @@ func getBucketTimes(interval, bucketTime, timeStart, timeEnd int64) (int64, int6
 	return bucketTime, bucketTime + interval
 }
 
-// appendIf appends a value to a slice, when this values doesn't exist in the slice already.
+// appendIf appends a value to a slice, when the predicate returns true
 func appendIf[T any](items []T, item T, predecate func(iter, newItem T) bool) []T {
 	for _, ele := range items {
 		if predecate(ele, item) {

--- a/plugins/plugin-klogs/pkg/instance/helpers.go
+++ b/plugins/plugin-klogs/pkg/instance/helpers.go
@@ -8,8 +8,21 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+type Field struct {
+	Name string `json:"name"`
+}
+
+func fieldsFromNames(names ...string) []Field {
+	ret := make([]Field, len(names))
+	for i, n := range names {
+		ret[i] = Field{Name: n}
+	}
+
+	return ret
+}
+
 var (
-	defaultFields  = []string{"timestamp", "cluster", "namespace", "app", "pod_name", "container_name", "host", "log"}
+	defaultFields  = fieldsFromNames("timestamp", "cluster", "namespace", "app", "pod_name", "container_name", "host", "log")
 	defaultColumns = "timestamp, cluster, namespace, app, pod_name, container_name, host, fields_string, fields_number, log"
 
 	fieldsMetric = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -138,7 +151,7 @@ func handleConditionParts(key, value, operator string, materializedColumns []str
 	// ALTER TABLE logs.logs ON CLUSTER '{cluster}' ADD COLUMN <FIELD> Float64 DEFAULT fields_number['<FIELD>'];
 	fieldsMetric.WithLabelValues(key).Inc()
 
-	if contains(defaultFields, key) || contains(materializedColumns, key) {
+	if containsField(defaultFields, Field{key}) || contains(materializedColumns, key) {
 		if operator == "=~" {
 			return fmt.Sprintf("%s ILIKE %s", key, value), nil
 		}
@@ -186,7 +199,7 @@ func handleConditionParts(key, value, operator string, materializedColumns []str
 }
 
 func handleExistsCondition(key string, materializedColumns []string) string {
-	if contains(defaultFields, key) || contains(materializedColumns, key) {
+	if containsField(defaultFields, Field{key}) || contains(materializedColumns, key) {
 		return fmt.Sprintf("%s IS NOT NULL", key)
 	}
 
@@ -205,7 +218,7 @@ func parseOrder(order, orderBy string, materializedColumns []string) string {
 	}
 
 	orderBy = strings.TrimSpace(orderBy)
-	if contains(defaultFields, orderBy) || contains(materializedColumns, orderBy) {
+	if containsField(defaultFields, Field{orderBy}) || contains(materializedColumns, orderBy) {
 		return fmt.Sprintf("%s %s", orderBy, order)
 	}
 
@@ -226,10 +239,10 @@ func getBucketTimes(interval, bucketTime, timeStart, timeEnd int64) (int64, int6
 	return bucketTime, bucketTime + interval
 }
 
-// appendIfMissing appends a value to a slice, when this values doesn't exist in the slice already.
-func appendIfMissing(items []string, item string) []string {
+// appendIf appends a value to a slice, when this values doesn't exist in the slice already.
+func appendIf[T any](items []T, item T, predecate func(iter, newItem T) bool) []T {
 	for _, ele := range items {
-		if ele == item {
+		if predecate(ele, item) {
 			return items
 		}
 	}
@@ -237,14 +250,26 @@ func appendIfMissing(items []string, item string) []string {
 	return append(items, item)
 }
 
-// contains checks if the given slice of string contains the given item. It returns true when the slice contains the
-// given item.
-func contains(items []string, item string) bool {
+func appendIfFieldIsMissing(items []Field, item Field) []Field {
+	return appendIf(items, item, func(a, b Field) bool { return a.Name == b.Name })
+}
+
+func some[T any](items []T, item T, predecate func(a, b T) bool) bool {
 	for _, ele := range items {
-		if ele == item {
+		if predecate(ele, item) {
 			return true
 		}
 	}
 
 	return false
+}
+
+// contains checks if the given slice of string contains the given item. It returns true when the slice contains the
+// given item.
+func contains(items []string, item string) bool {
+	return some(items, item, func(a, b string) bool { return a == b })
+}
+
+func containsField(items []Field, item Field) bool {
+	return some(items, item, func(a, b Field) bool { return a.Name == b.Name })
 }

--- a/plugins/plugin-klogs/pkg/instance/helpers_test.go
+++ b/plugins/plugin-klogs/pkg/instance/helpers_test.go
@@ -144,15 +144,39 @@ func TestGetInterval(t *testing.T) {
 	}
 }
 
-func TestAppendIfMissing(t *testing.T) {
-	items := []string{"foo", "bar"}
+func TestAppendIf(t *testing.T) {
+	t.Run("works with strings", func(t *testing.T) {
+		strCmpr := func(a, b string) bool { return a == b }
+		items := []string{"foo", "bar"}
 
-	items = appendIfMissing(items, "foo")
-	require.Equal(t, []string{"foo", "bar"}, items)
+		items = appendIf(items, "foo", strCmpr)
+		require.Equal(t, []string{"foo", "bar"}, items)
 
-	items = appendIfMissing(items, "hello")
-	items = appendIfMissing(items, "world")
-	require.Equal(t, []string{"foo", "bar", "hello", "world"}, items)
+		items = appendIf(items, "hello", strCmpr)
+		items = appendIf(items, "world", strCmpr)
+		require.Equal(t, []string{"foo", "bar", "hello", "world"}, items)
+	})
+
+	t.Run("works with int's", func(t *testing.T) {
+		appendIfGreater := func(items []int, item int) []int {
+			return appendIf(items, item, func(a, b int) bool { return a > b })
+		}
+
+		require.Equal(t, []int{1, 2, 3}, appendIfGreater([]int{1, 2, 3}, 0))
+		require.Equal(t, []int{1, 2, 3, 100}, appendIfGreater([]int{1, 2, 3}, 100))
+	})
+}
+
+func TestSome(t *testing.T) {
+	items := []int64{1, 2, 3}
+
+	require.True(t, some(items, 12, func(a, b int64) bool {
+		return a%10 == b%10
+	}))
+
+	require.False(t, some(items, 14, func(a, b int64) bool {
+		return a%10 == b%10
+	}))
 }
 
 func TestContains(t *testing.T) {

--- a/plugins/plugin-klogs/pkg/instance/instance.go
+++ b/plugins/plugin-klogs/pkg/instance/instance.go
@@ -55,6 +55,7 @@ type instance struct {
 	client              *sql.DB
 	materializedColumns []string
 	cachedFields        Fields
+	integrations        []Integration
 }
 
 func (i *instance) GetName() string {
@@ -249,6 +250,7 @@ func New(name string, options map[string]any) (Instance, error) {
 		database:            config.Database,
 		client:              client,
 		materializedColumns: config.MaterializedColumns,
+		integrations:        config.Integrations,
 	}
 
 	go instance.refreshCachedFields()

--- a/plugins/plugin-klogs/pkg/instance/structs.go
+++ b/plugins/plugin-klogs/pkg/instance/structs.go
@@ -6,8 +6,8 @@ import (
 
 // Fields is the struct for cached fields, which can be of type number or string.
 type Fields struct {
-	String []string
-	Number []string
+	String []Field
+	Number []Field
 }
 
 // Row is the struct which represents a single row in the logs table of ClickHouse.

--- a/plugins/plugin-klogs/src/components/page/Logs.tsx
+++ b/plugins/plugin-klogs/src/components/page/Logs.tsx
@@ -11,11 +11,14 @@ import {
   GridItem,
   Spinner,
 } from '@patternfly/react-core';
+import { IPluginInstance, ITimes } from '@kobsio/shared';
 import { QueryObserverResult, useQuery } from '@tanstack/react-query';
+
 import React from 'react';
+
 import { useNavigate } from 'react-router-dom';
 
-import { IPluginInstance, ITimes } from '@kobsio/shared';
+import { AutolinkReference } from '../../utils/ResolveReference';
 import { ILogsData } from '../../utils/interfaces';
 import LogsActions from './LogsActions';
 import LogsChart from '../panel/LogsChart';
@@ -166,15 +169,17 @@ const Logs: React.FunctionComponent<ILogsProps> = ({
 
         <Card isCompact={true} style={{ maxWidth: '100%', overflowX: 'scroll' }}>
           <CardBody>
-            <LogsDocuments
-              documents={data.documents}
-              fields={fields}
-              order={order}
-              orderBy={orderBy}
-              addFilter={addFilter}
-              changeOrder={changeOrder}
-              selectField={selectField}
-            />
+            <AutolinkReference.Context.Provider value={AutolinkReference.Factory([fakeAutolink], times)}>
+              <LogsDocuments
+                documents={data.documents}
+                fields={fields}
+                order={order}
+                orderBy={orderBy}
+                addFilter={addFilter}
+                changeOrder={changeOrder}
+                selectField={selectField}
+              />
+            </AutolinkReference.Context.Provider>
           </CardBody>
         </Card>
       </GridItem>
@@ -183,3 +188,7 @@ const Logs: React.FunctionComponent<ILogsProps> = ({
 };
 
 export default Logs;
+const fakeAutolink = {
+  fieldName: 'content_request_id',
+  path: `?query=content_request_id='<<value>>'`,
+};

--- a/plugins/plugin-klogs/src/components/page/Logs.tsx
+++ b/plugins/plugin-klogs/src/components/page/Logs.tsx
@@ -83,10 +83,7 @@ const Logs: React.FunctionComponent<ILogsProps> = ({
             throw new Error(json.error);
           }
 
-          return {
-            ...json,
-            fields: json.fields.map((f: string) => ({ name: f })),
-          };
+          return json;
         } else {
           if (json.error) {
             throw new Error(json.error);

--- a/plugins/plugin-klogs/src/components/page/Logs.tsx
+++ b/plugins/plugin-klogs/src/components/page/Logs.tsx
@@ -166,10 +166,9 @@ const Logs: React.FunctionComponent<ILogsProps> = ({
         </Card>
 
         <p>&nbsp;</p>
-
         <Card isCompact={true} style={{ maxWidth: '100%', overflowX: 'scroll' }}>
           <CardBody>
-            <AutolinkReference.Context.Provider value={AutolinkReference.Factory([fakeAutolink], times)}>
+            <AutolinkReference.Context.Provider value={AutolinkReference.Factory(data.fields || [], times)}>
               <LogsDocuments
                 documents={data.documents}
                 fields={fields}
@@ -188,7 +187,3 @@ const Logs: React.FunctionComponent<ILogsProps> = ({
 };
 
 export default Logs;
-const fakeAutolink = {
-  fieldName: 'content_request_id',
-  path: `?query=content_request_id='<<value>>'`,
-};

--- a/plugins/plugin-klogs/src/components/page/Logs.tsx
+++ b/plugins/plugin-klogs/src/components/page/Logs.tsx
@@ -18,8 +18,8 @@ import React from 'react';
 
 import { useNavigate } from 'react-router-dom';
 
+import { IField, ILogsData } from '../../utils/interfaces';
 import { AutolinkReference } from '../../utils/ResolveReference';
-import { ILogsData } from '../../utils/interfaces';
 import LogsActions from './LogsActions';
 import LogsChart from '../panel/LogsChart';
 import LogsDocuments from '../panel/LogsDocuments';
@@ -27,14 +27,14 @@ import LogsFields from './LogsFields';
 
 interface ILogsProps {
   instance: IPluginInstance;
-  fields?: string[];
+  fields?: IField[];
   order: string;
   orderBy: string;
   query: string;
   addFilter: (filter: string) => void;
   changeTime: (times: ITimes) => void;
   changeOrder: (order: string, orderBy: string) => void;
-  selectField: (field: string) => void;
+  selectField: (field: { name: string }) => void;
   changeFieldOrder: (oldIndex: number, newIndex: number) => void;
   times: ITimes;
 }
@@ -83,7 +83,10 @@ const Logs: React.FunctionComponent<ILogsProps> = ({
             throw new Error(json.error);
           }
 
-          return json;
+          return {
+            ...json,
+            fields: json.fields.map((f: string) => ({ name: f })),
+          };
         } else {
           if (json.error) {
             throw new Error(json.error);

--- a/plugins/plugin-klogs/src/components/page/LogsActions.tsx
+++ b/plugins/plugin-klogs/src/components/page/LogsActions.tsx
@@ -11,7 +11,7 @@ interface ILogsActionsProps {
   query: string;
   times: ITimes;
   documents?: IDocument[];
-  fields?: string[];
+  fields?: { name: string }[];
   isFetching: boolean;
 }
 
@@ -48,8 +48,8 @@ export const LogsActions: React.FunctionComponent<ILogsActionsProps> = ({
       for (const document of documents) {
         csv = csv + formatTime(document['timestamp']);
 
-        for (const field of fields) {
-          csv = csv + ';' + (document.hasOwnProperty(field) ? document[field] : '-');
+        for (const { name } of fields) {
+          csv = csv + ';' + (document.hasOwnProperty(name) ? document[name] : '-');
         }
 
         csv = csv + '\r\n';

--- a/plugins/plugin-klogs/src/components/page/LogsFields.tsx
+++ b/plugins/plugin-klogs/src/components/page/LogsFields.tsx
@@ -4,9 +4,9 @@ import React from 'react';
 import LogsFieldsItem from './LogsFieldsItem';
 
 export interface ILogsFieldsProps {
-  fields?: string[];
-  selectedFields?: string[];
-  selectField: (field: string) => void;
+  fields?: { name: string }[];
+  selectedFields?: { name: string }[];
+  selectField: (field: { name: string }) => void;
   changeFieldOrder: (oldIndex: number, newIndex: number) => void;
 }
 
@@ -44,7 +44,7 @@ const LogsFields: React.FunctionComponent<ILogsFieldsProps> = ({
         <SimpleListGroup title="Fields">
           {fields.map((field, index) => (
             <SimpleListItem key={index} onClick={(): void => selectField(field)} isActive={false}>
-              {field}
+              {field.name}
             </SimpleListItem>
           ))}
         </SimpleListGroup>

--- a/plugins/plugin-klogs/src/components/page/LogsFieldsItem.tsx
+++ b/plugins/plugin-klogs/src/components/page/LogsFieldsItem.tsx
@@ -8,8 +8,8 @@ import TrashIcon from '@patternfly/react-icons/dist/esm/icons/trash-icon';
 export interface ILogsFieldsItemProps {
   index: number;
   length: number;
-  field: string;
-  selectField: (field: string) => void;
+  field: { name: string };
+  selectField: (field: { name: string }) => void;
   changeFieldOrder: (oldIndex: number, newIndex: number) => void;
 }
 
@@ -22,16 +22,16 @@ const LogsFieldsItem: React.FunctionComponent<ILogsFieldsItemProps> = ({
 }: ILogsFieldsItemProps) => {
   const [showActions, setShowActions] = useState<boolean>(false);
 
-  const copyField = (field: string): void => {
+  const copyField = (field: { name: string }): void => {
     if (navigator.clipboard) {
-      navigator.clipboard.writeText(field);
+      navigator.clipboard.writeText(field.name);
     }
   };
 
   return (
     <SimpleListItem key={index} isActive={false}>
       <div onMouseEnter={(): void => setShowActions(true)} onMouseLeave={(): void => setShowActions(false)}>
-        {field}
+        {field.name}
         {showActions && (
           <div style={{ float: 'right' }}>
             {index !== length - 1 ? (

--- a/plugins/plugin-klogs/src/components/page/LogsPage.tsx
+++ b/plugins/plugin-klogs/src/components/page/LogsPage.tsx
@@ -2,7 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { IPluginInstance, ITimes, PageContentSection, PageHeaderSection, PluginPageTitle } from '@kobsio/shared';
-import { IOptions } from '../../utils/interfaces';
+
+import { IField, IOptions } from '../../utils/interfaces';
 import Logs from './Logs';
 import LogsPageActions from './LogsPageActions';
 import LogsToolbar from './LogsToolbar';
@@ -21,7 +22,7 @@ const LogsPage: React.FunctionComponent<ILogsPageProps> = ({ instance }: ILogsPa
   // changeOptions is used to change the options. Besides setting a new value for the options state we also reflect the
   // options in the current url.
   const changeOptions = (opts: IOptions): void => {
-    const fields = opts.fields ? opts.fields.map((field) => `&field=${field}`) : [];
+    const fields = opts.fields ? opts.fields.map((field) => `&field=${field.name}`) : [];
 
     navigate(
       `${location.pathname}?query=${encodeURIComponent(opts.query)}&order=${opts.order}&orderBy=${opts.orderBy}&time=${
@@ -32,15 +33,15 @@ const LogsPage: React.FunctionComponent<ILogsPageProps> = ({ instance }: ILogsPa
 
   // selectField is used to add a field as parameter, when it isn't present and to remove a fields from as parameter,
   // when it is already present via the changeOptions function.
-  const selectField = (field: string): void => {
+  const selectField = (field: { name: string }): void => {
     if (options) {
-      let tmpFields: string[] = [];
+      let tmpFields: IField[] = [];
       if (options.fields) {
         tmpFields = [...options.fields];
       }
 
-      if (tmpFields.includes(field)) {
-        tmpFields = tmpFields.filter((f) => f !== field);
+      if (tmpFields.some((tf) => tf.name === field.name)) {
+        tmpFields = tmpFields.filter((f) => f.name !== field.name);
       } else {
         tmpFields.push(field);
       }

--- a/plugins/plugin-klogs/src/components/panel/Logs.tsx
+++ b/plugins/plugin-klogs/src/components/panel/Logs.tsx
@@ -53,7 +53,10 @@ const Logs: React.FunctionComponent<ILogsProps> = ({ instance, query, times }: I
             throw new Error(json.error);
           }
 
-          return json;
+          return {
+            ...json,
+            fields: json.fields.map((f: string) => ({ name: f })),
+          };
         } else {
           if (json.error) {
             throw new Error(json.error);

--- a/plugins/plugin-klogs/src/components/panel/Logs.tsx
+++ b/plugins/plugin-klogs/src/components/panel/Logs.tsx
@@ -53,10 +53,7 @@ const Logs: React.FunctionComponent<ILogsProps> = ({ instance, query, times }: I
             throw new Error(json.error);
           }
 
-          return {
-            ...json,
-            fields: json.fields.map((f: string) => ({ name: f })),
-          };
+          return json;
         } else {
           if (json.error) {
             throw new Error(json.error);

--- a/plugins/plugin-klogs/src/components/panel/Logs.tsx
+++ b/plugins/plugin-klogs/src/components/panel/Logs.tsx
@@ -13,6 +13,8 @@ import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-i
 import React from 'react';
 
 import { ILogsData, IQuery } from '../../utils/interfaces';
+import { AutolinkReference } from '../../utils/ResolveReference';
+
 import { IPluginInstance, ITimes } from '@kobsio/shared';
 import LogsChart from './LogsChart';
 import LogsDocuments from '../panel/LogsDocuments';
@@ -116,7 +118,9 @@ const Logs: React.FunctionComponent<ILogsProps> = ({ instance, query, times }: I
       <LogsChart buckets={data.buckets} />
       <p>&nbsp;</p>
 
-      <LogsDocuments documents={data.documents} fields={query.fields} order={query.order} orderBy={query.orderBy} />
+      <AutolinkReference.Context.Provider value={AutolinkReference.Factory(data.fields || [], times)}>
+        <LogsDocuments documents={data.documents} fields={query.fields} order={query.order} orderBy={query.orderBy} />
+      </AutolinkReference.Context.Provider>
     </div>
   );
 };

--- a/plugins/plugin-klogs/src/components/panel/LogsDocument.tsx
+++ b/plugins/plugin-klogs/src/components/panel/LogsDocument.tsx
@@ -9,9 +9,9 @@ import '../../assets/logsdocuments.css';
 
 interface ILogsDocumentProps {
   document: IDocument;
-  fields?: string[];
+  fields?: { name: string }[];
   addFilter?: (filter: string) => void;
-  selectField?: (field: string) => void;
+  selectField?: (field: { name: string }) => void;
 }
 
 const LogsDocument: React.FunctionComponent<ILogsDocumentProps> = ({
@@ -49,8 +49,8 @@ const LogsDocument: React.FunctionComponent<ILogsDocumentProps> = ({
         </Td>
         {fields && fields.length > 0 ? (
           fields.map((field, index) => (
-            <Td key={index} className="pf-u-text-wrap pf-u-text-break-word" dataLabel={field}>
-              {document[field]}
+            <Td key={index} className="pf-u-text-wrap pf-u-text-break-word" dataLabel={field.name}>
+              {document[field.name]}
             </Td>
           ))
         ) : (

--- a/plugins/plugin-klogs/src/components/panel/LogsDocumentDetails.tsx
+++ b/plugins/plugin-klogs/src/components/panel/LogsDocumentDetails.tsx
@@ -9,7 +9,7 @@ import LogsDocumentDetailsRow from './LogsDocumentDetailsRow';
 export interface ILogsDocumentDetailsProps {
   document: IDocument;
   addFilter?: (filter: string) => void;
-  selectField?: (field: string) => void;
+  selectField?: (field: { name: string }) => void;
 }
 
 const LogsDocumentDetails: React.FunctionComponent<ILogsDocumentDetailsProps> = ({

--- a/plugins/plugin-klogs/src/components/panel/LogsDocumentDetailsRow.tsx
+++ b/plugins/plugin-klogs/src/components/panel/LogsDocumentDetailsRow.tsx
@@ -14,7 +14,7 @@ export interface ILogsDocumentDetailsRowProps {
   documentKey: string;
   documentValue: string;
   addFilter?: (filter: string) => void;
-  selectField?: (field: string) => void;
+  selectField?: (field: { name: string }) => void;
 }
 
 const LogsDocumentDetailsRow: React.FunctionComponent<ILogsDocumentDetailsRowProps> = ({
@@ -26,7 +26,6 @@ const LogsDocumentDetailsRow: React.FunctionComponent<ILogsDocumentDetailsRowPro
   const { getReferenceForField } = useContext(AutolinkReference.Context);
   const [showActions, setShowActions] = useState<boolean>(false);
   const reference = getReferenceForField(documentKey, documentValue);
-  console.log({ getReferenceForField });
 
   return (
     <Tr onMouseEnter={(): void => setShowActions(true)} onMouseLeave={(): void => setShowActions(false)}>
@@ -76,7 +75,7 @@ const LogsDocumentDetailsRow: React.FunctionComponent<ILogsDocumentDetailsRowPro
                   variant="plain"
                   aria-label="Toggle field in table"
                   isSmall={true}
-                  onClick={(): void => selectField(documentKey)}
+                  onClick={(): void => selectField({ name: documentKey })}
                 >
                   <ColumnsIcon />
                 </Button>

--- a/plugins/plugin-klogs/src/components/panel/LogsDocumentDetailsRow.tsx
+++ b/plugins/plugin-klogs/src/components/panel/LogsDocumentDetailsRow.tsx
@@ -1,10 +1,14 @@
 import { Button, Tooltip } from '@patternfly/react-core';
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { Td, Tr } from '@patternfly/react-table';
 import ColumnsIcon from '@patternfly/react-icons/dist/esm/icons/columns-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import SearchMinusIcon from '@patternfly/react-icons/dist/esm/icons/search-minus-icon';
 import SearchPlusIcon from '@patternfly/react-icons/dist/esm/icons/search-plus-icon';
+
+import { Link } from 'react-router-dom';
+
+import { AutolinkReference } from '../../utils/ResolveReference';
 
 export interface ILogsDocumentDetailsRowProps {
   documentKey: string;
@@ -19,7 +23,10 @@ const LogsDocumentDetailsRow: React.FunctionComponent<ILogsDocumentDetailsRowPro
   addFilter,
   selectField,
 }: ILogsDocumentDetailsRowProps) => {
+  const { getReferenceForField } = useContext(AutolinkReference.Context);
   const [showActions, setShowActions] = useState<boolean>(false);
+  const reference = getReferenceForField(documentKey, documentValue);
+  console.log({ getReferenceForField });
 
   return (
     <Tr onMouseEnter={(): void => setShowActions(true)} onMouseLeave={(): void => setShowActions(false)}>
@@ -82,7 +89,9 @@ const LogsDocumentDetailsRow: React.FunctionComponent<ILogsDocumentDetailsRowPro
         <b>{documentKey}</b>
       </Td>
       <Td className="pf-u-text-wrap pf-u-text-break-word" noPadding={true} dataLabel="Value">
-        <div style={{ whiteSpace: 'pre-wrap' }}>{documentValue}</div>
+        <div style={{ whiteSpace: 'pre-wrap' }}>
+          {reference ? <Link to={reference}>{documentValue}</Link> : documentValue}
+        </div>
       </Td>
     </Tr>
   );

--- a/plugins/plugin-klogs/src/components/panel/LogsDocuments.tsx
+++ b/plugins/plugin-klogs/src/components/panel/LogsDocuments.tsx
@@ -22,12 +22,12 @@ interface IPage {
 
 interface ILogsDocumentsProps {
   documents?: IDocument[];
-  fields?: string[];
+  fields?: { name: string }[];
   order?: string;
   orderBy?: string;
   addFilter?: (filter: string) => void;
   changeOrder?: (order: string, orderBy: string) => void;
-  selectField?: (field: string) => void;
+  selectField?: (field: { name: string }) => void;
 }
 
 const LogsDocuments: React.FunctionComponent<ILogsDocumentsProps> = ({
@@ -41,7 +41,8 @@ const LogsDocuments: React.FunctionComponent<ILogsDocumentsProps> = ({
 }: ILogsDocumentsProps) => {
   const [page, setPage] = useState<IPage>({ page: 1, perPage: 100 });
 
-  const activeSortIndex = fields && orderBy && orderBy !== 'timestamp' ? fields?.indexOf(orderBy) : -1;
+  const activeSortIndex =
+    fields && orderBy && orderBy !== 'timestamp' ? fields?.findIndex((f) => f.name === orderBy) : -1;
   const activeSortDirection = order === 'ascending' ? 'asc' : 'desc';
 
   useEffect(() => {
@@ -86,13 +87,13 @@ const LogsDocuments: React.FunctionComponent<ILogsDocumentsProps> = ({
                     extraData: IExtraColumnData,
                   ): void => {
                     if (changeOrder) {
-                      changeOrder(sortByDirection === 'asc' ? 'ascending' : 'descending', field);
+                      changeOrder(sortByDirection === 'asc' ? 'ascending' : 'descending', field.name);
                     }
                   },
                   sortBy: { direction: activeSortDirection, index: activeSortIndex },
                 }}
               >
-                {field}
+                {field.name}
               </Th>
             ))
           ) : (

--- a/plugins/plugin-klogs/src/utils/ResolveReference.ts
+++ b/plugins/plugin-klogs/src/utils/ResolveReference.ts
@@ -1,0 +1,35 @@
+import React from 'react';
+
+interface IResolveReference {
+  getReferenceForField: (field: string, value: string) => string | undefined;
+}
+const Context = React.createContext<IResolveReference>({
+  getReferenceForField: () => undefined,
+});
+
+type IFactory = (
+  fields: Array<{ fieldName: string; path: string }>,
+  times: { timeStart: number; timeEnd: number },
+) => IResolveReference;
+
+const Factory: IFactory = (fields, times) => {
+  return {
+    getReferenceForField: (field: string, value: string): string | undefined => {
+      let { path } = fields.find(({ fieldName }) => fieldName === field) || {};
+      if (!path) {
+        return;
+      }
+
+      path = path.replaceAll('<<value>>', value);
+      path = path.replaceAll('<<timeEnd>>', `${times.timeEnd}`);
+      path = path.replaceAll('<<timeStart>>', `${times.timeStart}`);
+
+      return path;
+    },
+  };
+};
+
+export const AutolinkReference = {
+  Context,
+  Factory,
+};

--- a/plugins/plugin-klogs/src/utils/ResolveReference.ts
+++ b/plugins/plugin-klogs/src/utils/ResolveReference.ts
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { IField } from './interfaces';
+
 interface IResolveReference {
   getReferenceForField: (field: string, value: string) => string | undefined;
 }
@@ -7,15 +9,26 @@ const Context = React.createContext<IResolveReference>({
   getReferenceForField: () => undefined,
 });
 
-type IFactory = (
-  fields: Array<{ fieldName: string; path: string }>,
-  times: { timeStart: number; timeEnd: number },
-) => IResolveReference;
+type IFactory = (fields: IField[], times: { timeStart: number; timeEnd: number }) => IResolveReference;
+
+interface IAutolink {
+  fieldName: string;
+  path: string;
+}
 
 const Factory: IFactory = (fields, times) => {
+  const autolinks = fields.reduce<IAutolink[]>((acc, curr) => {
+    const { autolinkPath } = curr;
+    if (typeof autolinkPath == 'undefined') {
+      return acc;
+    }
+
+    return [...acc, { fieldName: curr.name, path: autolinkPath }];
+  }, []);
+
   return {
     getReferenceForField: (field: string, value: string): string | undefined => {
-      let { path } = fields.find(({ fieldName }) => fieldName === field) || {};
+      let { path } = autolinks.find(({ fieldName }) => fieldName === field) || {};
       if (!path) {
         return;
       }

--- a/plugins/plugin-klogs/src/utils/helpers.ts
+++ b/plugins/plugin-klogs/src/utils/helpers.ts
@@ -10,7 +10,7 @@ export const getInitialOptions = (search: string, isInitial: boolean): IOptions 
   const query = params.get('query');
 
   return {
-    fields: fields.length > 0 ? fields : undefined,
+    fields: fields.length > 0 ? fields.map((name) => ({ name })) : undefined,
     order: order ? order : 'descending',
     orderBy: orderBy ? orderBy : '',
     query: query ? query : '',

--- a/plugins/plugin-klogs/src/utils/interfaces.ts
+++ b/plugins/plugin-klogs/src/utils/interfaces.ts
@@ -24,6 +24,11 @@ export interface IQuery {
   orderBy?: string;
 }
 
+interface IAutolinks {
+  fieldName: string;
+  path: string;
+}
+
 // ILogsData is the interface of the data returned from our Go API for the logs view of the klogs plugin.
 export interface ILogsData {
   offset: number;
@@ -31,6 +36,7 @@ export interface ILogsData {
   count?: number;
   took?: number;
   fields?: string[];
+  autolinks?: IAutolinks[];
   documents?: IDocument[];
   buckets?: IBucket[];
 }

--- a/plugins/plugin-klogs/src/utils/interfaces.ts
+++ b/plugins/plugin-klogs/src/utils/interfaces.ts
@@ -18,6 +18,7 @@ export interface IPanelOptions {
 
 export interface IField {
   name: string;
+  autolinkPath?: string;
 }
 
 export interface IQuery {
@@ -28,19 +29,13 @@ export interface IQuery {
   orderBy?: string;
 }
 
-interface IAutolinks {
-  fieldName: string;
-  path: string;
-}
-
 // ILogsData is the interface of the data returned from our Go API for the logs view of the klogs plugin.
 export interface ILogsData {
   offset: number;
   timeStart: number;
   count?: number;
   took?: number;
-  fields?: { name: string }[];
-  autolinks?: IAutolinks[];
+  fields?: IField[];
   documents?: IDocument[];
   buckets?: IBucket[];
 }

--- a/plugins/plugin-klogs/src/utils/interfaces.ts
+++ b/plugins/plugin-klogs/src/utils/interfaces.ts
@@ -2,7 +2,7 @@ import { ITimes } from '@kobsio/shared';
 
 // IOptions is the interface for all options, which can be set for an klogs query.
 export interface IOptions {
-  fields?: string[];
+  fields?: IField[];
   order: string;
   orderBy: string;
   query: string;
@@ -16,10 +16,14 @@ export interface IPanelOptions {
   aggregation: IAggregationOptions;
 }
 
+export interface IField {
+  name: string;
+}
+
 export interface IQuery {
   name?: string;
   query?: string;
-  fields?: string[];
+  fields?: IField[];
   order?: string;
   orderBy?: string;
 }
@@ -35,7 +39,7 @@ export interface ILogsData {
   timeStart: number;
   count?: number;
   took?: number;
-  fields?: string[];
+  fields?: { name: string }[];
   autolinks?: IAutolinks[];
   documents?: IDocument[];
   buckets?: IBucket[];


### PR DESCRIPTION
<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [app] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

This PR solves the issue https://github.com/kobsio/kobs/issues/255 for the klogs plugin. It allows users to specify a column name and a path to direct users to a different plugin inside kobs or any other place (grafana, jaeger, etc.). It's possible to:

 - specify a placeholder for the value with `<<value>>` (this is replaced with the actual document value for the specific column) and/or
 - specify a placeholder for `timeStart` and `timeEnd` (with `<<timeStart>>` and `<<timeEnd>>`). This can be useful to create a query for a different platform that benefits from limited time-ranges (e.g jaeger or grafana).

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
