### PR TITLE
[core] Fix Dashboard Updates for Back Button

### DIFF
--- a/app/packages/core/src/components/applications/TopologyPage.tsx
+++ b/app/packages/core/src/components/applications/TopologyPage.tsx
@@ -71,11 +71,13 @@ const TopologyInternal: FunctionComponent<ITopologyÜageInternalProps> = ({ opti
     >
       <TopologyGraph edges={data?.edges ?? []} nodes={data?.nodes ?? []} selectApplication={setSelectedApplicationID} />
 
-      <ApplicationsInsightsWrapper
-        id={selectedApplicationID}
-        open={selectedApplicationID !== undefined}
-        onClose={() => setSelectedApplicationID(undefined)}
-      />
+      {selectedApplicationID !== undefined && (
+        <ApplicationsInsightsWrapper
+          id={selectedApplicationID}
+          open={selectedApplicationID !== undefined}
+          onClose={() => setSelectedApplicationID(undefined)}
+        />
+      )}
     </UseQueryWrapper>
   );
 };

--- a/app/packages/core/src/components/applications/TopologyPanel.tsx
+++ b/app/packages/core/src/components/applications/TopologyPanel.tsx
@@ -61,11 +61,13 @@ const TopologyPanelInternal: FunctionComponent<ITopologyPanelInternalProps> = ({
         />
       </Box>
 
-      <ApplicationsInsightsWrapper
-        id={selectedApplicationID}
-        open={selectedApplicationID !== undefined}
-        onClose={() => setSelectedApplicationID(undefined)}
-      />
+      {selectedApplicationID !== undefined && (
+        <ApplicationsInsightsWrapper
+          id={selectedApplicationID}
+          open={selectedApplicationID !== undefined}
+          onClose={() => setSelectedApplicationID(undefined)}
+        />
+      )}
     </UseQueryWrapper>
   );
 };

--- a/app/packages/core/src/components/dashboards/Dashboards.tsx
+++ b/app/packages/core/src/components/dashboards/Dashboards.tsx
@@ -13,7 +13,7 @@ import {
   Typography,
 } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
-import { Fragment, FunctionComponent, useContext, useMemo, useState } from 'react';
+import { Fragment, FunctionComponent, useContext, useEffect, useMemo, useState } from 'react';
 import { WidthProvider, Responsive } from 'react-grid-layout';
 
 import { getVariableViaPlugin, interpolate, interpolateJSONPath } from './utils';
@@ -246,6 +246,18 @@ export const Dashboard: FunctionComponent<IDashboardProps> = ({ dashboard }) => 
       };
     }),
   );
+
+  useEffect(() => {
+    setVariables(
+      dashboard.variables?.map((variable) => {
+        return {
+          ...variable,
+          value: '',
+          values: [],
+        };
+      }),
+    );
+  }, [dashboard]);
 
   const { data } = useQuery<IVariableValues[] | null, APIError>(
     ['core/dashboards/variables', dashboard, variables, times],


### PR DESCRIPTION
When a user jumps from one application to another one using the topology tags on the application page and then uses the back button to go back to the original application the dashboards view wasn't updated.

This is now fixed by updating the variables from the dashboard property in the "Dashboard" component using "useEffect".

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
