### PR TITLE
[core] Fix Font Family for Monaco

### DIFF
--- a/app/packages/core/src/components/utils/editor/Editor.tsx
+++ b/app/packages/core/src/components/utils/editor/Editor.tsx
@@ -46,6 +46,7 @@ export const Editor: FunctionComponent<IEditorProps> = ({
       onMount={handleOnMount}
       onChange={onChange}
       options={{
+        fontFamily: 'monospace',
         lineNumbers: lineNumbers ? 'on' : 'off',
         minimap: {
           enabled: minimap,


### PR DESCRIPTION
Monaco should use the same font family as we use in other places in the app for monospaced text. MUI and xterm are using "monospace" as font family, so monaco should use the same.

Note: If we find a better font family, we can also change this in the future.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
