### PR TITLE
[klogs] Fix Page Parameter

### DIFF
--- a/app/packages/klogs/src/components/LogsPage.tsx
+++ b/app/packages/klogs/src/components/LogsPage.tsx
@@ -248,6 +248,7 @@ const LogsToolbar: FunctionComponent<{
         ...times,
         order: additionalFields[1].value === 'ascending' ? 'ascending' : 'descending',
         orderBy: additionalFields[0].value,
+        page: 1,
         query: query,
       });
     }
@@ -255,7 +256,7 @@ const LogsToolbar: FunctionComponent<{
 
   const handleSubmit = () => {
     addStateHistoryItem('kobs-klogs-queryhistory', query);
-    setOptions({ ...options, query: query });
+    setOptions({ ...options, page: 1, query: query });
   };
 
   useEffect(() => {
@@ -388,14 +389,14 @@ const LogsPage: FunctionComponent<IPluginPageProps> = ({ instance }) => {
    * `setTimes` changes the users selected time range to the provided `times`.
    */
   const setTimes = (times: ITimes) => {
-    setOptions({ ...options, ...times });
+    setOptions({ ...options, ...times, page: 1 });
   };
 
   /**
    * `addFilter` adds the given filter as string to the query, so that it can be used to filter down an existing query.
    */
   const addFilter = (filter: string) => {
-    setOptions({ ...options, query: `${options.query} ${filter}` });
+    setOptions({ ...options, page: 1, query: `${options.query} ${filter}` });
   };
 
   /**
@@ -403,7 +404,7 @@ const LogsPage: FunctionComponent<IPluginPageProps> = ({ instance }) => {
    */
   const changeOrder = (orderBy: string): void => {
     const isAscending = options.orderBy === orderBy && options.order === 'ascending';
-    setOptions({ ...options, order: isAscending ? 'descending' : 'ascending', orderBy: orderBy });
+    setOptions({ ...options, order: isAscending ? 'descending' : 'ascending', orderBy: orderBy, page: 1 });
   };
 
   return (


### PR DESCRIPTION
When a query in the klogs plugin was adjusted, the page parameter still had the old value of the selected page, which could result in an empty result table. To fix this the page parameter is now always reset to 1 when a query or the time range is adjusted.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
