### PR TITLE
[klogs]: parser adjustments

### DIFF
--- a/pkg/plugins/klogs/instance/parser/parser.go
+++ b/pkg/plugins/klogs/instance/parser/parser.go
@@ -21,7 +21,7 @@ type Predicate struct {
 	Lhs           Value       `parser:"@@"`
 	Op            string      `parser:"@Operators"`
 	Rhs           Value       `parser:"@@"`
-	Not           *Predicate  `parser:"| \"_NOT_\" @@"`
+	Not           *Predicate  `parser:"| (\"_NOT_\"|\"_not_\") @@"`
 	Exists        *string     `parser:"| (\"_EXISTS_\"|\"_exists_\") @Ident"`
 	Subexpression *Expression `parser:"| \"(\" @@ \")\""`
 }

--- a/pkg/plugins/klogs/instance/parser/parser_test.go
+++ b/pkg/plugins/klogs/instance/parser/parser_test.go
@@ -249,6 +249,11 @@ func TestParser(t *testing.T) {
 		require.Equal(t, "unsupported query, comparing two symbols isn't supported: namespace = container_name", parser.errors[0].Error())
 	})
 
+	t.Run("handles lowercase _not_", func(t *testing.T) {
+		_, err := defaultParser.Parse("namespace='brain' _and_ app='brain' _and_ container_name='brain' _and_ _NOT_ content_level='debug' _and_ _not_ content_level='info' _and_ _not_ content_level='warn'")
+		require.NoError(t, err)
+	})
+
 	t.Run("should handle brackets", func(t *testing.T) {
 		sqlParser := SQLParser{
 			defaultFields: []string{"namespace"},


### PR DESCRIPTION
<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

- added `_not_` to the parser

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
