### PR TITLE
[core] Fix "JavaScript heap out of memory" Error

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -107,5 +107,7 @@ jobs:
 
       - name: Build
         if: ${{ matrix.plugin == 'app' }}
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
         run: |
           npm run build

--- a/cmd/kobs/Dockerfile
+++ b/cmd/kobs/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /kobs
 COPY app /kobs/
 RUN npm config set fetch-timeout 3600000
 RUN npm clean-install
-RUN npm run build
+RUN export NODE_OPTIONS=--max-old-space-size=4096 && npm run build
 
 FROM golang:1.20.1 as api
 WORKDIR /kobs


### PR DESCRIPTION
The "Continuous Integration" and "Continuous Delivery" GitHub Actions are currently not running successfully, because we get the following error: "JavaScript heap out of memory"

To fix this error this commit increases the heap size to 4096 MB via the NODE_OPTIONS environment variable
("NODE_OPTIONS=--max-old-space-size=4096") in the effected GitHub Actions and the Docker image.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
