### PR TITLE
[core] Fix Session Duration Configuration

### DIFF
--- a/pkg/hub/auth/types_test.go
+++ b/pkg/hub/auth/types_test.go
@@ -1,0 +1,40 @@
+package auth
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type TestDuration struct {
+	Value Duration `json:"value"`
+}
+
+func TestDurationUnmarshalJSON(t *testing.T) {
+	t.Run("should unmarshal json into duration", func(t *testing.T) {
+		var data TestDuration
+		err := json.Unmarshal([]byte("{\"value\":\"168h\"}"), &data)
+		require.NoError(t, err)
+		require.Equal(t, 168.0, data.Value.Duration.Hours())
+	})
+
+	t.Run("should fail to unmarshal invalid json value into duration", func(t *testing.T) {
+		var data TestDuration
+		err := json.Unmarshal([]byte("{\"value\":\"168\"}"), &data)
+		require.Error(t, err)
+	})
+
+	t.Run("should unmarshal string into duration", func(t *testing.T) {
+		var data Duration
+		err := data.UnmarshalJSON([]byte("168h"))
+		require.NoError(t, err)
+		require.Equal(t, 168.0, data.Duration.Hours())
+	})
+
+	t.Run("should fail to unmarshal invalid duration into duration", func(t *testing.T) {
+		var data Duration
+		err := data.UnmarshalJSON([]byte("168"))
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
The session duration for the auth client couldn't be configured via the configuration file. This is now fixed, so that the session duration can be configured via the config file, command-line flag and environment variable.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
