### PR TITLE
[helm] Add Panel Actions

### DIFF
--- a/app/packages/helm/src/components/HelmPanel.tsx
+++ b/app/packages/helm/src/components/HelmPanel.tsx
@@ -1,4 +1,4 @@
-import { IPluginPanelProps, PluginPanel, PluginPanelError } from '@kobsio/core';
+import { IPluginPanelProps, pluginBasePath, PluginPanel, PluginPanelActionLinks, PluginPanelError } from '@kobsio/core';
 import { FunctionComponent } from 'react';
 
 import History from './History';
@@ -34,8 +34,18 @@ const HelmPanel: FunctionComponent<IPluginPanelProps<IOptions>> = ({
     options.type === 'releases' &&
     times
   ) {
+    const join = (v: string[] | undefined): string => (v && v.length > 0 ? v.join('') : '');
+    const c = join(options.clusters?.map((cluster) => `&clusters[]=${encodeURIComponent(cluster)}`));
+    const n = join(options.namespaces?.map((namespace) => `&namespaces[]=${encodeURIComponent(namespace)}`));
+
     return (
-      <PluginPanel title={title} description={description}>
+      <PluginPanel
+        title={title}
+        description={description}
+        actions={
+          <PluginPanelActionLinks links={[{ link: `${pluginBasePath(instance)}?${c}${n}`, title: 'Explore' }]} />
+        }
+      >
         <Releases instance={instance} clusters={options.clusters} namespaces={options.namespaces ?? []} times={times} />
       </PluginPanel>
     );
@@ -54,7 +64,22 @@ const HelmPanel: FunctionComponent<IPluginPanelProps<IOptions>> = ({
     times
   ) {
     return (
-      <PluginPanel title={title} description={description}>
+      <PluginPanel
+        title={title}
+        description={description}
+        actions={
+          <PluginPanelActionLinks
+            links={[
+              {
+                link: `${pluginBasePath(instance)}?&clusters[]=${encodeURIComponent(
+                  options.clusters[0],
+                )}&namespaces[]=${encodeURIComponent(options.namespaces[0])}`,
+                title: 'Explore',
+              },
+            ]}
+          />
+        }
+      >
         <History
           instance={instance}
           cluster={options.clusters[0]}

--- a/app/packages/helm/src/components/History.tsx
+++ b/app/packages/helm/src/components/History.tsx
@@ -7,7 +7,7 @@ import {
   ITimes,
   UseQueryWrapper,
 } from '@kobsio/core';
-import { Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
+import { Card, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { FunctionComponent, useContext, useState } from 'react';
 
@@ -84,7 +84,7 @@ const History: FunctionComponent<{
       noDataMessage="No Helm releases were found for your selected filters."
       refetch={refetch}
     >
-      <Paper>
+      <Card>
         {data && (
           <TableContainer>
             <Table size="small">
@@ -110,7 +110,7 @@ const History: FunctionComponent<{
             </Table>
           </TableContainer>
         )}
-      </Paper>
+      </Card>
     </UseQueryWrapper>
   );
 };

--- a/app/packages/helm/src/components/Releases.tsx
+++ b/app/packages/helm/src/components/Releases.tsx
@@ -7,7 +7,7 @@ import {
   ITimes,
   UseQueryWrapper,
 } from '@kobsio/core';
-import { Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
+import { Card, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { FunctionComponent, useContext, useState } from 'react';
 
@@ -94,7 +94,7 @@ const Releases: FunctionComponent<{
       noDataMessage="No Helm releases were found for your selected filters."
       refetch={refetch}
     >
-      <Paper>
+      <Card>
         {data && (
           <TableContainer>
             <Table size="small">
@@ -123,7 +123,7 @@ const Releases: FunctionComponent<{
             </Table>
           </TableContainer>
         )}
-      </Paper>
+      </Card>
     </UseQueryWrapper>
   );
 };


### PR DESCRIPTION
This commit adds an "Explore" action to the Helm panels, which allows a user to go to the Helm plugin page, from a dashboard panel. The provided clusters and namespaces are added as query parameters.

We also replaced the Paper component with a Card component to remove the bottom border which looks better when the plugin is used in a dashboard.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
