### PR TITLE
[core] Update Docker Image and GitHub Actions

### DIFF
--- a/.github/codeql/codeql-config.yaml
+++ b/.github/codeql/codeql-config.yaml
@@ -1,4 +1,4 @@
-name: "custom codeql config"
+name: "CodeQL Config"
 
 disable-default-queries: false
 

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -58,7 +58,9 @@ jobs:
         uses: actions/setup-go@v3
         if: ${{ matrix.language == 'go' }}
         with:
-          go-version: 1.19
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
 
       - name: Manualbuild
         if: ${{ matrix.language == 'go' }}

--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -46,5 +46,5 @@ jobs:
           push: true
           context: .
           file: ./cmd/kobs/Dockerfile
-          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
+          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
           tags: kobsio/kobs:${{ steps.tag.outputs.tag }}

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -18,20 +18,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup
+      - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
-
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
 
       - name: Download Dependencies
         run: |
@@ -72,21 +64,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
-
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            node_modules
-            */node_modules
-            */*/node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          node-version: 18
+          cache: npm
+          cache-dependency-path: app/package-lock.json
 
       - name: Install Dependencies
         run: |
@@ -107,12 +90,12 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: app/packages/${{ matrix.plugin }}/coverage
 
-      - name: Build (App)
-        if: ${{ matrix.plugin == 'app' }}
-        run: |
-          npm run build
-
       - name: Build (Plugin)
         if: ${{ matrix.plugin != 'app' }}
         run: |
           npm run build --workspace=@kobsio/${{ matrix.plugin }}
+
+      - name: Build (App)
+        if: ${{ matrix.plugin == 'app' }}
+        run: |
+          npm run build

--- a/cmd/kobs/Dockerfile
+++ b/cmd/kobs/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:18.14.1 as app
+FROM --platform=linux/amd64 node:18.14.2 as app
 WORKDIR /kobs
 COPY app /kobs/
 RUN npm config set fetch-timeout 3600000
 RUN npm clean-install
 RUN npm run build
 
-FROM golang:1.19.6 as api
+FROM golang:1.20.1 as api
 WORKDIR /kobs
 COPY go.mod go.sum /kobs/
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kobsio/kobs
 
-go 1.19
+go 1.20
 
 require (
 	github.com/alecthomas/kong v0.7.1


### PR DESCRIPTION
- Update Go version to 1.20 in go.mod, Docker image and the GitHub Actions.
- Update Docker image for Node.js to 18.14.2
- Remove custom caching logic for Go and Node.js in GitHub Action and use the built-in caching of the Actions.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
