### PR TITLE
[core] Fix "interpolate" Function for Objects

### DIFF
--- a/app/packages/core/src/components/dashboards/utils.ts
+++ b/app/packages/core/src/components/dashboards/utils.ts
@@ -22,7 +22,12 @@ export const interpolate = (
     if (variable.plugin.type === 'core' && variable.plugin.name === 'placeholder') {
       if (variable.plugin.options && variable.plugin.options.type && variable.plugin.options.type === 'number') {
         str = str.replaceAll(`"${interpolator[0]} .${variable.name} ${interpolator[1]}"`, variable.value);
-      } else if (variable.plugin.options && variable.plugin.options.type && variable.plugin.options.type === 'object') {
+      } else if (
+        variable.plugin.options &&
+        variable.plugin.options.type &&
+        variable.plugin.options.type === 'object' &&
+        variable.value
+      ) {
         str = str.replaceAll(
           `"${interpolator[0]} .${variable.name} ${interpolator[1]}"`,
           JSON.stringify(yaml.load(variable.value)),


### PR DESCRIPTION
The "interpolate" function has thrown an error when a placeholder of type "object" didn't had a value, because the "JSON.parse" function does not work in this case. We are now checking if the value for the placeholder is defined before we try to parse it.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
