### PR TITLE
[core] Extend Plugin Interface with Description

### DIFF
--- a/app/packages/core/src/components/plugins/PluginPage.test.tsx
+++ b/app/packages/core/src/components/plugins/PluginPage.test.tsx
@@ -46,6 +46,7 @@ describe('PluginPage', () => {
     render('/plugins/dev/bar/bar-instance', {
       getInstance: () => instance,
       getPlugin: () => ({
+        description: '',
         page: TestPage,
         type: 'bar',
       }),
@@ -69,6 +70,7 @@ describe('PluginPage', () => {
     render('/plugins/dev/bar/bar-instance', {
       getInstance: () => instance,
       getPlugin: () => ({
+        description: '',
         page: undefined,
         type: 'bar',
       }),
@@ -101,6 +103,7 @@ describe('PluginPage', () => {
     render('/plugins/dev/bar/bar-instance', {
       getInstance: () => instance,
       getPlugin: () => ({
+        description: '',
         page: TestPage,
         type: 'bar',
       }),

--- a/app/packages/core/src/components/plugins/PluginPanel.test.tsx
+++ b/app/packages/core/src/components/plugins/PluginPanel.test.tsx
@@ -100,6 +100,7 @@ describe('PluginPanel', () => {
     render('dev', 'bar-instance', 'bar', {
       getInstance: () => instance,
       getPlugin: () => ({
+        description: '',
         panel: TestPanel,
         type: 'bar',
       }),
@@ -123,6 +124,7 @@ describe('PluginPanel', () => {
     render('dev', 'bar-instance', 'bar', {
       getInstance: () => instance,
       getPlugin: () => ({
+        description: '',
         panel: undefined,
         type: 'bar',
       }),
@@ -155,6 +157,7 @@ describe('PluginPanel', () => {
     render('dev', 'bar-instance', 'bar', {
       getInstance: () => instance,
       getPlugin: () => ({
+        description: '',
         panel: TestPanel,
         type: 'bar',
       }),

--- a/app/packages/core/src/components/plugins/PluginsPage.tsx
+++ b/app/packages/core/src/components/plugins/PluginsPage.tsx
@@ -147,28 +147,36 @@ const PluginsPage: FunctionComponent = () => {
                 <Card>
                   <CardActionArea component={Link} to={`./${item.cluster}/${item.type}/${item.name}`}>
                     <CardContent sx={{ p: 6 }}>
-                      <Stack spacing={8}>
-                        <Stack direction="row" justifyContent="center">
-                          {((instance: IPluginInstance) => {
-                            const icon = getPlugin(instance.type)?.icon;
-                            if (!icon) {
-                              return <Extension sx={{ fontSize: 64 }} />;
-                            }
-                            return (
-                              <CardMedia
-                                sx={{ height: 64, width: 64 }}
-                                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                                image={icon as any}
-                                title={`${instance.name}-icon`}
-                              />
-                            );
-                          })(item)}
-                        </Stack>
-                        <Typography variant="h6" mb={6} textAlign="center">
-                          {item.name}
-                        </Typography>
-                        <Typography textAlign="center">{item.description}</Typography>
-                      </Stack>
+                      {((instance: IPluginInstance) => {
+                        const plugin = getPlugin(instance.type);
+                        const icon = plugin?.icon;
+
+                        return (
+                          <Stack spacing={8}>
+                            <Stack direction="row" justifyContent="center">
+                              {!icon ? (
+                                <Extension sx={{ fontSize: 64 }} />
+                              ) : (
+                                <CardMedia
+                                  sx={{ height: 64, width: 64 }}
+                                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                                  image={icon as any}
+                                  title={`${instance.name}-icon`}
+                                />
+                              )}
+                            </Stack>
+                            <Box textAlign="center">
+                              <Typography variant="h6">{item.name}</Typography>
+                              <Typography variant="caption" color="text.secondary">
+                                ({item.cluster} / {item.type})
+                              </Typography>
+                            </Box>
+                            <Typography textAlign="center">
+                              {item.description ? item.description : plugin?.description}
+                            </Typography>
+                          </Stack>
+                        );
+                      })(item)}
                     </CardContent>
                   </CardActionArea>
                 </Card>

--- a/app/packages/core/src/context/PluginContext.test.tsx
+++ b/app/packages/core/src/context/PluginContext.test.tsx
@@ -16,7 +16,7 @@ describe('PluginContext', () => {
     return _render(
       <QueryClientProvider>
         <APIContext.Provider value={{ client: apiClient, getUser: () => undefined }}>
-          <PluginContextProvider plugins={[{ type: 'foo' }]}>{children}</PluginContextProvider>
+          <PluginContextProvider plugins={[{ description: '', type: 'foo' }]}>{children}</PluginContextProvider>
         </APIContext.Provider>
       </QueryClientProvider>,
     );

--- a/app/packages/core/src/context/PluginContext.tsx
+++ b/app/packages/core/src/context/PluginContext.tsx
@@ -33,6 +33,7 @@ export interface IPluginPanelProps {
  * which is rendered as a `page` and a component for a `panel` in a dashboard.
  */
 export interface IPlugin {
+  description: string;
   icon?: ReactNode;
   page?: FunctionComponent<IPluginPageProps>;
   panel?: FunctionComponent<IPluginPanelProps>;


### PR DESCRIPTION
Each plugin must now contain a default description which is used when no description is configured for a plugin.

The plugin panel on the plugins page is also adjusted to include the plugin type and cluster.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
