### PR TITLE
`klogs-plugin`: use TextArea instead of TextInput

### DIFF
--- a/plugins/plugin-klogs/src/components/page/AggregationToolbar.tsx
+++ b/plugins/plugin-klogs/src/components/page/AggregationToolbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TextInput } from '@patternfly/react-core';
+import { TextArea } from '@patternfly/react-core';
 
 import { IOptionsAdditionalFields, ITimes, Options, Toolbar, ToolbarItem } from '@kobsio/shared';
 import { IAggregationOptions } from '../../utils/interfaces';
@@ -27,7 +27,14 @@ const AggregationToolbar: React.FunctionComponent<IAggregationToolbarProps> = ({
   return (
     <Toolbar usePageInsets={true}>
       <ToolbarItem grow={true}>
-        <TextInput aria-label="Query" type="text" value={options.query} onChange={changeQuery} />
+        <TextArea
+          aria-label="Query"
+          resizeOrientation="vertical"
+          rows={1}
+          type="text"
+          value={options.query}
+          onChange={changeQuery}
+        />
       </ToolbarItem>
 
       <Options times={options.times} showOptions={true} showSearchButton={false} setOptions={changeOptions} />

--- a/plugins/plugin-klogs/src/components/page/LogsToolbar.tsx
+++ b/plugins/plugin-klogs/src/components/page/LogsToolbar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { TextInput } from '@patternfly/react-core';
+import { TextArea } from '@patternfly/react-core';
 
 import { IOptionsAdditionalFields, ITimes, Options, Toolbar, ToolbarItem } from '@kobsio/shared';
 import { IOptions } from '../../utils/interfaces';
@@ -12,11 +12,12 @@ interface ILogsToolbarProps {
 const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({ options, setOptions }: ILogsToolbarProps) => {
   const [query, setQuery] = useState<string>(options.query);
 
-  // onEnter is used to detect if the user pressed the "ENTER" key. If this is the case we are calling the setOptions
-  // function to trigger the search.
-  // use "SHIFT" + "ENTER".
-  const onEnter = (e: React.KeyboardEvent<HTMLInputElement> | undefined): void => {
+  // onEnter is used to detect if the user pressed the "ENTER" key. If this is the case we will not add a newline.
+  // Instead of this we are calling the setOptions function to trigger the search.
+  // use "SHIFT" + "ENTER" to write multiple lines.
+  const onEnter = (e: React.KeyboardEvent<HTMLTextAreaElement> | undefined): void => {
     if (e?.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
       setOptions({ ...options, query: query });
     }
   };
@@ -42,8 +43,10 @@ const LogsToolbar: React.FunctionComponent<ILogsToolbarProps> = ({ options, setO
   return (
     <Toolbar usePageInsets={true}>
       <ToolbarItem grow={true}>
-        <TextInput
+        <TextArea
           aria-label="Query"
+          resizeOrientation="vertical"
+          rows={1}
           type="text"
           value={query}
           onChange={(value: string): void => setQuery(value)}

--- a/plugins/plugin-sql/src/components/page/PageToolbar.tsx
+++ b/plugins/plugin-sql/src/components/page/PageToolbar.tsx
@@ -20,7 +20,7 @@ const PageToolbar: React.FunctionComponent<IPageToolbarProps> = ({ options, setO
 
   // onEnter is used to detect if the user pressed the "ENTER" key. If this is the case we are calling the setOptions
   // function to trigger the search.
-  // use "SHIFT" + "ENTER".
+  // use "SHIFT" + "ENTER" to write multiple lines.
   const onEnter = (e: React.KeyboardEvent<HTMLTextAreaElement> | undefined): void => {
     if (e?.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();


### PR DESCRIPTION
<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [app] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

Klogs-Plugin now uses `TextArea` for Logs & Aggregation. This eases editing complex queries.
See: _(use SHIFT+ENTER for new lines)_

<img width="1064" alt="Bildschirm­foto 2022-12-29 um 15 33 12" src="https://user-images.githubusercontent.com/23010759/209971622-0a1269c4-09e9-4e76-a237-b5e393b16e06.png">
<img width="1058" alt="Bildschirm­foto 2022-12-29 um 16 05 10" src="https://user-images.githubusercontent.com/23010759/209971844-b8f51317-2abc-4ab4-ba03-138b264865f5.png">



<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).





