### PR TITLE
[klogs] Fix Break Down by Filters

### DIFF
--- a/app/packages/core/src/context/QueryClientProvider.tsx
+++ b/app/packages/core/src/context/QueryClientProvider.tsx
@@ -12,6 +12,7 @@ import { FunctionComponent, ReactNode } from 'react';
 const queryClientOptions: QueryClientConfig = {
   defaultOptions: {
     queries: {
+      networkMode: 'always',
       refetchInterval: false,
       refetchIntervalInBackground: false,
       refetchOnWindowFocus: false,

--- a/app/packages/klogs/src/components/AggregationPage.tsx
+++ b/app/packages/klogs/src/components/AggregationPage.tsx
@@ -366,6 +366,7 @@ const AggregationToolbar: FunctionComponent<{
           <Grid item={true} xs={12} md={10}>
             <Autocomplete
               size="small"
+              freeSolo={true}
               multiple={true}
               value={internalOptions.breakDownByFilters}
               onChange={(e, value) => setInternalOptions({ ...internalOptions, breakDownByFilters: value || [] })}


### PR DESCRIPTION
The "Break down by filters" field in the aggregation page couldn't be filled out by a user. This is now fixed by adding the "freeSolo" property to the underlying "Autocomplete" component.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
