### PR TITLE
[core] Allow Plugin Mounts to Return Nil

### DIFF
--- a/pkg/cluster/plugins/plugins.go
+++ b/pkg/cluster/plugins/plugins.go
@@ -64,7 +64,9 @@ func NewClient(plugins []plugins.Plugin, instances []plugin.Instance, kubernetes
 		if err != nil {
 			return nil, err
 		}
-		router.Mount(fmt.Sprintf("/%s", plugin.Type()), pluginRouter)
+		if pluginRouter != nil {
+			router.Mount(fmt.Sprintf("/%s", plugin.Type()), pluginRouter)
+		}
 	}
 
 	return &client{

--- a/pkg/hub/plugins/plugins.go
+++ b/pkg/hub/plugins/plugins.go
@@ -80,7 +80,9 @@ func NewClient(plugins []plugins.Plugin, instances []plugin.Instance, clustersCl
 		if err != nil {
 			return nil, err
 		}
-		router.Mount(fmt.Sprintf("/%s", plugin.Type()), pluginRouter)
+		if pluginRouter != nil {
+			router.Mount(fmt.Sprintf("/%s", plugin.Type()), pluginRouter)
+		}
 	}
 
 	return &client{

--- a/pkg/plugins/harbor/harbor.go
+++ b/pkg/plugins/harbor/harbor.go
@@ -21,9 +21,9 @@ func (p *Plugin) Type() string {
 }
 
 func (p *Plugin) MountCluster(instances []plugin.Instance, kubernetesClient kubernetes.Client) (chi.Router, error) {
-	return Mount(instances, nil)
+	return nil, nil
 }
 
 func (p *Plugin) MountHub(instances []plugin.Instance, clustersClient clusters.Client, dbClient db.Client) (chi.Router, error) {
-	return Mount(instances, clustersClient)
+	return Mount(instances)
 }

--- a/pkg/plugins/harbor/harbor_test.go
+++ b/pkg/plugins/harbor/harbor_test.go
@@ -19,15 +19,9 @@ func TestType(t *testing.T) {
 func TestMountCluster(t *testing.T) {
 	p := New()
 
-	t.Run("should return router", func(t *testing.T) {
-		router, err := p.MountCluster([]plugin.Instance{{Options: map[string]any{"address": "localhost"}}}, nil)
+	t.Run("should return nil", func(t *testing.T) {
+		router, err := p.MountCluster(nil, nil)
 		require.NoError(t, err)
-		require.NotNil(t, router)
-	})
-
-	t.Run("should return error for invalid instances", func(t *testing.T) {
-		router, err := p.MountCluster([]plugin.Instance{{Options: map[string]any{"address": []string{"localhost"}}}}, nil)
-		require.Error(t, err)
 		require.Nil(t, router)
 	})
 }

--- a/pkg/plugins/harbor/router.go
+++ b/pkg/plugins/harbor/router.go
@@ -3,12 +3,10 @@ package harbor
 import (
 	"net/http"
 
-	"github.com/kobsio/kobs/pkg/hub/clusters"
 	"github.com/kobsio/kobs/pkg/instrument/log"
 	"github.com/kobsio/kobs/pkg/plugins/harbor/instance"
 	"github.com/kobsio/kobs/pkg/plugins/plugin"
 	"github.com/kobsio/kobs/pkg/utils/middleware/errresponse"
-	"github.com/kobsio/kobs/pkg/utils/middleware/pluginproxy"
 	"go.uber.org/zap"
 
 	"github.com/go-chi/chi/v5"
@@ -189,7 +187,7 @@ func (router *Router) getBuildHistory(w http.ResponseWriter, r *http.Request) {
 	render.JSON(w, r, buildHistory)
 }
 
-func Mount(instances []plugin.Instance, clustersClient clusters.Client) (chi.Router, error) {
+func Mount(instances []plugin.Instance) (chi.Router, error) {
 	var harborInstances []instance.Instance
 
 	for _, i := range instances {
@@ -206,14 +204,12 @@ func Mount(instances []plugin.Instance, clustersClient clusters.Client) (chi.Rou
 		harborInstances,
 	}
 
-	proxy := pluginproxy.New(clustersClient)
-
-	router.With(proxy).Get("/projects", router.getProjects)
-	router.With(proxy).Get("/repositories", router.getRepositories)
-	router.With(proxy).Get("/artifacts", router.getArtifacts)
-	router.With(proxy).Get("/artifact", router.getArtifact)
-	router.With(proxy).Get("/vulnerabilities", router.getVulnerabilities)
-	router.With(proxy).Get("/buildhistory", router.getBuildHistory)
+	router.Get("/projects", router.getProjects)
+	router.Get("/repositories", router.getRepositories)
+	router.Get("/artifacts", router.getArtifacts)
+	router.Get("/artifact", router.getArtifact)
+	router.Get("/vulnerabilities", router.getVulnerabilities)
+	router.Get("/buildhistory", router.getBuildHistory)
 
 	return router, nil
 }

--- a/pkg/plugins/opsgenie/opsgenie.go
+++ b/pkg/plugins/opsgenie/opsgenie.go
@@ -1,8 +1,6 @@
 package opsgenie
 
 import (
-	"net/http"
-
 	"github.com/kobsio/kobs/pkg/cluster/kubernetes"
 	"github.com/kobsio/kobs/pkg/hub/clusters"
 	"github.com/kobsio/kobs/pkg/hub/db"
@@ -23,11 +21,7 @@ func (p *Plugin) Type() string {
 }
 
 func (p *Plugin) MountCluster(instances []plugin.Instance, kubernetesClient kubernetes.Client) (chi.Router, error) {
-	router := chi.NewRouter()
-	router.HandleFunc("/*", func(w http.ResponseWriter, r *http.Request) {
-		http.NotFound(w, r)
-	})
-	return router, nil
+	return nil, nil
 }
 
 func (p *Plugin) MountHub(instances []plugin.Instance, clustersClient clusters.Client, dbClient db.Client) (chi.Router, error) {

--- a/pkg/plugins/opsgenie/opsgenie_test.go
+++ b/pkg/plugins/opsgenie/opsgenie_test.go
@@ -18,10 +18,10 @@ func TestType(t *testing.T) {
 func TestMountCluster(t *testing.T) {
 	p := New()
 
-	t.Run("should return router", func(t *testing.T) {
+	t.Run("should return nil", func(t *testing.T) {
 		router, err := p.MountCluster(nil, nil)
 		require.NoError(t, err)
-		require.NotNil(t, router)
+		require.Nil(t, router)
 	})
 }
 

--- a/pkg/plugins/rss/router.go
+++ b/pkg/plugins/rss/router.go
@@ -4,13 +4,11 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/kobsio/kobs/pkg/hub/clusters"
 	"github.com/kobsio/kobs/pkg/instrument/log"
 	"github.com/kobsio/kobs/pkg/plugins/plugin"
 	"github.com/kobsio/kobs/pkg/plugins/rss/feed"
 	"github.com/kobsio/kobs/pkg/plugins/rss/instance"
 	"github.com/kobsio/kobs/pkg/utils/middleware/errresponse"
-	"github.com/kobsio/kobs/pkg/utils/middleware/pluginproxy"
 	"github.com/kobsio/kobs/pkg/utils/middleware/roundtripper"
 
 	"github.com/go-chi/chi/v5"
@@ -87,7 +85,7 @@ func (router *Router) getFeed(w http.ResponseWriter, r *http.Request) {
 	render.JSON(w, r, items)
 }
 
-func Mount(instances []plugin.Instance, clustersClient clusters.Client) (chi.Router, error) {
+func Mount(instances []plugin.Instance) (chi.Router, error) {
 	var rssInstances []instance.Instance
 
 	for _, i := range instances {
@@ -102,9 +100,7 @@ func Mount(instances []plugin.Instance, clustersClient clusters.Client) (chi.Rou
 		rssInstances,
 	}
 
-	proxy := pluginproxy.New(clustersClient)
-
-	router.With(proxy).Get("/feed", router.getFeed)
+	router.Get("/feed", router.getFeed)
 
 	return router, nil
 }

--- a/pkg/plugins/rss/router_test.go
+++ b/pkg/plugins/rss/router_test.go
@@ -117,7 +117,7 @@ func TestGetFeed(t *testing.T) {
 }
 
 func TestMount(t *testing.T) {
-	router, err := Mount([]plugin.Instance{{Name: "rss"}}, nil)
+	router, err := Mount([]plugin.Instance{{Name: "rss"}})
 	require.NoError(t, err)
 	require.NotNil(t, router)
 }

--- a/pkg/plugins/rss/rss.go
+++ b/pkg/plugins/rss/rss.go
@@ -21,9 +21,9 @@ func (p *Plugin) Type() string {
 }
 
 func (p *Plugin) MountCluster(instances []plugin.Instance, kubernetesClient kubernetes.Client) (chi.Router, error) {
-	return Mount(instances, nil)
+	return nil, nil
 }
 
 func (p *Plugin) MountHub(instances []plugin.Instance, clustersClient clusters.Client, dbClient db.Client) (chi.Router, error) {
-	return Mount(instances, clustersClient)
+	return Mount(instances)
 }

--- a/pkg/plugins/rss/rss_test.go
+++ b/pkg/plugins/rss/rss_test.go
@@ -18,10 +18,10 @@ func TestType(t *testing.T) {
 func TestMountCluster(t *testing.T) {
 	p := New()
 
-	t.Run("should return router", func(t *testing.T) {
+	t.Run("should return nil", func(t *testing.T) {
 		router, err := p.MountCluster(nil, nil)
 		require.NoError(t, err)
-		require.NotNil(t, router)
+		require.Nil(t, router)
 	})
 }
 

--- a/pkg/plugins/signalsciences/router.go
+++ b/pkg/plugins/signalsciences/router.go
@@ -4,12 +4,10 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/kobsio/kobs/pkg/hub/clusters"
 	"github.com/kobsio/kobs/pkg/instrument/log"
 	"github.com/kobsio/kobs/pkg/plugins/plugin"
 	"github.com/kobsio/kobs/pkg/plugins/signalsciences/instance"
 	"github.com/kobsio/kobs/pkg/utils/middleware/errresponse"
-	"github.com/kobsio/kobs/pkg/utils/middleware/pluginproxy"
 	"github.com/signalsciences/go-sigsci"
 
 	"github.com/go-chi/chi/v5"
@@ -134,7 +132,7 @@ func (router *Router) getRequests(w http.ResponseWriter, r *http.Request) {
 	render.JSON(w, r, data)
 }
 
-func Mount(instances []plugin.Instance, clustersClient clusters.Client) (chi.Router, error) {
+func Mount(instances []plugin.Instance) (chi.Router, error) {
 	var signalSciencesInstances []instance.Instance
 
 	for _, i := range instances {
@@ -151,12 +149,10 @@ func Mount(instances []plugin.Instance, clustersClient clusters.Client) (chi.Rou
 		signalSciencesInstances,
 	}
 
-	proxy := pluginproxy.New(clustersClient)
-
-	router.With(proxy).Get("/overview", router.getOverview)
-	router.With(proxy).Get("/sites", router.getSites)
-	router.With(proxy).Get("/agents", router.getAgents)
-	router.With(proxy).Get("/requests", router.getRequests)
+	router.Get("/overview", router.getOverview)
+	router.Get("/sites", router.getSites)
+	router.Get("/agents", router.getAgents)
+	router.Get("/requests", router.getRequests)
 
 	return router, nil
 }

--- a/pkg/plugins/signalsciences/router_test.go
+++ b/pkg/plugins/signalsciences/router_test.go
@@ -266,13 +266,13 @@ func TestGetRequests(t *testing.T) {
 
 func TestMount(t *testing.T) {
 	t.Run("should return error for invalid options", func(t *testing.T) {
-		router, err := Mount([]plugin.Instance{{Name: "signalsciences", Options: map[string]any{"corpName": []string{"test"}}}}, nil)
+		router, err := Mount([]plugin.Instance{{Name: "signalsciences", Options: map[string]any{"corpName": []string{"test"}}}})
 		require.Error(t, err)
 		require.Nil(t, router)
 	})
 
 	t.Run("should return router", func(t *testing.T) {
-		router, err := Mount([]plugin.Instance{{Name: "signalsciences"}}, nil)
+		router, err := Mount([]plugin.Instance{{Name: "signalsciences"}})
 		require.NoError(t, err)
 		require.NotNil(t, router)
 	})

--- a/pkg/plugins/signalsciences/signalsciences.go
+++ b/pkg/plugins/signalsciences/signalsciences.go
@@ -21,9 +21,9 @@ func (p *Plugin) Type() string {
 }
 
 func (p *Plugin) MountCluster(instances []plugin.Instance, kubernetesClient kubernetes.Client) (chi.Router, error) {
-	return Mount(instances, nil)
+	return nil, nil
 }
 
 func (p *Plugin) MountHub(instances []plugin.Instance, clustersClient clusters.Client, dbClient db.Client) (chi.Router, error) {
-	return Mount(instances, clustersClient)
+	return Mount(instances)
 }

--- a/pkg/plugins/signalsciences/signalsciences_test.go
+++ b/pkg/plugins/signalsciences/signalsciences_test.go
@@ -18,10 +18,10 @@ func TestType(t *testing.T) {
 func TestMountCluster(t *testing.T) {
 	p := New()
 
-	t.Run("should return router", func(t *testing.T) {
+	t.Run("should return nil", func(t *testing.T) {
 		router, err := p.MountCluster(nil, nil)
 		require.NoError(t, err)
-		require.NotNil(t, router)
+		require.Nil(t, router)
 	})
 }
 

--- a/pkg/plugins/sonarqube/router.go
+++ b/pkg/plugins/sonarqube/router.go
@@ -3,12 +3,10 @@ package sonarqube
 import (
 	"net/http"
 
-	"github.com/kobsio/kobs/pkg/hub/clusters"
 	"github.com/kobsio/kobs/pkg/instrument/log"
 	"github.com/kobsio/kobs/pkg/plugins/plugin"
 	"github.com/kobsio/kobs/pkg/plugins/sonarqube/instance"
 	"github.com/kobsio/kobs/pkg/utils/middleware/errresponse"
-	"github.com/kobsio/kobs/pkg/utils/middleware/pluginproxy"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
@@ -86,7 +84,7 @@ func (router *Router) getProjectMeasures(w http.ResponseWriter, r *http.Request)
 	render.JSON(w, r, projectMeasures)
 }
 
-func Mount(instances []plugin.Instance, clustersClient clusters.Client) (chi.Router, error) {
+func Mount(instances []plugin.Instance) (chi.Router, error) {
 	var sonarqubeInstances []instance.Instance
 
 	for _, i := range instances {
@@ -102,10 +100,8 @@ func Mount(instances []plugin.Instance, clustersClient clusters.Client) (chi.Rou
 		sonarqubeInstances,
 	}
 
-	proxy := pluginproxy.New(clustersClient)
-
-	router.With(proxy).Get("/projects", router.getProjects)
-	router.With(proxy).Get("/projectmeasures", router.getProjectMeasures)
+	router.Get("/projects", router.getProjects)
+	router.Get("/projectmeasures", router.getProjectMeasures)
 
 	return router, nil
 }

--- a/pkg/plugins/sonarqube/router_test.go
+++ b/pkg/plugins/sonarqube/router_test.go
@@ -158,13 +158,13 @@ func TestGetProjectMeasures(t *testing.T) {
 
 func TestMount(t *testing.T) {
 	t.Run("should return error for invalid instance", func(t *testing.T) {
-		router, err := Mount([]plugin.Instance{{Name: "sonarqube", Options: map[string]any{"address": []string{"localhost"}}}}, nil)
+		router, err := Mount([]plugin.Instance{{Name: "sonarqube", Options: map[string]any{"address": []string{"localhost"}}}})
 		require.Error(t, err)
 		require.Nil(t, router)
 	})
 
 	t.Run("should work", func(t *testing.T) {
-		router, err := Mount([]plugin.Instance{{Name: "sonarqube"}}, nil)
+		router, err := Mount([]plugin.Instance{{Name: "sonarqube"}})
 		require.NoError(t, err)
 		require.NotNil(t, router)
 	})

--- a/pkg/plugins/sonarqube/sonarqube.go
+++ b/pkg/plugins/sonarqube/sonarqube.go
@@ -21,9 +21,9 @@ func (p *Plugin) Type() string {
 }
 
 func (p *Plugin) MountCluster(instances []plugin.Instance, kubernetesClient kubernetes.Client) (chi.Router, error) {
-	return Mount(instances, nil)
+	return nil, nil
 }
 
 func (p *Plugin) MountHub(instances []plugin.Instance, clustersClient clusters.Client, dbClient db.Client) (chi.Router, error) {
-	return Mount(instances, clustersClient)
+	return Mount(instances)
 }

--- a/pkg/plugins/sonarqube/sonarqube_test.go
+++ b/pkg/plugins/sonarqube/sonarqube_test.go
@@ -18,10 +18,10 @@ func TestType(t *testing.T) {
 func TestMountCluster(t *testing.T) {
 	p := New()
 
-	t.Run("should return router", func(t *testing.T) {
+	t.Run("should return nil", func(t *testing.T) {
 		router, err := p.MountCluster(nil, nil)
 		require.NoError(t, err)
-		require.NotNil(t, router)
+		require.Nil(t, router)
 	})
 }
 


### PR DESCRIPTION
The "MountCluster" and "MountHub" function can now return "nil" for the router. This way we do not have to specify a not found route when the plugin can not be used within a "cluster" or "hub".

The following plugin were also adjusted, so that they can only be used within the "hub":

- Harbor
- Opsgenie
- RSS
- SignalSciences
- SonarQube

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
