### PR TITLE
[core] Ensure same Height for all Plugin Panels

### DIFF
--- a/app/packages/core/src/components/plugins/PluginsPage.tsx
+++ b/app/packages/core/src/components/plugins/PluginsPage.tsx
@@ -222,14 +222,47 @@ const PluginsPage: FunctionComponent = () => {
                                   )}
                                 </Stack>
                                 <Box textAlign="center">
-                                  <Typography variant="h6">{item.name}</Typography>
-                                  <Typography variant="caption" color="text.secondary">
+                                  <Typography
+                                    sx={{
+                                      WebkitBoxOrient: 'vertical',
+                                      WebkitLineClamp: '1',
+                                      display: '-webkit-box',
+                                      overflow: 'hidden',
+                                      textOverflow: 'ellipsis',
+                                    }}
+                                    variant="h6"
+                                  >
+                                    {item.name}
+                                  </Typography>
+                                  <Typography
+                                    sx={{
+                                      WebkitBoxOrient: 'vertical',
+                                      WebkitLineClamp: '1',
+                                      display: '-webkit-box',
+                                      overflow: 'hidden',
+                                      textOverflow: 'ellipsis',
+                                    }}
+                                    variant="caption"
+                                    color="text.secondary"
+                                  >
                                     ({item.cluster} / {item.type})
                                   </Typography>
                                 </Box>
-                                <Typography textAlign="center">
-                                  {item.description ? item.description : plugin?.description}
-                                </Typography>
+                                <Box
+                                  sx={(theme) => ({
+                                    WebkitBoxOrient: 'vertical',
+                                    WebkitLineClamp: '3',
+                                    display: '-webkit-box',
+                                    height: `${(theme.typography.body1.lineHeight as number) * 3}em`,
+                                    lineHeight: `${theme.typography.body1.lineHeight}em`,
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                  })}
+                                >
+                                  <Typography textAlign="center" variant="body1" color="text.primary">
+                                    {item.description ? item.description : plugin?.description}
+                                  </Typography>
+                                </Box>
                               </Stack>
                             );
                           })(item)}


### PR DESCRIPTION
This commit ensures that all panels shown on the plugins page are having the same height, for this we are always display three lines of the description. The title and cluster / type is capped to 1 line.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
