### PR TITLE
[flux] Add Panel Actions

### DIFF
--- a/app/packages/flux/src/components/FluxPanel.tsx
+++ b/app/packages/flux/src/components/FluxPanel.tsx
@@ -1,4 +1,4 @@
-import { IPluginPanelProps, PluginPanelError } from '@kobsio/core';
+import { IPluginPanelProps, pluginBasePath, PluginPanel, PluginPanelActionLinks, PluginPanelError } from '@kobsio/core';
 import { FunctionComponent } from 'react';
 
 import Resources from './Resources';
@@ -36,16 +36,30 @@ const FluxPanel: FunctionComponent<IPluginPanelProps<IOptions>> = ({
       options.type === 'kustomizations' ||
       options.type === 'helmreleases')
   ) {
+    const join = (v: string[] | undefined): string => (v && v.length > 0 ? v.join('') : '');
+    const c = join(options.clusters?.map((cluster) => `&clusters[]=${encodeURIComponent(cluster)}`));
+    const n = join(options.namespaces?.map((namespace) => `&namespaces[]=${encodeURIComponent(namespace)}`));
+
     return (
-      <Resources
-        instance={instance}
-        clusters={options.clusters}
-        namespaces={options.namespaces ?? []}
-        resource={options.type}
-        paramName={options.paramName ?? ''}
-        param={options.param ?? ''}
-        times={times}
-      />
+      <PluginPanel
+        title={title}
+        description={description}
+        actions={
+          <PluginPanelActionLinks
+            links={[{ link: `${pluginBasePath(instance)}?&type=${options.type}${c}${n}`, title: 'Explore' }]}
+          />
+        }
+      >
+        <Resources
+          instance={instance}
+          clusters={options.clusters}
+          namespaces={options.namespaces ?? []}
+          resource={options.type}
+          paramName={options.paramName ?? ''}
+          param={options.param ?? ''}
+          times={times}
+        />
+      </PluginPanel>
     );
   }
 
@@ -59,7 +73,7 @@ const FluxPanel: FunctionComponent<IPluginPanelProps<IOptions>> = ({
   name: flux
   type: flux
   options:
-    # Type must be gitrepositories, helmrepositories, buckets, kustomizations or helmreleases
+    # Type must be "gitrepositories", "helmrepositories", "buckets", "kustomizations" or "helmreleases"
     type: kustomizations
     clusters:
       - mycluster`}


### PR DESCRIPTION
This commit adds an "Explore" action to the Flux panel, which can be used to go to the Flux page, for the provided parameter in a panel.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
