### PR TITLE
[mongodb] Fix Production Build

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -21254,7 +21254,6 @@
         "typescript": "^4.9.3",
         "vite": "^4.1.0",
         "vite-plugin-dts": "^1.7.2",
-        "vite-plugin-top-level-await": "^1.3.0",
         "vitest": "^0.28.4"
       },
       "peerDependencies": {

--- a/app/packages/mongodb/package.json
+++ b/app/packages/mongodb/package.json
@@ -49,7 +49,6 @@
     "typescript": "^4.9.3",
     "vite": "^4.1.0",
     "vite-plugin-dts": "^1.7.2",
-    "vite-plugin-top-level-await": "^1.3.0",
     "vitest": "^0.28.4"
   },
   "dependencies": {

--- a/app/packages/mongodb/vite.config.ts
+++ b/app/packages/mongodb/vite.config.ts
@@ -3,7 +3,6 @@
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
-import topLevelAwait from 'vite-plugin-top-level-await';
 
 import { resolve } from 'path';
 
@@ -30,20 +29,14 @@ export default defineConfig({
       ],
     },
     sourcemap: false,
+    // For the MongoDB plugin we have to set the target to esnext, because otherwise the build will fail because of the
+    // top level await usage of the 'bson' package, see https://github.com/vitejs/vite/issues/6985
+    target: 'esnext',
   },
   plugins: [
     react(),
     dts({
       insertTypesEntry: true,
-    }),
-    // The topLevelAwait plugin is used to enable top level await. This is needed to avoid the following error caused
-    // by the `bson` package:
-    //
-    // [vite:esbuild-transpile] Transform failed with 1 error:
-    // index.js:1422:26: ERROR: Top-level await is not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari14" + 2 overrides)
-    topLevelAwait({
-      promiseExportName: '__tla',
-      promiseImportName: (i) => `__tla_${i}`,
     }),
   ],
   test: {


### PR DESCRIPTION
The production build wasn't working for the MongoDB plugin. To fix it we had to set the "build.target" to "esnext" and remove the "topLevelAwait" plugin.

In the final app build we can still use the "topLevelAwait" plugin, so that we can use the default build target there.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
