### PR TITLE
`klogs-plugin`: copy query from logs to aggregation

### DIFF
--- a/plugins/plugin-klogs/src/components/page/LogsPage.tsx
+++ b/plugins/plugin-klogs/src/components/page/LogsPage.tsx
@@ -99,7 +99,7 @@ const LogsPage: React.FunctionComponent<ILogsPageProps> = ({ instance }: ILogsPa
             satellite={instance.satellite}
             name={instance.name}
             description={instance.description || defaultDescription}
-            actions={<LogsPageActions instance={instance} />}
+            actions={<LogsPageActions instance={instance} query={options.query || ''} />}
           />
         }
       />

--- a/plugins/plugin-klogs/src/components/page/LogsPageActions.tsx
+++ b/plugins/plugin-klogs/src/components/page/LogsPageActions.tsx
@@ -2,7 +2,7 @@ import { Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 
-import { IPluginInstance, pluginBasePath } from '@kobsio/shared';
+import { IPluginInstance, addQueryUrlParameter, pluginBasePath } from '@kobsio/shared';
 
 interface ILogsPageActionsProps {
   instance: IPluginInstance;
@@ -26,7 +26,7 @@ export const LogsPageActions: React.FunctionComponent<ILogsPageActionsProps> = (
         <DropdownItem
           key={0}
           component={
-            <Link to={`${pluginBasePath(instance)}/aggregation?query=${encodeURIComponent(query)}`}>Aggregation</Link>
+            <Link to={addQueryUrlParameter(`${pluginBasePath(instance)}/aggregation`, query || '')}>Aggregation</Link>
           }
         />,
         <DropdownItem

--- a/plugins/plugin-klogs/src/components/page/LogsPageActions.tsx
+++ b/plugins/plugin-klogs/src/components/page/LogsPageActions.tsx
@@ -6,10 +6,12 @@ import { IPluginInstance, pluginBasePath } from '@kobsio/shared';
 
 interface ILogsPageActionsProps {
   instance: IPluginInstance;
+  query: string;
 }
 
 export const LogsPageActions: React.FunctionComponent<ILogsPageActionsProps> = ({
   instance,
+  query,
 }: ILogsPageActionsProps) => {
   const [show, setShow] = useState<boolean>(false);
 
@@ -21,7 +23,12 @@ export const LogsPageActions: React.FunctionComponent<ILogsPageActionsProps> = (
       isPlain={true}
       position="right"
       dropdownItems={[
-        <DropdownItem key={0} component={<Link to={`${pluginBasePath(instance)}/aggregation`}>Aggregation</Link>} />,
+        <DropdownItem
+          key={0}
+          component={
+            <Link to={`${pluginBasePath(instance)}/aggregation?query=${encodeURIComponent(query)}`}>Aggregation</Link>
+          }
+        />,
         <DropdownItem
           key={1}
           component={

--- a/plugins/shared/src/utils/plugins.ts
+++ b/plugins/shared/src/utils/plugins.ts
@@ -55,6 +55,13 @@ export const pluginBasePath = (instance: IPluginInstance): string => {
   )}`;
 };
 
+export const addQueryUrlParameter = (input: string, query: string | undefined): string => {
+  if (!query || query === '') {
+    return input;
+  }
+  return `${input}?query=${encodeURIComponent(query)}`;
+};
+
 export const pluginBasePathAlt = (satellite: string, type: string, name: string): string => {
   return `/plugins/${encodeURIComponent(satellite)}/${encodeURIComponent(type)}/${encodeURIComponent(name)}`;
 };


### PR DESCRIPTION
<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [app] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

The query string is copied over from the Logs Page to the Aggregation Page.

1. use query string in Klogs on Logs Page (hit Search)

<img width="1067" alt="Bildschirm­foto 2022-12-29 um 18 18 36" src="https://user-images.githubusercontent.com/23010759/209987437-326f0059-df19-4f0e-bbac-811917dbe6d7.png">


2. if you decide to do a Aggregation on that, you now get that query copied over (convenience)

<img width="1069" alt="Bildschirm­foto 2022-12-29 um 18 19 10" src="https://user-images.githubusercontent.com/23010759/209987449-ee3b58df-c69e-4ae2-9dd2-1c0d8476fd4c.png">



<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
