### PR TITLE
[core] Fix Page Overflow

### DIFF
--- a/app/packages/core/src/components/app/layout/Layout.tsx
+++ b/app/packages/core/src/components/app/layout/Layout.tsx
@@ -70,7 +70,7 @@ export const Layout: FunctionComponent<ILayoutProps> = ({ children }) => {
           display: 'flex',
           flex: 1,
           flexDirection: 'column',
-          maxWidth: '100%',
+          maxWidth: { md: `calc(100% - ${drawerWidth}px)`, xs: '100%' },
         }}
       >
         <Hidden mdUp={true}>


### PR DESCRIPTION
It could happen that the page overflows by the width of the drawer on larger screens, because we used the "maxWidth: 100%" on all screen sizes. To fix this we limit the width to "maxWidth: calc(100% - drawer width)" in the Layout component.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
