### PR TITLE
[core] Fix Returned Error Type from useQuery Hook

### DIFF
--- a/app/packages/core/src/components/applications/ApplicationsToolbar.tsx
+++ b/app/packages/core/src/components/applications/ApplicationsToolbar.tsx
@@ -15,7 +15,7 @@ import { useContext, FunctionComponent, useState, FormEvent, useEffect } from 'r
 
 import { IApplicationOptions } from './utils';
 
-import { APIContext, IAPIContext } from '../../context/APIContext';
+import { APIContext, APIError, IAPIContext } from '../../context/APIContext';
 import { ResourcesSelectClusters } from '../resources/ResourcesSelectClusters';
 import { ResourcesSelectNamespaces } from '../resources/ResourcesSelectNamespaces';
 import { Toolbar, ToolbarItem } from '../utils/Toolbar';
@@ -39,7 +39,7 @@ interface IApplicationsToolbarTagsProps {
 const ApplicationsToolbarTags: FunctionComponent<IApplicationsToolbarTagsProps> = ({ selectedTags, selectTags }) => {
   const apiContext = useContext<IAPIContext>(APIContext);
 
-  const { isLoading, data } = useQuery<string[], Error>(['core/applications/tags'], async () => {
+  const { isLoading, data } = useQuery<string[], APIError>(['core/applications/tags'], async () => {
     return apiContext.client.get<string[]>('/api/applications/tags');
   });
 

--- a/app/packages/core/src/components/dashboards/Dashboards.tsx
+++ b/app/packages/core/src/components/dashboards/Dashboards.tsx
@@ -246,7 +246,7 @@ export const Dashboard: FunctionComponent<IDashboardProps> = ({ dashboard }) => 
     }),
   );
 
-  const { data } = useQuery<IVariableValues[] | null, Error>(
+  const { data } = useQuery<IVariableValues[] | null, APIError>(
     ['core/dashboards/variables', dashboard, variables, times],
     async () => {
       if (!variables) {

--- a/app/packages/core/src/components/resources/ResourcesSelectClusters.tsx
+++ b/app/packages/core/src/components/resources/ResourcesSelectClusters.tsx
@@ -11,7 +11,7 @@ import {
 import { useQuery } from '@tanstack/react-query';
 import { useContext, FunctionComponent, SyntheticEvent } from 'react';
 
-import { APIContext, IAPIContext } from '../../context/APIContext';
+import { APIContext, APIError, IAPIContext } from '../../context/APIContext';
 
 const icon = <CheckBoxOutlineBlank fontSize="small" />;
 const checkedIcon = <CheckBox fontSize="small" />;
@@ -37,7 +37,7 @@ export const ResourcesSelectClusters: FunctionComponent<IResourcesSelectClusters
   const apiContext = useContext<IAPIContext>(APIContext);
   const filter = createFilterOptions<string>();
 
-  const { isLoading, data } = useQuery<string[], Error>(['core/clusters'], async () => {
+  const { isLoading, data } = useQuery<string[], APIError>(['core/clusters'], async () => {
     return apiContext.client.get<string[]>('/api/clusters');
   });
 

--- a/app/packages/core/src/components/resources/ResourcesSelectNamespaces.tsx
+++ b/app/packages/core/src/components/resources/ResourcesSelectNamespaces.tsx
@@ -3,7 +3,7 @@ import { Autocomplete, Checkbox, Chip, TextField } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { useContext, FunctionComponent } from 'react';
 
-import { APIContext, IAPIContext } from '../../context/APIContext';
+import { APIContext, APIError, IAPIContext } from '../../context/APIContext';
 
 const icon = <CheckBoxOutlineBlank fontSize="small" />;
 const checkedIcon = <CheckBox fontSize="small" />;
@@ -32,7 +32,7 @@ export const ResourcesSelectNamespaces: FunctionComponent<IResourcesSelectNamesp
 }) => {
   const apiContext = useContext<IAPIContext>(APIContext);
 
-  const { isLoading, data } = useQuery<string[], Error>(['core/namespaces', selectedClusters], async () => {
+  const { isLoading, data } = useQuery<string[], APIError>(['core/namespaces', selectedClusters], async () => {
     const c = selectedClusters.map((cluster) => `&cluster=${encodeURIComponent(cluster)}`);
     return apiContext.client.get<string[]>(`/api/clusters/namespaces?${c.length > 0 ? c.join('') : ''}`);
   });

--- a/app/packages/core/src/components/resources/ResourcesSelectResources.tsx
+++ b/app/packages/core/src/components/resources/ResourcesSelectResources.tsx
@@ -5,7 +5,7 @@ import { useContext, FunctionComponent, useState, useEffect } from 'react';
 
 import { IResource } from './utils';
 
-import { APIContext, IAPIContext } from '../../context/APIContext';
+import { APIContext, APIError, IAPIContext } from '../../context/APIContext';
 
 const icon = <CheckBoxOutlineBlank fontSize="small" />;
 const checkedIcon = <CheckBox fontSize="small" />;
@@ -88,7 +88,7 @@ export const ResourcesSelectResources: FunctionComponent<IResourcesSelectResourc
 }) => {
   const apiContext = useContext<IAPIContext>(APIContext);
 
-  const { data } = useQuery<IResource[], Error>(['core/resources'], async () => {
+  const { data } = useQuery<IResource[], APIError>(['core/resources'], async () => {
     return apiContext.client.get<IResource[]>('/api/clusters/resources');
   });
 

--- a/app/packages/core/src/components/resources/overview/Pod.tsx
+++ b/app/packages/core/src/components/resources/overview/Pod.tsx
@@ -27,7 +27,7 @@ import { FunctionComponent, ReactNode, useContext, useState } from 'react';
 
 import Conditions from './Conditions';
 
-import { APIContext, IAPIContext } from '../../../context/APIContext';
+import { APIContext, APIError, IAPIContext } from '../../../context/APIContext';
 import {
   DescriptionList,
   DescriptionListDescription,
@@ -445,7 +445,7 @@ const Pod: FunctionComponent<IPodProps> = ({ cluster, namespace, name, pod }) =>
     }
   }
 
-  const { isError, data } = useQuery<IMetricContainer[], Error>(
+  const { isError, data } = useQuery<IMetricContainer[], APIError>(
     ['core/resources/pod/metrics', cluster, namespace, name],
     async () => {
       const metric = await apiContext.client.get<IMetric>(

--- a/app/packages/core/src/context/PluginContext.tsx
+++ b/app/packages/core/src/context/PluginContext.tsx
@@ -2,7 +2,7 @@ import { Alert, AlertTitle, Box, Button, CircularProgress } from '@mui/material'
 import { useQuery } from '@tanstack/react-query';
 import { FunctionComponent, createContext, ReactNode, useContext } from 'react';
 
-import { APIContext } from './APIContext';
+import { APIContext, APIError } from './APIContext';
 
 import { ITimes } from '../utils/times';
 
@@ -104,7 +104,7 @@ interface IPluginContextProviderProps {
  */
 export const PluginContextProvider: FunctionComponent<IPluginContextProviderProps> = ({ plugins, children }) => {
   const { client } = useContext(APIContext);
-  const { isError, error, isLoading, data, refetch } = useQuery<IPluginInstance[] | null, Error>(
+  const { isError, error, isLoading, data, refetch } = useQuery<IPluginInstance[] | null, APIError>(
     ['core/plugincontext'],
     () => client.get<IPluginInstance[] | null>('/api/plugins'),
   );

--- a/app/packages/kiali/src/components/Edge.tsx
+++ b/app/packages/kiali/src/components/Edge.tsx
@@ -1,4 +1,12 @@
-import { APIContext, DetailsDrawer, IAPIContext, IPluginInstance, ITimes, UseQueryWrapper } from '@kobsio/core';
+import {
+  APIContext,
+  APIError,
+  DetailsDrawer,
+  IAPIContext,
+  IPluginInstance,
+  ITimes,
+  UseQueryWrapper,
+} from '@kobsio/core';
 import {
   Box,
   Card,
@@ -198,7 +206,7 @@ const EdgeMetricsTCP: FunctionComponent<{
 }> = ({ instance, times, sourceNode, targetNode }) => {
   const apiContext = useContext<IAPIContext>(APIContext);
 
-  const { isError, isLoading, error, data, refetch } = useQuery<IChart[], Error>(
+  const { isError, isLoading, error, data, refetch } = useQuery<IChart[], APIError>(
     ['kiali/metrics/edge/tcp', instance, times, sourceNode, targetNode],
     async () => {
       if (targetNode.data?.namespace === 'unknown') {
@@ -298,7 +306,7 @@ const EdgeMetricsHTTP: FunctionComponent<{
 }> = ({ instance, times, sourceNode, targetNode }) => {
   const apiContext = useContext<IAPIContext>(APIContext);
 
-  const { isError, isLoading, error, data, refetch } = useQuery<IChart[], Error>(
+  const { isError, isLoading, error, data, refetch } = useQuery<IChart[], APIError>(
     ['kiali/metrics/edge/http', instance, times, sourceNode, targetNode],
     async () => {
       if (targetNode.data?.namespace === 'unknown') {
@@ -407,7 +415,7 @@ const EdgeMetricsgRPC: FunctionComponent<{
 }> = ({ instance, times, sourceNode, targetNode }) => {
   const apiContext = useContext<IAPIContext>(APIContext);
 
-  const { isError, isLoading, error, data, refetch } = useQuery<IChart[], Error>(
+  const { isError, isLoading, error, data, refetch } = useQuery<IChart[], APIError>(
     ['kiali/metrics/edge/grpc', instance, times, sourceNode, targetNode],
     async () => {
       if (targetNode.data?.namespace === 'unknown') {

--- a/app/packages/kiali/src/components/KialiPage.tsx
+++ b/app/packages/kiali/src/components/KialiPage.tsx
@@ -1,5 +1,6 @@
 import {
   APIContext,
+  APIError,
   IAPIContext,
   IPluginInstance,
   IPluginPageProps,
@@ -34,7 +35,7 @@ const SelectNamespaces: FunctionComponent<{
 }> = ({ instance, selectedNamespaces, selectNamespaces }) => {
   const apiContext = useContext<IAPIContext>(APIContext);
 
-  const { isLoading, data } = useQuery<string[], Error>(['kiali/namespaces', instance], async () => {
+  const { isLoading, data } = useQuery<string[], APIError>(['kiali/namespaces', instance], async () => {
     return apiContext.client.get<string[]>('/api/plugins/kiali/namespaces', {
       headers: {
         'x-kobs-cluster': instance.cluster,

--- a/app/packages/kiali/src/components/Node.tsx
+++ b/app/packages/kiali/src/components/Node.tsx
@@ -1,4 +1,12 @@
-import { APIContext, DetailsDrawer, IAPIContext, IPluginInstance, ITimes, UseQueryWrapper } from '@kobsio/core';
+import {
+  APIContext,
+  APIError,
+  DetailsDrawer,
+  IAPIContext,
+  IPluginInstance,
+  ITimes,
+  UseQueryWrapper,
+} from '@kobsio/core';
 import {
   Box,
   Card,
@@ -204,7 +212,7 @@ const NodeMetrics: FunctionComponent<{
 }> = ({ instance, times, nodeNamespace, nodeType, nodeName, filters, byLabels, direction, reporter }) => {
   const apiContext = useContext<IAPIContext>(APIContext);
 
-  const { isError, isLoading, error, data, refetch } = useQuery<IChart[], Error>(
+  const { isError, isLoading, error, data, refetch } = useQuery<IChart[], APIError>(
     ['kiali/metrics/node', instance, times, nodeNamespace, nodeType, nodeName, filters, byLabels, direction, reporter],
     async () => {
       const response = await apiContext.client.get<IMetricsMap>(

--- a/app/packages/klogs/src/components/panel/AggregationPanel.tsx
+++ b/app/packages/klogs/src/components/panel/AggregationPanel.tsx
@@ -6,6 +6,7 @@ import {
   PluginPanel,
   PluginPanelActionLinks,
   IPluginInstance,
+  APIError,
 } from '@kobsio/core';
 import { useQuery } from '@tanstack/react-query';
 import queryString from 'query-string';
@@ -60,7 +61,7 @@ const AggregationPanel: FunctionComponent<IPluginPanelProps<IOptions>> = ({
   description,
 }) => {
   const { client } = useContext(APIContext);
-  const queryResult = useQuery<IAggregationData | null, Error>(
+  const queryResult = useQuery<IAggregationData | null, APIError>(
     ['klogs/aggregation', instance, options, times],
     async () => {
       if (!options) {


### PR DESCRIPTION
Our useQuery hook always returns an "APIError", but in some places we were still using "Error". These occurences are now replaces with the correct error type.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
