### PR TITLE
[core] Fix DetailsDrawer and Replace Paper Component

### DIFF
--- a/app/packages/core/src/components/app/signin/Signin.tsx
+++ b/app/packages/core/src/components/app/signin/Signin.tsx
@@ -1,4 +1,4 @@
-import { Stack, Alert, Box, Paper, TextField, Typography, Button } from '@mui/material';
+import { Stack, Alert, Box, TextField, Typography, Button, Card } from '@mui/material';
 import { FormEvent, FunctionComponent, useContext, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
@@ -61,7 +61,7 @@ const Signin: FunctionComponent = () => {
   return (
     <Box minHeight="100vh" minWidth="100%" display="flex" flexDirection="column" justifyContent="center">
       <Box sx={{ display: 'inline-flex', mx: 'auto' }}>
-        <Paper sx={{ p: 10 }} component="form" onSubmit={handleSubmit}>
+        <Card sx={{ p: 10 }} component="form" onSubmit={handleSubmit}>
           <Stack display="inline-flex" flexDirection="column" spacing={2}>
             <Box
               sx={{
@@ -128,7 +128,7 @@ const Signin: FunctionComponent = () => {
 
             <SigninOIDC />
           </Stack>
-        </Paper>
+        </Card>
       </Box>
     </Box>
   );

--- a/app/packages/core/src/components/resources/Resources.tsx
+++ b/app/packages/core/src/components/resources/Resources.tsx
@@ -2,7 +2,6 @@ import {
   Alert,
   AlertTitle,
   Button,
-  Paper,
   Tab,
   Table,
   TableBody,
@@ -12,6 +11,7 @@ import {
   TableRow,
   Tabs,
   Box,
+  Card,
 } from '@mui/material';
 import { useQuery, QueryObserverResult } from '@tanstack/react-query';
 import { FunctionComponent, useContext, useState } from 'react';
@@ -255,7 +255,7 @@ const Resources: FunctionComponent<IResourcesProps> = ({ options, times }) => {
       noDataMessage="No Kubernetes resources were found for your selected filters."
       refetch={refetch}
     >
-      <Paper>
+      <Card>
         <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
           <Tabs
             variant="scrollable"
@@ -285,7 +285,7 @@ const Resources: FunctionComponent<IResourcesProps> = ({ options, times }) => {
             )}
           </Box>
         ))}
-      </Paper>
+      </Card>
     </UseQueryWrapper>
   );
 };

--- a/app/packages/core/src/components/utils/DetailsDrawer.tsx
+++ b/app/packages/core/src/components/utils/DetailsDrawer.tsx
@@ -54,11 +54,12 @@ export const DetailsDrawer: FunctionComponent<IDetailsDrawerProps> = ({
               WebkitBoxOrient: 'vertical',
               WebkitLineClamp: '2',
               display: '-webkit-box',
+              flexGrow: 1,
               overflow: 'hidden',
               textOverflow: 'ellipsis',
             }}
           >
-            <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+            <Typography variant="h6" component="div">
               {title}
 
               {subtitle && (


### PR DESCRIPTION
This commit fixes the actions shown in the DetailsDrawer which were not aligned to the right side of the drawer. This is now fixed by adding the "flexGrow" property to the correct component.

This commit also replaces the Paper component on the sign in page and the resources panel with a Card component, so that we do not have a bottom boarder, which looks a bit nicer.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
