### PR TITLE
[techdocs] Fix Vertical Scrolling in Service Pages

### DIFF
--- a/app/packages/techdocs/src/components/ServiceMarkdown.tsx
+++ b/app/packages/techdocs/src/components/ServiceMarkdown.tsx
@@ -48,6 +48,7 @@ const ServiceMarkdownTableOfContents: FunctionComponent<{
           paddingLeft: 4,
           paddingRight: 4,
           paddingTop: 2,
+          wordBreak: 'break-all',
         },
         'li:hover': {
           backgroundColor: 'rgba(255, 255, 255, 0.08)',

--- a/app/packages/techdocs/src/components/TableOfContents.tsx
+++ b/app/packages/techdocs/src/components/TableOfContents.tsx
@@ -28,7 +28,7 @@ const TableOfContentsItem: FunctionComponent<{
   if (Array.isArray(tocItem[title])) {
     return (
       <>
-        <ListItemButton sx={{ pl: 4 * level }} onClick={() => setOpen(!open)}>
+        <ListItemButton sx={{ pl: 4 * level, wordBreak: 'break-all' }} onClick={() => setOpen(!open)}>
           <ListItemText primary={title} />
           {open ? <ExpandLess /> : <ExpandMore />}
         </ListItemButton>

--- a/app/packages/techdocs/src/utils/renderers.tsx
+++ b/app/packages/techdocs/src/utils/renderers.tsx
@@ -6,7 +6,8 @@ import {
   EmbeddedDashboards,
   TEmbeddedDashboards,
 } from '@kobsio/core';
-import { Box, Theme } from '@mui/material';
+import { ContentCopy } from '@mui/icons-material';
+import { Box, IconButton, Theme } from '@mui/material';
 import yaml from 'js-yaml';
 import { Children, ReactElement, createElement } from 'react';
 import { Link } from 'react-router-dom';
@@ -129,9 +130,28 @@ export const renderCode = (
 
   if (!inline) {
     return (
-      <SyntaxHighlighter style={prismTheme(theme)} language={match ? match[1] : undefined} PreTag="div">
-        {String(children).replace(/\n$/, '')}
-      </SyntaxHighlighter>
+      <Box sx={{ position: 'relative' }}>
+        <SyntaxHighlighter
+          style={prismTheme(theme)}
+          language={match ? match[1] : undefined}
+          PreTag="div"
+          showLineNumbers={true}
+          wrapLongLines={true}
+        >
+          {String(children).replace(/\n$/, '')}
+        </SyntaxHighlighter>
+        {navigator.clipboard && (
+          <Box sx={{ position: 'absolute', right: '1em', top: '1em' }}>
+            <IconButton
+              size="small"
+              disableRipple={true}
+              onClick={() => navigator.clipboard.writeText(String(children).replace(/\n$/, ''))}
+            >
+              <ContentCopy fontSize="small" />
+            </IconButton>
+          </Box>
+        )}
+      </Box>
     );
   }
 


### PR DESCRIPTION
When a code block contained very long lines it could happen that a user must scroll vertically on a service page. This is now fixed by wrapping long lines in a code block.

Because of this new setting copying content from a code block adds some useless newlines, so that we added a copy button to each code block to make it easier for users to copy the content.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
