### PR TITLE
[sql]: Fix `type: singlestats`

### DIFF
--- a/app/packages/sql/src/components/SQLChart.tsx
+++ b/app/packages/sql/src/components/SQLChart.tsx
@@ -41,7 +41,7 @@ export const SQLChart: FunctionComponent<{ chart: IChart; instance: IPluginInsta
         <SQLChartPie data={data} pieLabelColumn={chart.pieLabelColumn} pieValueColumn={chart.pieValueColumn} />
       )}
 
-      {data && chart.type === 'singlestat' && chart.yAxisColumns && (
+      {data && chart.type === 'singlestats' && chart.yAxisColumns && (
         <SQLChartSinglestats
           data={data}
           yAxisColumns={chart.yAxisColumns}

--- a/app/packages/sql/src/components/SQLPanel.test.tsx
+++ b/app/packages/sql/src/components/SQLPanel.test.tsx
@@ -51,12 +51,12 @@ describe('SQLPanel', () => {
     });
   });
 
-  it('should render Panel with singlestat chart', async () => {
+  it('should render Panel with singlestats chart', async () => {
     getSpy.mockResolvedValueOnce({
       columns: ['p50', 'p95', 'p99', 'other'],
       rows: [{ other: 16.05, p50: 2.99, p95: 4.31, p99: 16.05 }],
     });
-    render('singlestat chart', {
+    render('singlestats chart', {
       chart: {
         legend: { p50: 'P50', p95: 'P95', p99: 'P99' },
         query: 'SELECT 2.99 AS p50, 4.31 AS p95, 16.05 AS p99, 16.05 AS other;',
@@ -65,13 +65,13 @@ describe('SQLPanel', () => {
           '4': '#F0AB00',
           '6': '#C9190B',
         },
-        type: 'singlestat',
+        type: 'singlestats',
         yAxisColumns: ['p50', 'p95', 'p99'],
         yAxisUnit: 'ms',
       },
       type: 'chart',
     });
-    expect(screen.getByText('singlestat chart')).toBeInTheDocument();
+    expect(screen.getByText('singlestats chart')).toBeInTheDocument();
     await waitFor(() => {
       expect(screen.getByText('P50')).toBeInTheDocument();
       expect(screen.getByText('P95')).toBeInTheDocument();


### PR DESCRIPTION
<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

The type for the singlestats chart should be `singlestats`, not `singlestat`

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
