### PR TITLE
[core] Fix Exports for Components

### DIFF
--- a/app/packages/core/src/components/app/App.tsx
+++ b/app/packages/core/src/components/app/App.tsx
@@ -11,7 +11,7 @@ import SigninOIDCCallback from './signin/SigninOIDCCallback';
 import { APIContextProvider, APIContext, IAPIContext, APIError, IAPIUser } from '../../context/APIContext';
 import { AppContextProvider, IAppIcons } from '../../context/AppContext';
 import { PluginContextProvider, IPlugin } from '../../context/PluginContext';
-import QueryClientProvider from '../../context/QueryClientProvider';
+import { QueryClientProvider } from '../../context/QueryClientProvider';
 import theme from '../../utils/theme';
 import ApplicationPage from '../applications/ApplicationPage';
 import ApplicationsPage from '../applications/ApplicationsPage';

--- a/app/packages/core/src/components/app/Home.tsx
+++ b/app/packages/core/src/components/app/Home.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 
 import { APIContext, IAPIContext } from '../../context/APIContext';
 import Dashboards from '../dashboards/Dashboards';
-import Page from '../utils/Page';
+import { Page } from '../utils/Page';
 
 const Home: FunctionComponent = () => {
   const apiContext = useContext<IAPIContext>(APIContext);

--- a/app/packages/core/src/components/app/signin/Signin.test.tsx
+++ b/app/packages/core/src/components/app/signin/Signin.test.tsx
@@ -6,7 +6,7 @@ import { vi } from 'vitest';
 import Signin from './Signin';
 
 import { APIClient, APIContext } from '../../../context/APIContext';
-import QueryClientProvider from '../../../context/QueryClientProvider';
+import { QueryClientProvider } from '../../../context/QueryClientProvider';
 
 describe('Signin', () => {
   const apiClient: APIClient = new APIClient();

--- a/app/packages/core/src/components/app/signin/SigninOIDCCallback.test.tsx
+++ b/app/packages/core/src/components/app/signin/SigninOIDCCallback.test.tsx
@@ -5,7 +5,7 @@ import { vi } from 'vitest';
 import SigninOIDCCallback from './SigninOIDCCallback';
 
 import { APIClient, APIContext, APIError } from '../../../context/APIContext';
-import QueryClientProvider from '../../../context/QueryClientProvider';
+import { QueryClientProvider } from '../../../context/QueryClientProvider';
 
 describe('SigninOIDCCallback', () => {
   const apiClient = new APIClient();

--- a/app/packages/core/src/components/applications/ApplicationGroupsPanel.tsx
+++ b/app/packages/core/src/components/applications/ApplicationGroupsPanel.tsx
@@ -7,7 +7,7 @@ import { Link } from 'react-router-dom';
 import { APIContext, APIError, IAPIContext } from '../../context/APIContext';
 import { ITopology } from '../../crds/application';
 import { PluginPanel, PluginPanelError } from '../utils/PluginPanel';
-import UseQueryWrapper from '../utils/UseQueryWrapper';
+import { UseQueryWrapper } from '../utils/UseQueryWrapper';
 
 /**
  * `generateLinks` generates the links to all applications in the provided `application` based on the provided `groups`,

--- a/app/packages/core/src/components/applications/ApplicationPage.tsx
+++ b/app/packages/core/src/components/applications/ApplicationPage.tsx
@@ -9,8 +9,8 @@ import ApplicationLabels from './ApplicationLabels';
 import { APIContext, APIError, IAPIContext } from '../../context/APIContext';
 import { IApplication } from '../../crds/application';
 import Dashboards from '../dashboards/Dashboards';
-import Page from '../utils/Page';
-import UseQueryWrapper from '../utils/UseQueryWrapper';
+import { Page } from '../utils/Page';
+import { UseQueryWrapper } from '../utils/UseQueryWrapper';
 
 interface IApplicationParams extends Record<string, string | undefined> {
   cluster?: string;

--- a/app/packages/core/src/components/applications/ApplicationsInsights.tsx
+++ b/app/packages/core/src/components/applications/ApplicationsInsights.tsx
@@ -7,7 +7,7 @@ import { Link } from 'react-router-dom';
 import ApplicationLabels from './ApplicationLabels';
 
 import { IApplication } from '../../crds/application';
-import DetailsDrawer from '../utils/DetailsDrawer';
+import { DetailsDrawer } from '../utils/DetailsDrawer';
 
 interface IApplicationInsightsProps {
   application: IApplication;

--- a/app/packages/core/src/components/applications/ApplicationsPage.test.tsx
+++ b/app/packages/core/src/components/applications/ApplicationsPage.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import ApplicationsPage from './ApplicationsPage';
 
 import { APIContextProvider } from '../../context/APIContext';
-import QueryClientProvider from '../../context/QueryClientProvider';
+import { QueryClientProvider } from '../../context/QueryClientProvider';
 
 describe('ApplicationsPage', () => {
   const render = (): RenderResult => {

--- a/app/packages/core/src/components/applications/ApplicationsPage.tsx
+++ b/app/packages/core/src/components/applications/ApplicationsPage.tsx
@@ -10,10 +10,10 @@ import { IApplicationOptions } from './utils';
 
 import { APIContext, APIError, IAPIContext } from '../../context/APIContext';
 import { IApplication } from '../../crds/application';
-import useQueryState from '../../utils/hooks/useQueryState';
-import Page from '../utils/Page';
-import Pagination from '../utils/Pagination';
-import UseQueryWrapper from '../utils/UseQueryWrapper';
+import { useQueryState } from '../../utils/hooks/useQueryState';
+import { Page } from '../utils/Page';
+import { Pagination } from '../utils/Pagination';
+import { UseQueryWrapper } from '../utils/UseQueryWrapper';
 
 interface IApplicationsProps {
   options: IApplicationOptions;

--- a/app/packages/core/src/components/applications/ApplicationsPanel.tsx
+++ b/app/packages/core/src/components/applications/ApplicationsPanel.tsx
@@ -6,10 +6,10 @@ import Application from './Application';
 
 import { APIContext, APIError, IAPIContext } from '../../context/APIContext';
 import { IApplication } from '../../crds/application';
-import useQueryState from '../../utils/hooks/useQueryState';
-import Pagination from '../utils/Pagination';
+import { useQueryState } from '../../utils/hooks/useQueryState';
+import { Pagination } from '../utils/Pagination';
 import { PluginPanel } from '../utils/PluginPanel';
-import UseQueryWrapper from '../utils/UseQueryWrapper';
+import { UseQueryWrapper } from '../utils/UseQueryWrapper';
 
 interface IApplicationsPanelProps {
   description?: string;

--- a/app/packages/core/src/components/applications/ApplicationsToolbar.test.tsx
+++ b/app/packages/core/src/components/applications/ApplicationsToolbar.test.tsx
@@ -6,7 +6,7 @@ import ApplicationsToolbar from './ApplicationsToolbar';
 import { IApplicationOptions } from './utils';
 
 import { APIClient, APIContext } from '../../context/APIContext';
-import QueryClientProvider from '../../context/QueryClientProvider';
+import { QueryClientProvider } from '../../context/QueryClientProvider';
 
 describe('ApplicationsToolbar', () => {
   const render = async (

--- a/app/packages/core/src/components/applications/TopologyPage.tsx
+++ b/app/packages/core/src/components/applications/TopologyPage.tsx
@@ -7,9 +7,9 @@ import { ApplicationsInsightsWrapper, TopologyGraph } from './Topology';
 import { IApplicationOptions, ITopology } from './utils';
 
 import { APIContext, APIError, IAPIContext } from '../../context/APIContext';
-import useQueryState from '../../utils/hooks/useQueryState';
-import Page from '../utils/Page';
-import UseQueryWrapper from '../utils/UseQueryWrapper';
+import { useQueryState } from '../../utils/hooks/useQueryState';
+import { Page } from '../utils/Page';
+import { UseQueryWrapper } from '../utils/UseQueryWrapper';
 
 /**
  * `ITopologyÜageInternalProps` is the interface for the `Topology` component.

--- a/app/packages/core/src/components/applications/TopologyPanel.tsx
+++ b/app/packages/core/src/components/applications/TopologyPanel.tsx
@@ -7,7 +7,7 @@ import { ITopology } from './utils';
 
 import { APIContext, APIError, IAPIContext } from '../../context/APIContext';
 import { PluginPanel, PluginPanelError } from '../utils/PluginPanel';
-import UseQueryWrapper from '../utils/UseQueryWrapper';
+import { UseQueryWrapper } from '../utils/UseQueryWrapper';
 
 /**
  * `ITopologyPanelInternalProps` is the interface for the `TopologyPanelInternal` component.

--- a/app/packages/core/src/components/dashboards/Dashboards.tsx
+++ b/app/packages/core/src/components/dashboards/Dashboards.tsx
@@ -20,12 +20,12 @@ import { getVariableViaPlugin, interpolate, interpolateJSONPath } from './utils'
 import { APIContext, APIError, IAPIContext } from '../../context/APIContext';
 import { GridContextProvider } from '../../context/GridContext';
 import { IDashboard, IPanel, IReference, IRow, IVariableValues } from '../../crds/dashboard';
-import useQueryState from '../../utils/hooks/useQueryState';
+import { useQueryState } from '../../utils/hooks/useQueryState';
 import { ITimes, timeOptions, times as defaultTimes, TTime } from '../../utils/times';
 import PluginPanel from '../plugins/PluginPanel';
 import { IOptionsAdditionalFields, Options } from '../utils/Options';
 import { Toolbar, ToolbarItem } from '../utils/Toolbar';
-import UseQueryWrapper from '../utils/UseQueryWrapper';
+import { UseQueryWrapper } from '../utils/UseQueryWrapper';
 
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';

--- a/app/packages/core/src/components/dashboards/DashboardsPage.tsx
+++ b/app/packages/core/src/components/dashboards/DashboardsPage.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom';
 
 import { IReference } from '../../crds/dashboard';
 import Dashboards from '../dashboards/Dashboards';
-import Page from '../utils/Page';
+import { Page } from '../utils/Page';
 
 interface IPage {
   dashboards: IReference[];

--- a/app/packages/core/src/components/plugins/PluginsPage.test.tsx
+++ b/app/packages/core/src/components/plugins/PluginsPage.test.tsx
@@ -8,7 +8,7 @@ import PluginsPage from './PluginsPage';
 
 import { APIClient, APIContext } from '../../context/APIContext';
 import { PluginContextProvider, IPluginInstance } from '../../context/PluginContext';
-import QueryClientProvider from '../../context/QueryClientProvider';
+import { QueryClientProvider } from '../../context/QueryClientProvider';
 
 describe('PluginsPage', () => {
   const render = async (instances: IPluginInstance[], children?: ReactNode): Promise<RenderResult> => {

--- a/app/packages/core/src/components/plugins/PluginsPage.tsx
+++ b/app/packages/core/src/components/plugins/PluginsPage.tsx
@@ -18,9 +18,9 @@ import { FormEvent, FunctionComponent, useContext, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { IPluginInstance, PluginContext } from '../../context/PluginContext';
-import useQueryState from '../../utils/hooks/useQueryState';
-import Page from '../utils/Page';
-import Pagination from '../utils/Pagination';
+import { useQueryState } from '../../utils/hooks/useQueryState';
+import { Page } from '../utils/Page';
+import { Pagination } from '../utils/Pagination';
 import { Toolbar, ToolbarItem } from '../utils/Toolbar';
 
 const icon = <CheckBoxOutlineBlank fontSize="small" />;

--- a/app/packages/core/src/components/resources/ResourcesClusters.test.tsx
+++ b/app/packages/core/src/components/resources/ResourcesClusters.test.tsx
@@ -6,7 +6,7 @@ import { vi } from 'vitest';
 import ResourcesClusters from './ResourcesClusters';
 
 import { APIClient, APIContext } from '../../context/APIContext';
-import QueryClientProvider from '../../context/QueryClientProvider';
+import { QueryClientProvider } from '../../context/QueryClientProvider';
 
 describe('ResourcesClusters', () => {
   const render = async (

--- a/app/packages/core/src/components/resources/ResourcesNamespaces.test.tsx
+++ b/app/packages/core/src/components/resources/ResourcesNamespaces.test.tsx
@@ -6,7 +6,7 @@ import { vi } from 'vitest';
 import ResourcesNamespaces from './ResourcesNamespaces';
 
 import { APIClient, APIContext } from '../../context/APIContext';
-import QueryClientProvider from '../../context/QueryClientProvider';
+import { QueryClientProvider } from '../../context/QueryClientProvider';
 
 describe('ResourcesNamespaces', () => {
   const render = async (

--- a/app/packages/core/src/components/teams/TeamPage.tsx
+++ b/app/packages/core/src/components/teams/TeamPage.tsx
@@ -8,8 +8,8 @@ import { APIContext, APIError, IAPIContext } from '../../context/APIContext';
 import { IApplication } from '../../crds/application';
 import { ITeam } from '../../crds/team';
 import Dashboards from '../dashboards/Dashboards';
-import Page from '../utils/Page';
-import UseQueryWrapper from '../utils/UseQueryWrapper';
+import { Page } from '../utils/Page';
+import { UseQueryWrapper } from '../utils/UseQueryWrapper';
 
 interface ITeamParams extends Record<string, string | undefined> {
   id?: string;

--- a/app/packages/core/src/components/teams/Teams.tsx
+++ b/app/packages/core/src/components/teams/Teams.tsx
@@ -18,8 +18,8 @@ import { ITeamOptions } from './utils';
 
 import { APIContext, APIError, IAPIContext } from '../../context/APIContext';
 import { ITeam } from '../../crds/team';
-import Pagination from '../utils/Pagination';
-import UseQueryWrapper from '../utils/UseQueryWrapper';
+import { Pagination } from '../utils/Pagination';
+import { UseQueryWrapper } from '../utils/UseQueryWrapper';
 
 interface ITeamProps {
   team: ITeam;

--- a/app/packages/core/src/components/teams/TeamsPage.tsx
+++ b/app/packages/core/src/components/teams/TeamsPage.tsx
@@ -6,8 +6,8 @@ import { Link } from 'react-router-dom';
 import Teams from './Teams';
 import { ITeamOptions } from './utils';
 
-import useQueryState from '../../utils/hooks/useQueryState';
-import Page from '../utils/Page';
+import { useQueryState } from '../../utils/hooks/useQueryState';
+import { Page } from '../utils/Page';
 import { Toolbar, ToolbarItem } from '../utils/Toolbar';
 
 /**

--- a/app/packages/core/src/components/utils/DetailsDrawer.test.tsx
+++ b/app/packages/core/src/components/utils/DetailsDrawer.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 
-import DetailsDrawer from './DetailsDrawer';
+import { DetailsDrawer } from './DetailsDrawer';
 
 describe('Page', () => {
   it('should render title and children', async () => {

--- a/app/packages/core/src/components/utils/DetailsDrawer.tsx
+++ b/app/packages/core/src/components/utils/DetailsDrawer.tsx
@@ -19,7 +19,7 @@ interface IDetailsDrawerProps {
  * It is also possible to set a title, subtitle and some action which will be displayed on the left of the close button.
  * Therefor a action should be a `IconButton` where the `edge` property is set to `end`.
  */
-const DetailsDrawer: FunctionComponent<IDetailsDrawerProps> = ({
+export const DetailsDrawer: FunctionComponent<IDetailsDrawerProps> = ({
   actions,
   children,
   onClose,
@@ -68,5 +68,3 @@ const DetailsDrawer: FunctionComponent<IDetailsDrawerProps> = ({
     </Drawer>
   );
 };
-
-export default DetailsDrawer;

--- a/app/packages/core/src/components/utils/Page.test.tsx
+++ b/app/packages/core/src/components/utils/Page.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 
-import Page from './Page';
+import { Page } from './Page';
 
 describe('Page', () => {
   it('should render title and children', async () => {

--- a/app/packages/core/src/components/utils/Page.tsx
+++ b/app/packages/core/src/components/utils/Page.tsx
@@ -17,7 +17,15 @@ interface IPageProps {
  * property is set to true we do not render the diver between the page header and content (`children`), instead the we
  * have to take care that the tabs are rendered within the content and that they contain a divider.
  */
-const Page: FunctionComponent<IPageProps> = ({ actions, children, description, hasTabs, subtitle, title, toolbar }) => {
+export const Page: FunctionComponent<IPageProps> = ({
+  actions,
+  children,
+  description,
+  hasTabs,
+  subtitle,
+  title,
+  toolbar,
+}) => {
   return (
     <Stack minHeight="100%" minWidth="100%">
       <Grid justifyContent="space-between" container={true} spacing={6}>
@@ -58,5 +66,3 @@ const Page: FunctionComponent<IPageProps> = ({ actions, children, description, h
     </Stack>
   );
 };
-
-export default Page;

--- a/app/packages/core/src/components/utils/Pagination.test.tsx
+++ b/app/packages/core/src/components/utils/Pagination.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 
-import Pagination from './Pagination';
+import { Pagination } from './Pagination';
 
 describe('Pagination', () => {
   it('should render pagination', async () => {

--- a/app/packages/core/src/components/utils/Pagination.tsx
+++ b/app/packages/core/src/components/utils/Pagination.tsx
@@ -17,7 +17,13 @@ interface IPaginationProps {
  * The `Pagination` component can be used to show a pagination within another component. It will show a list of pages
  * and a select box to select the items per page.
  */
-const Pagination: FunctionComponent<IPaginationProps> = ({ handleChange, count, page, perPage, size = 'medium' }) => {
+export const Pagination: FunctionComponent<IPaginationProps> = ({
+  handleChange,
+  count,
+  page,
+  perPage,
+  size = 'medium',
+}) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
 
@@ -101,5 +107,3 @@ const Pagination: FunctionComponent<IPaginationProps> = ({ handleChange, count, 
     </Stack>
   );
 };
-
-export default Pagination;

--- a/app/packages/core/src/components/utils/UseQueryWrapper.test.tsx
+++ b/app/packages/core/src/components/utils/UseQueryWrapper.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 
-import UseQueryWrapper from './UseQueryWrapper';
+import { UseQueryWrapper } from './UseQueryWrapper';
 
 import { APIError } from '../../context/APIContext';
 

--- a/app/packages/core/src/components/utils/UseQueryWrapper.tsx
+++ b/app/packages/core/src/components/utils/UseQueryWrapper.tsx
@@ -27,7 +27,7 @@ interface IUseQueryWrapperProps {
  * the provided `errorTile` and `error`. When the `isNoData` property is `true` it will also render an alert but with
  * the info serverity. When none of these conditions is true it will render the provided `children`.
  */
-const UseQueryWrapper: FunctionComponent<IUseQueryWrapperProps> = ({
+export const UseQueryWrapper: FunctionComponent<IUseQueryWrapperProps> = ({
   children,
   errorTitle,
   error,
@@ -78,5 +78,3 @@ const UseQueryWrapper: FunctionComponent<IUseQueryWrapperProps> = ({
 
   return <>{children}</>;
 };
-
-export default UseQueryWrapper;

--- a/app/packages/core/src/context/PluginContext.test.tsx
+++ b/app/packages/core/src/context/PluginContext.test.tsx
@@ -6,7 +6,7 @@ import { vi } from 'vitest';
 import { APIClient, APIContext, APIError } from './APIContext';
 import { PluginContext, PluginContextProvider } from './PluginContext';
 
-import QueryClientProvider from '../context/QueryClientProvider';
+import { QueryClientProvider } from '../context/QueryClientProvider';
 
 describe('PluginContext', () => {
   const apiClient = new APIClient();

--- a/app/packages/core/src/context/QueryClientProvider.tsx
+++ b/app/packages/core/src/context/QueryClientProvider.tsx
@@ -29,10 +29,8 @@ interface IQueryClientProviderProps {
  * The `QueryClientProvider` components wraps the `InternalQueryClientProvider` component from the `react-query` package
  * to apply our app wide `queryClientOptions`.
  */
-const QueryClientProvider: FunctionComponent<IQueryClientProviderProps> = ({ children }) => {
+export const QueryClientProvider: FunctionComponent<IQueryClientProviderProps> = ({ children }) => {
   const queryClient = new QueryClient(queryClientOptions);
 
   return <InternalQueryClientProvider client={queryClient}>{children}</InternalQueryClientProvider>;
 };
-
-export default QueryClientProvider;

--- a/app/packages/core/src/index.ts
+++ b/app/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from './components/app/App';
 
 export * from './components/utils/DetailsDrawer';
+export * from './components/utils/Options';
 export * from './components/utils/Page';
 export * from './components/utils/Pagination';
 export * from './components/utils/PluginPanel';
@@ -15,6 +16,7 @@ export * from './context/QueryClientProvider';
 export * from './utils/hooks/useDebounce';
 export * from './utils/hooks/useDimensions';
 export * from './utils/hooks/useQueryState';
-export * from './utils/hooks/useQueryState';
 export * from './utils/hooks/useMemoizedFn';
 export * from './utils/hooks/useUpdate';
+
+export * from './utils/times';

--- a/app/packages/core/src/utils/hooks/useMemoizedFn.test.tsx
+++ b/app/packages/core/src/utils/hooks/useMemoizedFn.test.tsx
@@ -1,7 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { useState } from 'react';
 
-import useMemoizedFn from './useMemoizedFn';
+import { useMemoizedFn } from './useMemoizedFn';
 
 const useCount = () => {
   const [count, setCount] = useState(0);

--- a/app/packages/core/src/utils/hooks/useMemoizedFn.tsx
+++ b/app/packages/core/src/utils/hooks/useMemoizedFn.tsx
@@ -13,7 +13,7 @@ type PickFunction<T extends Noop> = (this: ThisParameterType<T>, ...args: Parame
  *
  * Note: This is required for the `useQueryState` and taken from https://ahooks.js.org/hooks/use-memoized-fn
  */
-function useMemoizedFn<T extends Noop>(fn: T) {
+export const useMemoizedFn = <T extends Noop>(fn: T) => {
   const fnRef = useRef<T>(fn);
 
   fnRef.current = useMemo(() => fn, [fn]);
@@ -26,6 +26,4 @@ function useMemoizedFn<T extends Noop>(fn: T) {
   }
 
   return memoizedFn.current as T;
-}
-
-export default useMemoizedFn;
+};

--- a/app/packages/core/src/utils/hooks/useQueryState.test.tsx
+++ b/app/packages/core/src/utils/hooks/useQueryState.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter, useLocation } from 'react-router-dom';
 
 import type { MemoryRouterProps } from 'react-router-dom';
 
-import useQueryState from './useQueryState';
+import { useQueryState } from './useQueryState';
 
 describe('useQueryState', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/packages/core/src/utils/hooks/useQueryState.tsx
+++ b/app/packages/core/src/utils/hooks/useQueryState.tsx
@@ -2,8 +2,8 @@ import queryString from 'query-string';
 import { useMemo, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
-import useMemoizedFn from './useMemoizedFn';
-import useUpdate from './useUpdate';
+import { useMemoizedFn } from './useMemoizedFn';
+import { useUpdate } from './useUpdate';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type QueryState = Record<string, any>;
@@ -15,7 +15,7 @@ type QueryState = Record<string, any>;
  * Router v6, uses `react-router-dom` instead of `react-router` and removes the options, which should always be the same
  * across all our components.
  */
-const useQueryState = <S extends QueryState = QueryState>(initialState?: S | (() => S)) => {
+export const useQueryState = <S extends QueryState = QueryState>(initialState?: S | (() => S)) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   type State = Partial<{ [key in keyof S]: any }>;
 
@@ -63,5 +63,3 @@ const useQueryState = <S extends QueryState = QueryState>(initialState?: S | (()
 
   return [targetQuery as S, useMemoizedFn(setState)] as const;
 };
-
-export default useQueryState;

--- a/app/packages/core/src/utils/hooks/useUpdate.test.tsx
+++ b/app/packages/core/src/utils/hooks/useUpdate.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook, act } from '@testing-library/react';
 
-import useMemoizedFn from './useMemoizedFn';
-import useUpdate from './useUpdate';
+import { useMemoizedFn } from './useMemoizedFn';
+import { useUpdate } from './useUpdate';
 
 describe('useUpdate', () => {
   it('should update', () => {

--- a/app/packages/core/src/utils/hooks/useUpdate.tsx
+++ b/app/packages/core/src/utils/hooks/useUpdate.tsx
@@ -5,10 +5,8 @@ import { useCallback, useState } from 'react';
  *
  * Note: This is required for the `useQueryState` and taken from https://ahooks.js.org/hooks/use-update
  */
-const useUpdate = () => {
+export const useUpdate = () => {
   const [, setState] = useState({});
 
   return useCallback(() => setState({}), []);
 };
-
-export default useUpdate;


### PR DESCRIPTION
Some components from the [core] package had a wrong export, so that they were not usable in other packages. This is now fixed and all components which are intended for the usage in other packages should be usable.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
