### PR TITLE
[core] Adjust DetailsDrawer

### DIFF
--- a/app/packages/core/src/components/applications/Application.tsx
+++ b/app/packages/core/src/components/applications/Application.tsx
@@ -119,7 +119,7 @@ const Application: FunctionComponent<IApplicationProps> = ({ application }) => {
         />
       </ListItem>
 
-      <ApplicationInsightsDrawer application={application} onClose={hideInsights} open={open} />
+      {open && <ApplicationInsightsDrawer application={application} onClose={hideInsights} open={open} />}
     </>
   );
 };

--- a/app/packages/core/src/components/resources/Resources.tsx
+++ b/app/packages/core/src/components/resources/Resources.tsx
@@ -91,17 +91,19 @@ const ResourceRow: FunctionComponent<IResourceRowProps> = ({ resource, row, dash
         </TableCell>
       </TableRow>
 
-      <ResourceDetails
-        resource={resource}
-        cluster={row.cluster}
-        namespace={row.namespace}
-        name={row.name}
-        manifest={row.manifest}
-        dashboards={dashboards}
-        refetch={refetch}
-        open={open}
-        onClose={() => setOpen(false)}
-      />
+      {open && (
+        <ResourceDetails
+          resource={resource}
+          cluster={row.cluster}
+          namespace={row.namespace}
+          name={row.name}
+          manifest={row.manifest}
+          dashboards={dashboards}
+          refetch={refetch}
+          open={open}
+          onClose={() => setOpen(false)}
+        />
+      )}
     </>
   );
 };

--- a/app/packages/flux/src/components/ResourceDetails.tsx
+++ b/app/packages/flux/src/components/ResourceDetails.tsx
@@ -89,7 +89,7 @@ const ResourceDetails: FunctionComponent<{
       {fluxResource.type === 'gitrepositories' ||
       fluxResource.type === 'buckets' ||
       fluxResource.type === 'helmrepositories' ? (
-        <Card sx={{ mb: 4 }}>
+        <Card sx={{ mb: 6 }}>
           <CardContent>
             <Typography variant="h6" pb={2}>
               Info
@@ -125,7 +125,7 @@ const ResourceDetails: FunctionComponent<{
       ) : null}
 
       {fluxResource.type === 'kustomizations' ? (
-        <Card sx={{ mb: 4 }}>
+        <Card sx={{ mb: 6 }}>
           <CardContent>
             <Typography variant="h6" pb={2}>
               Info
@@ -182,7 +182,7 @@ const ResourceDetails: FunctionComponent<{
       ) : null}
 
       {fluxResource.type === 'helmreleases' ? (
-        <Card sx={{ mb: 4 }}>
+        <Card sx={{ mb: 6 }}>
           <CardContent>
             <Typography variant="h6" pb={2}>
               Info
@@ -215,7 +215,7 @@ const ResourceDetails: FunctionComponent<{
       manifest.spec.chart &&
       manifest.spec.chart.spec &&
       manifest.spec.chart.spec.sourceRef ? (
-        <Card sx={{ mb: 4 }}>
+        <Card sx={{ mb: 6 }}>
           <CardContent>
             <Typography variant="h6" pb={2}>
               Source
@@ -259,7 +259,7 @@ const ResourceDetails: FunctionComponent<{
       ) : null}
 
       {fluxResource.type === 'gitrepositories' ? (
-        <Card sx={{ mb: 4 }}>
+        <Card sx={{ mb: 6 }}>
           <CardContent>
             <Typography variant="h6" pb={2}>
               Git Reference
@@ -287,7 +287,7 @@ const ResourceDetails: FunctionComponent<{
       ) : null}
 
       {manifest && manifest.status && manifest.status.artifact ? (
-        <Card sx={{ mb: 4 }}>
+        <Card sx={{ mb: 6 }}>
           <CardContent>
             <Typography variant="h6" pb={2}>
               Artifact
@@ -306,7 +306,7 @@ const ResourceDetails: FunctionComponent<{
         </Card>
       ) : null}
 
-      <Card sx={{ mb: 4 }}>
+      <Card sx={{ mb: 6 }}>
         <CardContent>
           <Typography variant="h6" pb={2}>
             Conditions

--- a/app/packages/flux/src/components/Resources.tsx
+++ b/app/packages/flux/src/components/Resources.tsx
@@ -182,19 +182,21 @@ const ResourceRow: FunctionComponent<{
         </TableCell>
       </TableRow>
 
-      <ResourceDetails
-        instance={instance}
-        fluxResource={fluxResource}
-        cluster={row.cells[2]}
-        namespace={row.cells[1]}
-        name={row.cells[0]}
-        manifest={row.manifest}
-        resource={resource}
-        path={path}
-        refetch={refetch}
-        open={open}
-        onClose={() => setOpen(false)}
-      />
+      {open && (
+        <ResourceDetails
+          instance={instance}
+          fluxResource={fluxResource}
+          cluster={row.cells[2]}
+          namespace={row.cells[1]}
+          name={row.cells[0]}
+          manifest={row.manifest}
+          resource={resource}
+          path={path}
+          refetch={refetch}
+          open={open}
+          onClose={() => setOpen(false)}
+        />
+      )}
     </>
   );
 };

--- a/app/packages/harbor/src/components/Artifacts.tsx
+++ b/app/packages/harbor/src/components/Artifacts.tsx
@@ -563,14 +563,16 @@ const Artifact: FunctionComponent<{
         />
       </ListItem>
 
-      <Details
-        instance={instance}
-        projectName={projectName}
-        repositoryName={repositoryName}
-        artifact={artifact}
-        onClose={hideDetails}
-        open={open}
-      />
+      {open && (
+        <Details
+          instance={instance}
+          projectName={projectName}
+          repositoryName={repositoryName}
+          artifact={artifact}
+          onClose={hideDetails}
+          open={open}
+        />
+      )}
     </>
   );
 };

--- a/app/packages/helm/src/components/History.tsx
+++ b/app/packages/helm/src/components/History.tsx
@@ -41,7 +41,15 @@ const Release: FunctionComponent<{
         <TableCell>{release.chart?.metadata?.appVersion || '-'}</TableCell>
       </TableRow>
 
-      <ReleaseDetails instance={instance} release={release} times={times} open={open} onClose={() => setOpen(false)} />
+      {open && (
+        <ReleaseDetails
+          instance={instance}
+          release={release}
+          times={times}
+          open={open}
+          onClose={() => setOpen(false)}
+        />
+      )}
     </>
   );
 };

--- a/app/packages/helm/src/components/Releases.tsx
+++ b/app/packages/helm/src/components/Releases.tsx
@@ -44,7 +44,15 @@ const Release: FunctionComponent<{
         <TableCell>{release.chart?.metadata?.appVersion || '-'}</TableCell>
       </TableRow>
 
-      <ReleaseDetails instance={instance} release={release} times={times} open={open} onClose={() => setOpen(false)} />
+      {open && (
+        <ReleaseDetails
+          instance={instance}
+          release={release}
+          times={times}
+          open={open}
+          onClose={() => setOpen(false)}
+        />
+      )}
     </>
   );
 };

--- a/app/packages/jira/src/components/Issues.tsx
+++ b/app/packages/jira/src/components/Issues.tsx
@@ -125,7 +125,7 @@ const IssueDetails: FunctionComponent<{
         </IconButton>
       }
     >
-      <Card sx={{ mb: 4 }}>
+      <Card sx={{ mb: 6 }}>
         <CardContent>
           <Typography variant="h6" pb={2}>
             Details
@@ -248,7 +248,7 @@ const IssueDetails: FunctionComponent<{
       </Card>
 
       {issue.fields?.subtasks && issue.fields?.subtasks.length > 0 && (
-        <Card sx={{ mb: 4 }}>
+        <Card sx={{ mb: 6 }}>
           <CardContent>
             <Typography variant="h6" pb={2}>
               Subtasks
@@ -266,7 +266,7 @@ const IssueDetails: FunctionComponent<{
       )}
 
       {issue.fields?.issuelinks && issue.fields?.issuelinks.length > 0 && (
-        <Card sx={{ mb: 4 }}>
+        <Card sx={{ mb: 6 }}>
           <CardContent>
             <Typography variant="h6" pb={2}>
               Linked Issues

--- a/app/packages/rss/src/components/Feed.tsx
+++ b/app/packages/rss/src/components/Feed.tsx
@@ -107,7 +107,7 @@ const Details: FunctionComponent<{
       subtitle={`(${item.feedTitle})`}
       actions={<Actions instance={instance} item={item} />}
     >
-      <Card>
+      <Card sx={{ mb: 6 }}>
         <CardContent>
           {item.published ? (
             <Typography variant="h6" pb={2}>

--- a/app/packages/signalsciences/src/components/Agents.tsx
+++ b/app/packages/signalsciences/src/components/Agents.tsx
@@ -98,7 +98,7 @@ const Details: FunctionComponent<{
       title={agent['agent.name']}
       subtitle={agent['host.remote_addr']}
     >
-      <Card>
+      <Card sx={{ mb: 6 }}>
         <CardContent>
           <DescriptionList>
             <DescriptionListGroup>
@@ -362,7 +362,7 @@ const Agent: FunctionComponent<{ agent: IAgent }> = ({ agent }) => {
         <TableCell sx={{ verticalAlign: 'top' }}>{roundNumber(agent['agent.latency_time_99th'])}ms</TableCell>
       </TableRow>
 
-      <Details agent={agent} open={open} onClose={() => setOpen(false)} />
+      {open && <Details agent={agent} open={open} onClose={() => setOpen(false)} />}
     </>
   );
 };

--- a/app/packages/signalsciences/src/components/Requests.tsx
+++ b/app/packages/signalsciences/src/components/Requests.tsx
@@ -69,7 +69,7 @@ const Details: FunctionComponent<{
 }> = ({ request, onClose, open }) => {
   return (
     <DetailsDrawer size="large" open={open} onClose={onClose} title={request.id || ''}>
-      <Card>
+      <Card sx={{ mb: 6 }}>
         <CardContent>
           <DescriptionList>
             <DescriptionListGroup>
@@ -231,7 +231,7 @@ const Request: FunctionComponent<{ request: IRequest }> = ({ request }) => {
         </TableCell>
       </TableRow>
 
-      <Details request={request} open={open} onClose={() => setOpen(false)} />
+      {open && <Details request={request} open={open} onClose={() => setOpen(false)} />}
     </>
   );
 };


### PR DESCRIPTION
In some places we didn't had a padding on the Cards displayed within the DetailsDrawer component. This is now fixed, so that all Cards should have a padding of the same size.

The DetailsDrawer was always mounted in some components, instead of just mounted when it is open. This was also fixed, so that the DetailsDrawer is only mounted when displayed.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
