### PR TITLE
[core] Add "@codemirror/state" as External Module

### DIFF
--- a/app/packages/core/vite.config.ts
+++ b/app/packages/core/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        '@codemirror/state',
         '@emotion/react',
         '@emotion/styled',
         '@mui/icons-material',

--- a/app/packages/flux/vite.config.ts
+++ b/app/packages/flux/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        '@codemirror/state',
         '@emotion/react',
         '@emotion/styled',
         '@kobsio/core',

--- a/app/packages/github/vite.config.ts
+++ b/app/packages/github/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        '@codemirror/state',
         '@emotion/react',
         '@emotion/styled',
         '@kobsio/core',

--- a/app/packages/grafana/vite.config.ts
+++ b/app/packages/grafana/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        '@codemirror/state',
         '@emotion/react',
         '@emotion/styled',
         '@kobsio/core',

--- a/app/packages/harbor/vite.config.ts
+++ b/app/packages/harbor/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        '@codemirror/state',
         '@emotion/react',
         '@emotion/styled',
         '@kobsio/core',

--- a/app/packages/helm/vite.config.ts
+++ b/app/packages/helm/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        '@codemirror/state',
         '@emotion/react',
         '@emotion/styled',
         '@kobsio/core',

--- a/app/packages/jaeger/vite.config.ts
+++ b/app/packages/jaeger/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        '@codemirror/state',
         '@emotion/react',
         '@emotion/styled',
         '@kobsio/core',

--- a/app/packages/jira/vite.config.ts
+++ b/app/packages/jira/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        '@codemirror/state',
         '@emotion/react',
         '@emotion/styled',
         '@kobsio/core',

--- a/app/packages/kiali/vite.config.ts
+++ b/app/packages/kiali/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        '@codemirror/state',
         '@emotion/react',
         '@emotion/styled',
         '@kobsio/core',

--- a/app/packages/klogs/vite.config.ts
+++ b/app/packages/klogs/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        '@codemirror/state',
         '@emotion/react',
         '@emotion/styled',
         '@kobsio/core',

--- a/app/packages/mongodb/vite.config.ts
+++ b/app/packages/mongodb/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        '@codemirror/state',
         '@emotion/react',
         '@emotion/styled',
         '@kobsio/core',

--- a/app/packages/opsgenie/vite.config.ts
+++ b/app/packages/opsgenie/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        '@codemirror/state',
         '@emotion/react',
         '@emotion/styled',
         '@kobsio/core',

--- a/app/packages/prometheus/vite.config.ts
+++ b/app/packages/prometheus/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        '@codemirror/state',
         '@emotion/react',
         '@emotion/styled',
         '@kobsio/core',

--- a/app/packages/rss/vite.config.ts
+++ b/app/packages/rss/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        '@codemirror/state',
         '@emotion/react',
         '@emotion/styled',
         '@kobsio/core',

--- a/app/packages/signalsciences/vite.config.ts
+++ b/app/packages/signalsciences/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        '@codemirror/state',
         '@emotion/react',
         '@emotion/styled',
         '@kobsio/core',

--- a/app/packages/sonarqube/vite.config.ts
+++ b/app/packages/sonarqube/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        '@codemirror/state',
         '@emotion/react',
         '@emotion/styled',
         '@kobsio/core',

--- a/app/packages/sql/vite.config.ts
+++ b/app/packages/sql/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        '@codemirror/state',
         '@emotion/react',
         '@emotion/styled',
         '@kobsio/core',

--- a/app/packages/techdocs/vite.config.ts
+++ b/app/packages/techdocs/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        '@codemirror/state',
         '@emotion/react',
         '@emotion/styled',
         '@kobsio/core',


### PR DESCRIPTION
Add "@codemirror/state" as external module to the rollup configuration to not load multiple instances, which caused the following error:

  Unrecognized extension value in extension set ([object Object]).
  This sometimes happens because multiple instances of
  @codemirror/state are loaded, breaking instanceof checks.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
