### PR TITLE
[core] Add Plugin Permission Check

### DIFF
--- a/app/packages/core/src/components/plugins/PluginsPage.test.tsx
+++ b/app/packages/core/src/components/plugins/PluginsPage.test.tsx
@@ -32,6 +32,12 @@ describe('PluginsPage', () => {
     return waitFor(() => screen.getByText(/A list of all available plugins/)).then(() => result);
   };
 
+  it('should render info when no plugins were found', async () => {
+    await render([]);
+
+    expect(screen.getByText(/No plugins were found/)).toBeInTheDocument();
+  });
+
   it('should render all plugins', async () => {
     await render([
       {

--- a/app/packages/core/src/components/plugins/PluginsPage.tsx
+++ b/app/packages/core/src/components/plugins/PluginsPage.tsx
@@ -1,6 +1,8 @@
 import { CheckBox, CheckBoxOutlineBlank, Clear, Extension, Search } from '@mui/icons-material';
 import {
+  Alert,
   Box,
+  Button,
   Card,
   CardActionArea,
   CardContent,
@@ -86,10 +88,13 @@ const PluginsPage: FunctionComponent = () => {
   const items = filteredItems.slice((options.page - 1) * options.perPage, options.page * options.perPage);
 
   /**
-   * `useEffect` is used to persist the options, when they are changed by a user.
+   * `useEffect` is used to persist the options, when they are changed by a user and to update the `searchTerm` state.
+   * The `searchTerm` state update is required, because we have to update the search term in the search field, when a
+   * user clicks on the "RESET FILTERS" button.
    */
   useEffect(() => {
     setPersistedOptions(options);
+    setSearchTerm(options.searchTerm ?? '');
   }, [options, setPersistedOptions]);
 
   return (
@@ -165,61 +170,88 @@ const PluginsPage: FunctionComponent = () => {
         </Toolbar>
       }
     >
-      <Grid container={true} spacing={6}>
-        <Grid item={true} xs={12} lg={12}>
+      {items.length === 0 ? (
+        <Alert
+          severity="info"
+          action={
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() =>
+                setOptions({
+                  clusters: [],
+                  page: 1,
+                  perPage: 10,
+                  pluginTypes: [],
+                  searchTerm: '',
+                })
+              }
+            >
+              RESET FILTERS
+            </Button>
+          }
+        >
+          No plugins were found
+        </Alert>
+      ) : (
+        <>
           <Grid container={true} spacing={6}>
-            {items.map((item) => (
-              <Grid key={item.id} item={true} xs={12} sm={6} md={3} lg={3} xl={3}>
-                <Card>
-                  <CardActionArea component={Link} to={`./${item.cluster}/${item.type}/${item.name}`}>
-                    <CardContent sx={{ p: 6 }}>
-                      {((instance: IPluginInstance) => {
-                        const plugin = getPlugin(instance.type);
-                        const icon = plugin?.icon;
+            <Grid item={true} xs={12} lg={12}>
+              <Grid container={true} spacing={6}>
+                {items.map((item) => (
+                  <Grid key={item.id} item={true} xs={12} sm={6} md={3} lg={3} xl={3}>
+                    <Card>
+                      <CardActionArea component={Link} to={`./${item.cluster}/${item.type}/${item.name}`}>
+                        <CardContent sx={{ p: 6 }}>
+                          {((instance: IPluginInstance) => {
+                            const plugin = getPlugin(instance.type);
+                            const icon = plugin?.icon;
 
-                        return (
-                          <Stack spacing={8}>
-                            <Stack direction="row" justifyContent="center">
-                              {!icon ? (
-                                <Extension sx={{ fontSize: 64 }} />
-                              ) : (
-                                <CardMedia
-                                  sx={{ height: 64, width: 64 }}
-                                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                                  image={icon as any}
-                                  title={`${instance.name}-icon`}
-                                />
-                              )}
-                            </Stack>
-                            <Box textAlign="center">
-                              <Typography variant="h6">{item.name}</Typography>
-                              <Typography variant="caption" color="text.secondary">
-                                ({item.cluster} / {item.type})
-                              </Typography>
-                            </Box>
-                            <Typography textAlign="center">
-                              {item.description ? item.description : plugin?.description}
-                            </Typography>
-                          </Stack>
-                        );
-                      })(item)}
-                    </CardContent>
-                  </CardActionArea>
-                </Card>
+                            return (
+                              <Stack spacing={8}>
+                                <Stack direction="row" justifyContent="center">
+                                  {!icon ? (
+                                    <Extension sx={{ fontSize: 64 }} />
+                                  ) : (
+                                    <CardMedia
+                                      sx={{ height: 64, width: 64 }}
+                                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                                      image={icon as any}
+                                      title={`${instance.name}-icon`}
+                                    />
+                                  )}
+                                </Stack>
+                                <Box textAlign="center">
+                                  <Typography variant="h6">{item.name}</Typography>
+                                  <Typography variant="caption" color="text.secondary">
+                                    ({item.cluster} / {item.type})
+                                  </Typography>
+                                </Box>
+                                <Typography textAlign="center">
+                                  {item.description ? item.description : plugin?.description}
+                                </Typography>
+                              </Stack>
+                            );
+                          })(item)}
+                        </CardContent>
+                      </CardActionArea>
+                    </Card>
+                  </Grid>
+                ))}
               </Grid>
-            ))}
+            </Grid>
           </Grid>
-        </Grid>
-      </Grid>
 
-      <Pagination
-        page={options.page}
-        perPage={options.perPage}
-        count={filteredItems.length}
-        handleChange={(page, perPage) =>
-          setOptions((prevOptions) => ({ ...prevOptions, page: page, perPage: perPage }))
-        }
-      />
+          <Pagination
+            page={options.page}
+            perPage={options.perPage}
+            count={filteredItems.length}
+            handleChange={(page, perPage) =>
+              setOptions((prevOptions) => ({ ...prevOptions, page: page, perPage: perPage }))
+            }
+          />
+        </>
+      )}
     </Page>
   );
 };

--- a/app/packages/flux/src/components/ResourceActions.tsx
+++ b/app/packages/flux/src/components/ResourceActions.tsx
@@ -1,4 +1,4 @@
-import { APIContext, APIError, IAPIContext } from '@kobsio/core';
+import { APIContext, APIError, IAPIContext, IPluginInstance } from '@kobsio/core';
 import { Refresh as SyncIcon, Pause as SuspendIcon, PlayArrow as ResumeIcon, MoreVert } from '@mui/icons-material';
 import { LoadingButton } from '@mui/lab';
 import {
@@ -56,11 +56,12 @@ const getJSONPatch = (manifest: any, action: TAction): any => {
 const Sync: FunctionComponent<{
   cluster: string;
   fluxResource: IFluxResource;
+  instance: IPluginInstance;
   name: string;
   namespace: string;
   onClose: (message: string, severity: 'success' | 'error') => void;
   open: boolean;
-}> = ({ fluxResource, cluster, namespace, name, open, onClose }) => {
+}> = ({ instance, fluxResource, cluster, namespace, name, open, onClose }) => {
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
   const apiContext = useContext<IAPIContext>(APIContext);
@@ -80,6 +81,7 @@ const Sync: FunctionComponent<{
         {
           headers: {
             'x-kobs-cluster': cluster,
+            'x-kobs-plugin': instance.name,
           },
         },
       );
@@ -199,7 +201,7 @@ const SuspendResume: FunctionComponent<{
           variant="contained"
           color="primary"
           size="small"
-          startIcon={<SyncIcon />}
+          startIcon={action === 'suspend' ? <SuspendIcon /> : <ResumeIcon />}
           loading={isLoading}
           loadingPosition="start"
           onClick={handleSuspendResume}
@@ -225,6 +227,7 @@ const SuspendResume: FunctionComponent<{
 const ResourceActions: FunctionComponent<{
   cluster: string;
   fluxResource: IFluxResource;
+  instance: IPluginInstance;
   isDrawerAction?: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   manifest: any;
@@ -233,7 +236,18 @@ const ResourceActions: FunctionComponent<{
   path: string;
   refetch: () => void;
   resource: string;
-}> = ({ fluxResource, cluster, namespace, name, manifest, resource, path, refetch, isDrawerAction = false }) => {
+}> = ({
+  instance,
+  fluxResource,
+  cluster,
+  namespace,
+  name,
+  manifest,
+  resource,
+  path,
+  refetch,
+  isDrawerAction = false,
+}) => {
   const [message, setMessage] = useState<{ message: string; severity: 'success' | 'error' }>();
   const [action, setAction] = useState<TAction>('');
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -326,6 +340,7 @@ const ResourceActions: FunctionComponent<{
 
       {action === 'sync' && (
         <Sync
+          instance={instance}
           fluxResource={fluxResource}
           cluster={cluster}
           namespace={namespace}

--- a/app/packages/flux/src/components/ResourceDetails.tsx
+++ b/app/packages/flux/src/components/ResourceDetails.tsx
@@ -74,6 +74,7 @@ const ResourceDetails: FunctionComponent<{
       subtitle={namespace ? `(${cluster} / ${namespace})` : `(${cluster})`}
       actions={
         <ResourceActions
+          instance={instance}
           fluxResource={fluxResource}
           cluster={cluster}
           namespace={namespace}

--- a/app/packages/flux/src/components/Resources.tsx
+++ b/app/packages/flux/src/components/Resources.tsx
@@ -169,6 +169,7 @@ const ResourceRow: FunctionComponent<{
         ))}
         <TableCell>
           <ResourceActions
+            instance={instance}
             fluxResource={fluxResource}
             cluster={row.cells[2]}
             namespace={row.cells[1]}

--- a/app/packages/helm/src/components/History.tsx
+++ b/app/packages/helm/src/components/History.tsx
@@ -67,6 +67,7 @@ const History: FunctionComponent<{
         {
           headers: {
             'x-kobs-cluster': cluster,
+            'x-kobs-plugin': instance.name,
           },
         },
       );

--- a/app/packages/helm/src/components/Releases.tsx
+++ b/app/packages/helm/src/components/Releases.tsx
@@ -73,6 +73,7 @@ const Releases: FunctionComponent<{
         const tmpReleases = await apiContext.client.get<IRelease[]>(`/api/plugins/helm/releases?${n}`, {
           headers: {
             'x-kobs-cluster': cluster,
+            'x-kobs-plugin': instance.name,
           },
         });
         if (tmpReleases) {

--- a/pkg/hub/plugins/helpers.go
+++ b/pkg/hub/plugins/helpers.go
@@ -1,7 +1,12 @@
 package plugins
 
 import (
+	"net/http"
+	"strings"
+
+	authContext "github.com/kobsio/kobs/pkg/hub/auth/context"
 	"github.com/kobsio/kobs/pkg/plugins/plugin"
+	"github.com/kobsio/kobs/pkg/utils/middleware/errresponse"
 )
 
 // filterInstances only returns the plugin instances, which have the specified type.
@@ -15,4 +20,27 @@ func filterInstances(pluginType string, instances []plugin.Instance) []plugin.In
 	}
 
 	return filteredInstances
+}
+
+func permissionHandler(next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/plugins" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		user := authContext.MustGetUser(r.Context())
+		cluster := r.Header.Get("x-kobs-cluster")
+		name := r.Header.Get("x-kobs-plugin")
+		plugin := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/plugins/"), "/")[0]
+
+		if !user.HasPluginAccess(cluster, plugin, name) {
+			errresponse.Render(w, r, http.StatusForbidden, "You don't have access to this plugin.")
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	}
+
+	return http.HandlerFunc(fn)
 }


### PR DESCRIPTION
This commit re-adds the permission check for plugins. We already checked if a user is allowed to access a plugin in former versions of kobs, but the check was migrated to the new plugin architecture yet. With this change the permission check is now also present in the new version and only allows users with the correct rights to access a plugin.

This commit also adjusts the Flux and Helm plugin to correctly use the permissions set for a user. Some parts of the Flux plugin can also be used without access to the plugin, because the "/api/resources" endpoint is used, for these requests the user must have the permissions to view resources on the mentioned "/api/resources" endpoint.

Last but not least the plugins returned by our API are now filtered before returned, so that a user only sees the plugins he has access to in the frontend.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
