### PR TITLE
[core] Add "Clear" Action to Search Fields

### DIFF
--- a/app/packages/core/src/components/applications/ApplicationsToolbar.tsx
+++ b/app/packages/core/src/components/applications/ApplicationsToolbar.tsx
@@ -1,4 +1,4 @@
-import { Search, CheckBox, CheckBoxOutlineBlank } from '@mui/icons-material';
+import { Search, CheckBox, CheckBoxOutlineBlank, Clear } from '@mui/icons-material';
 import {
   Autocomplete,
   Checkbox,
@@ -8,6 +8,7 @@ import {
   InputAdornment,
   ToggleButton,
   ToggleButtonGroup,
+  IconButton,
 } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { useContext, FunctionComponent, useState, FormEvent, useEffect } from 'react';
@@ -96,6 +97,15 @@ const ApplicationsToolbar: FunctionComponent<IApplicationsToolbarProps> = ({ opt
   };
 
   /**
+   * `handleClear` is the action which is executed when a user clicks the clear button in the search field. When the
+   * action is executed we set the search term to an empty string and we adjust the options accordingly.
+   */
+  const handleClear = () => {
+    setSearchTerm('');
+    setOptions({ ...options, page: 1, searchTerm: '' });
+  };
+
+  /**
    * Since the options can also be updated outside of the `ApplicationsToolbar` (e.g. set the `all` option to `true`,
    * when no applications were found) component we have to update the state everytime the options are changed.
    */
@@ -128,6 +138,13 @@ const ApplicationsToolbar: FunctionComponent<IApplicationsToolbarProps> = ({ opt
             placeholder="Search"
             fullWidth={true}
             InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton size="small" onClick={handleClear}>
+                    <Clear />
+                  </IconButton>
+                </InputAdornment>
+              ),
               startAdornment: (
                 <InputAdornment position="start">
                   <Search />

--- a/app/packages/core/src/components/plugins/PluginsPage.tsx
+++ b/app/packages/core/src/components/plugins/PluginsPage.tsx
@@ -1,4 +1,4 @@
-import { CheckBox, CheckBoxOutlineBlank, Extension, Search } from '@mui/icons-material';
+import { CheckBox, CheckBoxOutlineBlank, Clear, Extension, Search } from '@mui/icons-material';
 import {
   Box,
   Card,
@@ -8,6 +8,7 @@ import {
   Checkbox,
   Chip,
   Grid,
+  IconButton,
   InputAdornment,
   Stack,
   TextField,
@@ -53,9 +54,22 @@ const PluginsPage: FunctionComponent = () => {
   });
   const [searchTerm, setSearchTerm] = useState<string>(options.searchTerm ?? '');
 
+  /**
+   * `handleSubmit` handles the submission of the toolbar form, when a user has entered a search term. When the search
+   * term changes we also have to set the page options to their initial values.
+   */
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
     setOptions((prevOptions) => ({ ...prevOptions, page: 1, searchTerm: searchTerm }));
+  };
+
+  /**
+   * `handleClear` is the action which is executed when a user clicks the clear button in the search field. When the
+   * action is executed we set the search term to an empty string and we adjust the options accordingly.
+   */
+  const handleClear = () => {
+    setSearchTerm('');
+    setOptions((prevOptions) => ({ ...prevOptions, page: 1, searchTerm: '' }));
   };
 
   const filteredItems = instances
@@ -121,6 +135,13 @@ const PluginsPage: FunctionComponent = () => {
                 placeholder="Search"
                 fullWidth={true}
                 InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton size="small" onClick={handleClear}>
+                        <Clear />
+                      </IconButton>
+                    </InputAdornment>
+                  ),
                   startAdornment: (
                     <InputAdornment position="start">
                       <Search />

--- a/app/packages/core/src/components/teams/TeamsPage.tsx
+++ b/app/packages/core/src/components/teams/TeamsPage.tsx
@@ -1,5 +1,5 @@
-import { Add, Search } from '@mui/icons-material';
-import { Box, Button, InputAdornment, TextField, ToggleButton, ToggleButtonGroup } from '@mui/material';
+import { Add, Clear, Search } from '@mui/icons-material';
+import { Box, Button, IconButton, InputAdornment, TextField, ToggleButton, ToggleButtonGroup } from '@mui/material';
 import { FormEvent, FunctionComponent, useState } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -33,6 +33,15 @@ const TeamsPage: FunctionComponent = () => {
     setOptions((prevOptions) => ({ ...prevOptions, page: 1, searchTerm: searchTerm }));
   };
 
+  /**
+   * `handleClear` is the action which is executed when a user clicks the clear button in the search field. When the
+   * action is executed we set the search term to an empty string and we adjust the options accordingly.
+   */
+  const handleClear = () => {
+    setSearchTerm('');
+    setOptions((prevOptions) => ({ ...prevOptions, page: 1, searchTerm: '' }));
+  };
+
   return (
     <Page
       title="Teams"
@@ -62,6 +71,13 @@ const TeamsPage: FunctionComponent = () => {
                 placeholder="Search"
                 fullWidth={true}
                 InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton size="small" onClick={handleClear}>
+                        <Clear />
+                      </IconButton>
+                    </InputAdornment>
+                  ),
                   startAdornment: (
                     <InputAdornment position="start">
                       <Search />

--- a/app/packages/core/src/utils/statehistory.ts
+++ b/app/packages/core/src/utils/statehistory.ts
@@ -31,12 +31,14 @@ export const addStateHistoryItems = (key: string, items: string[]) => {
   try {
     const storedItems = localStorage.getItem(key);
     if (!storedItems) {
-      localStorage.setItem(key, JSON.stringify([...new Set(items.filter((item) => item !== ''))].slice(0, 10)));
+      localStorage.setItem(key, JSON.stringify([...new Set(items.filter((item) => item.trim() !== ''))].slice(0, 10)));
     } else {
       const storedItemsParsed: string[] = JSON.parse(storedItems);
       storedItemsParsed.unshift(...items);
-      storedItemsParsed.filter((item) => item !== '');
-      localStorage.setItem(key, JSON.stringify([...new Set(storedItemsParsed)].slice(0, 10)));
+      localStorage.setItem(
+        key,
+        JSON.stringify([...new Set(storedItemsParsed.filter((item) => item.trim() !== ''))].slice(0, 10)),
+      );
     }
   } catch {}
 };

--- a/app/packages/grafana/src/components/GrafanaPage.tsx
+++ b/app/packages/grafana/src/components/GrafanaPage.tsx
@@ -10,8 +10,18 @@ import {
   useQueryState,
   UseQueryWrapper,
 } from '@kobsio/core';
-import { Search } from '@mui/icons-material';
-import { Box, Divider, InputAdornment, List, ListItem, ListItemText, TextField, Typography } from '@mui/material';
+import { Clear, Search } from '@mui/icons-material';
+import {
+  Box,
+  Divider,
+  IconButton,
+  InputAdornment,
+  List,
+  ListItem,
+  ListItemText,
+  TextField,
+  Typography,
+} from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { FormEvent, Fragment, FunctionComponent, useContext, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
@@ -92,6 +102,15 @@ const GrafanaPageToolbar: FunctionComponent<{ options: IOptions; setOptions: (op
     setOptions({ query: query });
   };
 
+  /**
+   * `handleClear` is the action which is executed when a user clicks the clear button in the search field. When the
+   * action is executed we set the search term to an empty string and we adjust the options accordingly.
+   */
+  const handleClear = () => {
+    setQuery('');
+    setOptions({ query: '' });
+  };
+
   useEffect(() => {
     setQuery(options.query);
   }, [options.query]);
@@ -106,6 +125,13 @@ const GrafanaPageToolbar: FunctionComponent<{ options: IOptions; setOptions: (op
             placeholder="Search"
             fullWidth={true}
             InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton size="small" onClick={handleClear}>
+                    <Clear />
+                  </IconButton>
+                </InputAdornment>
+              ),
               startAdornment: (
                 <InputAdornment position="start">
                   <Search />

--- a/app/packages/harbor/src/components/HarborPage.tsx
+++ b/app/packages/harbor/src/components/HarborPage.tsx
@@ -1,6 +1,6 @@
 import { IPluginPageProps, Page, Toolbar, ToolbarItem, useQueryState } from '@kobsio/core';
-import { Search } from '@mui/icons-material';
-import { Box, InputAdornment, TextField } from '@mui/material';
+import { Clear, Search } from '@mui/icons-material';
+import { Box, IconButton, InputAdornment, TextField } from '@mui/material';
 import { FormEvent, FunctionComponent, useState } from 'react';
 import { Route, Routes, useParams } from 'react-router-dom';
 
@@ -29,6 +29,15 @@ const PageToolbar: FunctionComponent<{ options: IOptions; setOptions: (data: IOp
     setOptions({ query: query });
   };
 
+  /**
+   * `handleClear` is the action which is executed when a user clicks the clear button in the search field. When the
+   * action is executed we set the search term to an empty string and we adjust the options accordingly.
+   */
+  const handleClear = () => {
+    setQuery('');
+    setOptions({ ...options, query: '' });
+  };
+
   return (
     <Toolbar>
       <ToolbarItem grow={true}>
@@ -39,6 +48,13 @@ const PageToolbar: FunctionComponent<{ options: IOptions; setOptions: (data: IOp
             placeholder="Search"
             fullWidth={true}
             InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton size="small" onClick={handleClear}>
+                    <Clear />
+                  </IconButton>
+                </InputAdornment>
+              ),
               startAdornment: (
                 <InputAdornment position="start">
                   <Search />

--- a/app/packages/prometheus/src/components/PrometheusPage.tsx
+++ b/app/packages/prometheus/src/components/PrometheusPage.tsx
@@ -24,6 +24,7 @@ import {
   Box,
   Card,
   IconButton,
+  InputAdornment,
   InputBaseComponentProps,
   Menu,
   MenuItem,
@@ -423,6 +424,20 @@ const PrometheusToolbar: FunctionComponent<{
                     value={query}
                     onChange={(e) => changeQuery(index, e.target.value)}
                     InputProps={{
+                      endAdornment: (
+                        <InputAdornment position="end">
+                          <PrometheusHistory setQuery={(query) => changeQuery(index, query)} />
+                          {index === 0 ? (
+                            <IconButton size="small" onClick={addQuery}>
+                              <Add />
+                            </IconButton>
+                          ) : (
+                            <IconButton size="small" onClick={(): void => removeQuery(index)}>
+                              <Remove />
+                            </IconButton>
+                          )}
+                        </InputAdornment>
+                      ),
                       inputComponent: InternalEditor,
                       inputProps: {
                         callSubmit: callSubmit,
@@ -432,21 +447,6 @@ const PrometheusToolbar: FunctionComponent<{
                     fullWidth={true}
                   />
                 </Box>
-                {index === 0 ? (
-                  <>
-                    <PrometheusHistory setQuery={(query) => changeQuery(index, query)} />
-                    <IconButton size="small" onClick={addQuery}>
-                      <Add />
-                    </IconButton>
-                  </>
-                ) : (
-                  <>
-                    <PrometheusHistory setQuery={(query) => changeQuery(index, query)} />
-                    <IconButton size="small" onClick={(): void => removeQuery(index)}>
-                      <Remove />
-                    </IconButton>
-                  </>
-                )}
               </Box>
             </Box>
           ))}

--- a/app/packages/rss/src/components/RSSPage.tsx
+++ b/app/packages/rss/src/components/RSSPage.tsx
@@ -1,6 +1,6 @@
 import { IPluginPageProps, Page, Toolbar, ToolbarItem, useQueryState } from '@kobsio/core';
-import { Search } from '@mui/icons-material';
-import { Alert, AlertTitle, Box, InputAdornment, TextField } from '@mui/material';
+import { Clear, Search } from '@mui/icons-material';
+import { Alert, AlertTitle, Box, IconButton, InputAdornment, TextField } from '@mui/material';
 import { FormEvent, FunctionComponent, useEffect, useState } from 'react';
 
 import Feed from './Feed';
@@ -25,6 +25,15 @@ const RSSPageToolbar: FunctionComponent<{ options: IOptions; setOptions: (option
     setOptions({ url: url });
   };
 
+  /**
+   * `handleClear` is the action which is executed when a user clicks the clear button in the search field. When the
+   * action is executed we set the search term to an empty string and we adjust the options accordingly.
+   */
+  const handleClear = () => {
+    setURL('');
+    setOptions({ url: '' });
+  };
+
   useEffect(() => {
     setURL(options.url);
   }, [options.url]);
@@ -39,6 +48,13 @@ const RSSPageToolbar: FunctionComponent<{ options: IOptions; setOptions: (option
             placeholder="Search"
             fullWidth={true}
             InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton size="small" onClick={handleClear}>
+                    <Clear />
+                  </IconButton>
+                </InputAdornment>
+              ),
               startAdornment: (
                 <InputAdornment position="start">
                   <Search />

--- a/app/packages/sonarqube/src/components/SonarQubePage.tsx
+++ b/app/packages/sonarqube/src/components/SonarQubePage.tsx
@@ -11,12 +11,13 @@ import {
   useQueryState,
   UseQueryWrapper,
 } from '@kobsio/core';
-import { ExpandMore, Search } from '@mui/icons-material';
+import { Clear, ExpandMore, Search } from '@mui/icons-material';
 import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
   Box,
+  IconButton,
   InputAdornment,
   TextField,
   Typography,
@@ -104,6 +105,15 @@ const SonarQubePageToolbar: FunctionComponent<{ options: IOptions; setOptions: (
     setOptions({ ...options, page: 1, query: query });
   };
 
+  /**
+   * `handleClear` is the action which is executed when a user clicks the clear button in the search field. When the
+   * action is executed we set the search term to an empty string and we adjust the options accordingly.
+   */
+  const handleClear = () => {
+    setQuery('');
+    setOptions({ ...options, page: 1, query: '' });
+  };
+
   useEffect(() => {
     setQuery(options.query);
   }, [options.query]);
@@ -118,6 +128,13 @@ const SonarQubePageToolbar: FunctionComponent<{ options: IOptions; setOptions: (
             placeholder="Search"
             fullWidth={true}
             InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton size="small" onClick={handleClear}>
+                    <Clear />
+                  </IconButton>
+                </InputAdornment>
+              ),
               startAdornment: (
                 <InputAdornment position="start">
                   <Search />


### PR DESCRIPTION
This commit adds a clear action to all search fields, which should make it easier for users to delete a provided search term. The clear button is displayed within the TextField component via the input adornment API.

We also adjusted the query fields in the Prometheus plugin, so that the actions are also displayed within the TextField and not next to it, so that we have a similar style across the app.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
