### PR TITLE
[kiali] Fix package.json

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -16977,12 +16977,16 @@
       "name": "@kobsio/kiali",
       "version": "0.0.0",
       "dependencies": {
-        "react-virtuoso": "^4.1.0"
+        "cytoscape": "^3.23.0",
+        "cytoscape-dagre": "^2.5.0",
+        "cytoscape-node-html-label": "^1.2.2"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^14.4.3",
+        "@types/cytoscape": "^3.19.9",
+        "@types/cytoscape-dagre": "^2.3.0",
         "@types/node": "^14.18.36",
         "@types/react": "^18.0.27",
         "@types/react-dom": "^18.0.10",

--- a/app/packages/kiali/package.json
+++ b/app/packages/kiali/package.json
@@ -38,6 +38,8 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
+    "@types/cytoscape": "^3.19.9",
+    "@types/cytoscape-dagre": "^2.3.0",
     "@types/node": "^14.18.36",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
@@ -52,6 +54,8 @@
     "vitest": "^0.28.4"
   },
   "dependencies": {
-    "react-virtuoso": "^4.1.0"
+    "cytoscape": "^3.23.0",
+    "cytoscape-dagre": "^2.5.0",
+    "cytoscape-node-html-label": "^1.2.2"
   }
 }


### PR DESCRIPTION
Fix the package.json file for the Kiali plugin. The cytoscape packages were missing as dependencies and the react-virtuoso package is not required for the plugin.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
