### PR TITLE
[jaeger] Fix Traces Panel

### DIFF
--- a/app/packages/jaeger/src/components/JaegerPanel.tsx
+++ b/app/packages/jaeger/src/components/JaegerPanel.tsx
@@ -80,13 +80,13 @@ const TracesWrapper: FunctionComponent<{
           {activeTab === index && (
             <Traces
               instance={instance}
-              limit={queries[0].limit || '20'}
-              maxDuration={queries[0].maxDuration || ''}
-              minDuration={queries[0].minDuration || ''}
-              operation={queries[0].operation || ''}
-              service={queries[0].service || ''}
+              limit={query.limit || '20'}
+              maxDuration={query.maxDuration || ''}
+              minDuration={query.minDuration || ''}
+              operation={query.operation || ''}
+              service={query.service || ''}
               showChart={showChart || false}
-              tags={queries[0].tags || ''}
+              tags={query.tags || ''}
               times={times}
             />
           )}


### PR DESCRIPTION
The traces panel from the Jaeger plugin always displayed the first trace for all tabs. This is now fixed so that each tab will display the correct traces.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
