### PR TITLE
[techdocs] Fix Link Handling in Markdown Panels

### DIFF
--- a/app/packages/techdocs/src/components/Markdown.tsx
+++ b/app/packages/techdocs/src/components/Markdown.tsx
@@ -2,6 +2,7 @@ import { ITimes } from '@kobsio/core';
 import { Box, useTheme } from '@mui/material';
 import { FunctionComponent } from 'react';
 import ReactMarkdown from 'react-markdown';
+import { Link } from 'react-router-dom';
 import remarkDirective from 'remark-directive';
 import remarkGfm from 'remark-gfm';
 
@@ -68,6 +69,18 @@ export const Markdown: FunctionComponent<{
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkDirective, admonitionsPlugin]}
         components={{
+          a: ({ href, ...props }) => {
+            const url = (href || '').trim();
+            if (url.startsWith('http://') || url.startsWith('https://')) {
+              return (
+                <a href={href} target="_blank" rel="noreferrer">
+                  {props.children}
+                </a>
+              );
+            }
+
+            return <Link to={href ?? ''}>{props.children}</Link>;
+          },
           code: ({ node, inline, className, children, ...props }) =>
             renderCode({ children, className, inline, node, ...props }, theme, times, setTimes),
           'custom-admonitions': ({ node, children, ...props }) => renderAdmonitions({ children, node, ...props }),


### PR DESCRIPTION
In the markdown panels kobs internal links were rendered with a "a" tag instead of the "Link" component from react-router. This is now fixed, so that the page isn't reloaded for internal links.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
