### PR TITLE
[core] Sort Plugin Types Alphabetically

### DIFF
--- a/app/packages/core/src/context/PluginContext.test.tsx
+++ b/app/packages/core/src/context/PluginContext.test.tsx
@@ -85,7 +85,7 @@ describe('PluginContext', () => {
       expect(getInstance('foo-1')).toBeDefined();
       expect(getPlugin('foo')).toBeDefined();
       expect(getAvailableClusters()).toEqual(['dev', 'prod']);
-      expect(getAvailablePluginTypes()).toEqual(['foo', 'bar']);
+      expect(getAvailablePluginTypes()).toEqual(['bar', 'foo']);
       return <>has been rendered</>;
     };
 

--- a/app/packages/core/src/context/PluginContext.tsx
+++ b/app/packages/core/src/context/PluginContext.tsx
@@ -141,7 +141,7 @@ export const PluginContextProvider: FunctionComponent<IPluginContextProviderProp
       plugins.add(instance.type);
     }
 
-    return Array.from(plugins);
+    return Array.from(plugins).sort();
   };
 
   /**


### PR DESCRIPTION
The values in the plugin types dropdown menu on the plugins page are now sorted alphabetically.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
