### PR TITLE
`auth`: use oauth2 refresh tokens 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,9 +8,10 @@
       "mode": "debug",
       "program": "${workspaceFolder}/cmd/kobs",
       "args": [
+        "hub",
         "--log.level=debug",
         "--hub.config=../../deploy/docker/kobs/hub.yaml",
-        "--app.assets=''"
+        "--app.assets="
       ]
     },
     {
@@ -20,6 +21,7 @@
       "mode": "debug",
       "program": "${workspaceFolder}/cmd/kobs",
       "args": [
+        "satellite",
         "--log.level=debug",
         "--satellite.config=../../deploy/docker/kobs/satellite.yaml",
         "--satellite.token=unsecuretoken"

--- a/pkg/hub/store/bolt/bolt.go
+++ b/pkg/hub/store/bolt/bolt.go
@@ -23,8 +23,9 @@ import (
 )
 
 type client struct {
-	store  *bh.Store
-	tracer trace.Tracer
+	todoRefreshToken string // hack, will write db stuff later
+	store            *bh.Store
+	tracer           trace.Tracer
 }
 
 func NewClient(uri string) (*client, error) {
@@ -399,6 +400,16 @@ func (c *client) SaveTopology(ctx context.Context, satellite string, application
 		return err
 	}
 
+	return nil
+}
+
+func (c *client) GetRefreshToken(ctx context.Context, userId string) (string, error) {
+	return c.todoRefreshToken, nil
+}
+
+func (c *client) SaveRefreshToken(ctx context.Context, userId, token string) error {
+	fmt.Println("storing token", userId, token)
+	c.todoRefreshToken = token
 	return nil
 }
 

--- a/pkg/hub/store/mongodb/mongodb.go
+++ b/pkg/hub/store/mongodb/mongodb.go
@@ -32,9 +32,10 @@ type client struct {
 
 // NewClient creates a new MongoDB client which implements our store interface and can be used instead of Bolt. To
 // create a local MongoDB for testing the following commands can be used:
-//     docker run --name mongodb -d -p 27017:27017 mongo
-//     docker stop mongodb
-//     docker rm mongodb
+//
+//	docker run --name mongodb -d -p 27017:27017 mongo
+//	docker stop mongodb
+//	docker rm mongodb
 func NewClient(uri string) (*client, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -389,6 +390,14 @@ func (c *client) SaveTopology(ctx context.Context, satellite string, application
 		return err
 	}
 
+	return nil
+}
+
+func (c *client) GetRefreshToken(ctx context.Context, userId string) (string, error) {
+	return "", nil
+}
+
+func (c *client) SaveRefreshToken(ctx context.Context, userId, token string) error {
 	return nil
 }
 

--- a/pkg/hub/store/store.go
+++ b/pkg/hub/store/store.go
@@ -27,6 +27,8 @@ type Client interface {
 	SaveUsers(ctx context.Context, satellite string, users []userv1.UserSpec) error
 	SaveTags(ctx context.Context, applications []applicationv1.ApplicationSpec) error
 	SaveTopology(ctx context.Context, satellite string, applications []applicationv1.ApplicationSpec) error
+	GetRefreshToken(ctx context.Context, userId string) (string, error)
+	SaveRefreshToken(ctx context.Context, userId, token string) error
 	GetPlugins(ctx context.Context) ([]plugin.Instance, error)
 	GetClusters(ctx context.Context) ([]shared.Cluster, error)
 	GetNamespaces(ctx context.Context) ([]shared.Namespace, error)


### PR DESCRIPTION
Please add the `offline_access` scope to your `auth.oidc.scopes`:
```yaml
auth:
  enabled: true
  ...
  scopes: ["openid", "profile", "email", "groups", "offline_access"]
```

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[app]"

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [app] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
