### PR TITLE
[prometheus] Fix yAxis min and max Setting

### DIFF
--- a/app/packages/prometheus/src/components/Chart.tsx
+++ b/app/packages/prometheus/src/components/Chart.tsx
@@ -132,8 +132,8 @@ const Chart: FunctionComponent<IChartProps> = ({ metrics, type, stacked, unit, m
         scale={{ x: 'time', y: 'linear' }}
         width={chartSize.width}
         domain={{ x: [new Date(times.timeStart * 1000), new Date(times.timeEnd * 1000)] }}
-        // maxDomain={{ y: stacked ? undefined : max }}
-        // minDomain={{ y: stacked ? undefined : min }}
+        maxDomain={max ? { y: max } : undefined}
+        minDomain={min ? { y: min } : undefined}
       >
         <VictoryAxis dependentAxis={false} tickFormat={chartTickFormatTime} />
         <VictoryAxis dependentAxis={true} label={unit} tickFormat={chartTickFormatValue} />

--- a/app/packages/prometheus/src/components/PrometheusPanel.tsx
+++ b/app/packages/prometheus/src/components/PrometheusPanel.tsx
@@ -274,10 +274,10 @@ const PrometheusChart: FunctionComponent<{
           <Box
             height={
               gridContext.autoHeight
-                ? `${350 - 8}px`
+                ? `${350 - 10}px`
                 : legend === 'table'
-                ? dimensions.height - 80 - 8
-                : dimensions.height - 8
+                ? dimensions.height - 80 - 10
+                : dimensions.height - 10
             }
           >
             <Chart


### PR DESCRIPTION
The yAxis min and max settings were not used, which is now fixed.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
