### PR TITLE
[core] Fix Positioning of Options Component in Toolbar

### DIFF
--- a/app/packages/core/src/components/dashboards/Dashboards.tsx
+++ b/app/packages/core/src/components/dashboards/Dashboards.tsx
@@ -196,7 +196,9 @@ const DashboardToolbar: FunctionComponent<IDashboardToolbarProps> = ({ setTimes,
           ),
         )}
 
-        <Options times={times} showOptions={true} showSearchButton={false} setOptions={changeOptions} />
+        <ToolbarItem align="right" grow={true}>
+          <Options times={times} showOptions={true} showSearchButton={false} setOptions={changeOptions} />
+        </ToolbarItem>
       </Toolbar>
     </Card>
   );

--- a/app/packages/core/src/components/utils/Options.tsx
+++ b/app/packages/core/src/components/utils/Options.tsx
@@ -19,8 +19,6 @@ import {
 } from '@mui/material';
 import { FunctionComponent, useEffect, useState } from 'react';
 
-import { ToolbarItem } from './Toolbar';
-
 import { ITimes, TTime, formatTime, timeOptions } from '../../utils/times';
 
 export type TOptionsAdditionalFields = 'text' | 'select';
@@ -198,7 +196,7 @@ export const Options: FunctionComponent<IOptionsProps> = ({
   }, [times, additionalFields]);
 
   return (
-    <ToolbarItem align="right" grow={true}>
+    <>
       {showOptions && (
         <>
           {showSearchButton ? (
@@ -335,6 +333,6 @@ export const Options: FunctionComponent<IOptionsProps> = ({
           Search
         </Button>
       )}
-    </ToolbarItem>
+    </>
   );
 };


### PR DESCRIPTION
Instead of using the ToolbarItem directly in the Options component, the ToolbarItem wrapper should be set in the component which uses the Options, so that we can apply the correct ToolbarItem props.

This is required, because it was not possible to position the Option component in the toolbar next to a ToolbarItem, which already used the "grow" property.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
