### PR TITLE
[jaeger] Add Flamegraph

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -4028,6 +4028,17 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@pyroscope/flamegraph": {
+      "version": "0.35.5",
+      "resolved": "https://registry.npmjs.org/@pyroscope/flamegraph/-/flamegraph-0.35.5.tgz",
+      "integrity": "sha512-UkMoUEA9yDfCb81K3MST/hL3aMrm+M5zrpEEjAf5mmZx9kL+TmUjaejXJRO+YlJeRqvcSRglGmMtVnkQnxdZjw==",
+      "peerDependencies": {
+        "graphviz-react": "^1.2.5",
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0",
+        "true-myth": "^5.1.2"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.3.tgz",
@@ -6616,6 +6627,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-dispatch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==",
+      "peer": true
+    },
+    "node_modules/d3-drag": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.5.tgz",
+      "integrity": "sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==",
+      "peer": true,
+      "dependencies": {
+        "d3-dispatch": "1",
+        "d3-selection": "1"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
@@ -6631,6 +6658,56 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/d3-graphviz": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/d3-graphviz/-/d3-graphviz-2.6.1.tgz",
+      "integrity": "sha512-878AFSagQyr5tTOrM7YiVYeUC2/NoFcOB3/oew+LAML0xekyJSw9j3WOCUMBsc95KYe9XBYZ+SKKuObVya1tJQ==",
+      "peer": true,
+      "dependencies": {
+        "d3-dispatch": "^1.0.3",
+        "d3-format": "^1.2.0",
+        "d3-interpolate": "^1.1.5",
+        "d3-path": "^1.0.5",
+        "d3-selection": "^1.1.0",
+        "d3-timer": "^1.0.6",
+        "d3-transition": "^1.1.1",
+        "d3-zoom": "^1.5.0",
+        "viz.js": "^1.8.2"
+      }
+    },
+    "node_modules/d3-graphviz/node_modules/d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==",
+      "peer": true
+    },
+    "node_modules/d3-graphviz/node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==",
+      "peer": true
+    },
+    "node_modules/d3-graphviz/node_modules/d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "peer": true,
+      "dependencies": {
+        "d3-color": "1"
+      }
+    },
+    "node_modules/d3-graphviz/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "peer": true
+    },
+    "node_modules/d3-graphviz/node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==",
+      "peer": true
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
@@ -6665,6 +6742,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/d3-selection": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
+      "integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==",
+      "peer": true
     },
     "node_modules/d3-shape": {
       "version": "3.2.0",
@@ -6707,10 +6790,79 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-transition": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.3.2.tgz",
+      "integrity": "sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==",
+      "peer": true,
+      "dependencies": {
+        "d3-color": "1",
+        "d3-dispatch": "1",
+        "d3-ease": "1",
+        "d3-interpolate": "1",
+        "d3-selection": "^1.1.0",
+        "d3-timer": "1"
+      }
+    },
+    "node_modules/d3-transition/node_modules/d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==",
+      "peer": true
+    },
+    "node_modules/d3-transition/node_modules/d3-ease": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==",
+      "peer": true
+    },
+    "node_modules/d3-transition/node_modules/d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "peer": true,
+      "dependencies": {
+        "d3-color": "1"
+      }
+    },
+    "node_modules/d3-transition/node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==",
+      "peer": true
+    },
     "node_modules/d3-voronoi": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
       "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg=="
+    },
+    "node_modules/d3-zoom": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.8.3.tgz",
+      "integrity": "sha512-VoLXTK4wvy1a0JpH2Il+F2CiOhVu7VRXWF5M/LroMIh3/zBAC3WAt7QoIvPibOavVo20hN6/37vwAsdBejLyKQ==",
+      "peer": true,
+      "dependencies": {
+        "d3-dispatch": "1",
+        "d3-drag": "1",
+        "d3-interpolate": "1",
+        "d3-selection": "1",
+        "d3-transition": "1"
+      }
+    },
+    "node_modules/d3-zoom/node_modules/d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==",
+      "peer": true
+    },
+    "node_modules/d3-zoom/node_modules/d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "peer": true,
+      "dependencies": {
+        "d3-color": "1"
+      }
     },
     "node_modules/dagre": {
       "version": "0.8.5",
@@ -8960,6 +9112,21 @@
       "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
       "dependencies": {
         "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/graphviz-react": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/graphviz-react/-/graphviz-react-1.2.5.tgz",
+      "integrity": "sha512-IRFDzEt09hRzfqrrvAW1PAPBqG4t8hykArcoxq7UhEqO5RUKCBN6126D6rjiL2QAwAznbUSg0Fba2RnSH2V4sA==",
+      "peer": true,
+      "dependencies": {
+        "d3-graphviz": "^2.6.1"
+      },
+      "engines": {
+        "npm": ">= 8.3"
+      },
+      "peerDependencies": {
+        "react": ">= 16.13.1"
       }
     },
     "node_modules/gzip-size": {
@@ -15175,6 +15342,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/true-myth": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/true-myth/-/true-myth-5.4.0.tgz",
+      "integrity": "sha512-MonJqkJf+VOXZ2msbpvAI1uJWoyfCN7nirR8/fNK+IlFDWYNLb9iqeAc2uhIbAQBynHtM02azZgepQDQclOwAw==",
+      "peer": true,
+      "engines": {
+        "node": "12.* || 14.* || 16.* || >= 18.*"
+      }
+    },
     "node_modules/ts-morph": {
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-17.0.1.tgz",
@@ -16204,6 +16380,13 @@
         }
       }
     },
+    "node_modules/viz.js": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/viz.js/-/viz.js-1.8.2.tgz",
+      "integrity": "sha512-W+1+N/hdzLpQZEcvz79n2IgUE9pfx6JLdHh3Kh8RGvLL8P1LdJVQmi2OsDcLdY4QVID4OUy+FPelyerX0nJxIQ==",
+      "deprecated": "no longer supported",
+      "peer": true
+    },
     "node_modules/vscode-languageserver-textdocument": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
@@ -16934,6 +17117,7 @@
       "name": "@kobsio/jaeger",
       "version": "0.0.0",
       "dependencies": {
+        "@pyroscope/flamegraph": "^0.35.5",
         "react-virtuoso": "^4.1.0"
       },
       "devDependencies": {

--- a/app/packages/app/src/main.tsx
+++ b/app/packages/app/src/main.tsx
@@ -19,6 +19,7 @@ import '@fontsource/roboto/500.css';
 import '@fontsource/roboto/700.css';
 
 import '@kobsio/core/dist/style.css';
+import '@kobsio/jaeger/dist/style.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <StrictMode>

--- a/app/packages/jaeger/package.json
+++ b/app/packages/jaeger/package.json
@@ -11,6 +11,9 @@
   "exports": {
     ".": {
       "import": "./dist/index.js"
+    },
+    "./dist/style.css": {
+      "import": "./dist/style.css"
     }
   },
   "scripts": {
@@ -52,6 +55,7 @@
     "vitest": "^0.28.4"
   },
   "dependencies": {
+    "@pyroscope/flamegraph": "^0.35.5",
     "react-virtuoso": "^4.1.0"
   }
 }

--- a/app/packages/jaeger/src/components/Flamegraph.tsx
+++ b/app/packages/jaeger/src/components/Flamegraph.tsx
@@ -1,0 +1,25 @@
+import { IPluginInstance } from '@kobsio/core';
+import { FlamegraphRenderer, convertJaegerTraceToProfile } from '@pyroscope/flamegraph';
+import { FunctionComponent } from 'react';
+
+import '@pyroscope/flamegraph/dist/index.css';
+
+import { ITrace } from '../utils/utils';
+
+export const Flamegraph: FunctionComponent<{
+  colors: Record<string, string>;
+  instance: IPluginInstance;
+  trace: ITrace;
+}> = ({ instance, colors, trace }) => {
+  const convertedProfile = convertJaegerTraceToProfile(trace);
+
+  return (
+    <FlamegraphRenderer
+      colorMode="dark"
+      profile={convertedProfile}
+      showToolbar={false}
+      showCredit={false}
+      onlyDisplay="flamegraph"
+    />
+  );
+};

--- a/app/packages/jaeger/src/components/JaegerPanel.tsx
+++ b/app/packages/jaeger/src/components/JaegerPanel.tsx
@@ -200,11 +200,24 @@ const JaegerPanel: FunctionComponent<IPluginPanelProps<IOptions>> = ({
       description={description}
       message="Invalid options for Jaeger plugin"
       details="One of the required options is missing."
-      example={`plugin:
+      example={`# View a list of traces
+plugin:
   name: jaeger
   type: jaeger
   options:
-    project: myproject`}
+    showChart: true
+    queries:
+      - name: All Requests
+        service: productpage.bookinfo
+# View the metrics of a service
+plugin:
+  name: jaeger
+  type: jaeger
+  options:
+    metrics:
+      # The type must be "servicelatency", "serviceerrors", "servicecalls" or "operations".
+      type: servicelatency
+      service: productpage.bookinfo`}
       documentation="https://kobs.io/main/plugins/jaeger"
     />
   );

--- a/app/packages/jaeger/src/components/Traces.tsx
+++ b/app/packages/jaeger/src/components/Traces.tsx
@@ -17,6 +17,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Fragment, FunctionComponent, useContext, useMemo, useRef, useState } from 'react';
 import { VictoryChart, VictoryAxis, VictoryVoronoiContainer, VictoryScatter } from 'victory';
 
+import { Flamegraph } from './Flamegraph';
 import { Spans } from './Spans';
 import { TraceActions } from './Trace';
 
@@ -36,6 +37,8 @@ const TraceDetails: FunctionComponent<{
   open: boolean;
   trace: ITrace;
 }> = ({ instance, colors, trace, open, onClose }) => {
+  const [view, setView] = useState<'timeline' | 'flamegraph'>('timeline');
+
   return (
     <DetailsDrawer
       size="large"
@@ -43,7 +46,7 @@ const TraceDetails: FunctionComponent<{
       onClose={onClose}
       title={trace.traceName}
       subtitle={trace.traceID}
-      actions={<TraceActions instance={instance} trace={trace} isDrawerAction={true} />}
+      actions={<TraceActions instance={instance} trace={trace} view={view} setView={setView} isDrawerAction={true} />}
     >
       <>
         <span>
@@ -80,7 +83,11 @@ const TraceDetails: FunctionComponent<{
         </span>
 
         <Box sx={{ bgcolor: 'background.paper', height: 'calc(100vh - 64px - 48px - 8px)', mt: 4, p: 4 }}>
-          <Spans instance={instance} colors={colors} trace={trace} />
+          {view === 'timeline' ? (
+            <Spans instance={instance} colors={colors} trace={trace} />
+          ) : (
+            <Flamegraph instance={instance} colors={colors} trace={trace} />
+          )}
         </Box>
       </>
     </DetailsDrawer>
@@ -120,7 +127,7 @@ const Trace: FunctionComponent<{ colors: Record<string, string>; instance: IPlug
             <Stack direction="row" justifyContent="space-between">
               <Stack direction="row" spacing={4}>
                 <Chip size="small" label={`${trace.spans.length} Span${trace.spans.length !== 1 ? 's' : ''}`} />
-                <Stack direction="row" spacing={2}>
+                <Box sx={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', gap: 2 }}>
                   {trace.services.map((service, index) => (
                     <Chip
                       key={index}
@@ -129,9 +136,11 @@ const Trace: FunctionComponent<{ colors: Record<string, string>; instance: IPlug
                       label={`${service.name} (${service.numberOfSpans})`}
                     />
                   ))}
-                </Stack>
+                </Box>
               </Stack>
-              <Box>{formatTraceTime(trace.startTime)}</Box>
+              <Box>
+                <Typography noWrap={true}>{formatTraceTime(trace.startTime)}</Typography>
+              </Box>
             </Stack>
           }
         />


### PR DESCRIPTION
Add flamegraph visualization for graphs, this means a user can now switch between the timeline and flamegraph visualization via the trace actions. Similar to the official Jaeger UI we are using the "@pyroscope/flamegraph" package to render the flamegraph.

This commit also fixes a small bug in the traces view, when a trace contains a lot of services, which are now displayed on multiple lines to avoid the horizontal scrolling.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
