### PR TITLE
[mongodb] Fix History for Pipeline and Update

### DIFF
--- a/app/packages/mongodb/src/components/MongoDBPage.tsx
+++ b/app/packages/mongodb/src/components/MongoDBPage.tsx
@@ -98,6 +98,9 @@ const QueryPageToolbar: FunctionComponent<{
   const query = () => {
     addStateHistoryItem('kobs-mongodb-filterhistory', internalOptions.filter);
     addStateHistoryItem('kobs-mongodb-sorthistory', internalOptions.sort);
+    addStateHistoryItem('kobs-mongodb-updatehistory', internalOptions.update);
+    addStateHistoryItem('kobs-mongodb-pipelinehistory', internalOptions.pipeline);
+
     setOptions(internalOptions);
   };
 


### PR DESCRIPTION
The history of the pipeline and update fields were not saved, this is now fixed by saving the current entry of the pipeline and update field when a query is executed by the user.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
