### PR TITLE
[mongodb] Add Support for more Operations

### DIFF
--- a/app/packages/mongodb/src/components/Documents.tsx
+++ b/app/packages/mongodb/src/components/Documents.tsx
@@ -158,11 +158,7 @@ const SingleDocumentDetailsTree: FunctionComponent<{
           </TableHead>
           <TableBody>
             {Object.keys(value).map((key) => (
-              <SingleDocumentDetailsTree
-                key={value[key]?.toString() ?? 'null'}
-                documentKey={key}
-                documentValue={value[key]}
-              />
+              <SingleDocumentDetailsTree key={key} documentKey={key} documentValue={value[key]} />
             ))}
           </TableBody>
         </Table>
@@ -207,13 +203,13 @@ const SingleDocumentDetails: FunctionComponent<{
     <>
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
         <Tabs variant="scrollable" scrollButtons={false} value={activeTab} onChange={(_, value) => setActiveTab(value)}>
-          <Tab key="tree" label="Tree" value="tree" />
-          <Tab key="bson" label="BSON" value="bson" />
-          <Tab key="json" label="JSON" value="json" />
+          <Tab label="Tree" value="tree" />
+          <Tab label="BSON" value="bson" />
+          <Tab label="JSON" value="json" />
         </Tabs>
       </Box>
 
-      <Box key="tree" hidden={activeTab !== 'tree'} py={6}>
+      <Box hidden={activeTab !== 'tree'} py={6}>
         {activeTab === 'tree' && (
           <TableContainer>
             <Table size="small">
@@ -228,11 +224,7 @@ const SingleDocumentDetails: FunctionComponent<{
                 {Object.keys(document)
                   .filter((key) => key !== '_id')
                   .map((key) => (
-                    <SingleDocumentDetailsTree
-                      key={document[key]?.toString() ?? 'null'}
-                      documentKey={key}
-                      documentValue={document[key]}
-                    />
+                    <SingleDocumentDetailsTree key={key} documentKey={key} documentValue={document[key]} />
                   ))}
               </TableBody>
             </Table>
@@ -240,13 +232,13 @@ const SingleDocumentDetails: FunctionComponent<{
         )}
       </Box>
 
-      <Box key="bson" hidden={activeTab !== 'bson'} py={6}>
+      <Box hidden={activeTab !== 'bson'} py={6}>
         {activeTab === 'bson' && (
           <Editor language="json" value={JSON.stringify(EJSON.serialize(document, { relaxed: true }), null, 2)} />
         )}
       </Box>
 
-      <Box key="json" hidden={activeTab !== 'json'} py={6}>
+      <Box hidden={activeTab !== 'json'} py={6}>
         {activeTab === 'json' && <Editor language="json" value={JSON.stringify(document, null, 2)} />}
       </Box>
     </>
@@ -341,7 +333,13 @@ const SingleDocument: FunctionComponent<{
             {open ? <KeyboardArrowDown /> : <KeyboardArrowRight />}
           </IconButton>
         </TableCell>
-        <TableCell sx={{ verticalAlign: 'top' }}>{document['_id']?.toString() ?? 'null'}</TableCell>
+        <TableCell sx={{ verticalAlign: 'top' }}>
+          {document['_id']
+            ? typeof document['_id'] === 'object'
+              ? JSON.stringify(document['_id'])
+              : document['_id'].toString()
+            : null}
+        </TableCell>
         <TableCell sx={{ verticalAlign: 'top' }}>
           <Box
             sx={{
@@ -400,13 +398,8 @@ export const Documents: FunctionComponent<{
           </TableRow>
         </TableHead>
         <TableBody>
-          {documents.map((document) => (
-            <SingleDocument
-              key={document['_id']?.toString() ?? 'null'}
-              instance={instance}
-              collectionName={collectionName}
-              document={document}
-            />
+          {documents.map((document, index) => (
+            <SingleDocument key={index} instance={instance} collectionName={collectionName} document={document} />
           ))}
         </TableBody>
       </Table>

--- a/app/packages/mongodb/src/components/MongoDBPage.test.tsx
+++ b/app/packages/mongodb/src/components/MongoDBPage.test.tsx
@@ -32,6 +32,46 @@ vi.mock('./OperationFindOne', () => {
   };
 });
 
+vi.mock('./OperationFindOneAndUpdate', () => {
+  return {
+    OperationFindOneAndUpdate: () => {
+      return <>Mocked OperationFindOneAndUpdate</>;
+    },
+  };
+});
+
+vi.mock('./OperationFindOneAndDelete', () => {
+  return {
+    OperationFindOneAndDelete: () => {
+      return <>Mocked OperationFindOneAndDelete</>;
+    },
+  };
+});
+
+vi.mock('./OperationUpdateMany', () => {
+  return {
+    OperationUpdateMany: () => {
+      return <>Mocked OperationUpdateMany</>;
+    },
+  };
+});
+
+vi.mock('./OperationDeleteMany', () => {
+  return {
+    OperationDeleteMany: () => {
+      return <>Mocked OperationDeleteMany</>;
+    },
+  };
+});
+
+vi.mock('./OperationAggregate', () => {
+  return {
+    OperationAggregate: () => {
+      return <>Mocked OperationAggregate</>;
+    },
+  };
+});
+
 describe('MongoDBPage', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const render = (path: string): RenderResult => {
@@ -73,6 +113,10 @@ describe('MongoDBPage', () => {
           totalIndexSize: 36864,
           totalSize: 73728,
         };
+      }
+
+      if (path.startsWith('/api/plugins/mongodb/collections/indexes?collectionName=tags')) {
+        return [{ key: { _id: 1 }, name: '_id_', v: 2 }];
       }
 
       if (path.startsWith('/api/plugins/mongodb/collections')) {
@@ -127,6 +171,9 @@ describe('MongoDBPage', () => {
     await userEvent.click(screen.getByRole('button', { name: 'tags details' }));
     expect(await waitFor(() => screen.getByText('Collection Statistics'))).toBeInTheDocument();
     expect(await waitFor(() => screen.getByText('kobs.tags'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('Collection Indexes'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText(/key/))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText(/_id_/))).toBeInTheDocument();
   });
 
   it('should render document', async () => {
@@ -139,8 +186,8 @@ describe('MongoDBPage', () => {
     expect(await waitFor(() => screen.getByText('Mocked OperationFindOne'))).toBeInTheDocument();
   });
 
-  it('should render query', async () => {
-    render('/tags/query');
+  it('should render query with find toolbar', async () => {
+    render('/tags/query?operation=find');
 
     expect(screen.getByText('mongodb: tags')).toBeInTheDocument();
     expect(screen.getByText('(hub / mongodb)')).toBeInTheDocument();
@@ -151,5 +198,91 @@ describe('MongoDBPage', () => {
     expect(await waitFor(() => screen.getByText('Sort'))).toBeInTheDocument();
     expect(await waitFor(() => screen.getByText('Limit'))).toBeInTheDocument();
     expect(await waitFor(() => screen.getByText('Mocked OperationFind'))).toBeInTheDocument();
+  });
+
+  it('should render query with count toolbar', async () => {
+    render('/tags/query?operation=count');
+
+    expect(screen.getByText('mongodb: tags')).toBeInTheDocument();
+    expect(screen.getByText('(hub / mongodb)')).toBeInTheDocument();
+    expect(screen.getByText(description)).toBeInTheDocument();
+
+    expect(await waitFor(() => screen.getByText('Operation'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('Filter'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('Mocked OperationCount'))).toBeInTheDocument();
+  });
+
+  it('should render query with findOne toolbar', async () => {
+    render('/tags/query?operation=findOne');
+
+    expect(screen.getByText('mongodb: tags')).toBeInTheDocument();
+    expect(screen.getByText('(hub / mongodb)')).toBeInTheDocument();
+    expect(screen.getByText(description)).toBeInTheDocument();
+
+    expect(await waitFor(() => screen.getByText('Operation'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('Filter'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('Mocked OperationFindOne'))).toBeInTheDocument();
+  });
+
+  it('should render query with findOneAndUpdate toolbar', async () => {
+    render('/tags/query?operation=findOneAndUpdate');
+
+    expect(screen.getByText('mongodb: tags')).toBeInTheDocument();
+    expect(screen.getByText('(hub / mongodb)')).toBeInTheDocument();
+    expect(screen.getByText(description)).toBeInTheDocument();
+
+    expect(await waitFor(() => screen.getByText('Operation'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('Filter'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('Update'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('Mocked OperationFindOneAndUpdate'))).toBeInTheDocument();
+  });
+
+  it('should render query with findOneAndDelete toolbar', async () => {
+    render('/tags/query?operation=findOneAndDelete');
+
+    expect(screen.getByText('mongodb: tags')).toBeInTheDocument();
+    expect(screen.getByText('(hub / mongodb)')).toBeInTheDocument();
+    expect(screen.getByText(description)).toBeInTheDocument();
+
+    expect(await waitFor(() => screen.getByText('Operation'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('Filter'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('Mocked OperationFindOneAndDelete'))).toBeInTheDocument();
+  });
+
+  it('should render query with updateMany toolbar', async () => {
+    render('/tags/query?operation=updateMany');
+
+    expect(screen.getByText('mongodb: tags')).toBeInTheDocument();
+    expect(screen.getByText('(hub / mongodb)')).toBeInTheDocument();
+    expect(screen.getByText(description)).toBeInTheDocument();
+
+    expect(await waitFor(() => screen.getByText('Operation'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('Filter'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('Update'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('Mocked OperationUpdateMany'))).toBeInTheDocument();
+  });
+
+  it('should render query with deleteMany toolbar', async () => {
+    render('/tags/query?operation=deleteMany');
+
+    expect(screen.getByText('mongodb: tags')).toBeInTheDocument();
+    expect(screen.getByText('(hub / mongodb)')).toBeInTheDocument();
+    expect(screen.getByText(description)).toBeInTheDocument();
+
+    expect(await waitFor(() => screen.getByText('Operation'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('Filter'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('Mocked OperationDeleteMany'))).toBeInTheDocument();
+  });
+
+  it('should render query with aggregate toolbar', async () => {
+    render('/tags/query?operation=aggregate');
+
+    expect(screen.getByText('mongodb: tags')).toBeInTheDocument();
+    expect(screen.getByText('(hub / mongodb)')).toBeInTheDocument();
+    expect(screen.getByText(description)).toBeInTheDocument();
+
+    expect(await waitFor(() => screen.getByText('Operation'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('Pipeline'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('Mocked OperationAggregate'))).toBeInTheDocument();
   });
 });

--- a/app/packages/mongodb/src/components/MongoDBPage.tsx
+++ b/app/packages/mongodb/src/components/MongoDBPage.tsx
@@ -14,9 +14,14 @@ import { Route, Routes, useParams } from 'react-router-dom';
 
 import { Collections } from './Collections';
 import { DBStats } from './DBStats';
+import { OperationAggregate } from './OperationAggregate';
 import { OperationCount } from './OperationCount';
+import { OperationDeleteMany } from './OperationDeleteMany';
 import { OperationFind } from './OperationFind';
 import { OperationFindOne } from './OperationFindOne';
+import { OperationFindOneAndDelete } from './OperationFindOneAndDelete';
+import { OperationFindOneAndUpdate } from './OperationFindOneAndUpdate';
+import { OperationUpdateMany } from './OperationUpdateMany';
 
 import { codemirrorExtension, description } from '../utils/utils';
 
@@ -24,7 +29,9 @@ interface IQueryPageOptions {
   filter: string;
   limit: number;
   operation: string;
+  pipeline: string;
   sort: string;
+  update: string;
 }
 
 interface IQueryPageParams extends Record<string, string | undefined> {
@@ -109,29 +116,44 @@ const QueryPageToolbar: FunctionComponent<{
           <MenuItem value="find">find</MenuItem>
           <MenuItem value="count">count</MenuItem>
           <MenuItem value="findOne">findOne</MenuItem>
+          <MenuItem value="findOneAndUpdate">findOneAndUpdate</MenuItem>
+          <MenuItem value="findOneAndDelete">findOneAndDelete</MenuItem>
+          <MenuItem value="updateMany">updateMany</MenuItem>
+          <MenuItem value="deleteMany">deleteMany</MenuItem>
+          <MenuItem value="aggregate">aggregate</MenuItem>
         </Select>
       </Grid>
 
-      <Grid item={true} xs={12} md={2}>
-        Filter
-      </Grid>
-      <Grid item={true} xs={12} md={10}>
-        <Editor
-          language={codemirrorExtension()}
-          minimal={true}
-          value={internalOptions.filter}
-          onChange={(value) => setInternalOptions((prevOptions) => ({ ...prevOptions, filter: value }))}
-          adornment={
-            <InputAdornment position="end">
-              <QueryPageToolbarHistory
-                identifier="kobs-mongodb-filterhistory"
-                value={options.filter}
-                setValue={(value) => setInternalOptions((prevOptions) => ({ ...prevOptions, filter: value }))}
-              />
-            </InputAdornment>
-          }
-        />
-      </Grid>
+      {(internalOptions.operation === 'find' ||
+        internalOptions.operation === 'count' ||
+        internalOptions.operation === 'findOne' ||
+        internalOptions.operation === 'findOneAndUpdate' ||
+        internalOptions.operation === 'findOneAndDelete' ||
+        internalOptions.operation === 'updateMany' ||
+        internalOptions.operation === 'deleteMany') && (
+        <>
+          <Grid item={true} xs={12} md={2}>
+            Filter
+          </Grid>
+          <Grid item={true} xs={12} md={10}>
+            <Editor
+              language={codemirrorExtension()}
+              minimal={true}
+              value={internalOptions.filter}
+              onChange={(value) => setInternalOptions((prevOptions) => ({ ...prevOptions, filter: value }))}
+              adornment={
+                <InputAdornment position="end">
+                  <QueryPageToolbarHistory
+                    identifier="kobs-mongodb-filterhistory"
+                    value={options.filter}
+                    setValue={(value) => setInternalOptions((prevOptions) => ({ ...prevOptions, filter: value }))}
+                  />
+                </InputAdornment>
+              }
+            />
+          </Grid>
+        </>
+      )}
 
       {internalOptions.operation === 'find' && (
         <>
@@ -177,6 +199,56 @@ const QueryPageToolbar: FunctionComponent<{
         </>
       )}
 
+      {(internalOptions.operation === 'findOneAndUpdate' || internalOptions.operation === 'updateMany') && (
+        <>
+          <Grid item={true} xs={12} md={2}>
+            Update
+          </Grid>
+          <Grid item={true} xs={12} md={10}>
+            <Editor
+              language={codemirrorExtension()}
+              minimal={true}
+              value={internalOptions.update}
+              onChange={(value) => setInternalOptions((prevOptions) => ({ ...prevOptions, update: value }))}
+              adornment={
+                <InputAdornment position="end">
+                  <QueryPageToolbarHistory
+                    identifier="kobs-mongodb-updatehistory"
+                    value={options.update}
+                    setValue={(value) => setInternalOptions((prevOptions) => ({ ...prevOptions, update: value }))}
+                  />
+                </InputAdornment>
+              }
+            />
+          </Grid>
+        </>
+      )}
+
+      {internalOptions.operation === 'aggregate' && (
+        <>
+          <Grid item={true} xs={12} md={2}>
+            Pipeline
+          </Grid>
+          <Grid item={true} xs={12} md={10}>
+            <Editor
+              language={codemirrorExtension()}
+              minimal={true}
+              value={internalOptions.pipeline}
+              onChange={(value) => setInternalOptions((prevOptions) => ({ ...prevOptions, pipeline: value }))}
+              adornment={
+                <InputAdornment position="end">
+                  <QueryPageToolbarHistory
+                    identifier="kobs-mongodb-pipelinehistory"
+                    value={options.pipeline}
+                    setValue={(value) => setInternalOptions((prevOptions) => ({ ...prevOptions, pipeline: value }))}
+                  />
+                </InputAdornment>
+              }
+            />
+          </Grid>
+        </>
+      )}
+
       <Grid item={true} xs={12} md={2}></Grid>
       <Grid item={true} xs={12} md={10}>
         <Button variant="contained" color="primary" startIcon={<Search />} onClick={query}>
@@ -193,7 +265,9 @@ const QueryPage: FunctionComponent<IPluginPageProps> = ({ instance }) => {
     filter: '{}',
     limit: 50,
     operation: 'find',
+    pipeline: '[]',
     sort: '{"_id" : -1}',
+    update: '{}',
   });
 
   const times: ITimes = {
@@ -233,6 +307,48 @@ const QueryPage: FunctionComponent<IPluginPageProps> = ({ instance }) => {
           title="Result"
           collectionName={params.collectionName ?? ''}
           filter={options.filter}
+          times={times}
+        />
+      ) : options.operation === 'findOneAndUpdate' ? (
+        <OperationFindOneAndUpdate
+          instance={instance}
+          title="Result"
+          collectionName={params.collectionName ?? ''}
+          filter={options.filter}
+          update={options.update}
+          times={times}
+        />
+      ) : options.operation === 'findOneAndDelete' ? (
+        <OperationFindOneAndDelete
+          instance={instance}
+          title="Result"
+          collectionName={params.collectionName ?? ''}
+          filter={options.filter}
+          times={times}
+        />
+      ) : options.operation === 'updateMany' ? (
+        <OperationUpdateMany
+          instance={instance}
+          title="Result"
+          collectionName={params.collectionName ?? ''}
+          filter={options.filter}
+          update={options.update}
+          times={times}
+        />
+      ) : options.operation === 'deleteMany' ? (
+        <OperationDeleteMany
+          instance={instance}
+          title="Result"
+          collectionName={params.collectionName ?? ''}
+          filter={options.filter}
+          times={times}
+        />
+      ) : options.operation === 'aggregate' ? (
+        <OperationAggregate
+          instance={instance}
+          title="Result"
+          collectionName={params.collectionName ?? ''}
+          pipeline={options.pipeline}
           times={times}
         />
       ) : null}

--- a/app/packages/mongodb/src/components/MongoDBPanel.test.tsx
+++ b/app/packages/mongodb/src/components/MongoDBPanel.test.tsx
@@ -44,6 +44,14 @@ vi.mock('./OperationFindOne', () => {
   };
 });
 
+vi.mock('./OperationAggregate', () => {
+  return {
+    OperationAggregate: () => {
+      return <>Mocked OperationAggregate</>;
+    },
+  };
+});
+
 describe('MongoDBPanel', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const render = (options: any): RenderResult => {
@@ -104,5 +112,11 @@ describe('MongoDBPanel', () => {
     render({ operation: 'findOne', query: { collectionName: 'tags', filter: '{}' } });
 
     expect(await waitFor(() => screen.getByText(/Mocked OperationFindOne/))).toBeInTheDocument();
+  });
+
+  it('should render aggregate query', async () => {
+    render({ operation: 'aggregate', query: { collectionName: 'tags', pipeline: '{}' } });
+
+    expect(await waitFor(() => screen.getByText(/Mocked OperationAggregate/))).toBeInTheDocument();
   });
 });

--- a/app/packages/mongodb/src/components/MongoDBPanel.tsx
+++ b/app/packages/mongodb/src/components/MongoDBPanel.tsx
@@ -3,6 +3,7 @@ import { FunctionComponent } from 'react';
 
 import { Collections } from './Collections';
 import { DBStats } from './DBStats';
+import { OperationAggregate } from './OperationAggregate';
 import { OperationCount } from './OperationCount';
 import { OperationFind } from './OperationFind';
 import { OperationFindOne } from './OperationFindOne';
@@ -16,6 +17,7 @@ interface IQuery {
   collectionName?: string;
   filter?: string;
   limit?: number;
+  pipeline?: string;
   sort?: string;
 }
 
@@ -92,6 +94,26 @@ const MongoDBPanel: FunctionComponent<IPluginPanelProps<IOptions>> = ({
         description={description}
         collectionName={options.query.collectionName}
         filter={options.query.filter}
+        showActions={true}
+        times={times}
+      />
+    );
+  }
+
+  if (
+    options &&
+    options.operation === 'aggregate' &&
+    options.query &&
+    options.query.collectionName &&
+    options.query.pipeline
+  ) {
+    return (
+      <OperationAggregate
+        instance={instance}
+        title={title}
+        description={description}
+        collectionName={options.query.collectionName}
+        pipeline={options.query.pipeline}
         showActions={true}
         times={times}
       />

--- a/app/packages/mongodb/src/components/OperationAggregate.test.tsx
+++ b/app/packages/mongodb/src/components/OperationAggregate.test.tsx
@@ -1,0 +1,76 @@
+import { APIClient, APIContext, QueryClientProvider } from '@kobsio/core';
+import { render as _render, RenderResult, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+
+import { OperationAggregate } from './OperationAggregate';
+
+describe('OperationAggregate', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const render = (): RenderResult => {
+    const client = new APIClient();
+    const postSpy = vi.spyOn(client, 'post');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    postSpy.mockImplementation(async (path: string, _): Promise<any> => {
+      return [
+        {
+          _id: [
+            {
+              name: 'mongodb',
+            },
+            {
+              namespace: 'yopass',
+            },
+          ],
+          clusters: ['test1', 'test2'],
+          names: ['mongodb', 'mongodb'],
+          namespaces: ['yopass', 'yopass'],
+        },
+      ];
+    });
+
+    return _render(
+      <MemoryRouter>
+        <QueryClientProvider>
+          <APIContext.Provider value={{ client: client, getUser: () => undefined }}>
+            <OperationAggregate
+              title="Result"
+              instance={{
+                cluster: 'hub',
+                id: '/cluster/hub/type/mongodb/name/mongodb',
+                name: 'mongodb',
+                type: 'mongodb',
+              }}
+              times={{
+                time: 'last15Minutes',
+                timeEnd: 0,
+                timeStart: 0,
+              }}
+              showActions={true}
+              collectionName="applications"
+              pipeline={`[
+                {
+                  $group: {
+                    "_id": [
+                      {"name": "$name"},
+                      {"namespace": "$namespace"}
+                    ],
+                    "clusters": {$push: "$cluster"},
+                    "namespaces": {$push: "$namespace"},
+                    "names": {$push: "$name"},
+                  }
+                }
+              ]`}
+            />
+          </APIContext.Provider>
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+  };
+
+  it('should render result', async () => {
+    render();
+    expect(await waitFor(() => screen.getByText('Result'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('[{"name":"mongodb"},{"namespace":"yopass"}]'))).toBeInTheDocument();
+  });
+});

--- a/app/packages/mongodb/src/components/OperationDeleteMany.test.tsx
+++ b/app/packages/mongodb/src/components/OperationDeleteMany.test.tsx
@@ -1,0 +1,53 @@
+import { APIClient, APIContext, QueryClientProvider } from '@kobsio/core';
+import { render as _render, RenderResult, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+
+import { OperationDeleteMany } from './OperationDeleteMany';
+
+describe('OperationDeleteMany', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const render = (): RenderResult => {
+    const client = new APIClient();
+    const postSpy = vi.spyOn(client, 'post');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    postSpy.mockImplementation(async (path: string, _): Promise<any> => {
+      return {
+        count: 2,
+      };
+    });
+
+    return _render(
+      <MemoryRouter>
+        <QueryClientProvider>
+          <APIContext.Provider value={{ client: client, getUser: () => undefined }}>
+            <OperationDeleteMany
+              title="Result"
+              instance={{
+                cluster: 'hub',
+                id: '/cluster/hub/type/mongodb/name/mongodb',
+                name: 'mongodb',
+                type: 'mongodb',
+              }}
+              times={{
+                time: 'last15Minutes',
+                timeEnd: 0,
+                timeStart: 0,
+              }}
+              showActions={true}
+              collectionName="applications"
+              filter={`{name: 'app1'}`}
+            />
+          </APIContext.Provider>
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+  };
+
+  it('should render result', async () => {
+    render();
+    expect(await waitFor(() => screen.getByText('Result'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('Deleted Documents'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText(2))).toBeInTheDocument();
+  });
+});

--- a/app/packages/mongodb/src/components/OperationFindOne.tsx
+++ b/app/packages/mongodb/src/components/OperationFindOne.tsx
@@ -31,8 +31,7 @@ export const OperationFindOne: FunctionComponent<{
   const { isError, isLoading, error, data, refetch } = useQuery<Document[], APIError>(
     ['mongodb/operation/findone', instance, collectionName, filter, times],
     async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = await apiContext.client.post<any>(
+      const result = await apiContext.client.post<unknown>(
         `/api/plugins/mongodb/collections/findone?collectionName=${collectionName}`,
         {
           body: {
@@ -46,7 +45,6 @@ export const OperationFindOne: FunctionComponent<{
       );
 
       if (result) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return [EJSON.parse(JSON.stringify(result))];
       }
 

--- a/app/packages/mongodb/src/components/OperationFindOneAndDelete.test.tsx
+++ b/app/packages/mongodb/src/components/OperationFindOneAndDelete.test.tsx
@@ -1,0 +1,54 @@
+import { APIClient, APIContext, QueryClientProvider } from '@kobsio/core';
+import { render as _render, RenderResult, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+
+import { OperationFindOneAndDelete } from './OperationFindOneAndDelete';
+
+describe('OperationFindOneAndDelete', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const render = (): RenderResult => {
+    const client = new APIClient();
+    const postSpy = vi.spyOn(client, 'post');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    postSpy.mockImplementation(async (path: string, _): Promise<any> => {
+      return {
+        _id: '/tag/tracing',
+        tag: 'tracing',
+        updatedAt: 1680439130,
+      };
+    });
+
+    return _render(
+      <MemoryRouter>
+        <QueryClientProvider>
+          <APIContext.Provider value={{ client: client, getUser: () => undefined }}>
+            <OperationFindOneAndDelete
+              title="Result"
+              instance={{
+                cluster: 'hub',
+                id: '/cluster/hub/type/mongodb/name/mongodb',
+                name: 'mongodb',
+                type: 'mongodb',
+              }}
+              times={{
+                time: 'last15Minutes',
+                timeEnd: 0,
+                timeStart: 0,
+              }}
+              showActions={true}
+              collectionName="applications"
+              filter={`{_id: '/tag/tracing'}`}
+            />
+          </APIContext.Provider>
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+  };
+
+  it('should render result', async () => {
+    render();
+    expect(await waitFor(() => screen.getByText('Result'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('/tag/tracing'))).toBeInTheDocument();
+  });
+});

--- a/app/packages/mongodb/src/components/OperationFindOneAndUpdate.test.tsx
+++ b/app/packages/mongodb/src/components/OperationFindOneAndUpdate.test.tsx
@@ -1,0 +1,56 @@
+import { APIClient, APIContext, QueryClientProvider } from '@kobsio/core';
+import { render as _render, RenderResult, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+
+import { OperationFindOneAndUpdate } from './OperationFindOneAndUpdate';
+
+describe('OperationFindOneAndUpdate', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const render = (): RenderResult => {
+    const client = new APIClient();
+    const postSpy = vi.spyOn(client, 'post');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    postSpy.mockImplementation(async (path: string, _): Promise<any> => {
+      return {
+        _id: '/tag/tracing',
+        tag: 'tracingnew',
+        updatedAt: 1680439130,
+      };
+    });
+
+    return _render(
+      <MemoryRouter>
+        <QueryClientProvider>
+          <APIContext.Provider value={{ client: client, getUser: () => undefined }}>
+            <OperationFindOneAndUpdate
+              title="Result"
+              instance={{
+                cluster: 'hub',
+                id: '/cluster/hub/type/mongodb/name/mongodb',
+                name: 'mongodb',
+                type: 'mongodb',
+              }}
+              times={{
+                time: 'last15Minutes',
+                timeEnd: 0,
+                timeStart: 0,
+              }}
+              showActions={true}
+              collectionName="applications"
+              filter={`{_id: '/tag/tracing'}`}
+              update={`{$set: {tag: 'tracingnew'}}`}
+            />
+          </APIContext.Provider>
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+  };
+
+  it('should render result', async () => {
+    render();
+    expect(await waitFor(() => screen.getByText('Result'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('/tag/tracing'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('tracingnew'))).toBeInTheDocument();
+  });
+});

--- a/app/packages/mongodb/src/components/OperationUpdateMany.test.tsx
+++ b/app/packages/mongodb/src/components/OperationUpdateMany.test.tsx
@@ -1,0 +1,56 @@
+import { APIClient, APIContext, QueryClientProvider } from '@kobsio/core';
+import { render as _render, RenderResult, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+
+import { OperationUpdateMany } from './OperationUpdateMany';
+
+describe('OperationUpdateMany', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const render = (): RenderResult => {
+    const client = new APIClient();
+    const postSpy = vi.spyOn(client, 'post');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    postSpy.mockImplementation(async (path: string, _): Promise<any> => {
+      return {
+        matchedCount: 2,
+        modifiedCount: 2,
+      };
+    });
+
+    return _render(
+      <MemoryRouter>
+        <QueryClientProvider>
+          <APIContext.Provider value={{ client: client, getUser: () => undefined }}>
+            <OperationUpdateMany
+              title="Result"
+              instance={{
+                cluster: 'hub',
+                id: '/cluster/hub/type/mongodb/name/mongodb',
+                name: 'mongodb',
+                type: 'mongodb',
+              }}
+              times={{
+                time: 'last15Minutes',
+                timeEnd: 0,
+                timeStart: 0,
+              }}
+              showActions={true}
+              collectionName="applications"
+              filter={`{name: 'app1'}`}
+              update={`{$set: {name: 'app2'}}`}
+            />
+          </APIContext.Provider>
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+  };
+
+  it('should render result', async () => {
+    render();
+    expect(await waitFor(() => screen.getByText('Result'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('Matched Documents'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('Modified Documents'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.queryAllByText(2).length)).toBe(2);
+  });
+});

--- a/app/packages/mongodb/src/components/OperationUpdateMany.tsx
+++ b/app/packages/mongodb/src/components/OperationUpdateMany.tsx
@@ -1,0 +1,98 @@
+import {
+  APIContext,
+  APIError,
+  IAPIContext,
+  IPluginInstance,
+  ITimes,
+  pluginBasePath,
+  PluginPanel,
+  PluginPanelActionLinks,
+  UseQueryWrapper,
+} from '@kobsio/core';
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
+import { useQuery } from '@tanstack/react-query';
+import { FunctionComponent, useContext } from 'react';
+
+import { toExtendedJson } from '../utils/utils';
+
+export const OperationUpdateMany: FunctionComponent<{
+  collectionName: string;
+  description?: string;
+  filter: string;
+  instance: IPluginInstance;
+  showActions?: boolean;
+  times: ITimes;
+  title: string;
+  update: string;
+}> = ({ instance, title, description, collectionName, filter, update, showActions, times }) => {
+  const apiContext = useContext<IAPIContext>(APIContext);
+
+  const { isError, isLoading, error, data, refetch } = useQuery<
+    { matchedCount: number; modifiedCount: number },
+    APIError
+  >(['mongodb/operation/updatemany', instance, collectionName, filter, update, times], async () => {
+    return apiContext.client.post<{ matchedCount: number; modifiedCount: number }>(
+      `/api/plugins/mongodb/collections/updatemany?collectionName=${collectionName}`,
+      {
+        body: {
+          filter: toExtendedJson(filter),
+          update: toExtendedJson(update),
+        },
+        headers: {
+          'x-kobs-cluster': instance.cluster,
+          'x-kobs-plugin': instance.name,
+        },
+      },
+    );
+  });
+
+  return (
+    <PluginPanel
+      title={title}
+      description={description}
+      actions={
+        showActions && (
+          <PluginPanelActionLinks
+            links={[
+              {
+                link: `${pluginBasePath(
+                  instance,
+                )}/${collectionName}/query?operation=updateMany&filter=${encodeURIComponent(
+                  filter,
+                )}&update=${encodeURIComponent(update)}`,
+                title: 'Explore',
+              },
+            ]}
+          />
+        )
+      }
+    >
+      <UseQueryWrapper
+        error={error}
+        errorTitle="Failed to update documents"
+        isError={isError}
+        isLoading={isLoading}
+        isNoData={!data}
+        noDataTitle="No documents were updated"
+        refetch={refetch}
+      >
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Matched Documents</TableCell>
+                <TableCell>Modified Documents</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              <TableRow>
+                <TableCell>{data?.matchedCount ?? 0}</TableCell>
+                <TableCell>{data?.modifiedCount ?? 0}</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </UseQueryWrapper>
+    </PluginPanel>
+  );
+};

--- a/app/packages/prometheus/src/components/PrometheusPage.tsx
+++ b/app/packages/prometheus/src/components/PrometheusPage.tsx
@@ -374,7 +374,6 @@ const PrometheusToolbar: FunctionComponent<{
    * easy access to the last 10 queries he run.
    */
   const handleSubmit = () => {
-    console.log(queries);
     addStateHistoryItems('kobs-prometheus-queryhistory', queries);
     setOptions({ ...options, queries: queries });
   };

--- a/pkg/plugins/mongodb/instance/instance_mock.go
+++ b/pkg/plugins/mongodb/instance/instance_mock.go
@@ -35,6 +35,21 @@ func (m *MockInstance) EXPECT() *MockInstanceMockRecorder {
 	return m.recorder
 }
 
+// Aggregate mocks base method.
+func (m *MockInstance) Aggregate(ctx context.Context, collectionName, pipeline string) ([]bson.D, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Aggregate", ctx, collectionName, pipeline)
+	ret0, _ := ret[0].([]bson.D)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Aggregate indicates an expected call of Aggregate.
+func (mr *MockInstanceMockRecorder) Aggregate(ctx, collectionName, pipeline interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Aggregate", reflect.TypeOf((*MockInstance)(nil).Aggregate), ctx, collectionName, pipeline)
+}
+
 // Count mocks base method.
 func (m *MockInstance) Count(ctx context.Context, collectionName, filter string) (int64, error) {
 	m.ctrl.T.Helper()
@@ -48,6 +63,21 @@ func (m *MockInstance) Count(ctx context.Context, collectionName, filter string)
 func (mr *MockInstanceMockRecorder) Count(ctx, collectionName, filter interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockInstance)(nil).Count), ctx, collectionName, filter)
+}
+
+// DeleteMany mocks base method.
+func (m *MockInstance) DeleteMany(ctx context.Context, collectionName, filter string) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteMany", ctx, collectionName, filter)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteMany indicates an expected call of DeleteMany.
+func (mr *MockInstanceMockRecorder) DeleteMany(ctx, collectionName, filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMany", reflect.TypeOf((*MockInstance)(nil).DeleteMany), ctx, collectionName, filter)
 }
 
 // Find mocks base method.
@@ -78,6 +108,51 @@ func (m *MockInstance) FindOne(ctx context.Context, collectionName, filter strin
 func (mr *MockInstanceMockRecorder) FindOne(ctx, collectionName, filter interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindOne", reflect.TypeOf((*MockInstance)(nil).FindOne), ctx, collectionName, filter)
+}
+
+// FindOneAndDelete mocks base method.
+func (m *MockInstance) FindOneAndDelete(ctx context.Context, collectionName, filter string) (*bson.M, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindOneAndDelete", ctx, collectionName, filter)
+	ret0, _ := ret[0].(*bson.M)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindOneAndDelete indicates an expected call of FindOneAndDelete.
+func (mr *MockInstanceMockRecorder) FindOneAndDelete(ctx, collectionName, filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindOneAndDelete", reflect.TypeOf((*MockInstance)(nil).FindOneAndDelete), ctx, collectionName, filter)
+}
+
+// FindOneAndUpdate mocks base method.
+func (m *MockInstance) FindOneAndUpdate(ctx context.Context, collectionName, filter, update string) (*bson.M, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindOneAndUpdate", ctx, collectionName, filter, update)
+	ret0, _ := ret[0].(*bson.M)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindOneAndUpdate indicates an expected call of FindOneAndUpdate.
+func (mr *MockInstanceMockRecorder) FindOneAndUpdate(ctx, collectionName, filter, update interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindOneAndUpdate", reflect.TypeOf((*MockInstance)(nil).FindOneAndUpdate), ctx, collectionName, filter, update)
+}
+
+// GetDBCollectionIndexes mocks base method.
+func (m *MockInstance) GetDBCollectionIndexes(ctx context.Context, collectionName string) ([]bson.D, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDBCollectionIndexes", ctx, collectionName)
+	ret0, _ := ret[0].([]bson.D)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDBCollectionIndexes indicates an expected call of GetDBCollectionIndexes.
+func (mr *MockInstanceMockRecorder) GetDBCollectionIndexes(ctx, collectionName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDBCollectionIndexes", reflect.TypeOf((*MockInstance)(nil).GetDBCollectionIndexes), ctx, collectionName)
 }
 
 // GetDBCollectionNames mocks base method.
@@ -137,4 +212,20 @@ func (m *MockInstance) GetName() string {
 func (mr *MockInstanceMockRecorder) GetName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockInstance)(nil).GetName))
+}
+
+// UpdateMany mocks base method.
+func (m *MockInstance) UpdateMany(ctx context.Context, collectionName, filter, update string) (int64, int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateMany", ctx, collectionName, filter, update)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// UpdateMany indicates an expected call of UpdateMany.
+func (mr *MockInstanceMockRecorder) UpdateMany(ctx, collectionName, filter, update interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMany", reflect.TypeOf((*MockInstance)(nil).UpdateMany), ctx, collectionName, filter, update)
 }


### PR DESCRIPTION
The MongoDB plugin supports the following operations now:

- findOneAndUpdate
- findOneAndDelete
- updateMany
- deleteMany
- aggregate

The "aggregate" operation can also be used within a MongoDB panel on a dashboard, while the other operations can only be used on the MongoDB page.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
