### PR TITLE
[sonarqube] Change API Endpoint to Get Projects

### DIFF
--- a/app/packages/sonarqube/src/components/Measures.tsx
+++ b/app/packages/sonarqube/src/components/Measures.tsx
@@ -147,7 +147,7 @@ const Measures: FunctionComponent<{
       noDataTitle="No measures were found"
       refetch={refetch}
     >
-      <Box sx={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', gap: 12 }}>
+      <Box sx={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', gap: 12, justifyContent: 'center' }}>
         {data?.component?.measures?.map((measure) => (
           <Measure key={measure.metric} measure={measure} metrics={data.metrics} />
         ))}

--- a/app/packages/sonarqube/src/components/SonarQubePage.test.tsx
+++ b/app/packages/sonarqube/src/components/SonarQubePage.test.tsx
@@ -20,21 +20,17 @@ describe('SonarQubePage', () => {
           components: [
             {
               key: 'project-key-1',
-              lastAnalysisDate: '2017-03-01T11:39:03+0300',
               name: 'Project Name 1',
-              organization: 'my-org-1',
+              organization: 'myorg',
+              project: 'myproject1',
               qualifier: 'TRK',
-              revision: 'cfb82f55c6ef32e61828c4cb3db2da12795fd767',
-              visibility: 'public',
             },
             {
               key: 'project-key-2',
-              lastAnalysisDate: '2017-03-02T15:21:47+0300',
               name: 'Project Name 2',
-              organization: 'my-org-1',
+              organization: 'myorg',
+              project: 'myproject2',
               qualifier: 'TRK',
-              revision: '7be96a94ac0c95a61ee6ee0ef9c6f808d386a355',
-              visibility: 'private',
             },
           ],
           paging: {
@@ -234,6 +230,6 @@ describe('SonarQubePage', () => {
 
     await userEvent.click(screen.getByText(/Project Name 1/));
     screen.debug();
-    expect(await waitFor(() => screen.getAllByText(/Quality Gate Status/).length)).toBe(2);
+    expect(await waitFor(() => screen.getAllByText(/Quality Gate Status/).length)).toBe(1);
   });
 });

--- a/app/packages/sonarqube/src/components/SonarQubePage.tsx
+++ b/app/packages/sonarqube/src/components/SonarQubePage.tsx
@@ -71,7 +71,7 @@ const Projects: FunctionComponent<{
       refetch={refetch}
     >
       {data?.components?.map((component, index) => (
-        <Accordion key={component.key}>
+        <Accordion key={component.key} TransitionProps={{ unmountOnExit: true }}>
           <AccordionSummary expandIcon={<ExpandMore />}>
             <Typography>{component.name}</Typography>
           </AccordionSummary>

--- a/app/packages/sonarqube/src/components/SonarQubePanel.test.tsx
+++ b/app/packages/sonarqube/src/components/SonarQubePanel.test.tsx
@@ -17,21 +17,17 @@ describe('SonarQubePanel', () => {
           components: [
             {
               key: 'project-key-1',
-              lastAnalysisDate: '2017-03-01T11:39:03+0300',
-              name: 'Project Name 1',
-              organization: 'my-org-1',
+              name: 'project 1',
+              organization: 'myorg',
+              project: 'myproject1',
               qualifier: 'TRK',
-              revision: 'cfb82f55c6ef32e61828c4cb3db2da12795fd767',
-              visibility: 'public',
             },
             {
               key: 'project-key-2',
-              lastAnalysisDate: '2017-03-02T15:21:47+0300',
-              name: 'Project Name 2',
-              organization: 'my-org-1',
+              name: 'project 2',
+              organization: 'myorg',
+              project: 'myproject2',
               qualifier: 'TRK',
-              revision: '7be96a94ac0c95a61ee6ee0ef9c6f808d386a355',
-              visibility: 'private',
             },
           ],
           paging: {

--- a/app/packages/sonarqube/src/utils/utils.ts
+++ b/app/packages/sonarqube/src/utils/utils.ts
@@ -16,11 +16,10 @@ export interface IPaging {
 
 export interface IProject {
   key: string;
-  lastAnalysisDate: string;
   name: string;
+  organization: string;
+  project: string;
   qualifier: string;
-  revision: string;
-  visibility: string;
 }
 
 /**

--- a/pkg/plugins/sonarqube/instance/instance.go
+++ b/pkg/plugins/sonarqube/instance/instance.go
@@ -43,7 +43,12 @@ func (i *instance) GetName() string {
 
 // GetProjects returns a list of projects from SonarQube.
 func (i *instance) GetProjects(ctx context.Context, query, page, perPage string) (*ResponseProjects, error) {
-	projects, err := doRequest[ResponseProjects](ctx, i.client, fmt.Sprintf("%s/api/projects/search?organization=%s&p=%s&ps=%s&q=%s", i.address, i.organization, page, perPage, query))
+	url := fmt.Sprintf("%s/api/components/search?organization=%s&p=%s&ps=%s&q=%s", i.address, i.organization, page, perPage, query)
+	if strings.TrimSpace(query) == "" {
+		url = fmt.Sprintf("%s/api/components/search?organization=%s&p=%s&ps=%s", i.address, i.organization, page, perPage)
+	}
+
+	projects, err := doRequest[ResponseProjects](ctx, i.client, url)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugins/sonarqube/instance/instance_test.go
+++ b/pkg/plugins/sonarqube/instance/instance_test.go
@@ -20,7 +20,7 @@ func TestGetName(t *testing.T) {
 func TestGetProjects(t *testing.T) {
 	t.Run("should return request error", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/api/projects/search" {
+			if r.URL.Path == "/api/components/search" {
 				w.WriteHeader(http.StatusBadRequest)
 			}
 		}))
@@ -38,7 +38,7 @@ func TestGetProjects(t *testing.T) {
 
 	t.Run("should return error for invalid json", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/api/projects/search" {
+			if r.URL.Path == "/api/components/search" {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(`[]`))
@@ -58,7 +58,7 @@ func TestGetProjects(t *testing.T) {
 
 	t.Run("should return projects", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/api/projects/search" {
+			if r.URL.Path == "/api/components/search" {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(`{"paging": {"pageIndex": 1, "pageSize": 1, "total": 1}}`))

--- a/pkg/plugins/sonarqube/instance/types.go
+++ b/pkg/plugins/sonarqube/instance/types.go
@@ -19,12 +19,11 @@ type Paging struct {
 }
 
 type Project struct {
-	Key              string `json:"key"`
-	Name             string `json:"name"`
-	Qualifier        string `json:"qualifier"`
-	Visibility       string `json:"visibility"`
-	LastAnalysisDate string `json:"lastAnalysisDate"`
-	Revision         string `json:"revision"`
+	Organization string `json:"organization"`
+	Key          string `json:"key"`
+	Qualifier    string `json:"qualifier"`
+	Name         string `json:"name"`
+	Project      string `json:"project"`
 }
 
 type ResponseProjectMeasures struct {


### PR DESCRIPTION
Until now we used the "api/projects/search" API endpoint of SonarQube to get a list of projects. This is now changed to "api/components/search" because this endpoint requires less permissions for the provided token and also works with a normal token.

We also added "unmountOnExit" property to the accordion in the projects list, so that the measures for a project are only loaded when the accordion is opened.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
