### PR TITLE
[core] Improve Padding for Plugin Panels

### DIFF
--- a/app/packages/core/src/components/applications/ApplicationGroupsPanel.tsx
+++ b/app/packages/core/src/components/applications/ApplicationGroupsPanel.tsx
@@ -275,10 +275,10 @@ const ApplicationGroupsPanelInternal: FunctionComponent<IApplicationGroupsPanelI
       refetch={refetch}
     >
       <List sx={{ bgcolor: 'background.paper' }} disablePadding={true}>
-        {data?.map((application) => (
+        {data?.map((application, index) => (
           <Fragment key={`${application?.id?.cluster}-${application?.id?.namespace}-${application?.id?.name}`}>
             <ApplicationGroup groups={groups} application={application} />
-            <Divider component="li" />
+            {index + 1 !== data?.length && <Divider component="li" />}
           </Fragment>
         ))}
       </List>

--- a/app/packages/core/src/components/utils/PluginPanel.tsx
+++ b/app/packages/core/src/components/utils/PluginPanel.tsx
@@ -45,26 +45,35 @@ export const PluginPanel: FunctionComponent<IPluginPanelProps> = ({ title, descr
   }
 
   return (
-    <Card sx={{ height: gridContext.autoHeight ? undefined : '100%', p: 4, width: '100%' }}>
-      <Stack sx={{ pb: 2 }} direction="row" justifyContent="space-between" alignItems="center">
-        <Tooltip title={description}>
-          <Typography noWrap={true} variant="subtitle2">
-            <strong>{title}</strong>
-          </Typography>
-        </Tooltip>
+    <Card
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        flexWrap: 'nowrap',
+        height: gridContext.autoHeight ? undefined : '100%',
+        p: 4,
+        width: '100%',
+      }}
+    >
+      <Box sx={{ flexShrink: 0, pb: 2 }}>
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Tooltip title={description}>
+            <Typography noWrap={true} variant="subtitle2">
+              <strong>{title}</strong>
+            </Typography>
+          </Tooltip>
 
-        {actions && <Box pl={6}>{actions}</Box>}
-      </Stack>
+          {actions && <Box pl={6}>{actions}</Box>}
+        </Stack>
+      </Box>
 
       <Box
         sx={{
           '&::-webkit-scrollbar': {
             display: 'none',
           },
-          height: '100%',
+          flexGrow: 1,
           overflowY: 'auto',
-          pb: 4,
-          width: '100%',
         }}
       >
         {children}

--- a/app/packages/prometheus/src/components/PrometheusPanel.tsx
+++ b/app/packages/prometheus/src/components/PrometheusPanel.tsx
@@ -18,7 +18,7 @@ import {
 import { Box, Stack, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, useTheme } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { FunctionComponent, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { VictoryArea, VictoryChart, VictoryGroup } from 'victory';
+import { VictoryArea, VictoryGroup } from 'victory';
 
 import Chart from './Chart';
 import Legend from './Legend';
@@ -108,6 +108,7 @@ const PrometheusSparkline: FunctionComponent<{
   value: string | undefined;
 }> = ({ queries, metrics, times, unit, mappings, value }) => {
   const theme = useTheme();
+  const gridContext = useContext<IGridContext>(GridContext);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const dimensions = useDimensions(wrapperRef);
 
@@ -140,32 +141,31 @@ const PrometheusSparkline: FunctionComponent<{
   }
 
   return (
-    <div style={{ height: '100%', position: 'relative' }}>
-      <div style={{ height: '100%', width: '100%' }} ref={wrapperRef}>
+    <div style={{ height: gridContext.autoHeight ? '150px' : 'calc(100% - 5px)', position: 'relative' }}>
+      <div style={{ height: gridContext.autoHeight ? '145px' : '100%', width: '100%' }} ref={wrapperRef}>
         {dimensions.height > 0 && (
-          <VictoryChart
-            height={dimensions.height - 24}
+          <VictoryGroup
+            color={theme.palette.primary.main}
+            height={dimensions.height}
             padding={{ bottom: 0, left: 0, right: 0, top: 0 }}
             scale={{ x: 'time', y: 'linear' }}
             width={dimensions.width}
             domain={{ x: [new Date(times.timeStart * 1000), new Date(times.timeEnd * 1000)] }}
           >
-            <VictoryGroup color={theme.palette.primary.main}>
-              {metrics.length > 0 && (
-                <VictoryArea
-                  key={metrics[0].label}
-                  data={metrics[0].data}
-                  name={metrics[0].label}
-                  interpolation="monotoneX"
-                  style={{
-                    data: {
-                      fillOpacity: 0.5,
-                    },
-                  }}
-                />
-              )}
-            </VictoryGroup>
-          </VictoryChart>
+            {metrics.length > 0 && (
+              <VictoryArea
+                key={metrics[0].label}
+                data={metrics[0].data}
+                name={metrics[0].label}
+                interpolation="monotoneX"
+                style={{
+                  data: {
+                    fillOpacity: 0.5,
+                  },
+                }}
+              />
+            )}
+          </VictoryGroup>
         )}
       </div>
       {dimensions.height > 0 && (
@@ -174,7 +174,7 @@ const PrometheusSparkline: FunctionComponent<{
             fontSize: '24px',
             position: 'absolute',
             textAlign: 'center',
-            top: `${(dimensions.height - 24) / 2}px`,
+            top: `${dimensions.height / 2}px`,
             width: '100%',
           }}
         >
@@ -243,7 +243,11 @@ const PrometheusChart: FunctionComponent<{
         <Stack direction="column" spacing={2}>
           <Box
             height={
-              gridContext.autoHeight ? '350px' : legend === 'table' ? dimensions.height - 80 : dimensions.height - 16
+              gridContext.autoHeight
+                ? `${350 - 8}px`
+                : legend === 'table'
+                ? dimensions.height - 80 - 8
+                : dimensions.height - 8
             }
           >
             <Chart
@@ -268,7 +272,6 @@ const PrometheusChart: FunctionComponent<{
                   display: 'none',
                 },
                 overflowY: 'auto',
-                pb: gridContext.autoHeight ? 0 : 6,
               }}
             >
               <Legend


### PR DESCRIPTION
The padding applied to the content of a plugin panel was missing when the provided content was scrollable, this is now fixed, so that there is always a bottom padding for the panels, so that the look better within a dashboard.

Because of the changes in the PluginPanel component, we also had to adjust the Prometheus Plugin so that there is no scrolling in scrolling applied to the charts.

This commit also fixes the applications group panel, where the divider was also rendered after the last element in the list, which was not intended, so that the last divider is now removed.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
