### PR TITLE
[core] Persist User Selected Options

### DIFF
--- a/app/packages/core/src/components/app/layout/Sidebar.tsx
+++ b/app/packages/core/src/components/app/layout/Sidebar.tsx
@@ -381,7 +381,7 @@ const SidebarFooter: FunctionComponent = () => {
     try {
       await apiContext.client.signout();
       navigate(`/auth?redirect=${encodeURIComponent(location.pathname + location.search)}`);
-    } catch (_) {}
+    } catch {}
   };
 
   /**

--- a/app/packages/core/src/components/app/signin/Signin.tsx
+++ b/app/packages/core/src/components/app/signin/Signin.tsx
@@ -52,7 +52,7 @@ const Signin: FunctionComponent = () => {
       setIsLoading(false);
       setState(SigninState.OK);
       navigate(params.get('redirect') || '/');
-    } catch (_) {
+    } catch {
       setIsLoading(false);
       setState(state | SigninState.INVALID_CREDENTIALS);
     }

--- a/app/packages/core/src/components/applications/ApplicationsPage.tsx
+++ b/app/packages/core/src/components/applications/ApplicationsPage.tsx
@@ -1,7 +1,7 @@
 import { Add } from '@mui/icons-material';
 import { Button, Divider, List } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
-import { Fragment, FunctionComponent, useContext } from 'react';
+import { Fragment, FunctionComponent, useContext, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 
 import Application from './Application';
@@ -10,6 +10,7 @@ import { IApplicationOptions } from './utils';
 
 import { APIContext, APIError, IAPIContext } from '../../context/APIContext';
 import { IApplication } from '../../crds/application';
+import { useLocalStorageState } from '../../utils/hooks/useLocalStorageState';
 import { useQueryState } from '../../utils/hooks/useQueryState';
 import { Page } from '../utils/Page';
 import { Pagination } from '../utils/Pagination';
@@ -94,15 +95,26 @@ const Applications: FunctionComponent<IApplicationsProps> = ({ options, setOptio
  * applications are then loaded and shown via the `Applications` component.
  */
 const ApplicationsPage: FunctionComponent = () => {
-  const [options, setOptions] = useQueryState<IApplicationOptions>({
-    all: false,
-    clusters: [],
-    namespaces: [],
-    page: 1,
-    perPage: 10,
-    searchTerm: '',
-    tags: [],
-  });
+  const [persistedOptions, setPersistedOptions] = useLocalStorageState<IApplicationOptions>(
+    'kobs-core-applicationspage-options',
+    {
+      all: false,
+      clusters: [],
+      namespaces: [],
+      page: 1,
+      perPage: 10,
+      searchTerm: '',
+      tags: [],
+    },
+  );
+  const [options, setOptions] = useQueryState<IApplicationOptions>(persistedOptions);
+
+  /**
+   * `useEffect` is used to persist the options, when they are changed by a user.
+   */
+  useEffect(() => {
+    setPersistedOptions(options);
+  }, [options, setPersistedOptions]);
 
   return (
     <Page

--- a/app/packages/core/src/components/applications/TopologyPage.tsx
+++ b/app/packages/core/src/components/applications/TopologyPage.tsx
@@ -1,12 +1,13 @@
 import { Alert, AlertTitle, Button } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
-import { FunctionComponent, useContext, useState } from 'react';
+import { FunctionComponent, useContext, useEffect, useState } from 'react';
 
 import ApplicationsToolbar from './ApplicationsToolbar';
 import { ApplicationsInsightsWrapper, TopologyGraph } from './Topology';
 import { IApplicationOptions, ITopology } from './utils';
 
 import { APIContext, APIError, IAPIContext } from '../../context/APIContext';
+import { useLocalStorageState } from '../../utils/hooks/useLocalStorageState';
 import { useQueryState } from '../../utils/hooks/useQueryState';
 import { Page } from '../utils/Page';
 import { UseQueryWrapper } from '../utils/UseQueryWrapper';
@@ -84,15 +85,26 @@ const TopologyInternal: FunctionComponent<ITopologyÜageInternalProps> = ({ opti
  * can be filtered by the same options as the applications on the `ApplicationsPage`.
  */
 const TopologyPage: FunctionComponent = () => {
-  const [options, setOptions] = useQueryState<IApplicationOptions>({
-    all: false,
-    clusters: [],
-    namespaces: [],
-    page: undefined,
-    perPage: undefined,
-    searchTerm: '',
-    tags: [],
-  });
+  const [persistedOptions, setPersistedOptions] = useLocalStorageState<IApplicationOptions>(
+    'kobs-core-topologypage-options',
+    {
+      all: false,
+      clusters: [],
+      namespaces: [],
+      page: undefined,
+      perPage: undefined,
+      searchTerm: '',
+      tags: [],
+    },
+  );
+  const [options, setOptions] = useQueryState<IApplicationOptions>(persistedOptions);
+
+  /**
+   * `useEffect` is used to persist the options, when they are changed by a user.
+   */
+  useEffect(() => {
+    setPersistedOptions(options);
+  }, [options, setPersistedOptions]);
 
   return (
     <Page

--- a/app/packages/core/src/components/plugins/PluginsPage.tsx
+++ b/app/packages/core/src/components/plugins/PluginsPage.tsx
@@ -14,10 +14,11 @@ import {
   Typography,
 } from '@mui/material';
 import Autocomplete from '@mui/material/Autocomplete';
-import { FormEvent, FunctionComponent, useContext, useState } from 'react';
+import { FormEvent, FunctionComponent, useContext, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { IPluginInstance, PluginContext } from '../../context/PluginContext';
+import { useLocalStorageState } from '../../utils/hooks/useLocalStorageState';
 import { useQueryState } from '../../utils/hooks/useQueryState';
 import { Page } from '../utils/Page';
 import { Pagination } from '../utils/Pagination';
@@ -44,13 +45,14 @@ interface IOptions {
 const PluginsPage: FunctionComponent = () => {
   const { getClusters, getPluginTypes, getPlugin, instances } = useContext(PluginContext);
 
-  const [options, setOptions] = useQueryState<IOptions>({
+  const [persistedOptions, setPersistedOptions] = useLocalStorageState<IOptions>('kobs-core-pluginspage-options', {
     clusters: [],
     page: 1,
     perPage: 10,
     pluginTypes: [],
     searchTerm: '',
   });
+  const [options, setOptions] = useQueryState<IOptions>(() => persistedOptions);
   const [searchTerm, setSearchTerm] = useState<string>(options.searchTerm ?? '');
 
   const handleSubmit = (e: FormEvent) => {
@@ -68,6 +70,13 @@ const PluginsPage: FunctionComponent = () => {
     );
 
   const items = filteredItems.slice((options.page - 1) * options.perPage, options.page * options.perPage);
+
+  /**
+   * `useEffect` is used to persist the options, when they are changed by a user.
+   */
+  useEffect(() => {
+    setPersistedOptions(options);
+  }, [options, setPersistedOptions]);
 
   return (
     <Page

--- a/app/packages/core/src/components/resources/ResourcesPage.tsx
+++ b/app/packages/core/src/components/resources/ResourcesPage.tsx
@@ -1,6 +1,6 @@
 import { Refresh } from '@mui/icons-material';
 import { Alert, AlertTitle, Box, Button, FormControl, InputLabel, MenuItem, Select, TextField } from '@mui/material';
-import { FormEvent, FunctionComponent, useState } from 'react';
+import { FormEvent, FunctionComponent, useEffect, useState } from 'react';
 
 import Resources from './Resources';
 import { ResourcesSelectClusters } from './ResourcesSelectClusters';
@@ -8,6 +8,7 @@ import { ResourcesSelectNamespaces } from './ResourcesSelectNamespaces';
 import { ResourcesSelectResources } from './ResourcesSelectResources';
 import { IOptions } from './utils';
 
+import { useLocalStorageState } from '../../utils/hooks/useLocalStorageState';
 import { useQueryState } from '../../utils/hooks/useQueryState';
 import { useUpdate } from '../../utils/hooks/useUpdate';
 import { Page } from '../utils/Page';
@@ -15,11 +16,12 @@ import { Toolbar, ToolbarItem } from '../utils/Toolbar';
 
 const ResourcesPage: FunctionComponent = () => {
   const update = useUpdate();
-  const [options, setOptions] = useQueryState<IOptions>({
+  const [persistedOptions, setPersistedOptions] = useLocalStorageState<IOptions>('kobs-core-resourcespage-options', {
     clusters: [],
     namespaces: [],
     resources: [],
   });
+  const [options, setOptions] = useQueryState<IOptions>(persistedOptions);
   const [param, setParam] = useState<string>(options.param ?? '');
 
   /**
@@ -29,6 +31,13 @@ const ResourcesPage: FunctionComponent = () => {
     e.preventDefault();
     setOptions((prevOptions) => ({ ...prevOptions, param: param }));
   };
+
+  /**
+   * `useEffect` is used to persist the options, when they are changed by a user.
+   */
+  useEffect(() => {
+    setPersistedOptions(options);
+  }, [options, setPersistedOptions]);
 
   return (
     <Page

--- a/app/packages/core/src/components/teams/TeamsPage.tsx
+++ b/app/packages/core/src/components/teams/TeamsPage.tsx
@@ -1,11 +1,12 @@
 import { Add, Search } from '@mui/icons-material';
 import { Box, Button, InputAdornment, TextField, ToggleButton, ToggleButtonGroup } from '@mui/material';
-import { FormEvent, FunctionComponent, useState } from 'react';
+import { FormEvent, FunctionComponent, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import Teams from './Teams';
 import { ITeamOptions } from './utils';
 
+import { useLocalStorageState } from '../../utils/hooks/useLocalStorageState';
 import { useQueryState } from '../../utils/hooks/useQueryState';
 import { Page } from '../utils/Page';
 import { Toolbar, ToolbarItem } from '../utils/Toolbar';
@@ -16,12 +17,13 @@ import { Toolbar, ToolbarItem } from '../utils/Toolbar';
  * The teams can also be filtered by a search team, which should match the teams id.
  */
 const TeamsPage: FunctionComponent = () => {
-  const [options, setOptions] = useQueryState<ITeamOptions>({
+  const [persistedOptions, setPersistedOptions] = useLocalStorageState<ITeamOptions>('kobs-core-teamspage-options', {
     all: false,
     page: 1,
     perPage: 10,
     searchTerm: '',
   });
+  const [options, setOptions] = useQueryState<ITeamOptions>(persistedOptions);
   const [searchTerm, setSearchTerm] = useState<string>(options.searchTerm ?? '');
 
   /**
@@ -32,6 +34,13 @@ const TeamsPage: FunctionComponent = () => {
     e.preventDefault();
     setOptions((prevOptions) => ({ ...prevOptions, page: 1, perPage: 10, searchTerm: searchTerm }));
   };
+
+  /**
+   * `useEffect` is used to persist the options, when they are changed by a user.
+   */
+  useEffect(() => {
+    setPersistedOptions(options);
+  }, [options, setPersistedOptions]);
 
   return (
     <Page

--- a/app/packages/core/src/index.ts
+++ b/app/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export * from './context/QueryClientProvider';
 export * from './utils/hooks/useDebounce';
 export * from './utils/hooks/useDimensions';
 export * from './utils/hooks/useLatest';
+export * from './utils/hooks/useLocalStorageState';
 export * from './utils/hooks/useQueryState';
 export * from './utils/hooks/useMemoizedFn';
 export * from './utils/hooks/useUpdate';

--- a/app/packages/core/src/setupTests.ts
+++ b/app/packages/core/src/setupTests.ts
@@ -5,6 +5,47 @@ import { afterEach, expect } from 'vitest';
 
 expect.extend(matchers);
 
+/**
+ * `LocalStorageMock` implements the `localStorage` interface, so that we can use it in our app for testing the
+ * `useLocalStorageState` hook.
+ */
+class LocalStorageMock {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  store: Record<string, any> = {};
+
+  constructor() {
+    this.store = {};
+  }
+
+  clear() {
+    this.store = {};
+  }
+
+  getItem(key: string) {
+    return this.store[key] || null;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  setItem(key: string, value: any) {
+    this.store[key] = value;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  removeItem(key: string) {
+    delete this.store[key];
+  }
+
+  get length() {
+    return Object.keys(this.store).length;
+  }
+
+  key(index: number) {
+    return Object.keys(this.store)[index];
+  }
+}
+
+global.localStorage = new LocalStorageMock();
+
 afterEach(() => {
   cleanup();
 });

--- a/app/packages/core/src/utils/hooks/useLocalStorageState.test.ts
+++ b/app/packages/core/src/utils/hooks/useLocalStorageState.test.ts
@@ -1,0 +1,119 @@
+import { renderHook, act } from '@testing-library/react';
+
+import { useLocalStorageState } from './useLocalStorageState';
+
+describe('useLocalStorageState', () => {
+  const setup = <T>(key: string, value: T) =>
+    renderHook(() => {
+      const [state, setState] = useLocalStorageState<T>(key, value);
+      return {
+        setState,
+        state,
+      } as const;
+    });
+
+  it('getKey should work', () => {
+    const LOCAL_STORAGE_KEY = 'test-key';
+    const hook = setup(LOCAL_STORAGE_KEY, 'A');
+    expect(hook.result.current.state).toBe('A');
+    act(() => {
+      hook.result.current.setState('B');
+    });
+    expect(hook.result.current.state).toBe('B');
+    const anotherHook = setup(LOCAL_STORAGE_KEY, 'A');
+    expect(anotherHook.result.current.state).toBe('B');
+    act(() => {
+      anotherHook.result.current.setState('C');
+    });
+    expect(anotherHook.result.current.state).toBe('C');
+    expect(hook.result.current.state).toBe('B');
+  });
+
+  it('should support object', () => {
+    const LOCAL_STORAGE_KEY = 'test-object-key';
+    const hook = setup<{ name: string }>(LOCAL_STORAGE_KEY, {
+      name: 'A',
+    });
+    expect(hook.result.current.state).toEqual({ name: 'A' });
+    act(() => {
+      hook.result.current.setState({ name: 'B' });
+    });
+    expect(hook.result.current.state).toEqual({ name: 'B' });
+    const anotherHook = setup(LOCAL_STORAGE_KEY, {
+      name: 'C',
+    });
+    expect(anotherHook.result.current.state).toEqual({ name: 'B' });
+    act(() => {
+      anotherHook.result.current.setState({
+        name: 'C',
+      });
+    });
+    expect(anotherHook.result.current.state).toEqual({ name: 'C' });
+    expect(hook.result.current.state).toEqual({ name: 'B' });
+  });
+
+  it('should support number', () => {
+    const LOCAL_STORAGE_KEY = 'test-number-key';
+    const hook = setup(LOCAL_STORAGE_KEY, 1);
+    expect(hook.result.current.state).toBe(1);
+    act(() => {
+      hook.result.current.setState(2);
+    });
+    expect(hook.result.current.state).toBe(2);
+    const anotherHook = setup(LOCAL_STORAGE_KEY, 3);
+    expect(anotherHook.result.current.state).toBe(2);
+    act(() => {
+      anotherHook.result.current.setState(3);
+    });
+    expect(anotherHook.result.current.state).toBe(3);
+    expect(hook.result.current.state).toBe(2);
+  });
+
+  it('should support boolean', () => {
+    const LOCAL_STORAGE_KEY = 'test-boolean-key';
+    const hook = setup(LOCAL_STORAGE_KEY, true);
+    expect(hook.result.current.state).toBe(true);
+    act(() => {
+      hook.result.current.setState(false);
+    });
+    expect(hook.result.current.state).toBe(false);
+    const anotherHook = setup(LOCAL_STORAGE_KEY, true);
+    expect(anotherHook.result.current.state).toBe(false);
+    act(() => {
+      anotherHook.result.current.setState(true);
+    });
+    expect(anotherHook.result.current.state).toBe(true);
+    expect(hook.result.current.state).toBe(false);
+  });
+
+  it('should support null', () => {
+    const LOCAL_STORAGE_KEY = 'test-boolean-key-with-null';
+    const hook = setup<boolean | null>(LOCAL_STORAGE_KEY, false);
+    expect(hook.result.current.state).toBe(false);
+    act(() => {
+      hook.result.current.setState(null);
+    });
+    expect(hook.result.current.state).toBeNull();
+    const anotherHook = setup(LOCAL_STORAGE_KEY, false);
+    expect(anotherHook.result.current.state).toBeNull();
+  });
+
+  it('should support function updater', () => {
+    const LOCAL_STORAGE_KEY = 'test-func-updater';
+    const hook = setup<string | null>(LOCAL_STORAGE_KEY, 'hello world');
+    expect(hook.result.current.state).toBe('hello world');
+    act(() => {
+      hook.result.current.setState((state) => `${state}, test`);
+    });
+    expect(hook.result.current.state).toBe('hello world, test');
+  });
+
+  it('should save the default value in localStorage', () => {
+    const LOCAL_STORAGE_KEY = 'test-default-value-key';
+    const defaultValue = 'Hello';
+    const hook = setup(LOCAL_STORAGE_KEY, defaultValue);
+    expect(hook.result.current.state).toBe(defaultValue);
+    const localStorageValue = localStorage.getItem(LOCAL_STORAGE_KEY);
+    expect(localStorageValue).toBe(JSON.stringify(defaultValue));
+  });
+});

--- a/app/packages/core/src/utils/hooks/useLocalStorageState.ts
+++ b/app/packages/core/src/utils/hooks/useLocalStorageState.ts
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+
+import { useMemoizedFn } from './useMemoizedFn';
+
+interface IFuncUpdater<T> {
+  (previousState?: T): T;
+}
+
+/**
+ * `useLocalStorageState` is a React hook, which allows us to store the state into localStorage.
+ *
+ * Note: The implementation is heavily inspired by https://ahooks.js.org/hooks/use-local-storage-state, but doesn't
+ * support custom serialization deserialization, like the original one.
+ */
+export const useLocalStorageState = <T>(key: string, defaultValue?: T) => {
+  function setStoredValue(value?: T) {
+    if (typeof value === 'undefined') {
+      localStorage.removeItem(key);
+    } else {
+      try {
+        localStorage.setItem(key, JSON.stringify(value));
+      } catch {
+        // If user is in private mode or has storage restriction localStorage can throw. Also JSON.stringify can throw.
+      }
+    }
+  }
+
+  function getStoredValue() {
+    try {
+      const raw = localStorage.getItem(key);
+      if (raw) {
+        return JSON.parse(raw);
+      }
+    } catch {
+      // If user is in private mode or has storage restriction localStorage can throw. Also JSON.parse can throw.
+    }
+
+    const internalDefaultValue =
+      typeof defaultValue === 'function' ? (defaultValue as IFuncUpdater<T>)() : defaultValue;
+
+    setStoredValue(internalDefaultValue);
+
+    return internalDefaultValue;
+  }
+
+  const [state, setState] = useState<T>(() => getStoredValue());
+
+  const updateState = (value: T | IFuncUpdater<T>) => {
+    const currentState = typeof value === 'function' ? (value as IFuncUpdater<T>)(state) : value;
+
+    setState(currentState);
+    setStoredValue(currentState);
+  };
+
+  return [state, useMemoizedFn(updateState)] as const;
+};

--- a/app/packages/flux/src/components/FluxPage.tsx
+++ b/app/packages/flux/src/components/FluxPage.tsx
@@ -5,12 +5,13 @@ import {
   ResourcesSelectNamespaces,
   Toolbar,
   ToolbarItem,
+  useLocalStorageState,
   useQueryState,
   useUpdate,
 } from '@kobsio/core';
 import { Refresh } from '@mui/icons-material';
 import { Alert, AlertTitle, Button, ToggleButton, ToggleButtonGroup } from '@mui/material';
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useEffect } from 'react';
 
 import Resources from './Resources';
 
@@ -35,13 +36,21 @@ interface IOptions {
  */
 const FluxPage: FunctionComponent<IPluginPageProps> = ({ instance }) => {
   const update = useUpdate();
-  const [options, setOptions] = useQueryState<IOptions>({
+  const [persistedOptions, setPersistedOptions] = useLocalStorageState<IOptions>('kobs-flux-fluxpage-options', {
     clusters: [],
     namespaces: [],
     param: '',
     paramName: '',
     type: 'kustomizations',
   });
+  const [options, setOptions] = useQueryState<IOptions>(persistedOptions);
+
+  /**
+   * `useEffect` is used to persist the options, when they are changed by a user.
+   */
+  useEffect(() => {
+    setPersistedOptions(options);
+  }, [options, setPersistedOptions]);
 
   return (
     <Page

--- a/app/packages/helm/src/components/HelmPage.tsx
+++ b/app/packages/helm/src/components/HelmPage.tsx
@@ -5,12 +5,13 @@ import {
   ResourcesSelectNamespaces,
   Toolbar,
   ToolbarItem,
+  useLocalStorageState,
   useQueryState,
   useUpdate,
 } from '@kobsio/core';
 import { Refresh } from '@mui/icons-material';
 import { Alert, AlertTitle, Button } from '@mui/material';
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useEffect } from 'react';
 
 import Releases from './Releases';
 
@@ -31,10 +32,18 @@ interface IOptions {
  */
 const HelmPage: FunctionComponent<IPluginPageProps> = ({ instance }) => {
   const update = useUpdate();
-  const [options, setOptions] = useQueryState<IOptions>({
+  const [persistedOptions, setPersistedOptions] = useLocalStorageState<IOptions>('kobs-helm-helmpage-options', {
     clusters: [],
     namespaces: [],
   });
+  const [options, setOptions] = useQueryState<IOptions>(persistedOptions);
+
+  /**
+   * `useEffect` is used to persist the options, when they are changed by a user.
+   */
+  useEffect(() => {
+    setPersistedOptions(options);
+  }, [options, setPersistedOptions]);
 
   return (
     <Page


### PR DESCRIPTION
The options which are selected by a user in a toolbar are now persisted, so that the user will can reuse the options when he navigates a second time to the same page. To achieve this we had to adjust the "useQueryState" hook, so that we can overwrite the default value of an array with an empty array. We also introduced a new hook "useLocalStorageState" which is used to persist the option in the browsers localStorage.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
