### PR TITLE
[core] Don't Reset "perPage" Option

### DIFF
--- a/app/packages/core/src/components/applications/ApplicationsToolbar.test.tsx
+++ b/app/packages/core/src/components/applications/ApplicationsToolbar.test.tsx
@@ -60,7 +60,7 @@ describe('ApplicationsToolbar', () => {
     await userEvent.click(tagOption);
 
     expect(setOptions).toHaveBeenCalledTimes(1);
-    expect(setOptions).toHaveBeenCalledWith({ page: 1, perPage: 10, tags: ['tag1'] });
+    expect(setOptions).toHaveBeenCalledWith({ page: 1, tags: ['tag1'] });
   });
 
   it('should preserve default options', async () => {
@@ -80,7 +80,6 @@ describe('ApplicationsToolbar', () => {
       clusters: ['cluster1'],
       namespaces: ['namespace1'],
       page: 1,
-      perPage: 10,
       tags: ['tag2', 'tag1'],
     });
   });

--- a/app/packages/core/src/components/applications/ApplicationsToolbar.tsx
+++ b/app/packages/core/src/components/applications/ApplicationsToolbar.tsx
@@ -88,11 +88,11 @@ const ApplicationsToolbar: FunctionComponent<IApplicationsToolbarProps> = ({ opt
    */
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
-    setOptions({ ...options, page: 1, perPage: 10, searchTerm: searchTerm });
+    setOptions({ ...options, page: 1, searchTerm: searchTerm });
   };
 
   const handleChange = (key: string, value: boolean | string | string[]) => {
-    setOptions({ ...options, [key]: value, page: 1, perPage: 10 });
+    setOptions({ ...options, [key]: value, page: 1 });
   };
 
   /**

--- a/app/packages/core/src/components/plugins/PluginsPage.tsx
+++ b/app/packages/core/src/components/plugins/PluginsPage.tsx
@@ -55,7 +55,7 @@ const PluginsPage: FunctionComponent = () => {
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
-    setOptions((prevOptions) => ({ ...prevOptions, page: 1, perPage: 10, searchTerm: searchTerm }));
+    setOptions((prevOptions) => ({ ...prevOptions, page: 1, searchTerm: searchTerm }));
   };
 
   const filteredItems = instances
@@ -83,9 +83,7 @@ const PluginsPage: FunctionComponent = () => {
               options={getClusters()}
               getOptionLabel={(option) => option ?? ''}
               value={options.clusters}
-              onChange={(e, value) =>
-                setOptions((prevOptions) => ({ ...prevOptions, clusters: value, page: 1, perPage: 10 }))
-              }
+              onChange={(e, value) => setOptions((prevOptions) => ({ ...prevOptions, clusters: value, page: 1 }))}
               renderTags={(value) => <Chip size="small" label={value.length} />}
               renderOption={(props, option, { selected }) => (
                 <li {...props} style={{ padding: 1 }}>
@@ -104,9 +102,7 @@ const PluginsPage: FunctionComponent = () => {
               options={getPluginTypes()}
               getOptionLabel={(option) => option ?? ''}
               value={options.pluginTypes}
-              onChange={(e, value) =>
-                setOptions((prevOptions) => ({ ...prevOptions, page: 1, perPage: 10, pluginTypes: value }))
-              }
+              onChange={(e, value) => setOptions((prevOptions) => ({ ...prevOptions, page: 1, pluginTypes: value }))}
               renderTags={(value) => <Chip size="small" label={value.length} />}
               renderOption={(props, option, { selected }) => (
                 <li {...props} style={{ padding: 1 }}>

--- a/app/packages/core/src/components/teams/TeamsPage.tsx
+++ b/app/packages/core/src/components/teams/TeamsPage.tsx
@@ -30,7 +30,7 @@ const TeamsPage: FunctionComponent = () => {
    */
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
-    setOptions((prevOptions) => ({ ...prevOptions, page: 1, perPage: 10, searchTerm: searchTerm }));
+    setOptions((prevOptions) => ({ ...prevOptions, page: 1, searchTerm: searchTerm }));
   };
 
   return (
@@ -44,9 +44,7 @@ const TeamsPage: FunctionComponent = () => {
               size="small"
               value={options.all}
               exclusive={true}
-              onChange={(_, value) =>
-                setOptions((prevOptions) => ({ ...prevOptions, all: value ?? false, page: 1, perPage: 10 }))
-              }
+              onChange={(_, value) => setOptions((prevOptions) => ({ ...prevOptions, all: value ?? false, page: 1 }))}
             >
               <ToggleButton sx={{ px: 4 }} value={false}>
                 Owned

--- a/app/packages/sonarqube/src/components/SonarQubePage.tsx
+++ b/app/packages/sonarqube/src/components/SonarQubePage.tsx
@@ -101,7 +101,7 @@ const SonarQubePageToolbar: FunctionComponent<{ options: IOptions; setOptions: (
    */
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
-    setOptions({ page: 1, perPage: 10, query: query });
+    setOptions({ ...options, page: 1, query: query });
   };
 
   useEffect(() => {


### PR DESCRIPTION
In some places of the app we were resetting the user selected "perPage" option, when the user changed other options in the same state. This is now changed/fixed, so that the users selected value for the "perPage" option is preserved when other values in the state are changed.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
