### PR TITLE
[core] Add Debug Endpoints

### DIFF
--- a/cmd/kobs/cluster/cluster.go
+++ b/cmd/kobs/cluster/cluster.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kobsio/kobs/pkg/cluster/api"
 	"github.com/kobsio/kobs/pkg/cluster/kubernetes"
 	clusterPlugins "github.com/kobsio/kobs/pkg/cluster/plugins"
+	"github.com/kobsio/kobs/pkg/instrument/debug"
 	"github.com/kobsio/kobs/pkg/instrument/log"
 	"github.com/kobsio/kobs/pkg/instrument/metrics"
 	"github.com/kobsio/kobs/pkg/instrument/tracer"
@@ -23,6 +24,7 @@ type Cmd struct {
 	Config string `env:"KOBS_CONFIG" default:"config.yaml" help:"The path to the configuration file for the cluster."`
 
 	Cluster struct {
+		Debug      debug.Config      `json:"debug" embed:"" prefix:"debug." envprefix:"DEBUG_"`
 		Log        log.Config        `json:"log" embed:"" prefix:"log." envprefix:"LOG_"`
 		Tracer     tracer.Config     `json:"tracer" embed:"" prefix:"tracer." envprefix:"TRACER_"`
 		Metrics    metrics.Config    `json:"metrics" embed:"" prefix:"metrics." envprefix:"METRICS_"`
@@ -56,6 +58,12 @@ func (r *Cmd) Run(plugins []plugins.Plugin) error {
 	metricsServer := metrics.New(cfg.Cluster.Metrics)
 	go metricsServer.Start()
 	defer metricsServer.Stop()
+
+	if cfg.Cluster.Debug.Enabled {
+		debugServer := debug.New(cfg.Cluster.Debug)
+		go debugServer.Start()
+		defer debugServer.Stop()
+	}
 
 	kubernetesClient, err := kubernetes.NewClient(cfg.Cluster.Kubernetes)
 	if err != nil {

--- a/docs/getting-started/configuration/cluster.md
+++ b/docs/getting-started/configuration/cluster.md
@@ -9,6 +9,8 @@ The following command-line arguments and environment variables are available.
 | Command-line Argument | Environment Variable | Description | Default |
 | --------------------- | -------------------- | ----------- | ------- |
 | `--config` | `KOBS_CONFIG` | The path to the configuration file for the cluster | `config.yaml` |
+| `--cluster.debug.enabled` | `KOBS_CLUSTER_DEBUG_ENABLED` | Start the debug server. | `false` |
+| `--cluster.debug.address` | `KOBS_CLUSTER_DEBUG_ADDRESS` | The address where the debug server should listen on. | `:15225` |
 | `--cluster.log.format` | `KOBS_CLUSTER_LOG_FORMAT` | Set the output format of the logs. Must be `console` or `json`. | `console` |
 | `--cluster.log.level` | `KOBS_CLUSTER_LOG_LEVEL` | Set the log level. Must be `debug`, `info`, `warn`, `error`, `fatal` or `panic`. | `info` |
 | `--cluster.tracer.enabled` | `KOBS_CLUSTER_TRACER_ENABLED` | Enable tracing. | `false` |

--- a/docs/getting-started/configuration/hub.md
+++ b/docs/getting-started/configuration/hub.md
@@ -9,6 +9,8 @@ The following command-line arguments and environment variables are available.
 | Command-line Argument | Environment Variable | Description | Default |
 | --------------------- | -------------------- | ----------- | ------- |
 | `--config` | `KOBS_CONFIG` | The path to the configuration file for the hub | `config.yaml` |
+| `--hub.debug.enabled` | `KOBS_HUB_DEBUG_ENABLED` | Start the debug server. | `false` |
+| `--hub.debug.address` | `KOBS_HUB_DEBUG_ADDRESS` | The address where the debug server should listen on. | `:15225` |
 | `--hub.log.format` | `KOBS_HUB_LOG_FORMAT` | Set the output format of the logs. Must be `console` or `json`. | `console` |
 | `--hub.log.level` | `KOBS_HUB_LOG_LEVEL` | Set the log level. Must be `debug`, `info`, `warn`, `error`, `fatal` or `panic`. | `info` |
 | `--hub.tracer.enabled` | `KOBS_HUB_TRACER_ENABLED` | Enable tracing. | `false` |

--- a/docs/getting-started/configuration/watcher.md
+++ b/docs/getting-started/configuration/watcher.md
@@ -9,6 +9,8 @@ The following command-line arguments and environment variables are available.
 | Command-line Argument | Environment Variable | Description | Default |
 | --------------------- | -------------------- | ----------- | ------- |
 | `--config` | `KOBS_CONFIG` | The path to the configuration file for the watcher | `config.yaml` |
+| `--watcher.debug.enabled` | `KOBS_WATCHER_DEBUG_ENABLED` | Start the debug server. | `false` |
+| `--watcher.debug.address` | `KOBS_WATCHER_DEBUG_ADDRESS` | The address where the debug server should listen on. | `:15225` |
 | `--watcher.log.format` | `KOBS_WATCHER_LOG_FORMAT` | Set the output format of the logs. Must be `console` or `json`. | `console` |
 | `--watcher.log.level` | `KOBS_WATCHER_LOG_LEVEL` | Set the log level. Must be `debug`, `info`, `warn`, `error`, `fatal` or `panic`. | `info` |
 | `--watcher.tracer.enabled` | `KOBS_WATCHER_TRACER_ENABLED` | Enable tracing. | `false` |

--- a/pkg/instrument/debug/debug.go
+++ b/pkg/instrument/debug/debug.go
@@ -1,0 +1,101 @@
+package debug
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/http/pprof"
+	"time"
+
+	"github.com/kobsio/kobs/pkg/instrument/log"
+
+	"github.com/go-chi/chi/v5"
+	"go.uber.org/zap"
+)
+
+type Config struct {
+	Enabled bool   `json:"enabled" env:"ENABLED" default:"false" help:"Start the debug server."`
+	Address string `json:"address" env:"ADDRESS" default:":15225" help:"The address where the debug server should listen on."`
+}
+
+// Server is the interface of a debug service, which provides the options to start and stop the underlying http
+// server.
+type Server interface {
+	Start()
+	Stop()
+}
+
+// server implements the Server interface.
+type server struct {
+	*http.Server
+}
+
+// Start starts serving the debug server.
+func (s *server) Start() {
+	log.Info(context.Background(), "Debug server started", zap.String("address", s.Addr))
+
+	if err := s.ListenAndServe(); err != nil {
+		if err != http.ErrServerClosed {
+			log.Error(context.Background(), "Debug server died unexpected", zap.Error(err))
+		}
+	}
+}
+
+// Stop terminates the debug server gracefully.
+func (s *server) Stop() {
+	log.Debug(context.Background(), "Start shutdown of the debug server")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	err := s.Shutdown(ctx)
+	if err != nil {
+		log.Error(context.Background(), "Graceful shutdown of the debug server failed", zap.Error(err))
+	}
+}
+
+// New return a new debug server. The server listens on the provided address and is used to provide the pprof endpoints
+// and a /request/dump endpoint, which can be used to dump the request.
+func New(config Config) Server {
+	router := chi.NewRouter()
+
+	router.Get("/debug/request/dump", func(w http.ResponseWriter, r *http.Request) {
+		dump, err := httputil.DumpRequest(r, true)
+		if err != nil {
+			http.Error(w, fmt.Sprint(err), http.StatusInternalServerError)
+			return
+		}
+
+		fmt.Fprintf(w, "%s", string(dump))
+	})
+	router.Get("/debug/request/timeout", func(w http.ResponseWriter, r *http.Request) {
+		timeout := r.URL.Query().Get("timeout")
+		if parsedTimeout, err := time.ParseDuration(timeout); err == nil {
+			time.Sleep(parsedTimeout)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	router.HandleFunc("/debug/pprof/", pprof.Index)
+	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	router.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+
+	router.Handle("/debug/pprof/allocs", pprof.Handler("allocs"))
+	router.Handle("/debug/pprof/block", pprof.Handler("block"))
+	router.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+	router.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+	router.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
+	router.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+	router.Handle("/debug/pprof/trace", pprof.Handler("trace"))
+
+	return &server{
+		&http.Server{
+			Addr:              config.Address,
+			Handler:           router,
+			ReadHeaderTimeout: 3 * time.Second,
+		},
+	}
+}

--- a/pkg/instrument/debug/debug_test.go
+++ b/pkg/instrument/debug/debug_test.go
@@ -1,0 +1,20 @@
+package debug
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestServer(t *testing.T) {
+	debugServer := New(Config{Address: ":8090"})
+	require.NotNil(t, debugServer)
+
+	require.NotPanics(t, func() {
+		go debugServer.Start()
+	})
+
+	require.NotPanics(t, func() {
+		debugServer.Stop()
+	})
+}


### PR DESCRIPTION
This commit adds some debug endpoints which are provided via an additional debug server, which listens on port 15225 by default and can be enabled in the configuration file via the "debug.enabled" property.

The debug endpoints containing the pprof endpoints and two custom endpoints for testing request timesouts and dumping a whole request.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
