### PR TITLE
[klogs]: parser - fix `_not_` with subexpression

### DIFF
--- a/pkg/plugins/klogs/instance/parser/parser.go
+++ b/pkg/plugins/klogs/instance/parser/parser.go
@@ -35,7 +35,7 @@ type Value struct {
 // Parser
 var (
 	lex = lexer.MustSimple([]lexer.SimpleRule{
-		{Name: `Keyword`, Pattern: `_and_|_AND_|_or_|_OR_`},
+		{Name: `Keyword`, Pattern: `_and_|_AND_|_or_|_OR_|_not_|_NOT_`},
 		{Name: `Ident`, Pattern: `[a-zA-Z_][a-zA-Z0-9_\/]*`},
 		{Name: `Number`, Pattern: `[-+]?\d*\.?\d+([eE][-+]?\d+)?`},
 		{Name: `String`, Pattern: `\'(?:[^\']|\\.)*\'`},
@@ -128,7 +128,7 @@ func (s *SQLParser) parsePredicate(p *Predicate) string {
 	}
 
 	if p.Not != nil {
-		return fmt.Sprintf("NOT ( %s )", s.parsePredicate(p.Not))
+		return fmt.Sprintf("NOT %s", s.parsePredicate(p.Not))
 	}
 
 	if p.Exists != nil {


### PR DESCRIPTION
<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

- `_not_` wasn't listed inside the keywords of the lexer, which caused errors when parsing the query into an AST

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
