### PR TITLE
[mongodb] Allow Download of all Documents

### DIFF
--- a/app/packages/mongodb/src/components/OperationActions.tsx
+++ b/app/packages/mongodb/src/components/OperationActions.tsx
@@ -1,0 +1,82 @@
+import { fileDownload, IPluginInstance } from '@kobsio/core';
+import { Download, MoreVert, OpenInNew } from '@mui/icons-material';
+import { IconButton, ListItemIcon, ListItemText, Menu, MenuItem } from '@mui/material';
+import { Document, EJSON } from 'bson';
+import { FunctionComponent, MouseEvent, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+export const OperationActions: FunctionComponent<{
+  collectionName: string;
+  documents?: Document[];
+  instance: IPluginInstance;
+  link: string;
+  showActions?: boolean;
+}> = ({ showActions, instance, collectionName, link, documents }) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
+  /**
+   * `handleOpenMenu` opens the menu, which is used to display the link.
+   */
+  const handleOpenMenu = (e: MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(e.currentTarget);
+  };
+
+  /**
+   * `handleCloseMenu` closes the menu, wich displays the link.
+   */
+  const handleCloseMenu = (e: Event) => {
+    setAnchorEl(null);
+  };
+
+  const download = (type: 'bson' | 'json') => {
+    if (type === 'bson') {
+      fileDownload(JSON.stringify(EJSON.serialize(documents, { relaxed: true }), null, 2), `${collectionName}.bson`);
+    } else if (type === 'json') {
+      fileDownload(JSON.stringify(documents, null, 2), `${collectionName}.json`);
+    }
+
+    setAnchorEl(null);
+  };
+
+  if (!showActions && (!documents || documents.length === 0)) {
+    return null;
+  }
+
+  return (
+    <>
+      <IconButton size="small" sx={{ m: 0, p: 0 }} disableRipple={true} onClick={handleOpenMenu}>
+        <MoreVert />
+      </IconButton>
+
+      <Menu anchorEl={anchorEl} open={open} onClose={handleCloseMenu}>
+        {showActions && (
+          <MenuItem component={Link} to={link}>
+            <ListItemIcon>
+              <OpenInNew fontSize="small" />
+            </ListItemIcon>
+            <ListItemText>Explore</ListItemText>
+          </MenuItem>
+        )}
+
+        {documents && (
+          <MenuItem onClick={() => download('bson')}>
+            <ListItemIcon>
+              <Download fontSize="small" />
+            </ListItemIcon>
+            <ListItemText>Download BSON</ListItemText>
+          </MenuItem>
+        )}
+
+        {documents && (
+          <MenuItem onClick={() => download('json')}>
+            <ListItemIcon>
+              <Download fontSize="small" />
+            </ListItemIcon>
+            <ListItemText>Download JSON</ListItemText>
+          </MenuItem>
+        )}
+      </Menu>
+    </>
+  );
+};

--- a/app/packages/mongodb/src/components/OperationAggregate.tsx
+++ b/app/packages/mongodb/src/components/OperationAggregate.tsx
@@ -6,7 +6,6 @@ import {
   ITimes,
   pluginBasePath,
   PluginPanel,
-  PluginPanelActionLinks,
   UseQueryWrapper,
 } from '@kobsio/core';
 import { useQuery } from '@tanstack/react-query';
@@ -14,6 +13,7 @@ import { Document, EJSON } from 'bson';
 import { FunctionComponent, useContext } from 'react';
 
 import { Documents } from './Documents';
+import { OperationActions } from './OperationActions';
 
 import { toExtendedJson } from '../utils/utils';
 
@@ -76,18 +76,15 @@ export const OperationAggregate: FunctionComponent<{
       title={title}
       description={description}
       actions={
-        showActions && (
-          <PluginPanelActionLinks
-            links={[
-              {
-                link: `${pluginBasePath(
-                  instance,
-                )}/${collectionName}/query?operation=aggregate&pipeline=${encodeURIComponent(pipeline)}`,
-                title: 'Explore',
-              },
-            ]}
-          />
-        )
+        <OperationActions
+          showActions={showActions}
+          instance={instance}
+          collectionName={collectionName}
+          link={`${pluginBasePath(instance)}/${collectionName}/query?operation=aggregate&pipeline=${encodeURIComponent(
+            pipeline,
+          )}`}
+          documents={data}
+        />
       }
     >
       <UseQueryWrapper

--- a/app/packages/mongodb/src/components/OperationFind.tsx
+++ b/app/packages/mongodb/src/components/OperationFind.tsx
@@ -6,7 +6,6 @@ import {
   ITimes,
   pluginBasePath,
   PluginPanel,
-  PluginPanelActionLinks,
   UseQueryWrapper,
 } from '@kobsio/core';
 import { useQuery } from '@tanstack/react-query';
@@ -14,6 +13,7 @@ import { Document, EJSON } from 'bson';
 import { FunctionComponent, useContext } from 'react';
 
 import { Documents } from './Documents';
+import { OperationActions } from './OperationActions';
 
 import { toExtendedJson } from '../utils/utils';
 
@@ -61,18 +61,15 @@ export const OperationFind: FunctionComponent<{
       title={title}
       description={description}
       actions={
-        showActions && (
-          <PluginPanelActionLinks
-            links={[
-              {
-                link: `${pluginBasePath(instance)}/${collectionName}/query?operation=find&filter=${encodeURIComponent(
-                  filter,
-                )}&sort=${encodeURIComponent(sort)}&limit=${limit}`,
-                title: 'Explore',
-              },
-            ]}
-          />
-        )
+        <OperationActions
+          showActions={showActions}
+          instance={instance}
+          collectionName={collectionName}
+          link={`${pluginBasePath(instance)}/${collectionName}/query?operation=find&filter=${encodeURIComponent(
+            filter,
+          )}&sort=${encodeURIComponent(sort)}&limit=${limit}`}
+          documents={data}
+        />
       }
     >
       <UseQueryWrapper

--- a/app/packages/mongodb/src/components/OperationFindOne.tsx
+++ b/app/packages/mongodb/src/components/OperationFindOne.tsx
@@ -6,7 +6,6 @@ import {
   ITimes,
   pluginBasePath,
   PluginPanel,
-  PluginPanelActionLinks,
   UseQueryWrapper,
 } from '@kobsio/core';
 import { useQuery } from '@tanstack/react-query';
@@ -14,6 +13,7 @@ import { Document, EJSON } from 'bson';
 import { FunctionComponent, useContext } from 'react';
 
 import { Documents } from './Documents';
+import { OperationActions } from './OperationActions';
 
 import { toExtendedJson } from '../utils/utils';
 
@@ -57,18 +57,15 @@ export const OperationFindOne: FunctionComponent<{
       title={title}
       description={description}
       actions={
-        showActions && (
-          <PluginPanelActionLinks
-            links={[
-              {
-                link: `${pluginBasePath(
-                  instance,
-                )}/${collectionName}/query?operation=findOne&filter=${encodeURIComponent(filter)}`,
-                title: 'Explore',
-              },
-            ]}
-          />
-        )
+        <OperationActions
+          showActions={showActions}
+          instance={instance}
+          collectionName={collectionName}
+          link={`${pluginBasePath(instance)}/${collectionName}/query?operation=findOne&filter=${encodeURIComponent(
+            filter,
+          )}`}
+          documents={data}
+        />
       }
     >
       <UseQueryWrapper

--- a/app/packages/mongodb/src/components/OperationFindOneAndDelete.tsx
+++ b/app/packages/mongodb/src/components/OperationFindOneAndDelete.tsx
@@ -6,7 +6,6 @@ import {
   ITimes,
   pluginBasePath,
   PluginPanel,
-  PluginPanelActionLinks,
   UseQueryWrapper,
 } from '@kobsio/core';
 import { useQuery } from '@tanstack/react-query';
@@ -14,6 +13,7 @@ import { Document, EJSON } from 'bson';
 import { FunctionComponent, useContext } from 'react';
 
 import { Documents } from './Documents';
+import { OperationActions } from './OperationActions';
 
 import { toExtendedJson } from '../utils/utils';
 
@@ -57,18 +57,15 @@ export const OperationFindOneAndDelete: FunctionComponent<{
       title={title}
       description={description}
       actions={
-        showActions && (
-          <PluginPanelActionLinks
-            links={[
-              {
-                link: `${pluginBasePath(
-                  instance,
-                )}/${collectionName}/query?operation=findOneAndDelete&filter=${encodeURIComponent(filter)}`,
-                title: 'Explore',
-              },
-            ]}
-          />
-        )
+        <OperationActions
+          showActions={showActions}
+          instance={instance}
+          collectionName={collectionName}
+          link={`${pluginBasePath(
+            instance,
+          )}/${collectionName}/query?operation=findOneAndDelete&filter=${encodeURIComponent(filter)}`}
+          documents={data}
+        />
       }
     >
       <UseQueryWrapper

--- a/app/packages/mongodb/src/components/OperationFindOneAndUpdate.tsx
+++ b/app/packages/mongodb/src/components/OperationFindOneAndUpdate.tsx
@@ -6,7 +6,6 @@ import {
   ITimes,
   pluginBasePath,
   PluginPanel,
-  PluginPanelActionLinks,
   UseQueryWrapper,
 } from '@kobsio/core';
 import { useQuery } from '@tanstack/react-query';
@@ -14,6 +13,7 @@ import { Document, EJSON } from 'bson';
 import { FunctionComponent, useContext } from 'react';
 
 import { Documents } from './Documents';
+import { OperationActions } from './OperationActions';
 
 import { toExtendedJson } from '../utils/utils';
 
@@ -59,20 +59,17 @@ export const OperationFindOneAndUpdate: FunctionComponent<{
       title={title}
       description={description}
       actions={
-        showActions && (
-          <PluginPanelActionLinks
-            links={[
-              {
-                link: `${pluginBasePath(
-                  instance,
-                )}/${collectionName}/query?operation=findOneAndUpdate&filter=${encodeURIComponent(
-                  filter,
-                )}&update=${encodeURIComponent(update)}`,
-                title: 'Explore',
-              },
-            ]}
-          />
-        )
+        <OperationActions
+          showActions={showActions}
+          instance={instance}
+          collectionName={collectionName}
+          link={`${pluginBasePath(
+            instance,
+          )}/${collectionName}/query?operation=findOneAndUpdate&filter=${encodeURIComponent(
+            filter,
+          )}&update=${encodeURIComponent(update)}`}
+          documents={data}
+        />
       }
     >
       <UseQueryWrapper

--- a/app/packages/mongodb/src/utils/utils.ts
+++ b/app/packages/mongodb/src/utils/utils.ts
@@ -7,13 +7,13 @@ export const example = `plugin:
   name: mongodb
   type: mongodb
   options:
-    # The type must be
+    # The operation must be
     #   - "db" to show the database statistics
     #   - "collections" to show the database collections and collection statistics
     #   - "count" to show the number of documents in a collection for provided filter
     #   - "find" to show the documents in a collection for provided filter, sort and limit
     #   - "findOne" to show a single document in a collection for the provided filter
-    type: find
+    operation: find
     query:
       collectionName: applications
       filter: '{"namespace": "default"}'


### PR DESCRIPTION
It is now possible to download all documents returned by an operation. This feature is implemented for all operations which are returning documents, these are: find, findOne, findOneAndDelete, findOneAndUpdate and aggregate.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
