### PR TITLE
[core] Use GitHub Container Registry instead of Docker Hub

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -11,6 +11,9 @@ jobs:
   docker:
     name: Docker
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -21,11 +24,10 @@ jobs:
         id: tag
         run: |
           if [[ $GITHUB_REF == refs/tags/* ]]; then
-            DOCKER_TAG="${GITHUB_REF:10}"
+            echo TAG=${GITHUB_REF:10} >> $GITHUB_ENV
           else
-            DOCKER_TAG="main"
+            echo TAG=main >> $GITHUB_ENV
           fi
-          echo ::set-output name=tag::${DOCKER_TAG}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -36,8 +38,9 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
 
       - name: Build and Push Docker Image
         id: docker_build
@@ -47,4 +50,4 @@ jobs:
           context: .
           file: ./cmd/kobs/Dockerfile
           platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
-          tags: kobsio/kobs:${{ steps.tag.outputs.tag }}
+          tags: ghcr.io/${{ github.repository_owner }}/kobs:${{ env.TAG }}


### PR DESCRIPTION
Docker Hub will remove access for free organization on 14. April, so that we need a new container registry for our Docker images. Therefor we want to use GitHub Container Registry in the future (ghcr.io).

This commit also removes the depreacted "set-output" command and replaces it with the recommended way from
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
