### PR TITLE
[core] Fix Variable Handling

### DIFF
--- a/app/packages/core/src/components/dashboards/utils.ts
+++ b/app/packages/core/src/components/dashboards/utils.ts
@@ -84,8 +84,7 @@ export const getVariableViaPlugin = async (
   times: ITimes,
 ): Promise<IVariableValues> => {
   const result = await apiClient.post<string[]>(
-    '/api/variables',
-    //`/api/plugins/${variable.plugin.type}/variable?timeStart=${times.timeStart}&timeEnd=${times.timeEnd}`,
+    `/api/plugins/${variable.plugin.type}/variable?timeStart=${times.timeStart}&timeEnd=${times.timeEnd}`,
     {
       body: JSON.parse(interpolate(JSON.stringify(variable.plugin.options), variables, times)),
       headers: {

--- a/pkg/hub/api/dashboards/dashboards_test.go
+++ b/pkg/hub/api/dashboards/dashboards_test.go
@@ -125,7 +125,7 @@ func TestGetDashboard(t *testing.T) {
 		router.getDashboard(w, req)
 
 		utils.AssertStatusEq(t, w, http.StatusOK)
-		utils.AssertJSONEq(t, w, `{"placeholders":[{"name":"key1"}],"variables":[{"name":"key1","label":"key1","hide":true,"plugin":{"type":"app","name":"placeholder","options":{"type":"string","value":"value1"}}}],"rows":null}`)
+		utils.AssertJSONEq(t, w, `{"placeholders":[{"name":"key1"}],"variables":[{"name":"key1","label":"key1","hide":true,"plugin":{"type":"core","name":"placeholder","options":{"type":"string","value":"value1"}}}],"rows":null}`)
 	})
 }
 

--- a/pkg/hub/api/dashboards/variables.go
+++ b/pkg/hub/api/dashboards/variables.go
@@ -38,7 +38,7 @@ func addPlaceholdersAsVariables(placeholders []dashboardv1.Placeholder, variable
 				Hide:  true,
 				Plugin: dashboardv1.Plugin{
 					Name:    "placeholder",
-					Type:    "app",
+					Type:    "core",
 					Options: &apiextensionsv1.JSON{Raw: options},
 				},
 			})

--- a/pkg/hub/api/dashboards/variables_test.go
+++ b/pkg/hub/api/dashboards/variables_test.go
@@ -18,7 +18,7 @@ func TestAddPlaceholdersAsVariables(t *testing.T) {
 				Hide:  true,
 				Plugin: dashboardv1.Plugin{
 					Name:    "placeholder",
-					Type:    "app",
+					Type:    "core",
 					Options: &apiextensionsv1.JSON{Raw: []byte(`{"type":"string","value":"value1"}`)},
 				},
 			},
@@ -37,7 +37,7 @@ func TestAddPlaceholdersAsVariables(t *testing.T) {
 				Hide:  true,
 				Plugin: dashboardv1.Plugin{
 					Name:    "static",
-					Type:    "app",
+					Type:    "core",
 					Options: &apiextensionsv1.JSON{Raw: []byte(`["value1"]`)},
 				},
 			},
@@ -48,7 +48,7 @@ func TestAddPlaceholdersAsVariables(t *testing.T) {
 				Hide:  true,
 				Plugin: dashboardv1.Plugin{
 					Name:    "static",
-					Type:    "app",
+					Type:    "core",
 					Options: &apiextensionsv1.JSON{Raw: []byte(`["value1"]`)},
 				},
 			},
@@ -63,7 +63,7 @@ func TestAddPlaceholdersAsVariables(t *testing.T) {
 				Hide:  true,
 				Plugin: dashboardv1.Plugin{
 					Name:    "placeholder",
-					Type:    "app",
+					Type:    "core",
 					Options: &apiextensionsv1.JSON{Raw: []byte(`{"type":"string","value":"value1"}`)},
 				},
 			},
@@ -73,7 +73,7 @@ func TestAddPlaceholdersAsVariables(t *testing.T) {
 				Hide:  true,
 				Plugin: dashboardv1.Plugin{
 					Name:    "static",
-					Type:    "app",
+					Type:    "core",
 					Options: &apiextensionsv1.JSON{Raw: []byte(`["value1"]`)},
 				},
 			},
@@ -88,7 +88,7 @@ func TestAddPlaceholdersAsVariables(t *testing.T) {
 				Hide:  true,
 				Plugin: dashboardv1.Plugin{
 					Name:    "static",
-					Type:    "app",
+					Type:    "core",
 					Options: &apiextensionsv1.JSON{Raw: []byte(`["value1"]`)},
 				},
 			},
@@ -103,7 +103,7 @@ func TestAddPlaceholdersAsVariables(t *testing.T) {
 				Hide:  true,
 				Plugin: dashboardv1.Plugin{
 					Name:    "placeholder",
-					Type:    "app",
+					Type:    "core",
 					Options: &apiextensionsv1.JSON{Raw: []byte(`{"type":"string","value":"default1"}`)},
 				},
 			},


### PR DESCRIPTION
The API path to get the variable values for a plugin was wrong and is now fixed. We also used the old "app" type in the dashboards logic instead of the new "core" type for the built-in variables and placeholders.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
