### PR TITLE
[core] Use EmbeddedDashboards Component for Resources

### DIFF
--- a/app/packages/core/src/components/resources/ResourceDetails.tsx
+++ b/app/packages/core/src/components/resources/ResourceDetails.tsx
@@ -15,7 +15,6 @@ import Resources from './Resources';
 import { IResource, getSelector, getDashboards, IDashboard } from './utils';
 
 import { timeDifference } from '../../utils/times';
-import { Dashboards } from '../dashboards/Dashboards';
 import {
   DescriptionList,
   DescriptionListDescription,
@@ -24,6 +23,7 @@ import {
 } from '../utils/DescriptionList';
 import { DetailsDrawer } from '../utils/DetailsDrawer';
 import { Editor } from '../utils/editor/Editor';
+import { EmbeddedDashboards } from '../utils/embedded/EmbeddedDashboards';
 
 /**
  * `IResourceOverviewProps` is the interface, which defines the properties for the `ResourceOverview` component.
@@ -184,7 +184,7 @@ const ResourceDashboards: FunctionComponent<IResourceDashboardsProps> = ({
     );
   }
 
-  return <Dashboards manifest={manifest} references={references} />;
+  return <EmbeddedDashboards manifest={manifest} references={references} />;
 };
 
 /**


### PR DESCRIPTION
The integrations for resources are now using the "EmbeddedDashboards" component instead of the default "Dashboards" component, to show the dashboards for a resource in the details. This is changed to improve the layout of the dashboards in the details.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
