### PR TITLE
[core] Improve `<Options/>` component

### DIFF
--- a/app/packages/core/src/components/dashboards/Dashboards.tsx
+++ b/app/packages/core/src/components/dashboards/Dashboards.tsx
@@ -21,7 +21,7 @@ import { APIContext, APIError, IAPIContext } from '../../context/APIContext';
 import { GridContextProvider } from '../../context/GridContext';
 import { IDashboard, IPanel, IReference, IRow, IVariableValues } from '../../crds/dashboard';
 import useQueryState from '../../utils/hooks/useQueryState';
-import { ITimes, timeOptions, times as defaultTimes, TTime } from '../../utils/times';
+import { ITimes, timeOptions, times as defaultTimes } from '../../utils/times';
 import PluginPanel from '../plugins/PluginPanel';
 import { IOptionsAdditionalFields, Options } from '../utils/Options';
 import { Toolbar, ToolbarItem } from '../utils/Toolbar';

--- a/app/packages/core/src/components/dashboards/Dashboards.tsx
+++ b/app/packages/core/src/components/dashboards/Dashboards.tsx
@@ -212,10 +212,7 @@ const Dashboard: FunctionComponent<IDashboardProps> = ({ dashboard }) => {
   const apiContext = useContext<IAPIContext>(APIContext);
 
   const [times, setTimes] = useState<ITimes>({
-    time:
-      dashboard.defaultTime && dashboard.defaultTime in timeOptions
-        ? (dashboard.defaultTime as TTime)
-        : 'last15Minutes',
+    time: dashboard.defaultTime && dashboard.defaultTime in timeOptions ? dashboard.defaultTime : 'last15Minutes',
     timeEnd: Math.floor(Date.now() / 1000),
     timeStart:
       Math.floor(Date.now() / 1000) -

--- a/app/packages/core/src/components/utils/Options.tsx
+++ b/app/packages/core/src/components/utils/Options.tsx
@@ -16,12 +16,13 @@ import {
   Select,
   Stack,
   ButtonGroup,
+  Typography,
 } from '@mui/material';
 import { useEffect, useState } from 'react';
 
 import { ToolbarItem } from './Toolbar';
 
-import { ITimes, TTime, formatTime, timeOptions } from '../../utils/times';
+import { ITimes, formatTime, timeOptions, TTimeQuick } from '../../utils/times';
 
 export type TOptionsAdditionalFields = 'text' | 'select';
 
@@ -139,7 +140,7 @@ export const Options: React.FunctionComponent<IOptionsProps> = ({
    * `quick` is the function for the quick select option. We always use the current time in seconds and substract the
    * seconds specified in the quick select option.
    */
-  const quick = (t: TTime) => {
+  const quick = (t: TTimeQuick) => {
     setOptions(
       {
         time: t,
@@ -203,16 +204,20 @@ export const Options: React.FunctionComponent<IOptionsProps> = ({
         <>
           {showSearchButton ? (
             <Button variant="contained" color="primary" size="small" onClick={() => setShow(true)}>
-              {times.time === 'custom'
-                ? `${formatTime(times.timeStart)} to ${formatTime(times.timeEnd)}`
-                : timeOptions[times.time].label}
+              <Typography noWrap={true}>
+                {times.time === 'custom'
+                  ? `${formatTime(times.timeStart)} to ${formatTime(times.timeEnd)}`
+                  : timeOptions[times.time].label}
+              </Typography>
             </Button>
           ) : (
             <ButtonGroup variant="contained" color="primary" size="small">
               <Button onClick={() => setShow(true)}>
-                {times.time === 'custom'
-                  ? `${formatTime(times.timeStart)} to ${formatTime(times.timeEnd)}`
-                  : timeOptions[times.time].label}
+                <Typography noWrap={true}>
+                  {times.time === 'custom'
+                    ? `${formatTime(times.timeStart)} to ${formatTime(times.timeEnd)}`
+                    : timeOptions[times.time].label}
+                </Typography>
               </Button>
               <Button onClick={refreshTimes}>
                 <Refresh />

--- a/app/packages/core/src/crds/dashboard.ts
+++ b/app/packages/core/src/crds/dashboard.ts
@@ -1,6 +1,8 @@
+import { TTimeQuick } from '../utils/times';
+
 export interface IDashboard {
   cluster: string;
-  defaultTime?: string;
+  defaultTime?: TTimeQuick;
   description?: string;
   hideToolbar?: boolean;
   id: string;

--- a/app/packages/core/src/index.ts
+++ b/app/packages/core/src/index.ts
@@ -6,6 +6,8 @@ export * from './components/utils/Pagination';
 export * from './components/utils/PluginPanel';
 export * from './components/utils/Toolbar';
 export * from './components/utils/UseQueryWrapper';
+export * from './components/utils/Options';
+export * from './utils/times';
 
 export * from './context/APIContext';
 export * from './context/AppContext';

--- a/app/packages/core/src/utils/times.ts
+++ b/app/packages/core/src/utils/times.ts
@@ -20,6 +20,8 @@ export type TTime =
   | 'last7Days'
   | 'last90Days';
 
+export type TTimeQuick = Exclude<TTime, 'custom'>;
+
 /**
  * `ITimes` is the interface for handling times in kobs. Each time object must have a `time` of type `TTime` and a
  * start and end time. The start and end time is a unix timestamp in seconds.
@@ -34,7 +36,7 @@ export interface ITimes {
  * `times` is an array with all valid options for the `TTime` type. It can be used to validate user provided input, so
  * that we are save that the input matchs the `TTime` type.
  */
-export const times = [
+export const times: TTime[] = [
   'custom',
   'last12Hours',
   'last15Minutes',
@@ -57,12 +59,13 @@ export const times = [
  * The `label` key can be used to show a prettified text for the selected time option, while the `seconds` key is used
  * to calculate the start time based on the selected time (the end time always defaults to now).
  */
-export const timeOptions: {
-  [key: string]: {
+export const timeOptions: Record<
+  TTimeQuick,
+  {
     label: string;
     seconds: number;
-  };
-} = {
+  }
+> = {
   last12Hours: { label: 'Last 12 Hours', seconds: 43200 },
   last15Minutes: { label: 'Last 15 Minutes', seconds: 900 },
   last1Day: { label: 'Last 1 Day', seconds: 86400 },
@@ -120,9 +123,9 @@ export const formatTime = (timestamp: number): string => {
 export const getTimeParams = (
   params: URLSearchParams,
   isInitial: boolean,
-  defaultTime: TTime = 'last15Minutes',
+  defaultTime: TTimeQuick = 'last15Minutes',
 ): ITimes => {
-  const time = params.get('time');
+  const time = params.get('time') as TTime | undefined;
   const timeEnd = params.get('timeEnd');
   const timeStart = params.get('timeStart');
 


### PR DESCRIPTION
<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

Various improvements for the `<Options .../>` component:

 - disable wrap on the Button, to allow usage in flex layouts that should take 100% screen width
 - add export lines for `times.ts` and `Options.tsx`
 - improve time related types

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
