### PR TITLE
[core] Fix Topology Graph in Rows with "autoHeight"

### DIFF
--- a/app/packages/core/src/components/applications/TopologyPanel.tsx
+++ b/app/packages/core/src/components/applications/TopologyPanel.tsx
@@ -6,6 +6,7 @@ import { ApplicationsInsightsWrapper, TopologyGraph } from './Topology';
 import { ITopology } from './utils';
 
 import { APIContext, APIError, IAPIContext } from '../../context/APIContext';
+import { GridContext, IGridContext } from '../../context/GridContext';
 import { PluginPanel, PluginPanelError } from '../utils/PluginPanel';
 import { UseQueryWrapper } from '../utils/UseQueryWrapper';
 
@@ -85,29 +86,37 @@ interface ITopologyPanelProps {
  * an example if an required property is missing.
  */
 const TopologyPanel: FunctionComponent<ITopologyPanelProps> = ({ title, description, options }) => {
-  if (!options || !options.cluster || !options.namespace || !options.name) {
+  const gridContext = useContext<IGridContext>(GridContext);
+
+  if (options && options.cluster && options.namespace && options.name) {
     return (
-      <PluginPanelError
-        title={title}
-        description={description}
-        message="Invalid options for topology plugin"
-        details="One of the required options: cluster, namespace or name is missing"
-        example={`plugin:
+      <PluginPanel title={title} description={description}>
+        {gridContext.autoHeight ? (
+          <Box height="300px">
+            <TopologyPanelInternal cluster={options.cluster} namespace={options.namespace} name={options.name} />
+          </Box>
+        ) : (
+          <TopologyPanelInternal cluster={options.cluster} namespace={options.namespace} name={options.name} />
+        )}
+      </PluginPanel>
+    );
+  }
+
+  return (
+    <PluginPanelError
+      title={title}
+      description={description}
+      message="Invalid options for topology plugin"
+      details="One of the required options: cluster, namespace or name is missing"
+      example={`plugin:
   name: topology
   type: core
   options:
     cluster: "<% $.cluster %>"
     namespace: "<% $.namespace %>"
     name: "<% $.name %>"`}
-        documentation="https://kobs.io/main/plugins/#topology"
-      />
-    );
-  }
-
-  return (
-    <PluginPanel title={title} description={description}>
-      <TopologyPanelInternal cluster={options.cluster} namespace={options.namespace} name={options.name} />
-    </PluginPanel>
+      documentation="https://kobs.io/main/plugins/#topology"
+    />
   );
 };
 

--- a/app/packages/core/src/components/plugins/PluginPanel.tsx
+++ b/app/packages/core/src/components/plugins/PluginPanel.tsx
@@ -53,9 +53,6 @@ const CorePanel: FunctionComponent<ICorePanelProps> = ({ cluster, name, title, d
     return <TopologyPanel title={title} description={description} options={options} />;
   }
 
-  if (name === 'insights') {
-  }
-
   if (name === 'teams') {
     return <TeamsPanel title={title} description={description} />;
   }


### PR DESCRIPTION
The topology graph plugin from the core plugins wasn't working in rows, which are using the "autoHeight" option. This should now be fixed, so that the topology graph can be used in all rows, independently from the "autoHeight" option.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
