### PR TITLE
[core] Fix Save Function when Save is Disabled

### DIFF
--- a/app/packages/core/src/components/edit/EditPage.tsx
+++ b/app/packages/core/src/components/edit/EditPage.tsx
@@ -772,21 +772,27 @@ const EditHeaderActions: FunctionComponent<{
 
     try {
       const parsedValue = yaml.load(saveOptions.value);
-      await apiContext.client.post(apiPath, { body: parsedValue });
 
-      setSaveOptions({ ...saveOptions, isLoading: false, message: 'Saved', severity: 'success' });
-      setOptions({ ...options, state: btoa(JSON.stringify(parsedValue)) });
-    } catch (err) {
-      if (err instanceof APIError) {
-        setSaveOptions({
-          ...saveOptions,
-          isLoading: false,
-          message: `Save failed: ${err.message}`,
-          severity: err.statusCode === 405 ? 'warning' : 'error',
-        });
-      } else {
-        setSaveOptions({ ...saveOptions, isLoading: false, message: 'Save failed', severity: 'error' });
+      try {
+        await apiContext.client.post(apiPath, { body: parsedValue });
+
+        setSaveOptions({ ...saveOptions, isLoading: false, message: 'Saved', severity: 'success' });
+        setOptions({ ...options, state: btoa(JSON.stringify(parsedValue)) });
+      } catch (err) {
+        if (err instanceof APIError) {
+          setSaveOptions({
+            ...saveOptions,
+            isLoading: false,
+            message: `Save failed: ${err.message}`,
+            severity: err.statusCode === 405 ? 'warning' : 'error',
+          });
+          setOptions({ ...options, state: btoa(JSON.stringify(parsedValue)) });
+        } else {
+          setSaveOptions({ ...saveOptions, isLoading: false, message: 'Save failed', severity: 'error' });
+        }
       }
+    } catch (err) {
+      setSaveOptions({ ...saveOptions, isLoading: false, message: 'Save failed', severity: 'error' });
     }
   };
 


### PR DESCRIPTION
When the "save" options is disabled a user should still be able to edit the yaml file of an application, team or user directly via the frontend. Until now this wasn't working because the changes made to a resource in the save preview field only changed the resource when the save option was enabled. This is now changed so that the yaml file can also be adjusted when the save option is disabled.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
