### PR TITLE
[core] Fix GetTopologyByIDs Function

### DIFF
--- a/pkg/hub/db/db.go
+++ b/pkg/hub/db/db.go
@@ -986,6 +986,10 @@ func (c *client) GetTags(ctx context.Context) ([]Tag, error) {
 }
 
 func (c *client) GetTopologyByIDs(ctx context.Context, field string, ids []string) ([]Topology, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
 	_, span := c.tracer.Start(ctx, "db.GetTopologyByIDs")
 	span.SetAttributes(attribute.Key("field").String(field))
 	span.SetAttributes(attribute.Key("ids").StringSlice(ids))


### PR DESCRIPTION
If the passed slice of IDs is nil the function shouldn't throw an error, instead the function should return nil, so that we not show an error message in the frontend, but an info that no applications where found for the requested topology graph.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
