### PR TITLE
[core] Fix Applications and Teams

### DIFF
--- a/app/packages/core/src/components/applications/ApplicationPage.tsx
+++ b/app/packages/core/src/components/applications/ApplicationPage.tsx
@@ -1,5 +1,5 @@
 import { Edit } from '@mui/icons-material';
-import { Box, Button } from '@mui/material';
+import { Button } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { FunctionComponent, useContext } from 'react';
 import { Link, useParams } from 'react-router-dom';
@@ -64,7 +64,6 @@ const ApplicationPage: FunctionComponent = () => {
         {data?.dashboards && data.dashboards.length > 0 ? (
           <Dashboards manifest={data} references={data?.dashboards} />
         ) : null}
-        <Box>TODO: Show Dashboards</Box>
       </Page>
     </UseQueryWrapper>
   );

--- a/app/packages/core/src/components/applications/ApplicationsPanel.tsx
+++ b/app/packages/core/src/components/applications/ApplicationsPanel.tsx
@@ -1,12 +1,11 @@
 import { Divider, List } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
-import { Fragment, FunctionComponent, useContext } from 'react';
+import { Fragment, FunctionComponent, useContext, useState } from 'react';
 
 import Application from './Application';
 
 import { APIContext, APIError, IAPIContext } from '../../context/APIContext';
 import { IApplication } from '../../crds/application';
-import { useQueryState } from '../../utils/hooks/useQueryState';
 import { Pagination } from '../utils/Pagination';
 import { PluginPanel } from '../utils/PluginPanel';
 import { UseQueryWrapper } from '../utils/UseQueryWrapper';
@@ -25,7 +24,7 @@ interface IApplicationsPanelProps {
  */
 const ApplicationsPanel: FunctionComponent<IApplicationsPanelProps> = ({ title, description, options }) => {
   const apiContext = useContext<IAPIContext>(APIContext);
-  const [internalOptions, setInternalOptions] = useQueryState<{ page: number; perPage: number }>({
+  const [internalOptions, setInternalOptions] = useState<{ page: number; perPage: number }>({
     page: 1,
     perPage: 10,
   });

--- a/app/packages/core/src/components/teams/TeamPage.tsx
+++ b/app/packages/core/src/components/teams/TeamPage.tsx
@@ -72,7 +72,6 @@ const TeamPage: FunctionComponent = () => {
         {data?.dashboards && data.dashboards.length > 0 ? (
           <Dashboards manifest={data} references={data?.dashboards} />
         ) : null}
-        <Box>TODO: Show Dashboards</Box>
       </Page>
     </UseQueryWrapper>
   );


### PR DESCRIPTION
The application and team page were still showing the "TODO: Show Dashboards" message, which was already implemented, but we forgot to remove this placeholder.

The applications panel used the used the useQueryState hook for the page and per page state, wiche caused that all panels were rerendered when a user select a new page in the panel. This is now fixed by using the useState hook to manage the state.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
