### PR TITLE
[app] Fix User Authentication

### DIFF
--- a/pkg/hub/auth/types.go
+++ b/pkg/hub/auth/types.go
@@ -37,3 +37,8 @@ type SigninRequest struct {
 	Email    string `json:"email"`
 	Password string `json:"password"`
 }
+
+type Session struct {
+	Email string   `json:"email"`
+	Teams []string `json:"teams"`
+}


### PR DESCRIPTION
For users with a lot of teams and permissions the authentication process was broken, because we saved all the users teams and permissions within the cookie, so that the cookie could exceed the maximum size of 4096 characters.

This is now fixed by just adding the users email address and team to the cookie and getting the permissions within each API call via the auth middleware.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [app] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
