### PR TITLE
[klogs] Add Query History

### DIFF
--- a/app/packages/klogs/src/components/AggregationPage.tsx
+++ b/app/packages/klogs/src/components/AggregationPage.tsx
@@ -10,6 +10,7 @@ import {
   ITimes,
   Options,
   Page,
+  addStateHistoryItem,
   pluginBasePath,
   useQueryState,
 } from '@kobsio/core';
@@ -19,6 +20,7 @@ import {
   FilterOptionsState,
   Grid,
   IconButton,
+  InputAdornment,
   ListItemText,
   Menu,
   MenuItem,
@@ -32,6 +34,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { Aggregation } from './Aggregation';
+import { QueryHistory } from './QueryHistory';
 
 import { IAggregationOptions } from '../utils/aggregation';
 import { description } from '../utils/utils';
@@ -115,6 +118,7 @@ const AggregationToolbar: FunctionComponent<{
   });
 
   const changeOptions = (times: ITimes, additionalFields: IOptionsAdditionalFields[] | undefined) => {
+    addStateHistoryItem('kobs-klogs-queryhistory', internalOptions.query);
     setOptions({
       ...internalOptions,
       ...times,
@@ -122,6 +126,7 @@ const AggregationToolbar: FunctionComponent<{
   };
 
   const handleSubmit = () => {
+    addStateHistoryItem('kobs-klogs-queryhistory', internalOptions.query);
     setOptions(internalOptions);
   };
 
@@ -156,6 +161,14 @@ const AggregationToolbar: FunctionComponent<{
             value={internalOptions.query}
             onChange={(value) => setInternalOptions({ ...internalOptions, query: value })}
             handleSubmit={handleSubmit}
+            adornment={
+              <InputAdornment position="end">
+                <QueryHistory
+                  optionsQuery={options.query}
+                  setQuery={(query) => setInternalOptions({ ...internalOptions, query: query })}
+                />
+              </InputAdornment>
+            }
           />
         )}
       </Grid>

--- a/app/packages/klogs/src/components/LogsPage.tsx
+++ b/app/packages/klogs/src/components/LogsPage.tsx
@@ -1,5 +1,6 @@
 import { Completion, autocompletion, completeFromList } from '@codemirror/autocomplete';
 import {
+  addStateHistoryItem,
   APIContext,
   APIError,
   Editor,
@@ -23,6 +24,7 @@ import {
   Card,
   Divider,
   IconButton,
+  InputAdornment,
   List,
   ListItem,
   ListItemButton,
@@ -42,6 +44,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { Logs } from './Logs';
+import { QueryHistory } from './QueryHistory';
 
 import { description, ILogsData } from '../utils/utils';
 
@@ -256,6 +259,7 @@ const LogsToolbar: FunctionComponent<{
 
   const changeOptions = (times: ITimes, additionalFields: IOptionsAdditionalFields[] | undefined) => {
     if (additionalFields && additionalFields.length === 2) {
+      addStateHistoryItem('kobs-klogs-queryhistory', query);
       setOptions({
         ...options,
         ...times,
@@ -267,6 +271,7 @@ const LogsToolbar: FunctionComponent<{
   };
 
   const handleSubmit = () => {
+    addStateHistoryItem('kobs-klogs-queryhistory', query);
     setOptions({ ...options, query: query });
   };
 
@@ -288,6 +293,11 @@ const LogsToolbar: FunctionComponent<{
             value={query}
             onChange={(value) => setQuery(value)}
             handleSubmit={handleSubmit}
+            adornment={
+              <InputAdornment position="end">
+                <QueryHistory optionsQuery={options.query} setQuery={(query) => setQuery(query)} />
+              </InputAdornment>
+            }
           />
         )}
       </ToolbarItem>

--- a/app/packages/klogs/src/components/QueryHistory.test.tsx
+++ b/app/packages/klogs/src/components/QueryHistory.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import { QueryHistory } from './QueryHistory';
+
+describe('QueryHistory', () => {
+  it('should return selected query from history', async () => {
+    localStorage.setItem('kobs-klogs-queryhistory', '["namespace = \'kobs\'","namespace = \'default\'"]');
+
+    const setQuery = vi.fn();
+    render(<QueryHistory optionsQuery="" setQuery={setQuery} />);
+
+    const historyButton = screen.getByRole('button');
+    await userEvent.click(historyButton);
+
+    expect(screen.getByText("namespace = 'kobs'")).toBeInTheDocument();
+    expect(screen.getByText("namespace = 'default'")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText("namespace = 'kobs'"));
+    expect(setQuery).toHaveBeenCalledWith("namespace = 'kobs'");
+  });
+
+  it('should not render the history button if history is empty', async () => {
+    localStorage.setItem('kobs-klogs-queryhistory', '');
+
+    const setQuery = vi.fn();
+    render(<QueryHistory optionsQuery="" setQuery={setQuery} />);
+
+    const hisotryButton = screen.queryByTestId('klogs-query-history');
+    expect(hisotryButton).not.toBeInTheDocument();
+  });
+});

--- a/app/packages/klogs/src/components/QueryHistory.tsx
+++ b/app/packages/klogs/src/components/QueryHistory.tsx
@@ -1,0 +1,68 @@
+import { getStateHistory } from '@kobsio/core';
+import { ManageSearch } from '@mui/icons-material';
+import { IconButton, Menu, MenuItem, Typography } from '@mui/material';
+import { FunctionComponent, MouseEvent, useMemo, useState } from 'react';
+
+export const QueryHistory: FunctionComponent<{ optionsQuery: string; setQuery: (query: string) => void }> = ({
+  optionsQuery,
+  setQuery,
+}) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
+  /**
+   * `queries` is a list of queries which are saved in the history. We refresh the list of queries each time the
+   * provided `optionsQuery` (from the `options.query` property) is changed, because this means that the user executed a
+   * new request and a new query was added to the history. This way we can save some unnecessary calls to the
+   * `getStateHistory` function.
+   */
+  const queries = useMemo(() => {
+    return getStateHistory('kobs-klogs-queryhistory');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [optionsQuery]);
+
+  /**
+   * `handleOpen` opens the menu, which is used to display the history, with all queries which were executed by a user
+   * in the past.
+   */
+  const handleOpen = (e: MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(e.currentTarget);
+  };
+
+  /**
+   * `handleClose` closes the menu, wich displays the history, with all queries which were executed by a user in the
+   * past.
+   */
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  /**
+   * `handleSelect` handles the selection of a query in the history menu. The query will be passed to the `setQuery`
+   * function and the menu will be closed.
+   */
+  const handleSelect = (query: string) => {
+    handleClose();
+    setQuery(query);
+  };
+
+  if (queries.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <IconButton size="small" onClick={handleOpen} data-testid="klogs-query-history">
+        <ManageSearch />
+      </IconButton>
+
+      <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
+        {queries.map((query, index) => (
+          <MenuItem key={index} onClick={() => handleSelect(query)}>
+            <Typography noWrap={true}>{query}</Typography>
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+};

--- a/app/packages/klogs/src/setupTests.ts
+++ b/app/packages/klogs/src/setupTests.ts
@@ -5,8 +5,50 @@ import { afterEach, expect } from 'vitest';
 
 expect.extend(matchers);
 
-// xterm uses HTMLCanvas inside of core.
-// The lib throws errors in our test output, when this isn't defined
+/**
+ * `LocalStorageMock` implements the `localStorage` interface, so that we can use it in our app for testing the
+ * `useLocalStorageState` hook and the state history.
+ */
+class LocalStorageMock {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  store: Record<string, any> = {};
+
+  constructor() {
+    this.store = {};
+  }
+
+  clear() {
+    this.store = {};
+  }
+
+  getItem(key: string) {
+    return this.store[key] || null;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  setItem(key: string, value: any) {
+    this.store[key] = value;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  removeItem(key: string) {
+    delete this.store[key];
+  }
+
+  get length() {
+    return Object.keys(this.store).length;
+  }
+
+  key(index: number) {
+    return Object.keys(this.store)[index];
+  }
+}
+
+global.localStorage = new LocalStorageMock();
+
+/**
+ * xterm uses HTMLCanvas inside of core. The lib throws errors in our test output, when this isn't defined.
+ */
 HTMLCanvasElement.prototype.getContext = () => {
   return null;
 };


### PR DESCRIPTION
The queries which a user executes are now saved in the local storage with the "kobs-klogs-queryhistory" key. This allows a user to quickly select queries which he already executed again. The history can be accessed via the adornment in the query editor.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
