### PR TITLE
[core] Add useQueryState Hook

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -6924,6 +6924,14 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/decode-uri-component": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
+      "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "dev": true,
@@ -8460,6 +8468,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
+      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/find-root": {
@@ -13007,6 +13026,22 @@
         "teleport": ">=0.2.0"
       }
     },
+    "node_modules/query-string": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-8.1.0.tgz",
+      "integrity": "sha512-BFQeWxJOZxZGix7y+SByG3F36dA0AbTy9o6pSmKFcFz7DAj0re9Frkty3saBn3nHo3D0oZJ/+rx3r8H8r8Jbpw==",
+      "dependencies": {
+        "decode-uri-component": "^0.4.1",
+        "filter-obj": "^5.1.0",
+        "split-on-first": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "dev": true,
@@ -14144,6 +14179,17 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/split-on-first": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-3.0.0.tgz",
+      "integrity": "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/split2": {
@@ -15741,7 +15787,8 @@
       "name": "@kobsio/core",
       "version": "0.0.0",
       "dependencies": {
-        "md5": "^2.3.0"
+        "md5": "^2.3.0",
+        "query-string": "^8.1.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.5",

--- a/app/packages/core/package.json
+++ b/app/packages/core/package.json
@@ -48,6 +48,7 @@
     "vitest": "^0.28.4"
   },
   "dependencies": {
-    "md5": "^2.3.0"
+    "md5": "^2.3.0",
+    "query-string": "^8.1.0"
   }
 }

--- a/app/packages/core/src/index.ts
+++ b/app/packages/core/src/index.ts
@@ -1,3 +1,8 @@
 export * from './components/app/App';
+
 export * from './context/AppContext';
 export * from './context/PluginContext';
+
+export * from './utils/hooks/useQueryState';
+export * from './utils/hooks/useMemoizedFn';
+export * from './utils/hooks/useUpdate';

--- a/app/packages/core/src/utils/hooks/useMemoizedFn.test.tsx
+++ b/app/packages/core/src/utils/hooks/useMemoizedFn.test.tsx
@@ -1,0 +1,36 @@
+import { act, renderHook } from '@testing-library/react';
+import { useState } from 'react';
+
+import useMemoizedFn from './useMemoizedFn';
+
+const useCount = () => {
+  const [count, setCount] = useState(0);
+
+  const addCount = () => {
+    setCount((c) => c + 1);
+  };
+
+  const memoizedFn = useMemoizedFn(() => count);
+
+  return { addCount, memoizedFn };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let hook: any;
+
+describe('useMemoizedFn', () => {
+  it('should work', () => {
+    act(() => {
+      hook = renderHook(() => useCount());
+    });
+    const currentFn = hook.result.current.memoizedFn;
+    expect(hook.result.current.memoizedFn()).toBe(0);
+
+    act(() => {
+      hook.result.current.addCount();
+    });
+
+    expect(currentFn).toEqual(hook.result.current.memoizedFn);
+    expect(hook.result.current.memoizedFn()).toBe(1);
+  });
+});

--- a/app/packages/core/src/utils/hooks/useMemoizedFn.tsx
+++ b/app/packages/core/src/utils/hooks/useMemoizedFn.tsx
@@ -1,0 +1,31 @@
+import { useMemo, useRef } from 'react';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Noop = (this: any, ...args: any[]) => any;
+
+type PickFunction<T extends Noop> = (this: ThisParameterType<T>, ...args: Parameters<T>) => ReturnType<T>;
+
+/**
+ * `useMemoizedFn` is a React hook for persistent functions. In theory, `useMemoizedFn` can be used instead of
+ * `useCallback`. In some scenarios, we need to use useCallback to cache a function, but when the second parameter deps
+ * changes, the function will be regenerated, causing the function reference to change. Using `useMemoizedFn`, you can
+ * omit the second parameter deps, and ensure that the function reference never change.
+ *
+ * Note: This is required for the `useQueryState` and taken from https://ahooks.js.org/hooks/use-memoized-fn
+ */
+function useMemoizedFn<T extends Noop>(fn: T) {
+  const fnRef = useRef<T>(fn);
+
+  fnRef.current = useMemo(() => fn, [fn]);
+
+  const memoizedFn = useRef<PickFunction<T>>();
+  if (!memoizedFn.current) {
+    memoizedFn.current = function (this, ...args) {
+      return fnRef.current.apply(this, args);
+    };
+  }
+
+  return memoizedFn.current as T;
+}
+
+export default useMemoizedFn;

--- a/app/packages/core/src/utils/hooks/useQueryState.test.tsx
+++ b/app/packages/core/src/utils/hooks/useQueryState.test.tsx
@@ -1,0 +1,76 @@
+import { act } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+
+import type { MemoryRouterProps } from 'react-router-dom';
+
+import useQueryState from './useQueryState';
+
+describe('useQueryState', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const setup = (initialEntries: MemoryRouterProps['initialEntries'], initialState: any = {}) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = {} as any;
+
+    const Component = () => {
+      const [state, setState] = useQueryState(initialState);
+      const location = useLocation();
+      Object.assign(res, { location, setState, state });
+      return null;
+    };
+
+    render(
+      <MemoryRouter initialEntries={initialEntries}>
+        <Component />
+      </MemoryRouter>,
+    );
+
+    return res;
+  };
+
+  it('should add state to url search params', () => {
+    const res = setup([
+      {
+        pathname: '/index',
+        search: '?count=1',
+      },
+    ]);
+    expect(res.state).toMatchObject({ count: '1' });
+  });
+
+  it('shoule change url when setState is used', () => {
+    const res = setup(['/index']);
+    expect(res.state).toMatchObject({});
+    act(() => {
+      res.setState({ count: 1 });
+    });
+    expect(res.state).toMatchObject({ count: '1' });
+  });
+
+  it('should be work with multiple states', () => {
+    const res = setup(['/index']);
+    act(() => {
+      res.setState({ page: 1 });
+    });
+    act(() => {
+      res.setState({ pageSize: 10 });
+    });
+    expect(res.state).toMatchObject({ page: '1', pageSize: '10' });
+  });
+
+  it('should keep location.state', () => {
+    const res = setup([
+      {
+        pathname: '/index',
+        state: 'state',
+      },
+    ]);
+    expect(res.location.state).toBe('state');
+    act(() => {
+      res.setState({ count: 1 });
+    });
+    expect(res.state).toMatchObject({ count: '1' });
+    expect(res.location.state).toBe('state');
+  });
+});

--- a/app/packages/core/src/utils/hooks/useQueryState.tsx
+++ b/app/packages/core/src/utils/hooks/useQueryState.tsx
@@ -1,0 +1,64 @@
+import queryString from 'query-string';
+import { useMemo, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import useMemoizedFn from './useMemoizedFn';
+import useUpdate from './useUpdate';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type QueryState = Record<string, any>;
+
+/**
+ * `useQueryState` is a React hook, which allows us to store the state into a url query.
+ *
+ * Note: The implementation is heavily inspired by https://ahooks.js.org/hooks/use-url-state, but only supports React
+ * Router v6, uses `react-router-dom` instead of `react-router` and removes the options, which should always be the same
+ * across all our components.
+ */
+const useQueryState = <S extends QueryState = QueryState>(initialState?: S | (() => S)) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  type State = Partial<{ [key in keyof S]: any }>;
+
+  const location = useLocation();
+  const navigate = useNavigate();
+  const update = useUpdate();
+
+  const initialStateRef = useRef(typeof initialState === 'function' ? (initialState as () => S)() : initialState || {});
+
+  const queryFromUrl = useMemo(() => {
+    return queryString.parse(location.search, { parseBooleans: false, parseNumbers: false });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.search]);
+
+  const targetQuery: State = useMemo(
+    () => ({
+      ...initialStateRef.current,
+      ...queryFromUrl,
+    }),
+    [queryFromUrl],
+  );
+
+  const setState = (s: React.SetStateAction<State>) => {
+    const newQuery = typeof s === 'function' ? s(targetQuery) : s;
+
+    update();
+
+    if (navigate) {
+      navigate(
+        {
+          hash: location.hash,
+          search:
+            queryString.stringify({ ...queryFromUrl, ...newQuery }, { skipEmptyString: false, skipNull: false }) || '?',
+        },
+        {
+          replace: false,
+          state: location.state,
+        },
+      );
+    }
+  };
+
+  return [targetQuery, useMemoizedFn(setState)] as const;
+};
+
+export default useQueryState;

--- a/app/packages/core/src/utils/hooks/useUpdate.test.tsx
+++ b/app/packages/core/src/utils/hooks/useUpdate.test.tsx
@@ -1,0 +1,31 @@
+import { renderHook, act } from '@testing-library/react';
+
+import useMemoizedFn from './useMemoizedFn';
+import useUpdate from './useUpdate';
+
+describe('useUpdate', () => {
+  it('should update', () => {
+    let count = 0;
+    const hooks = renderHook(() => {
+      const update = useUpdate();
+      return {
+        count,
+        onChange: useMemoizedFn(() => {
+          count++;
+          update();
+        }),
+        update,
+      };
+    });
+    expect(hooks.result.current.count).toBe(0);
+    act(hooks.result.current.onChange);
+    expect(hooks.result.current.count).toBe(1);
+  });
+
+  it('should return same update function', () => {
+    const hooks = renderHook(() => useUpdate());
+    const preUpdate = hooks.result.current;
+    hooks.rerender();
+    expect(hooks.result.current).toEqual(preUpdate);
+  });
+});

--- a/app/packages/core/src/utils/hooks/useUpdate.tsx
+++ b/app/packages/core/src/utils/hooks/useUpdate.tsx
@@ -1,0 +1,14 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * `useUpdate` is a React hook that returns a function which can be used to force the component to re-render.
+ *
+ * Note: This is required for the `useQueryState` and taken from https://ahooks.js.org/hooks/use-update
+ */
+const useUpdate = () => {
+  const [, setState] = useState({});
+
+  return useCallback(() => setState({}), []);
+};
+
+export default useUpdate;


### PR DESCRIPTION
The added useQueryState hook can be used to handle the state of a component via URL query parameters. This is similar to the "useState" hook, but reflects the state within the url, so that a user can share his state (by sharing the url) with other users.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
