### PR TITLE
[core] Fix Sizing of MUIEditor Component

### DIFF
--- a/app/packages/core/src/components/utils/editor/Editor.tsx
+++ b/app/packages/core/src/components/utils/editor/Editor.tsx
@@ -1,4 +1,5 @@
 import MonacoEditorReact, { Monaco } from '@monaco-editor/react';
+import { Box } from '@mui/material';
 import * as monaco from 'monaco-editor';
 import { FunctionComponent, useState } from 'react';
 
@@ -28,6 +29,20 @@ export const Editor: FunctionComponent<IEditorProps> = ({ language, readOnly = f
     monaco.editor.defineTheme('nord', nordTheme);
   };
 
+  const handleOnMount = (editor: monaco.editor.IStandaloneCodeEditor, monaco: Monaco) => {
+    editor.addCommand(monaco.KeyCode.F1, () => {
+      // Disable command pallete, by "stealing" its keybindings.
+      // See: https://github.com/microsoft/monaco-editor/issues/419
+    });
+
+    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyF, () => {
+      // Since the find action is "disabled" in the `MUIEditor` component we have to re-add the command here. If we
+      // wouldn't do this the find action would not work in the `Editor` component, after a user used the `MUIEditor`
+      // component.
+      editor.getAction('actions.find')?.run();
+    });
+  };
+
   return (
     <MonacoEditorReact
       theme="nord"
@@ -35,6 +50,7 @@ export const Editor: FunctionComponent<IEditorProps> = ({ language, readOnly = f
       language={language}
       value={value}
       beforeMount={handleBeforeMount}
+      onMount={handleOnMount}
       onChange={onChange}
       options={{
         fontFamily: 'monospace',
@@ -112,39 +128,55 @@ export const MUIEditor: FunctionComponent<IMUIEditorProps> = ({
   };
 
   return (
-    <MonacoEditorReact
-      theme="mui"
-      height={height}
-      language={language}
-      value={value}
-      beforeMount={handleBeforeMount}
-      onMount={handleOnMount}
-      onChange={onChange}
-      options={{
-        cursorWidth: 1,
-        folding: false,
-        fontFamily: 'monospace',
-        fontSize: 13,
-        glyphMargin: false,
-        lineDecorationsWidth: 12,
-        lineHeight: 18.6875,
-        lineNumbers: 'off',
-        lineNumbersMinChars: 0,
-        minimap: {
-          enabled: false,
+    <Box
+      sx={{
+        '.kobsio-monaco-editor': {
+          height: '100%',
+          position: 'absolute',
+          width: '100%',
         },
-        overviewRulerLanes: 0,
-        padding: { bottom: 8.5, top: 8.5 },
-        readOnly: readOnly,
-        renderLineHighlight: 'none',
-        scrollBeyondLastLine: false,
-        scrollbar: {
-          handleMouseWheel: false,
-          horizontal: 'hidden',
-          vertical: 'hidden',
-        },
-        wordWrap: 'on',
+
+        height: '100%',
+        position: 'relative',
+        width: '100%',
       }}
-    />
+    >
+      <MonacoEditorReact
+        theme="mui"
+        height={height}
+        language={language}
+        value={value}
+        beforeMount={handleBeforeMount}
+        onMount={handleOnMount}
+        onChange={onChange}
+        className="kobsio-monaco-editor"
+        options={{
+          contextmenu: false,
+          cursorWidth: 1,
+          folding: false,
+          fontFamily: 'monospace',
+          fontSize: 13,
+          glyphMargin: false,
+          lineDecorationsWidth: 12,
+          lineHeight: 18.6875,
+          lineNumbers: 'off',
+          lineNumbersMinChars: 0,
+          minimap: {
+            enabled: false,
+          },
+          overviewRulerLanes: 0,
+          padding: { bottom: 8.5, top: 8.5 },
+          readOnly: readOnly,
+          renderLineHighlight: 'none',
+          scrollBeyondLastLine: false,
+          scrollbar: {
+            handleMouseWheel: false,
+            horizontal: 'hidden',
+            vertical: 'hidden',
+          },
+          wordWrap: 'on',
+        }}
+      />
+    </Box>
   );
 };

--- a/app/packages/prometheus/src/components/PrometheusPage.tsx
+++ b/app/packages/prometheus/src/components/PrometheusPage.tsx
@@ -397,45 +397,38 @@ const PrometheusToolbar: FunctionComponent<{
   return (
     <Toolbar>
       <ToolbarItem grow={true}>
-        <Box sx={{ display: 'flex', flexDirection: 'column', flexWrap: 'wrap', gap: 3 }}>
-          {queries.map((query, index) => (
-            <Box key={index} sx={{ flexGrow: 1 }}>
-              <Box sx={{ alignItems: 'start', display: 'flex', flexDirection: 'row', flexWrap: 'nowrap', gap: 3 }}>
-                <Box sx={{ flexGrow: 1 }}>
-                  <TextField
-                    value={query}
-                    onChange={(e) => changeQuery(index, e.target.value)}
-                    InputProps={{
-                      endAdornment: (
-                        <InputAdornment position="end">
-                          <PrometheusHistory
-                            optionsQueries={options.queries}
-                            setQuery={(query) => changeQuery(index, query)}
-                          />
-                          {index === 0 ? (
-                            <IconButton size="small" onClick={addQuery}>
-                              <Add />
-                            </IconButton>
-                          ) : (
-                            <IconButton size="small" onClick={(): void => removeQuery(index)}>
-                              <Remove />
-                            </IconButton>
-                          )}
-                        </InputAdornment>
-                      ),
-                      inputComponent: Editor,
-                      inputProps: {
-                        callSubmit: callSubmit,
-                        loadCompletionItems: loadCompletionItems,
-                      },
-                    }}
-                    fullWidth={true}
-                  />
-                </Box>
-              </Box>
-            </Box>
-          ))}
-        </Box>
+        {queries.map((query, index) => (
+          <TextField
+            key={index}
+            sx={{
+              mb: index !== queries.length - 1 ? 3 : 0,
+            }}
+            value={query}
+            onChange={(e) => changeQuery(index, e.target.value)}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <PrometheusHistory optionsQueries={options.queries} setQuery={(query) => changeQuery(index, query)} />
+                  {index === 0 ? (
+                    <IconButton size="small" onClick={addQuery}>
+                      <Add />
+                    </IconButton>
+                  ) : (
+                    <IconButton size="small" onClick={(): void => removeQuery(index)}>
+                      <Remove />
+                    </IconButton>
+                  )}
+                </InputAdornment>
+              ),
+              inputComponent: Editor,
+              inputProps: {
+                callSubmit: callSubmit,
+                loadCompletionItems: loadCompletionItems,
+              },
+            }}
+            fullWidth={true}
+          />
+        ))}
       </ToolbarItem>
 
       <ToolbarItem align="right">


### PR DESCRIPTION
The MUIEditor component was not properly sized, when displayed in a Toolbar with other components. This means the editor forces to break other elements to a new line when the size of the other component was increased. This is now fixed and the MUIEditor is properly resized.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
