### PR TITLE
[klogs] Return Parser Errors

### DIFF
--- a/pkg/plugins/klogs/instance/parser/parser.go
+++ b/pkg/plugins/klogs/instance/parser/parser.go
@@ -182,13 +182,14 @@ func NewSQLParser(defaultFields, materializedColumns []string) SQLParser {
 
 func (s *SQLParser) Parse(query string) (string, error) {
 	s.errors = nil
-	if expr, err := P.ParseString("", query); err != nil {
-		return "", fmt.Errorf("couldn't parse query, error: %w", err)
-	} else {
-		r := s.parseExpr(expr)
-		if s.errors != nil {
-			return r, fmt.Errorf("couldn't convert query to sql")
-		}
-		return r, nil
+	expr, err := P.ParseString("", query)
+	if err != nil {
+		return "", fmt.Errorf("Failed to parse query: %w", err)
 	}
+
+	r := s.parseExpr(expr)
+	if s.errors != nil {
+		return r, fmt.Errorf("Failed to convert query to SQL")
+	}
+	return r, nil
 }

--- a/pkg/plugins/klogs/instance/parser/parser_test.go
+++ b/pkg/plugins/klogs/instance/parser/parser_test.go
@@ -236,7 +236,7 @@ func TestParser(t *testing.T) {
 	t.Run("with parsing errors", func(t *testing.T) {
 		_, err := defaultParser.Parse("namespace = 'hello' _ant_ content_level='ERROR'")
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "couldn't parse query")
+		require.Contains(t, err.Error(), "Failed to parse query:")
 	})
 
 	t.Run("comparing columns with each other isn't supported", func(t *testing.T) {

--- a/pkg/plugins/klogs/router.go
+++ b/pkg/plugins/klogs/router.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -129,6 +130,11 @@ func (router *Router) getLogs(w http.ResponseWriter, r *http.Request) {
 
 	documents, fields, count, took, buckets, err := i.GetLogs(r.Context(), query, order, orderBy, 1000, parsedTimeStart, parsedTimeEnd)
 	if err != nil {
+		if strings.Contains(err.Error(), "Failed to parse query:") {
+			log.Error(r.Context(), "Failed to parse query", zap.Error(err))
+			errresponse.Render(w, r, http.StatusInternalServerError, err.Error())
+			return
+		}
 		log.Error(r.Context(), "Failed to get logs", zap.Error(err))
 		errresponse.Render(w, r, http.StatusInternalServerError, "Failed to get logs")
 		return

--- a/pkg/plugins/klogs/router_test.go
+++ b/pkg/plugins/klogs/router_test.go
@@ -122,6 +122,27 @@ func TestGetLogs(t *testing.T) {
 		utils.AssertJSONEq(t, w, `{"errors":["Failed to get logs"]}`)
 	})
 
+	t.Run("should handle error from instance.GetLogs for invalid query", func(t *testing.T) {
+		timeEnd := time.Now()
+		timeStart := timeEnd.Add(-30 * time.Minute)
+
+		ctrl := gomock.NewController(t)
+		mockInstance := instance.NewMockInstance(ctrl)
+		mockInstance.EXPECT().GetName().Return("instance")
+		mockInstance.EXPECT().GetLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), int64(1000), timeStart.Unix(), timeEnd.Unix()).Return([]map[string]any{}, []instance.Field{}, int64(0), int64(0), []instance.Bucket{}, fmt.Errorf(`Failed to parse query: 1:24: unexpected token "<EOF>" (expected ")")`))
+
+		path := fmt.Sprintf("/logs?timeStart=%d&timeEnd=%d", timeStart.Unix(), timeEnd.Unix())
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, path, nil)
+		req.Header.Add("x-kobs-plugin", "instance")
+		w := httptest.NewRecorder()
+
+		router := Router{instances: []instance.Instance{mockInstance}}
+		router.getLogs(w, req)
+
+		utils.AssertStatusEq(t, w, http.StatusInternalServerError)
+		utils.AssertJSONEq(t, w, `{"errors":["Failed to parse query: 1:24: unexpected token \"<EOF>\" (expected \")\")"]}`)
+	})
+
 	t.Run("should handle unknown instance", func(t *testing.T) {
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/logs", nil)
 		w := httptest.NewRecorder()


### PR DESCRIPTION
If we could not return the logs, because the provided user query is wrong the error from the query parser is now returned to the user. Other error messages are not returned to not leak some confidential information.

Closes #451

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml for the hub](https://github.com/kobsio/kobs/blob/main/deploy/helm/hub/values.yaml) / [values.yaml for the satellite](https://github.com/kobsio/kobs/blob/main/deploy/helm/satellite/values.yaml) file and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
