### PR TITLE
[core] Fix Label Selector for Resources

### DIFF
--- a/pkg/hub/api/resources/resources.go
+++ b/pkg/hub/api/resources/resources.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"sync"
@@ -179,7 +180,7 @@ func (router *Router) resourcesHandler(w http.ResponseWriter, r *http.Request) {
 							ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 							defer cancel()
 
-							manifest, err := clusterClient.Request(ctx, http.MethodGet, fmt.Sprintf("/api/resources?namespace=%s&resource=%s&path=%s&paramName=%s&param=%s", "", r.Resource, r.Path, paramName, param), nil)
+							manifest, err := clusterClient.Request(ctx, http.MethodGet, fmt.Sprintf("/api/resources?namespace=%s&resource=%s&path=%s&paramName=%s&param=%s", "", r.Resource, r.Path, paramName, url.QueryEscape(param)), nil)
 							if err != nil {
 								log.Error(ctx, "Failed to get resources", zap.Error(err))
 								muClusters.Lock()


### PR DESCRIPTION
This commit fixes the label selector for resources, so that we can use similar expressions like for kubectl: "kubectl get pods -A -l 'app in (app1, app2)'". This wasn't working because the "param" query parameter wasn't escaped when it was passed to the cluster.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
