### PR TITLE
[core] Fix Links in Application Groups Panel

### DIFF
--- a/app/packages/core/src/components/applications/ApplicationGroupsPanel.tsx
+++ b/app/packages/core/src/components/applications/ApplicationGroupsPanel.tsx
@@ -1,5 +1,16 @@
-import { HubOutlined, PeopleOutlined } from '@mui/icons-material';
-import { Box, Divider, List, Chip, ListItem, ListItemText, Typography, Button, Menu, MenuItem } from '@mui/material';
+import { AppsOutlined, HubOutlined, PeopleOutlined } from '@mui/icons-material';
+import {
+  Box,
+  Divider,
+  List,
+  Chip,
+  ListItem,
+  ListItemText,
+  Typography,
+  Menu,
+  MenuItem,
+  IconButton,
+} from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { Fragment, FunctionComponent, MouseEvent, useContext, useState } from 'react';
 import { Link } from 'react-router-dom';
@@ -154,9 +165,9 @@ const ApplicationGroup: FunctionComponent<IApplicationGroupProps> = ({ groups, a
       secondaryAction={
         links && links.length > 0 ? (
           <>
-            <Button variant="contained" color="primary" size="small" onClick={handleOpen}>
-              Environments
-            </Button>
+            <IconButton onClick={handleOpen}>
+              <AppsOutlined />
+            </IconButton>
             <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
               {links.map((link) => (
                 <MenuItem key={link.link} component={Link} to={link.link}>


### PR DESCRIPTION
The "Environment" button overflowed the description of an application in some cases. To fix this the button is replaced with an icon button with the apps icon, which can be used to view an shown application for the different environments.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
