### PR TITLE
[core] Add Select All Option for Clusters

### DIFF
--- a/app/packages/core/src/components/resources/ResourcesSelectClusters.test.tsx
+++ b/app/packages/core/src/components/resources/ResourcesSelectClusters.test.tsx
@@ -1,6 +1,5 @@
 import { render as _render, RenderResult, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 import { vi } from 'vitest';
 
 import ResourcesSelectClusters from './ResourcesSelectClusters';
@@ -64,5 +63,35 @@ describe('ResourcesSelectClusters', () => {
 
     expect(selectCluster).toHaveBeenCalledTimes(1);
     expect(selectCluster).toHaveBeenCalledWith(['cluster1']);
+  });
+
+  it('should select all clusters', async () => {
+    const selectCluster = vi.fn();
+
+    await render(['cluster1', 'cluster2'], [], selectCluster);
+
+    const clustersInput = screen.getByLabelText('Clusters');
+    await userEvent.type(clustersInput, 'cluster');
+
+    const cluster1Option = screen.getByRole('option', { name: 'Select all' });
+    await userEvent.click(cluster1Option);
+
+    expect(selectCluster).toHaveBeenCalledTimes(1);
+    expect(selectCluster).toHaveBeenCalledWith(['cluster1', 'cluster2']);
+  });
+
+  it('should unselect all clusters', async () => {
+    const selectCluster = vi.fn();
+
+    await render(['cluster1', 'cluster2'], ['cluster1', 'cluster2'], selectCluster);
+
+    const clustersInput = screen.getByLabelText('Clusters');
+    await userEvent.type(clustersInput, 'cluster');
+
+    const cluster1Option = screen.getByRole('option', { name: 'Select all' });
+    await userEvent.click(cluster1Option);
+
+    expect(selectCluster).toHaveBeenCalledTimes(1);
+    expect(selectCluster).toHaveBeenCalledWith([]);
   });
 });

--- a/app/packages/core/src/components/resources/ResourcesSelectClusters.tsx
+++ b/app/packages/core/src/components/resources/ResourcesSelectClusters.tsx
@@ -1,12 +1,21 @@
 import { CheckBox, CheckBoxOutlineBlank } from '@mui/icons-material';
-import { Autocomplete, Checkbox, Chip, TextField } from '@mui/material';
+import {
+  Autocomplete,
+  AutocompleteChangeReason,
+  Checkbox,
+  Chip,
+  TextField,
+  createFilterOptions,
+  FilterOptionsState,
+} from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
-import { useContext, FunctionComponent } from 'react';
+import { useContext, FunctionComponent, SyntheticEvent } from 'react';
 
 import { APIContext, IAPIContext } from '../../context/APIContext';
 
 const icon = <CheckBoxOutlineBlank fontSize="small" />;
 const checkedIcon = <CheckBox fontSize="small" />;
+const selectAllValue = 'Select all';
 
 /**
  * `IResourcesSelectClustersProps` is the interface for the `ResourcesSelectClusters` component, which requires a list
@@ -26,10 +35,37 @@ const ResourcesSelectClusters: FunctionComponent<IResourcesSelectClustersProps> 
   selectClusters,
 }) => {
   const apiContext = useContext<IAPIContext>(APIContext);
+  const filter = createFilterOptions<string>();
 
   const { isLoading, data } = useQuery<string[], Error>(['core/clusters'], async () => {
     return apiContext.client.get<string[]>('/api/clusters');
   });
+
+  /**
+   * `onChange` handles select, remove and clear operation of the `Autocomplete` component. This is required so that we
+   * can handle the `Select all` option. When the user clicks on this option we add all clusters to the list of selected
+   * clusters or when the list already contains all clusters we remove all clusters.
+   *
+   * When another option is select we add / remove the selected option as usual. When the clear button was clicked we
+   * remove all selected clusters.
+   *
+   * See: https://github.com/mui/material-ui/issues/21211
+   */
+  const onChange = (e: SyntheticEvent, value: string[], reason: AutocompleteChangeReason) => {
+    if (reason === 'selectOption' || reason === 'removeOption') {
+      if (value.find((option) => option === selectAllValue)) {
+        if (data?.length === selectedClusters.length) {
+          selectClusters([]);
+        } else {
+          selectClusters(data ?? []);
+        }
+      } else {
+        selectClusters(value);
+      }
+    } else if (reason === 'clear') {
+      selectClusters([]);
+    }
+  };
 
   return (
     <Autocomplete
@@ -39,15 +75,34 @@ const ResourcesSelectClusters: FunctionComponent<IResourcesSelectClustersProps> 
       loading={isLoading}
       options={data ?? []}
       getOptionLabel={(option) => option ?? ''}
+      filterOptions={(options: string[], state: FilterOptionsState<string>) => {
+        const filtered = filter(options, state);
+        if (!data || data.length === 0) {
+          return filtered;
+        }
+        return [selectAllValue, ...filtered];
+      }}
       value={selectedClusters}
-      onChange={(e, value) => selectClusters(value)}
+      onChange={onChange}
       renderTags={(value) => <Chip size="small" label={value.length} />}
-      renderOption={(props, option, { selected }) => (
-        <li {...props} style={{ padding: 1 }}>
-          <Checkbox icon={icon} checkedIcon={checkedIcon} style={{ marginRight: 8 }} checked={selected} />
-          {option}
-        </li>
-      )}
+      renderOption={(props, option, { selected }) =>
+        option === selectAllValue ? (
+          <li {...props} style={{ padding: 1 }}>
+            <Checkbox
+              icon={icon}
+              checkedIcon={checkedIcon}
+              style={{ marginRight: 8 }}
+              checked={data?.length === selectedClusters.length}
+            />
+            {option}
+          </li>
+        ) : (
+          <li {...props} style={{ padding: 1 }}>
+            <Checkbox icon={icon} checkedIcon={checkedIcon} style={{ marginRight: 8 }} checked={selected} />
+            {option}
+          </li>
+        )
+      }
       renderInput={(params) => <TextField {...params} label="Clusters" placeholder="Clusters" />}
     />
   );


### PR DESCRIPTION
The select box for clusters contains a "Select all" option now, which can be used to select all clusters at once.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
