### PR TITLE
[jaeger] Do Not Decode Response

### DIFF
--- a/pkg/plugins/jaeger/instance/instance_mock.go
+++ b/pkg/plugins/jaeger/instance/instance_mock.go
@@ -35,10 +35,10 @@ func (m *MockInstance) EXPECT() *MockInstanceMockRecorder {
 }
 
 // GetMetrics mocks base method.
-func (m *MockInstance) GetMetrics(ctx context.Context, metric, service, groupByOperation, quantile, ratePer, step string, spanKinds []string, timeStart, timeEnd int64) (map[string]any, error) {
+func (m *MockInstance) GetMetrics(ctx context.Context, metric, service, groupByOperation, quantile, ratePer, step string, spanKinds []string, timeStart, timeEnd int64) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMetrics", ctx, metric, service, groupByOperation, quantile, ratePer, step, spanKinds, timeStart, timeEnd)
-	ret0, _ := ret[0].(map[string]any)
+	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -64,10 +64,10 @@ func (mr *MockInstanceMockRecorder) GetName() *gomock.Call {
 }
 
 // GetOperations mocks base method.
-func (m *MockInstance) GetOperations(ctx context.Context, service string) (map[string]any, error) {
+func (m *MockInstance) GetOperations(ctx context.Context, service string) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOperations", ctx, service)
-	ret0, _ := ret[0].(map[string]any)
+	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -79,10 +79,10 @@ func (mr *MockInstanceMockRecorder) GetOperations(ctx, service interface{}) *gom
 }
 
 // GetServices mocks base method.
-func (m *MockInstance) GetServices(ctx context.Context) (map[string]any, error) {
+func (m *MockInstance) GetServices(ctx context.Context) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetServices", ctx)
-	ret0, _ := ret[0].(map[string]any)
+	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -94,10 +94,10 @@ func (mr *MockInstanceMockRecorder) GetServices(ctx interface{}) *gomock.Call {
 }
 
 // GetTrace mocks base method.
-func (m *MockInstance) GetTrace(ctx context.Context, traceID string) (map[string]any, error) {
+func (m *MockInstance) GetTrace(ctx context.Context, traceID string) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTrace", ctx, traceID)
-	ret0, _ := ret[0].(map[string]any)
+	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -109,10 +109,10 @@ func (mr *MockInstanceMockRecorder) GetTrace(ctx, traceID interface{}) *gomock.C
 }
 
 // GetTraces mocks base method.
-func (m *MockInstance) GetTraces(ctx context.Context, limit, maxDuration, minDuration, operation, service, tags string, timeStart, timeEnd int64) (map[string]any, error) {
+func (m *MockInstance) GetTraces(ctx context.Context, limit, maxDuration, minDuration, operation, service, tags string, timeStart, timeEnd int64) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTraces", ctx, limit, maxDuration, minDuration, operation, service, tags, timeStart, timeEnd)
-	ret0, _ := ret[0].(map[string]any)
+	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -124,10 +124,10 @@ func (mr *MockInstanceMockRecorder) GetTraces(ctx, limit, maxDuration, minDurati
 }
 
 // doRequest mocks base method.
-func (m *MockInstance) doRequest(ctx context.Context, url string) (map[string]any, error) {
+func (m *MockInstance) doRequest(ctx context.Context, url string) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "doRequest", ctx, url)
-	ret0, _ := ret[0].(map[string]any)
+	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/plugins/jaeger/instance/instance_test.go
+++ b/pkg/plugins/jaeger/instance/instance_test.go
@@ -50,20 +50,7 @@ func TestDoRequest(t *testing.T) {
 		i := &instance{name: "jaeger", client: ts.Client(), address: ts.URL}
 		res, err := i.doRequest(context.Background(), "/")
 		require.NoError(t, err)
-		require.Equal(t, map[string]any{"key": "value"}, res)
-	})
-
-	t.Run("should fail if invalid json is returned", func(t *testing.T) {
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"key": "value}`))
-		}))
-		defer ts.Close()
-
-		i := &instance{name: "jaeger", client: ts.Client(), address: ts.URL}
-		_, err := i.doRequest(context.Background(), "/")
-		require.Error(t, err)
+		require.Equal(t, []byte(`{"key": "value"}`), res)
 	})
 
 	t.Run("should return error", func(t *testing.T) {
@@ -106,7 +93,7 @@ func TestGetServices(t *testing.T) {
 		i := &instance{name: "jaeger", client: ts.Client(), address: ts.URL}
 		res, err := i.GetServices(context.Background())
 		require.NoError(t, err)
-		require.Equal(t, map[string]any{"key": "value"}, res)
+		require.Equal(t, []byte(`{"key": "value"}`), res)
 	})
 }
 
@@ -122,7 +109,7 @@ func TestGetOperations(t *testing.T) {
 		i := &instance{name: "jaeger", client: ts.Client(), address: ts.URL}
 		res, err := i.GetOperations(context.Background(), "service")
 		require.NoError(t, err)
-		require.Equal(t, map[string]any{"key": "value"}, res)
+		require.Equal(t, []byte(`{"key": "value"}`), res)
 	})
 }
 
@@ -138,7 +125,7 @@ func TestGetTraces(t *testing.T) {
 		i := &instance{name: "jaeger", client: ts.Client(), address: ts.URL}
 		res, err := i.GetTraces(context.Background(), "", "", "", "operation", "service", "", 0, 0)
 		require.NoError(t, err)
-		require.Equal(t, map[string]any{"key": "value"}, res)
+		require.Equal(t, []byte(`{"key": "value"}`), res)
 	})
 }
 
@@ -154,7 +141,7 @@ func TestGetTrace(t *testing.T) {
 		i := &instance{name: "jaeger", client: ts.Client(), address: ts.URL}
 		res, err := i.GetTrace(context.Background(), "")
 		require.NoError(t, err)
-		require.Equal(t, map[string]any{"key": "value"}, res)
+		require.Equal(t, []byte(`{"key": "value"}`), res)
 	})
 }
 
@@ -170,7 +157,7 @@ func TestGetMetrics(t *testing.T) {
 		i := &instance{name: "jaeger", client: ts.Client(), address: ts.URL}
 		res, err := i.GetMetrics(context.Background(), "", "", "", "", "", "", []string{"kind1", "kind2"}, 0, 0)
 		require.NoError(t, err)
-		require.Equal(t, map[string]any{"key": "value"}, res)
+		require.Equal(t, []byte(`{"key": "value"}`), res)
 	})
 }
 

--- a/pkg/plugins/jaeger/router.go
+++ b/pkg/plugins/jaeger/router.go
@@ -57,7 +57,8 @@ func (router *Router) getServices(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	render.JSON(w, r, body)
+	render.SetContentType(render.ContentTypeJSON)
+	render.Data(w, r, body)
 }
 
 func (router *Router) getOperations(w http.ResponseWriter, r *http.Request) {
@@ -80,7 +81,8 @@ func (router *Router) getOperations(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	render.JSON(w, r, body)
+	render.SetContentType(render.ContentTypeJSON)
+	render.Data(w, r, body)
 }
 
 func (router *Router) getTraces(w http.ResponseWriter, r *http.Request) {
@@ -124,7 +126,8 @@ func (router *Router) getTraces(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	render.JSON(w, r, body)
+	render.SetContentType(render.ContentTypeJSON)
+	render.Data(w, r, body)
 }
 
 func (router *Router) getTrace(w http.ResponseWriter, r *http.Request) {
@@ -147,7 +150,8 @@ func (router *Router) getTrace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	render.JSON(w, r, body)
+	render.SetContentType(render.ContentTypeJSON)
+	render.Data(w, r, body)
 }
 
 func (router *Router) getMetrics(w http.ResponseWriter, r *http.Request) {
@@ -192,7 +196,8 @@ func (router *Router) getMetrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	render.JSON(w, r, body)
+	render.SetContentType(render.ContentTypeJSON)
+	render.Data(w, r, body)
 }
 
 func Mount(instances []plugin.Instance, clustersClient clusters.Client) (chi.Router, error) {

--- a/pkg/plugins/jaeger/router_test.go
+++ b/pkg/plugins/jaeger/router_test.go
@@ -89,7 +89,7 @@ func TestGetServices(t *testing.T) {
 	t.Run("should return services", func(t *testing.T) {
 		i, router := newRouter(t)
 		i.EXPECT().GetName().Return("jaeger")
-		i.EXPECT().GetServices(gomock.Any()).Return(nil, nil)
+		i.EXPECT().GetServices(gomock.Any()).Return([]byte(`{"key": "value"}`), nil)
 
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/services", nil)
 		req.Header.Set("x-kobs-plugin", "jaeger")
@@ -98,7 +98,7 @@ func TestGetServices(t *testing.T) {
 		router.getServices(w, req)
 
 		utils.AssertStatusEq(t, w, http.StatusOK)
-		utils.AssertJSONEq(t, w, `null`)
+		utils.AssertJSONEq(t, w, `{"key": "value"}`)
 	})
 }
 
@@ -143,7 +143,7 @@ func TestGetOperations(t *testing.T) {
 	t.Run("should return operations", func(t *testing.T) {
 		i, router := newRouter(t)
 		i.EXPECT().GetName().Return("jaeger")
-		i.EXPECT().GetOperations(gomock.Any(), gomock.Any()).Return(nil, nil)
+		i.EXPECT().GetOperations(gomock.Any(), gomock.Any()).Return([]byte(`{"key": "value"}`), nil)
 
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/operations", nil)
 		req.Header.Set("x-kobs-plugin", "jaeger")
@@ -152,7 +152,7 @@ func TestGetOperations(t *testing.T) {
 		router.getOperations(w, req)
 
 		utils.AssertStatusEq(t, w, http.StatusOK)
-		utils.AssertJSONEq(t, w, `null`)
+		utils.AssertJSONEq(t, w, `{"key": "value"}`)
 	})
 }
 
@@ -225,7 +225,7 @@ func TestGetTraces(t *testing.T) {
 	t.Run("should return traces", func(t *testing.T) {
 		i, router := newRouter(t)
 		i.EXPECT().GetName().Return("jaeger")
-		i.EXPECT().GetTraces(gomock.Any(), "", "", "", "myoperation", "myservice", "", int64(0), int64(0)).Return(map[string]any{"data": []map[string]any{{"traceID": "f821489350cd7465fcc727e92e32a237"}}}, nil)
+		i.EXPECT().GetTraces(gomock.Any(), "", "", "", "myoperation", "myservice", "", int64(0), int64(0)).Return([]byte(`{"data": [{"traceID": "f821489350cd7465fcc727e92e32a237"}]}`), nil)
 
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/traces?operation=myoperation&service=myservice&timeStart=0&timeEnd=0", nil)
 		req.Header.Set("x-kobs-plugin", "jaeger")
@@ -279,7 +279,7 @@ func TestGetTrace(t *testing.T) {
 	t.Run("should return trace", func(t *testing.T) {
 		i, router := newRouter(t)
 		i.EXPECT().GetName().Return("jaeger")
-		i.EXPECT().GetTrace(gomock.Any(), gomock.Any()).Return(nil, nil)
+		i.EXPECT().GetTrace(gomock.Any(), gomock.Any()).Return([]byte(`{"key": "value"}`), nil)
 
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/trace", nil)
 		req.Header.Set("x-kobs-plugin", "jaeger")
@@ -288,7 +288,7 @@ func TestGetTrace(t *testing.T) {
 		router.getTrace(w, req)
 
 		utils.AssertStatusEq(t, w, http.StatusOK)
-		utils.AssertJSONEq(t, w, `null`)
+		utils.AssertJSONEq(t, w, `{"key": "value"}`)
 	})
 }
 
@@ -361,7 +361,7 @@ func TestGetMetrics(t *testing.T) {
 	t.Run("should return metrics", func(t *testing.T) {
 		i, router := newRouter(t)
 		i.EXPECT().GetName().Return("jaeger")
-		i.EXPECT().GetMetrics(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+		i.EXPECT().GetMetrics(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]byte(`{"key": "value"}`), nil)
 
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/metrics?timeStart=0&timeEnd=0", nil)
 		req.Header.Set("x-kobs-plugin", "jaeger")
@@ -370,7 +370,7 @@ func TestGetMetrics(t *testing.T) {
 		router.getMetrics(w, req)
 
 		utils.AssertStatusEq(t, w, http.StatusOK)
-		utils.AssertJSONEq(t, w, `null`)
+		utils.AssertJSONEq(t, w, `{"key": "value"}`)
 	})
 }
 


### PR DESCRIPTION
We do not decode the response from Jaeger anymore, because kobs consumes a lot of memory for large traces. Instead we just read the body and directly write it.

Note: This could be improved in the future to directly write the response body from Jaeger, but then we would have to rework the error handling, so that we decided to try this quick solution first.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
