### PR TITLE
[core] Fix TeamPage

### DIFF
--- a/app/packages/core/src/components/teams/TeamPage.tsx
+++ b/app/packages/core/src/components/teams/TeamPage.tsx
@@ -24,7 +24,7 @@ const TeamPage: FunctionComponent = () => {
   const apiContext = useContext<IAPIContext>(APIContext);
 
   const { isError, isLoading, error, data, refetch } = useQuery<ITeam, APIError>(
-    ['core/teams/team', params.cluster, params.namespace, params.name],
+    ['core/teams/team', params.id],
     async () => {
       return apiContext.client.get<IApplication>(`/api/teams/team?id=${encodeURIComponent(params.id || '')}`);
     },

--- a/app/packages/core/src/components/teams/Teams.tsx
+++ b/app/packages/core/src/components/teams/Teams.tsx
@@ -110,11 +110,7 @@ const Teams: FunctionComponent<ITeamsProps> = ({ isPanel, options, setOptions })
         {data?.slice((page - 1) * perPage, page * perPage).map((team, index) => (
           <Fragment key={team.id}>
             <Team team={team} />
-            {isPanel ? (
-              <Divider variant="inset" component="li" />
-            ) : index + 1 !== data?.length ? (
-              <Divider variant="inset" component="li" />
-            ) : null}
+            {index + 1 !== data?.slice((page - 1) * perPage, page * perPage).length && <Divider component="li" />}
           </Fragment>
         ))}
       </List>


### PR DESCRIPTION
The useQuery parameter in the TeamPage component was wrong, instead of the "id" we were using the "cluster", "namespace" and "name" parameters. This is now fixed.

Also the divider shown in the teams list was fixed, so that the divider is now displayed in the same cases as in the applications page.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
