### PR TITLE
[prometheus] Add Query History

### DIFF
--- a/app/packages/core/src/components/utils/editor/Editor.tsx
+++ b/app/packages/core/src/components/utils/editor/Editor.tsx
@@ -32,8 +32,8 @@ export const Editor: FunctionComponent<IEditorProps> = ({ language, readOnly = f
     <MonacoEditorReact
       theme="nord"
       height="100%"
-      defaultLanguage={language}
-      defaultValue={value}
+      language={language}
+      value={value}
       beforeMount={handleBeforeMount}
       onChange={onChange}
       options={{
@@ -108,8 +108,8 @@ export const MUIEditor: FunctionComponent<IMUIEditorProps> = ({
     <MonacoEditorReact
       theme="mui"
       height={height}
-      defaultLanguage={language}
-      defaultValue={value}
+      language={language}
+      value={value}
       beforeMount={handleBeforeMount}
       onMount={handleOnMount}
       onChange={onChange}

--- a/app/packages/core/src/index.ts
+++ b/app/packages/core/src/index.ts
@@ -29,4 +29,5 @@ export * from './utils/hooks/useUpdate';
 export * from './utils/charts';
 export * from './utils/fileDownload';
 export * from './utils/numbers';
+export * from './utils/statehistory';
 export * from './utils/times';

--- a/app/packages/core/src/setupTests.ts
+++ b/app/packages/core/src/setupTests.ts
@@ -5,6 +5,48 @@ import { afterEach, expect } from 'vitest';
 
 expect.extend(matchers);
 
+/**
+ * `LocalStorageMock` implements the `localStorage` interface, so that we can use it in our app for testing the
+ * `useLocalStorageState` hook and the state history.
+ */
+class LocalStorageMock {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  store: Record<string, any> = {};
+
+  constructor() {
+    this.store = {};
+  }
+
+  clear() {
+    this.store = {};
+  }
+
+  getItem(key: string) {
+    return this.store[key] || null;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  setItem(key: string, value: any) {
+    this.store[key] = value;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  removeItem(key: string) {
+    delete this.store[key];
+  }
+
+  get length() {
+    return Object.keys(this.store).length;
+  }
+
+  key(index: number) {
+    return Object.keys(this.store)[index];
+  }
+}
+
+global.localStorage = new LocalStorageMock();
+
 afterEach(() => {
+  global.localStorage.clear();
   cleanup();
 });

--- a/app/packages/core/src/utils/statehistory.test.ts
+++ b/app/packages/core/src/utils/statehistory.test.ts
@@ -1,0 +1,52 @@
+import { getStateHistory, addStateHistoryItem, addStateHistoryItems } from './statehistory';
+
+describe('statehistory', () => {
+  it('should return items from history', () => {
+    expect(getStateHistory('test')).toEqual([]);
+    localStorage.setItem('test', JSON.stringify(['item1', 'item2']));
+    expect(getStateHistory('test')).toEqual(['item1', 'item2']);
+  });
+
+  it('should save items to history', () => {
+    addStateHistoryItems('test', ['item1', 'item2']);
+    expect(getStateHistory('test')).toEqual(['item1', 'item2']);
+  });
+
+  it('should save last 10 items to history', () => {
+    addStateHistoryItems('test', [
+      'item1',
+      'item2',
+      'item3',
+      'item4',
+      'item5',
+      'item6',
+      'item7',
+      'item8',
+      'item9',
+      'item10',
+    ]);
+    addStateHistoryItems('test', ['item11']);
+    expect(getStateHistory('test')).toEqual([
+      'item11',
+      'item1',
+      'item2',
+      'item3',
+      'item4',
+      'item5',
+      'item6',
+      'item7',
+      'item8',
+      'item9',
+    ]);
+  });
+
+  it('should save items to history which are not empty', () => {
+    addStateHistoryItems('test', ['item1', '', 'item2']);
+    expect(getStateHistory('test')).toEqual(['item1', 'item2']);
+  });
+
+  it('should save single item to history', () => {
+    addStateHistoryItem('test', 'item1');
+    expect(getStateHistory('test')).toEqual(['item1']);
+  });
+});

--- a/app/packages/core/src/utils/statehistory.ts
+++ b/app/packages/core/src/utils/statehistory.ts
@@ -1,0 +1,42 @@
+/**
+ * `getStateHistory` returns the history for the provided `key`. If the `key` is not found in the localStorage an empty
+ * list is returned.
+ */
+export const getStateHistory = (key: string): string[] => {
+  try {
+    const storedItems = localStorage.getItem(key);
+    if (storedItems) {
+      const storedItemsParsed: string[] = JSON.parse(storedItems);
+      return storedItemsParsed;
+    }
+  } catch {}
+
+  return [];
+};
+
+/**
+ * `addStateHistoryItem` adds the provided `item` to the history for the provided `key` by calling the
+ * `addStateHistoryItems` function.
+ */
+export const addStateHistoryItem = (key: string, item: string) => {
+  addStateHistoryItems(key, [item]);
+};
+
+/**
+ * `addStateHistoryItems` adds the provided `items` to the history of the provided `key`. The history is saved in the
+ * localStorage of the users browser. Before the new items are added we remove all items which are empty or a duplicate
+ * of another item. Then the last 10 items are saved.
+ */
+export const addStateHistoryItems = (key: string, items: string[]) => {
+  try {
+    const storedItems = localStorage.getItem(key);
+    if (!storedItems) {
+      localStorage.setItem(key, JSON.stringify([...new Set(items.filter((item) => item !== ''))].slice(0, 10)));
+    } else {
+      const storedItemsParsed: string[] = JSON.parse(storedItems);
+      storedItemsParsed.unshift(...items);
+      storedItemsParsed.filter((item) => item !== '');
+      localStorage.setItem(key, JSON.stringify([...new Set(storedItemsParsed)].slice(0, 10)));
+    }
+  } catch {}
+};

--- a/app/packages/prometheus/src/components/PrometheusPage.tsx
+++ b/app/packages/prometheus/src/components/PrometheusPage.tsx
@@ -14,8 +14,10 @@ import {
   APIError,
   UseQueryWrapper,
   getChartColor,
+  getStateHistory,
+  addStateHistoryItems,
 } from '@kobsio/core';
-import { Add, Remove } from '@mui/icons-material';
+import { Add, ManageSearch, Remove } from '@mui/icons-material';
 import {
   Alert,
   AlertTitle,
@@ -23,13 +25,16 @@ import {
   Card,
   IconButton,
   InputBaseComponentProps,
+  Menu,
+  MenuItem,
   Stack,
   TextField,
   ToggleButton,
   ToggleButtonGroup,
+  Typography,
 } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
-import { forwardRef, FunctionComponent, useContext, useEffect, useState } from 'react';
+import { forwardRef, FunctionComponent, MouseEvent, useContext, useEffect, useState } from 'react';
 
 import Chart from './Chart';
 import Legend from './Legend';
@@ -241,6 +246,63 @@ const PrometheusWrapper: FunctionComponent<{
 };
 
 /**
+ * The `PrometheusHistory` can be used to display a button next to a query field, which allows a user to access the
+ * queries he run in the past. When the user clicks on the button, a menu with a list of the queries saved in the
+ * history is shown. When a user clicks on a query the `setQuery` function is triggered for this query and should
+ * replace the current value in the query field.
+ */
+const PrometheusHistory: FunctionComponent<{ setQuery: (query: string) => void }> = ({ setQuery }) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const queries = getStateHistory('kobs-prometheus-queryhistory');
+
+  /**
+   * `handleOpen` opens the menu, which is used to display the history, with all queries which were executed by a user
+   * in the past.
+   */
+  const handleOpen = (e: MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(e.currentTarget);
+  };
+
+  /**
+   * `handleClose` closes the menu, wich displays the history, with all queries which were executed by a user in the
+   * past.
+   */
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  /**
+   * `handleSelect` handles the selection of a query in the history menu. The query will be passed to the `setQuery`
+   * function and the menu will be closed.
+   */
+  const handleSelect = (query: string) => {
+    handleClose();
+    setQuery(query);
+  };
+
+  if (queries.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <IconButton size="small" onClick={handleOpen}>
+        <ManageSearch />
+      </IconButton>
+
+      <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
+        {queries.map((query, index) => (
+          <MenuItem key={index} onClick={() => handleSelect(query)}>
+            <Typography noWrap={true}>{query}</Typography>
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+};
+
+/**
  * The `InternalEditor` component is a wrapper around our `MUIEditor` component, which allows us to use the editor
  * within a `TextField` component of MUI.
  */
@@ -326,9 +388,13 @@ const PrometheusToolbar: FunctionComponent<{
   /**
    * `changeOptions` is the function which is passed to the `Options` component, to call the `setOptions` function when
    * a user clicks on the search button, changes the selected time range or sets a resolution.
+   *
+   * We also add all the queries to the history of Prometheus queries when the function is triggered, so that a user has
+   * easy access to the last 10 queries he run.
    */
   const changeOptions = (times: ITimes, additionalFields: IOptionsAdditionalFields[] | undefined) => {
     if (additionalFields && additionalFields.length === 1) {
+      addStateHistoryItems('kobs-prometheus-queryhistory', queries);
       setOptions({ ...times, queries: queries, resolution: additionalFields[0].value });
     }
   };
@@ -336,8 +402,12 @@ const PrometheusToolbar: FunctionComponent<{
   /**
    * `callSubmit` is the function we pass to our `MUIEditor` component so that we can submit the provided query by
    * calling the `setOptions` function when a user presses `Shift + Enter`.
+   *
+   * We also add all the queries to the history of Prometheus queries when the function is triggered, so that a user has
+   * easy access to the last 10 queries he run.
    */
   const callSubmit = () => {
+    addStateHistoryItems('kobs-prometheus-queryhistory', queries);
     setOptions({ ...options, queries: queries });
   };
 
@@ -363,13 +433,19 @@ const PrometheusToolbar: FunctionComponent<{
                   />
                 </Box>
                 {index === 0 ? (
-                  <IconButton size="small" onClick={addQuery}>
-                    <Add />
-                  </IconButton>
+                  <>
+                    <PrometheusHistory setQuery={(query) => changeQuery(index, query)} />
+                    <IconButton size="small" onClick={addQuery}>
+                      <Add />
+                    </IconButton>
+                  </>
                 ) : (
-                  <IconButton size="small" onClick={(): void => removeQuery(index)}>
-                    <Remove />
-                  </IconButton>
+                  <>
+                    <PrometheusHistory setQuery={(query) => changeQuery(index, query)} />
+                    <IconButton size="small" onClick={(): void => removeQuery(index)}>
+                      <Remove />
+                    </IconButton>
+                  </>
                 )}
               </Box>
             </Box>


### PR DESCRIPTION
All queries which are executed by a user are now added to the state history, so that a user can always access the latest queries he executed. The history is saved in the localStorage of the users browser. To reuse the logic some new helpers where added, these are:

- "getStateHistory": to return the history for a provided key from the localStorage.
- "addStateHistoryItem": to add a single item to the history
- "addStateHistoryItems": to add a list of items to the history, before the items are added, empty items are filtered and the items are deduplicated, then we store the 10 latest items in the localStorage

This commit also fixed a bug in the "Editor" and "MUIEditor" component, where we used the "defaultValue" and "defaultLanguage" properties, so that the value was not updated in the monaco editor when it was changed in another component (e.g. value from the history). Now we are using the "language" and "value" properties so that the value is always updated.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
