### PR TITLE
[mongodb] Improve Overview Page

### DIFF
--- a/app/packages/mongodb/src/components/MongoDBPage.tsx
+++ b/app/packages/mongodb/src/components/MongoDBPage.tsx
@@ -8,7 +8,18 @@ import {
   useQueryState,
 } from '@kobsio/core';
 import { ManageSearch, Search } from '@mui/icons-material';
-import { Button, Grid, IconButton, InputAdornment, Menu, MenuItem, Select, TextField, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  Grid,
+  IconButton,
+  InputAdornment,
+  Menu,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from '@mui/material';
 import { FunctionComponent, MouseEvent, useMemo, useState } from 'react';
 import { Route, Routes, useParams } from 'react-router-dom';
 
@@ -397,10 +408,14 @@ const OverviewPage: FunctionComponent<IPluginPageProps> = ({ instance }) => {
     >
       <Grid container={true} spacing={4}>
         <Grid item={true} xs={12} lg={7} xl={9}>
-          <Collections instance={instance} title="Collections" />
+          <Box sx={{ display: 'flex' }}>
+            <Collections instance={instance} title="Collections" />
+          </Box>
         </Grid>
         <Grid item={true} xs={12} lg={5} xl={3}>
-          <DBStats instance={instance} title="Database Statistics" />
+          <Box sx={{ display: 'flex' }}>
+            <DBStats instance={instance} title="Database Statistics" />
+          </Box>
         </Grid>
       </Grid>
     </Page>


### PR DESCRIPTION
Improve the overview page of the MongoDB plugin, so that the collections and database statistics view only takes the height of the content and not the complete available space.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
