### PR TITLE
[klogs] Fix Logs Page Layout

### DIFF
--- a/app/packages/klogs/src/components/Logs.tsx
+++ b/app/packages/klogs/src/components/Logs.tsx
@@ -577,7 +577,16 @@ export const Logs: FunctionComponent<{
   changeOrder,
 }) => {
   return (
-    <Stack direction="column" sx={{ width: '100%' }}>
+    <Stack
+      direction="column"
+      sx={{
+        '&::-webkit-scrollbar': {
+          display: 'none',
+        },
+        overflowX: 'auto',
+        width: '100%',
+      }}
+    >
       {showChart && (
         <Card sx={{ mb: 6 }}>
           <Stack direction="row" justifyContent="space-between" p={4}>


### PR DESCRIPTION
When a user selected a lot of fields in the logs table, the fields sidebar shrunk until it wasn't visible anymore. This is now fixed by adding the "overflowX" property to the logs bucket chart and table, so that the fields sidebar has always a width of 250px.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
