### PR TITLE
[harbor] Add Panel Actions

### DIFF
--- a/app/packages/harbor/src/components/HarborPanel.tsx
+++ b/app/packages/harbor/src/components/HarborPanel.tsx
@@ -1,4 +1,4 @@
-import { IPluginPanelProps, PluginPanel, PluginPanelError } from '@kobsio/core';
+import { IPluginPanelProps, pluginBasePath, PluginPanel, PluginPanelActionLinks, PluginPanelError } from '@kobsio/core';
 import { FunctionComponent } from 'react';
 
 import Artifacts from './Artifacts';
@@ -25,7 +25,11 @@ export interface IOptionsArtifacts {
 const HarborPanel: FunctionComponent<IPluginPanelProps<IOptions>> = ({ title, description, options, instance }) => {
   if (options && options.type === 'projects') {
     return (
-      <PluginPanel title={title} description={description}>
+      <PluginPanel
+        title={title}
+        description={description}
+        actions={<PluginPanelActionLinks links={[{ link: `${pluginBasePath(instance)}`, title: 'Explore' }]} />}
+      >
         <Projects instance={instance} />
       </PluginPanel>
     );
@@ -33,7 +37,22 @@ const HarborPanel: FunctionComponent<IPluginPanelProps<IOptions>> = ({ title, de
 
   if (options && options.type === 'repositories' && options.repositories && options.repositories.projectName) {
     return (
-      <PluginPanel title={title} description={description}>
+      <PluginPanel
+        title={title}
+        description={description}
+        actions={
+          <PluginPanelActionLinks
+            links={[
+              {
+                link: `${pluginBasePath(instance)}/${options.repositories.projectName}?query=${
+                  options.repositories.query || ''
+                }`,
+                title: 'Explore',
+              },
+            ]}
+          />
+        }
+      >
         <Repositories
           instance={instance}
           projectName={options.repositories.projectName}
@@ -51,7 +70,22 @@ const HarborPanel: FunctionComponent<IPluginPanelProps<IOptions>> = ({ title, de
     options.artifacts.repositoryName
   ) {
     return (
-      <PluginPanel title={title} description={description}>
+      <PluginPanel
+        title={title}
+        description={description}
+        actions={
+          <PluginPanelActionLinks
+            links={[
+              {
+                link: `${pluginBasePath(instance)}/${options.artifacts.projectName}/${
+                  options.artifacts.repositoryName
+                }?query=${options.artifacts.query || ''}`,
+                title: 'Explore',
+              },
+            ]}
+          />
+        }
+      >
         <Artifacts
           instance={instance}
           projectName={options.artifacts.projectName}


### PR DESCRIPTION
This commit adds an "Explore" action to the Harbor panels when it is used within a dashboard. This allows a user to directly go to the plugin page from the dashboard.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
