### PR TITLE
[github] Fix Data Loading

### DIFF
--- a/app/packages/github/src/components/GithubPage.tsx
+++ b/app/packages/github/src/components/GithubPage.tsx
@@ -1,4 +1,4 @@
-import { IPluginInstance, IPluginPageProps, Page } from '@kobsio/core';
+import { IPluginInstance, IPluginPageProps, ITimes, Page } from '@kobsio/core';
 import { Box, Grid } from '@mui/material';
 import { FunctionComponent } from 'react';
 import { Route, Routes } from 'react-router-dom';
@@ -11,18 +11,24 @@ import { AuthContextProvider } from '../context/AuthContext';
 import { description } from '../utils/utils';
 
 const Overview: FunctionComponent<{ instance: IPluginInstance }> = ({ instance }) => {
+  const times: ITimes = {
+    time: 'last15Minutes',
+    timeEnd: Math.floor(Date.now() / 1000),
+    timeStart: Math.floor(Date.now() / 1000) - 900,
+  };
+
   return (
     <AuthContextProvider title="" instance={instance}>
       <Grid container={true} spacing={6}>
         <Grid item={true} xs={12} md={6}>
           <Box sx={{ display: 'flex' }}>
-            <OrgRepos title="Repositories" instance={instance} />
+            <OrgRepos title="Repositories" instance={instance} times={times} />
           </Box>
         </Grid>
 
         <Grid item={true} xs={12} md={6}>
           <Box sx={{ display: 'flex' }}>
-            <OrgPullRequests title="Pull Requests" instance={instance} />
+            <OrgPullRequests title="Pull Requests" instance={instance} times={times} />
           </Box>
         </Grid>
       </Grid>

--- a/app/packages/github/src/components/GithubPanel.tsx
+++ b/app/packages/github/src/components/GithubPanel.tsx
@@ -19,11 +19,17 @@ interface IOptions {
   type?: string;
 }
 
-const GithubPanel: FunctionComponent<IPluginPanelProps<IOptions>> = ({ title, description, options, instance }) => {
+const GithubPanel: FunctionComponent<IPluginPanelProps<IOptions>> = ({
+  title,
+  description,
+  options,
+  instance,
+  times,
+}) => {
   if (options && options.type && options.type === 'orgpullrequests') {
     return (
       <AuthContextProvider title={title} instance={instance}>
-        <OrgPullRequests title={title} description={description} instance={instance} />
+        <OrgPullRequests title={title} description={description} instance={instance} times={times} />
       </AuthContextProvider>
     );
   }
@@ -31,7 +37,7 @@ const GithubPanel: FunctionComponent<IPluginPanelProps<IOptions>> = ({ title, de
   if (options && options.type && options.type === 'orgrepositories') {
     return (
       <AuthContextProvider title={title} instance={instance}>
-        <OrgRepos title={title} description={description} instance={instance} />
+        <OrgRepos title={title} description={description} instance={instance} times={times} />
       </AuthContextProvider>
     );
   }
@@ -39,7 +45,7 @@ const GithubPanel: FunctionComponent<IPluginPanelProps<IOptions>> = ({ title, de
   if (options && options.type && options.type === 'teammembers' && options.team) {
     return (
       <AuthContextProvider title={title} instance={instance}>
-        <TeamMembers title={title} description={description} slug={options.team} instance={instance} />
+        <TeamMembers title={title} description={description} slug={options.team} instance={instance} times={times} />
       </AuthContextProvider>
     );
   }
@@ -47,7 +53,7 @@ const GithubPanel: FunctionComponent<IPluginPanelProps<IOptions>> = ({ title, de
   if (options && options.type && options.type === 'teamrepositories' && options.team) {
     return (
       <AuthContextProvider title={title} instance={instance}>
-        <TeamRepos title={title} description={description} slug={options.team} instance={instance} />
+        <TeamRepos title={title} description={description} slug={options.team} instance={instance} times={times} />
       </AuthContextProvider>
     );
   }
@@ -55,7 +61,13 @@ const GithubPanel: FunctionComponent<IPluginPanelProps<IOptions>> = ({ title, de
   if (options && options.type && options.type === 'repositoryissues' && options.repository) {
     return (
       <AuthContextProvider title={title} instance={instance}>
-        <RepositoryIssues title={title} description={description} repo={options.repository} instance={instance} />
+        <RepositoryIssues
+          title={title}
+          description={description}
+          repo={options.repository}
+          instance={instance}
+          times={times}
+        />
       </AuthContextProvider>
     );
   }
@@ -63,7 +75,13 @@ const GithubPanel: FunctionComponent<IPluginPanelProps<IOptions>> = ({ title, de
   if (options && options.type && options.type === 'repositorypullrequests' && options.repository) {
     return (
       <AuthContextProvider title={title} instance={instance}>
-        <RepositoryPullRequests title={title} description={description} repo={options.repository} instance={instance} />
+        <RepositoryPullRequests
+          title={title}
+          description={description}
+          repo={options.repository}
+          instance={instance}
+          times={times}
+        />
       </AuthContextProvider>
     );
   }
@@ -71,7 +89,13 @@ const GithubPanel: FunctionComponent<IPluginPanelProps<IOptions>> = ({ title, de
   if (options && options.type && options.type === 'repositoryworkflowruns' && options.repository) {
     return (
       <AuthContextProvider title={title} instance={instance}>
-        <RepositoryWorkflowRuns title={title} description={description} repo={options.repository} instance={instance} />
+        <RepositoryWorkflowRuns
+          title={title}
+          description={description}
+          repo={options.repository}
+          instance={instance}
+          times={times}
+        />
       </AuthContextProvider>
     );
   }
@@ -79,7 +103,7 @@ const GithubPanel: FunctionComponent<IPluginPanelProps<IOptions>> = ({ title, de
   if (options && options.type && options.type === 'userpullrequests') {
     return (
       <AuthContextProvider title={title} instance={instance}>
-        <UserPullRequests title={title} description={description} instance={instance} />
+        <UserPullRequests title={title} description={description} instance={instance} times={times} />
       </AuthContextProvider>
     );
   }

--- a/app/packages/github/src/components/org/OrgPullRequests.test.tsx
+++ b/app/packages/github/src/components/org/OrgPullRequests.test.tsx
@@ -34,6 +34,7 @@ describe('OrgPullRequests', () => {
                 name: 'github',
                 type: 'github',
               }}
+              times={{ time: 'last15Minutes', timeEnd: 2, timeStart: 1 }}
             />
           </AuthContext.Provider>
         </QueryClientProvider>

--- a/app/packages/github/src/components/org/OrgPullRequests.tsx
+++ b/app/packages/github/src/components/org/OrgPullRequests.tsx
@@ -1,4 +1,4 @@
-import { IPluginInstance, Pagination, PluginPanel, UseQueryWrapper } from '@kobsio/core';
+import { IPluginInstance, ITimes, Pagination, PluginPanel, UseQueryWrapper } from '@kobsio/core';
 import { Divider, List } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { Fragment, FunctionComponent, useContext, useState } from 'react';
@@ -10,15 +10,16 @@ import { PullRequest } from '../shared/PullRequest';
 export const OrgPullRequests: FunctionComponent<{
   description?: string;
   instance: IPluginInstance;
+  times: ITimes;
   title: string;
-}> = ({ title, description, instance }) => {
+}> = ({ title, description, instance, times }) => {
   const authContext = useContext<IAuthContext>(AuthContext);
   const [options, setOptions] = useState<{ page: number; perPage: number }>({ page: 1, perPage: 10 });
 
   const { isError, isLoading, error, data, refetch } = useQuery<
     { count: number; pullRequests: TSearchIssuesAndPullRequests },
     Error
-  >(['github/org/pullrequests', authContext.organization, instance, options.page, options.perPage], async () => {
+  >(['github/org/pullrequests', authContext.organization, instance, times, options.page, options.perPage], async () => {
     const octokit = authContext.getOctokitClient();
     const result = await octokit.search.issuesAndPullRequests({
       order: 'desc',

--- a/app/packages/github/src/components/org/OrgRepos.test.tsx
+++ b/app/packages/github/src/components/org/OrgRepos.test.tsx
@@ -34,6 +34,7 @@ describe('OrgRepos', () => {
                 name: 'github',
                 type: 'github',
               }}
+              times={{ time: 'last15Minutes', timeEnd: 2, timeStart: 1 }}
             />
           </AuthContext.Provider>
         </QueryClientProvider>

--- a/app/packages/github/src/components/org/OrgRepos.tsx
+++ b/app/packages/github/src/components/org/OrgRepos.tsx
@@ -1,4 +1,4 @@
-import { IPluginInstance, Pagination, PluginPanel, UseQueryWrapper } from '@kobsio/core';
+import { IPluginInstance, ITimes, Pagination, PluginPanel, UseQueryWrapper } from '@kobsio/core';
 import { Clear, Search } from '@mui/icons-material';
 import { Box, Divider, IconButton, InputAdornment, List, TextField } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
@@ -59,9 +59,9 @@ const OrgReposToolbar: FunctionComponent<{ filter: string; setFilter: (filter: s
 export const OrgRepos: FunctionComponent<{
   description?: string;
   instance: IPluginInstance;
-  setDetails?: (details: React.ReactNode) => void;
+  times: ITimes;
   title: string;
-}> = ({ title, description, instance, setDetails }) => {
+}> = ({ title, description, instance, times }) => {
   const authContext = useContext<IAuthContext>(AuthContext);
   const [options, setOptions] = useState<{ filter: string; page: number; perPage: number }>({
     filter: '',
@@ -70,7 +70,7 @@ export const OrgRepos: FunctionComponent<{
   });
 
   const { isError, isLoading, error, data, refetch } = useQuery<{ count: number; repos: TSearchRepos }, Error>(
-    ['github/org/repos', authContext.organization, instance, options],
+    ['github/org/repos', authContext.organization, instance, times, options],
     async () => {
       const octokit = authContext.getOctokitClient();
       const result = await octokit.search.repos({
@@ -112,6 +112,7 @@ export const OrgRepos: FunctionComponent<{
                 forksCount={repo.forks_count}
                 openIssuesCount={repo.open_issues_count}
                 pushedAt={repo.pushed_at}
+                times={times}
               />
               {index + 1 !== data?.repos.length && <Divider component="li" />}
             </Fragment>

--- a/app/packages/github/src/components/repos/RepositoryIssues.test.tsx
+++ b/app/packages/github/src/components/repos/RepositoryIssues.test.tsx
@@ -35,6 +35,7 @@ describe('RepositoryIssues', () => {
                 name: 'github',
                 type: 'github',
               }}
+              times={{ time: 'last15Minutes', timeEnd: 2, timeStart: 1 }}
             />
           </AuthContext.Provider>
         </QueryClientProvider>

--- a/app/packages/github/src/components/repos/RepositoryIssues.tsx
+++ b/app/packages/github/src/components/repos/RepositoryIssues.tsx
@@ -1,4 +1,4 @@
-import { IPluginInstance, Pagination, PluginPanel, UseQueryWrapper, formatTimeString } from '@kobsio/core';
+import { IPluginInstance, ITimes, Pagination, PluginPanel, UseQueryWrapper, formatTimeString } from '@kobsio/core';
 import {
   Box,
   Chip,
@@ -22,8 +22,9 @@ export const RepositoryIssues: FunctionComponent<{
   description?: string;
   instance: IPluginInstance;
   repo: string;
+  times: ITimes;
   title: string;
-}> = ({ title, description, repo, instance }) => {
+}> = ({ title, description, repo, instance, times }) => {
   const authContext = useContext<IAuthContext>(AuthContext);
   const [options, setOptions] = useState<{ filter: string; page: number; perPage: number }>({
     filter: '',
@@ -34,7 +35,7 @@ export const RepositoryIssues: FunctionComponent<{
   const { isError, isLoading, error, data, refetch } = useQuery<
     { count: number; issues: TSearchIssuesAndPullRequests },
     Error
-  >(['github/repo/issues', authContext.organization, instance, repo, options], async () => {
+  >(['github/repo/issues', authContext.organization, instance, times, repo, options], async () => {
     const octokit = authContext.getOctokitClient();
     const result = await octokit.search.issuesAndPullRequests({
       order: 'desc',

--- a/app/packages/github/src/components/repos/RepositoryPullRequests.test.tsx
+++ b/app/packages/github/src/components/repos/RepositoryPullRequests.test.tsx
@@ -35,6 +35,7 @@ describe('RepositoryPullRequests', () => {
                 name: 'github',
                 type: 'github',
               }}
+              times={{ time: 'last15Minutes', timeEnd: 2, timeStart: 1 }}
             />
           </AuthContext.Provider>
         </QueryClientProvider>

--- a/app/packages/github/src/components/repos/RepositoryPullRequests.tsx
+++ b/app/packages/github/src/components/repos/RepositoryPullRequests.tsx
@@ -1,4 +1,4 @@
-import { IPluginInstance, Pagination, PluginPanel, UseQueryWrapper } from '@kobsio/core';
+import { IPluginInstance, ITimes, Pagination, PluginPanel, UseQueryWrapper } from '@kobsio/core';
 import { Divider, List, ToggleButton, ToggleButtonGroup } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { Fragment, FunctionComponent, useContext, useState } from 'react';
@@ -11,8 +11,9 @@ export const RepositoryPullRequests: FunctionComponent<{
   description?: string;
   instance: IPluginInstance;
   repo: string;
+  times: ITimes;
   title: string;
-}> = ({ title, description, repo, instance }) => {
+}> = ({ title, description, repo, instance, times }) => {
   const authContext = useContext<IAuthContext>(AuthContext);
   const [options, setOptions] = useState<{ filter: ''; page: number; perPage: number }>({
     filter: '',
@@ -23,7 +24,7 @@ export const RepositoryPullRequests: FunctionComponent<{
   const { isError, isLoading, error, data, refetch } = useQuery<
     { count: number; pullRequests: TSearchIssuesAndPullRequests },
     Error
-  >(['github/repo/pullrequests', authContext.organization, instance, repo, options], async () => {
+  >(['github/repo/pullrequests', authContext.organization, instance, times, repo, options], async () => {
     const octokit = authContext.getOctokitClient();
     const result = await octokit.search.issuesAndPullRequests({
       order: 'desc',

--- a/app/packages/github/src/components/repos/RepositoryWorkflowRuns.test.tsx
+++ b/app/packages/github/src/components/repos/RepositoryWorkflowRuns.test.tsx
@@ -41,6 +41,7 @@ describe('RepositoryWorkflowRuns', () => {
                 name: 'github',
                 type: 'github',
               }}
+              times={{ time: 'last15Minutes', timeEnd: 2, timeStart: 1 }}
             />
           </AuthContext.Provider>
         </QueryClientProvider>

--- a/app/packages/github/src/components/repos/RepositoryWorkflowRuns.tsx
+++ b/app/packages/github/src/components/repos/RepositoryWorkflowRuns.tsx
@@ -2,6 +2,7 @@ import {
   DetailsDrawer,
   Editor,
   IPluginInstance,
+  ITimes,
   Pagination,
   PluginPanel,
   UseQueryWrapper,
@@ -37,11 +38,12 @@ const RepositoryWorkflowRunsDetailsJobsLogs: FunctionComponent<{
   id: number;
   instance: IPluginInstance;
   repo: string;
-}> = ({ repo, id, instance }) => {
+  times: ITimes;
+}> = ({ repo, id, instance, times }) => {
   const authContext = useContext<IAuthContext>(AuthContext);
 
   const { data } = useQuery<string, Error>(
-    ['github/repo/workflowruns/jobs/logs', authContext.organization, repo, id, instance],
+    ['github/repo/workflowruns/jobs/logs', authContext.organization, times, repo, id, instance],
     async () => {
       const octokit = authContext.getOctokitClient();
       const logs = await octokit.actions.downloadJobLogsForWorkflowRun({
@@ -70,11 +72,12 @@ const RepositoryWorkflowRunsDetailsJobs: FunctionComponent<{
   id: number;
   instance: IPluginInstance;
   repo: string;
-}> = ({ repo, id, attempt, instance }) => {
+  times: ITimes;
+}> = ({ repo, id, attempt, instance, times }) => {
   const authContext = useContext<IAuthContext>(AuthContext);
 
   const { isError, isLoading, error, data, refetch } = useQuery<TRepositoryWorkflowRunsJobs, Error>(
-    ['github/repo/workflowruns/jobs', authContext.organization, repo, id, attempt, instance],
+    ['github/repo/workflowruns/jobs', authContext.organization, repo, id, attempt, instance, times],
     async () => {
       const octokit = authContext.getOctokitClient();
       const jobs = await octokit.actions.listJobsForWorkflowRunAttempt({
@@ -151,7 +154,7 @@ const RepositoryWorkflowRunsDetailsJobs: FunctionComponent<{
               </TableContainer>
             )}
 
-            <RepositoryWorkflowRunsDetailsJobsLogs instance={instance} id={job.id} repo={repo} />
+            <RepositoryWorkflowRunsDetailsJobsLogs instance={instance} id={job.id} repo={repo} times={times} />
           </AccordionDetails>
         </Accordion>
       ))}
@@ -165,7 +168,8 @@ const RepositoryWorkflowRunDetails: FunctionComponent<{
   open: boolean;
   repo: string;
   run: TRepositoryWorkflowRun;
-}> = ({ instance, run, repo, open, onClose }) => {
+  times: ITimes;
+}> = ({ instance, run, repo, times, open, onClose }) => {
   return (
     <DetailsDrawer
       size="large"
@@ -185,7 +189,13 @@ const RepositoryWorkflowRunDetails: FunctionComponent<{
         </>
       }
     >
-      <RepositoryWorkflowRunsDetailsJobs instance={instance} id={run.id} attempt={run.run_attempt ?? 1} repo={repo} />
+      <RepositoryWorkflowRunsDetailsJobs
+        instance={instance}
+        id={run.id}
+        attempt={run.run_attempt ?? 1}
+        repo={repo}
+        times={times}
+      />
     </DetailsDrawer>
   );
 };
@@ -194,7 +204,8 @@ const RepositoryWorkflowRun: FunctionComponent<{
   instance: IPluginInstance;
   repo: string;
   run: TRepositoryWorkflowRun;
-}> = ({ instance, run, repo }) => {
+  times: ITimes;
+}> = ({ instance, run, repo, times }) => {
   const [open, setOpen] = useState<boolean>(false);
 
   return (
@@ -238,6 +249,7 @@ const RepositoryWorkflowRun: FunctionComponent<{
           instance={instance}
           run={run}
           repo={repo}
+          times={times}
           open={open}
           onClose={() => setOpen(false)}
         />
@@ -250,13 +262,14 @@ export const RepositoryWorkflowRuns: FunctionComponent<{
   description?: string;
   instance: IPluginInstance;
   repo: string;
+  times: ITimes;
   title: string;
-}> = ({ title, description, repo, instance }) => {
+}> = ({ title, description, repo, instance, times }) => {
   const authContext = useContext<IAuthContext>(AuthContext);
   const [options, setOptions] = useState<{ page: number; perPage: number }>({ page: 1, perPage: 10 });
 
   const { isError, isLoading, error, data, refetch } = useQuery<TRepositoryWorkflowRuns, Error>(
-    ['github/repo/workflowruns', authContext.organization, instance, repo, options],
+    ['github/repo/workflowruns', authContext.organization, instance, times, repo, options],
     async () => {
       const octokit = authContext.getOctokitClient();
       const workflowRuns = await octokit.actions.listWorkflowRunsForRepo({
@@ -283,7 +296,7 @@ export const RepositoryWorkflowRuns: FunctionComponent<{
         <List disablePadding={true}>
           {data?.workflow_runs.map((run, index) => (
             <Fragment key={run.id}>
-              <RepositoryWorkflowRun instance={instance} run={run} repo={repo} />
+              <RepositoryWorkflowRun instance={instance} run={run} repo={repo} times={times} />
               {index + 1 !== data?.workflow_runs.length && <Divider component="li" />}
             </Fragment>
           ))}

--- a/app/packages/github/src/components/shared/Repository.tsx
+++ b/app/packages/github/src/components/shared/Repository.tsx
@@ -1,4 +1,4 @@
-import { DetailsDrawer, IPluginInstance, timeDifference } from '@kobsio/core';
+import { DetailsDrawer, IPluginInstance, ITimes, timeDifference } from '@kobsio/core';
 import { Box, ListItem, ListItemText, Tab, Tabs, Typography } from '@mui/material';
 import { IssueOpenedIcon, RepoForkedIcon, StarIcon } from '@primer/octicons-react';
 import { FunctionComponent, useState } from 'react';
@@ -13,7 +13,8 @@ const RepositoryDetails: FunctionComponent<{
   onClose: () => void;
   open: boolean;
   repo: string;
-}> = ({ instance, repo, open, onClose }) => {
+  times: ITimes;
+}> = ({ instance, repo, times, open, onClose }) => {
   const [activeTab, setActiveTab] = useState('issues');
 
   return (
@@ -27,18 +28,18 @@ const RepositoryDetails: FunctionComponent<{
       </Box>
 
       <Box key="issues" hidden={activeTab !== 'issues'} py={6}>
-        {activeTab === 'issues' && <RepositoryIssues instance={instance} title="Issues" repo={repo} />}
+        {activeTab === 'issues' && <RepositoryIssues instance={instance} title="Issues" repo={repo} times={times} />}
       </Box>
 
       <Box key="pullrequests" hidden={activeTab !== 'pullrequests'} py={6}>
         {activeTab === 'pullrequests' && (
-          <RepositoryPullRequests instance={instance} title="Pull Requests" repo={repo} />
+          <RepositoryPullRequests instance={instance} title="Pull Requests" repo={repo} times={times} />
         )}
       </Box>
 
       <Box key="workflowruns" hidden={activeTab !== 'workflowruns'} py={6}>
         {activeTab === 'workflowruns' && (
-          <RepositoryWorkflowRuns instance={instance} title="Workflow Runs" repo={repo} />
+          <RepositoryWorkflowRuns instance={instance} title="Workflow Runs" repo={repo} times={times} />
         )}
       </Box>
     </DetailsDrawer>
@@ -54,7 +55,8 @@ export const Repository: FunctionComponent<{
   openIssuesCount: number | undefined;
   pushedAt: string | null | undefined;
   stargazersCount: number | undefined;
-}> = ({ instance, name, description, language, stargazersCount, forksCount, openIssuesCount, pushedAt }) => {
+  times: ITimes;
+}> = ({ instance, name, description, language, stargazersCount, forksCount, openIssuesCount, pushedAt, times }) => {
   const [open, setOpen] = useState(false);
 
   return (
@@ -127,7 +129,9 @@ export const Repository: FunctionComponent<{
         />
       </ListItem>
 
-      {open && <RepositoryDetails instance={instance} repo={name} onClose={() => setOpen(false)} open={open} />}
+      {open && (
+        <RepositoryDetails instance={instance} repo={name} times={times} onClose={() => setOpen(false)} open={open} />
+      )}
     </>
   );
 };

--- a/app/packages/github/src/components/teams/TeamMembers.test.tsx
+++ b/app/packages/github/src/components/teams/TeamMembers.test.tsx
@@ -40,6 +40,7 @@ describe('TeamMembers', () => {
                 name: 'github',
                 type: 'github',
               }}
+              times={{ time: 'last15Minutes', timeEnd: 2, timeStart: 1 }}
             />
           </AuthContext.Provider>
         </QueryClientProvider>

--- a/app/packages/github/src/components/teams/TeamMembers.tsx
+++ b/app/packages/github/src/components/teams/TeamMembers.tsx
@@ -1,4 +1,4 @@
-import { IPluginInstance, Pagination, PluginPanel, UseQueryWrapper } from '@kobsio/core';
+import { IPluginInstance, ITimes, Pagination, PluginPanel, UseQueryWrapper } from '@kobsio/core';
 import { Avatar, Box } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { FunctionComponent, useContext, useState } from 'react';
@@ -11,13 +11,14 @@ export const TeamMembers: FunctionComponent<{
   description?: string;
   instance: IPluginInstance;
   slug: string;
+  times: ITimes;
   title: string;
-}> = ({ title, description, slug, instance }) => {
+}> = ({ title, description, slug, instance, times }) => {
   const authContext = useContext<IAuthContext>(AuthContext);
   const [options, setOptions] = useState<{ page: number; perPage: number }>({ page: 1, perPage: 20 });
 
   const { isError, isLoading, error, data, refetch } = useQuery<TTeamMembers, Error>(
-    ['github/team/members', authContext.organization, slug, instance],
+    ['github/team/members', authContext.organization, slug, instance, times],
     async () => {
       const octokit = authContext.getOctokitClient();
       const members = await octokit.paginate(octokit.teams.listMembersInOrg, {

--- a/app/packages/github/src/components/teams/TeamRepos.test.tsx
+++ b/app/packages/github/src/components/teams/TeamRepos.test.tsx
@@ -35,6 +35,7 @@ describe('TeamRepos', () => {
                 name: 'github',
                 type: 'github',
               }}
+              times={{ time: 'last15Minutes', timeEnd: 2, timeStart: 1 }}
             />
           </AuthContext.Provider>
         </QueryClientProvider>

--- a/app/packages/github/src/components/teams/TeamRepos.tsx
+++ b/app/packages/github/src/components/teams/TeamRepos.tsx
@@ -1,4 +1,4 @@
-import { IPluginInstance, PluginPanel, UseQueryWrapper } from '@kobsio/core';
+import { IPluginInstance, ITimes, PluginPanel, UseQueryWrapper } from '@kobsio/core';
 import { Button, Divider, List } from '@mui/material';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { Fragment, FunctionComponent, useContext } from 'react';
@@ -13,8 +13,9 @@ export const TeamRepos: FunctionComponent<{
   description?: string;
   instance: IPluginInstance;
   slug: string;
+  times: ITimes;
   title: string;
-}> = ({ title, description, slug, instance }) => {
+}> = ({ title, description, slug, instance, times }) => {
   const authContext = useContext<IAuthContext>(AuthContext);
 
   const fetchRepos = async (page = 1) => {
@@ -31,9 +32,13 @@ export const TeamRepos: FunctionComponent<{
   const { isLoading, isError, data, error, refetch, isFetchingNextPage, hasNextPage, fetchNextPage } = useInfiniteQuery<
     TTeamRepos,
     Error
-  >(['github/team/repos', authContext.organization, slug, instance], ({ pageParam = 1 }) => fetchRepos(pageParam), {
-    getNextPageParam: (lastPage, allPages) => (lastPage.length < reposPerPage ? undefined : allPages.length + 1),
-  });
+  >(
+    ['github/team/repos', authContext.organization, slug, instance, times],
+    ({ pageParam = 1 }) => fetchRepos(pageParam),
+    {
+      getNextPageParam: (lastPage, allPages) => (lastPage.length < reposPerPage ? undefined : allPages.length + 1),
+    },
+  );
 
   return (
     <PluginPanel title={title} description={description}>
@@ -59,6 +64,7 @@ export const TeamRepos: FunctionComponent<{
                   forksCount={repo.forks_count}
                   openIssuesCount={repo.open_issues_count}
                   pushedAt={repo.pushed_at}
+                  times={times}
                 />
                 {pageIndex + 1 === data?.pages.length &&
                 repoIndex + 1 === data?.pages[data.pages.length - 1].length ? null : (

--- a/app/packages/github/src/components/users/UserPullRequests.test.tsx
+++ b/app/packages/github/src/components/users/UserPullRequests.test.tsx
@@ -34,6 +34,7 @@ describe('UserPullRequests', () => {
                 name: 'github',
                 type: 'github',
               }}
+              times={{ time: 'last15Minutes', timeEnd: 2, timeStart: 1 }}
             />
           </AuthContext.Provider>
         </QueryClientProvider>

--- a/app/packages/github/src/components/users/UserPullRequests.tsx
+++ b/app/packages/github/src/components/users/UserPullRequests.tsx
@@ -1,4 +1,4 @@
-import { IPluginInstance, Pagination, PluginPanel, UseQueryWrapper } from '@kobsio/core';
+import { IPluginInstance, ITimes, Pagination, PluginPanel, UseQueryWrapper } from '@kobsio/core';
 import { Divider, List, ToggleButton, ToggleButtonGroup } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { Fragment, FunctionComponent, useContext, useState } from 'react';
@@ -10,8 +10,9 @@ import { PullRequest } from '../shared/PullRequest';
 export const UserPullRequests: FunctionComponent<{
   description?: string;
   instance: IPluginInstance;
+  times: ITimes;
   title: string;
-}> = ({ title, description, instance }) => {
+}> = ({ title, description, instance, times }) => {
   const authContext = useContext<IAuthContext>(AuthContext);
   const [options, setOptions] = useState<{ filter: string; page: number; perPage: number }>({
     filter: 'author',
@@ -22,17 +23,20 @@ export const UserPullRequests: FunctionComponent<{
   const { isError, isLoading, error, data, refetch } = useQuery<
     { count: number; pullRequests: TSearchIssuesAndPullRequests },
     Error
-  >(['github/users/pullrequests', authContext.organization, authContext.username, instance, options], async () => {
-    const octokit = authContext.getOctokitClient();
-    const result = await octokit.search.issuesAndPullRequests({
-      order: 'desc',
-      page: options.page,
-      per_page: options.perPage,
-      q: `is:pull-request ${options.filter}:${authContext.username}`,
-      sort: 'updated',
-    });
-    return { count: result.data.total_count, pullRequests: result.data.items };
-  });
+  >(
+    ['github/users/pullrequests', authContext.organization, authContext.username, instance, times, options],
+    async () => {
+      const octokit = authContext.getOctokitClient();
+      const result = await octokit.search.issuesAndPullRequests({
+        order: 'desc',
+        page: options.page,
+        per_page: options.perPage,
+        q: `is:pull-request ${options.filter}:${authContext.username}`,
+        sort: 'updated',
+      });
+      return { count: result.data.total_count, pullRequests: result.data.items };
+    },
+  );
 
   return (
     <PluginPanel


### PR DESCRIPTION
When a user viewed the loaded data once, it wasn't refreshed, because the query keys did not changed, therefor this commit adds the "times" property to the panels, so that the data is refreshed, when the interval in a dashboard changes or the GitHub page is revisited.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
