### PR TITLE
[jaeger] Do Not Read Response

### DIFF
--- a/pkg/plugins/jaeger/instance/instance_mock.go
+++ b/pkg/plugins/jaeger/instance/instance_mock.go
@@ -6,6 +6,7 @@ package instance
 
 import (
 	context "context"
+	http "net/http"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -35,18 +36,17 @@ func (m *MockInstance) EXPECT() *MockInstanceMockRecorder {
 }
 
 // GetMetrics mocks base method.
-func (m *MockInstance) GetMetrics(ctx context.Context, metric, service, groupByOperation, quantile, ratePer, step string, spanKinds []string, timeStart, timeEnd int64) ([]byte, error) {
+func (m *MockInstance) GetMetrics(ctx context.Context, w http.ResponseWriter, metric, service, groupByOperation, quantile, ratePer, step string, spanKinds []string, timeStart, timeEnd int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMetrics", ctx, metric, service, groupByOperation, quantile, ratePer, step, spanKinds, timeStart, timeEnd)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "GetMetrics", ctx, w, metric, service, groupByOperation, quantile, ratePer, step, spanKinds, timeStart, timeEnd)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // GetMetrics indicates an expected call of GetMetrics.
-func (mr *MockInstanceMockRecorder) GetMetrics(ctx, metric, service, groupByOperation, quantile, ratePer, step, spanKinds, timeStart, timeEnd interface{}) *gomock.Call {
+func (mr *MockInstanceMockRecorder) GetMetrics(ctx, w, metric, service, groupByOperation, quantile, ratePer, step, spanKinds, timeStart, timeEnd interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetrics", reflect.TypeOf((*MockInstance)(nil).GetMetrics), ctx, metric, service, groupByOperation, quantile, ratePer, step, spanKinds, timeStart, timeEnd)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetrics", reflect.TypeOf((*MockInstance)(nil).GetMetrics), ctx, w, metric, service, groupByOperation, quantile, ratePer, step, spanKinds, timeStart, timeEnd)
 }
 
 // GetName mocks base method.
@@ -64,76 +64,71 @@ func (mr *MockInstanceMockRecorder) GetName() *gomock.Call {
 }
 
 // GetOperations mocks base method.
-func (m *MockInstance) GetOperations(ctx context.Context, service string) ([]byte, error) {
+func (m *MockInstance) GetOperations(ctx context.Context, w http.ResponseWriter, service string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOperations", ctx, service)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "GetOperations", ctx, w, service)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // GetOperations indicates an expected call of GetOperations.
-func (mr *MockInstanceMockRecorder) GetOperations(ctx, service interface{}) *gomock.Call {
+func (mr *MockInstanceMockRecorder) GetOperations(ctx, w, service interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperations", reflect.TypeOf((*MockInstance)(nil).GetOperations), ctx, service)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperations", reflect.TypeOf((*MockInstance)(nil).GetOperations), ctx, w, service)
 }
 
 // GetServices mocks base method.
-func (m *MockInstance) GetServices(ctx context.Context) ([]byte, error) {
+func (m *MockInstance) GetServices(ctx context.Context, w http.ResponseWriter) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetServices", ctx)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "GetServices", ctx, w)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // GetServices indicates an expected call of GetServices.
-func (mr *MockInstanceMockRecorder) GetServices(ctx interface{}) *gomock.Call {
+func (mr *MockInstanceMockRecorder) GetServices(ctx, w interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServices", reflect.TypeOf((*MockInstance)(nil).GetServices), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServices", reflect.TypeOf((*MockInstance)(nil).GetServices), ctx, w)
 }
 
 // GetTrace mocks base method.
-func (m *MockInstance) GetTrace(ctx context.Context, traceID string) ([]byte, error) {
+func (m *MockInstance) GetTrace(ctx context.Context, w http.ResponseWriter, traceID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTrace", ctx, traceID)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "GetTrace", ctx, w, traceID)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // GetTrace indicates an expected call of GetTrace.
-func (mr *MockInstanceMockRecorder) GetTrace(ctx, traceID interface{}) *gomock.Call {
+func (mr *MockInstanceMockRecorder) GetTrace(ctx, w, traceID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTrace", reflect.TypeOf((*MockInstance)(nil).GetTrace), ctx, traceID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTrace", reflect.TypeOf((*MockInstance)(nil).GetTrace), ctx, w, traceID)
 }
 
 // GetTraces mocks base method.
-func (m *MockInstance) GetTraces(ctx context.Context, limit, maxDuration, minDuration, operation, service, tags string, timeStart, timeEnd int64) ([]byte, error) {
+func (m *MockInstance) GetTraces(ctx context.Context, w http.ResponseWriter, limit, maxDuration, minDuration, operation, service, tags string, timeStart, timeEnd int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTraces", ctx, limit, maxDuration, minDuration, operation, service, tags, timeStart, timeEnd)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "GetTraces", ctx, w, limit, maxDuration, minDuration, operation, service, tags, timeStart, timeEnd)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // GetTraces indicates an expected call of GetTraces.
-func (mr *MockInstanceMockRecorder) GetTraces(ctx, limit, maxDuration, minDuration, operation, service, tags, timeStart, timeEnd interface{}) *gomock.Call {
+func (mr *MockInstanceMockRecorder) GetTraces(ctx, w, limit, maxDuration, minDuration, operation, service, tags, timeStart, timeEnd interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTraces", reflect.TypeOf((*MockInstance)(nil).GetTraces), ctx, limit, maxDuration, minDuration, operation, service, tags, timeStart, timeEnd)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTraces", reflect.TypeOf((*MockInstance)(nil).GetTraces), ctx, w, limit, maxDuration, minDuration, operation, service, tags, timeStart, timeEnd)
 }
 
 // doRequest mocks base method.
-func (m *MockInstance) doRequest(ctx context.Context, url string) ([]byte, error) {
+func (m *MockInstance) doRequest(ctx context.Context, w http.ResponseWriter, url string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "doRequest", ctx, url)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "doRequest", ctx, w, url)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // doRequest indicates an expected call of doRequest.
-func (mr *MockInstanceMockRecorder) doRequest(ctx, url interface{}) *gomock.Call {
+func (mr *MockInstanceMockRecorder) doRequest(ctx, w, url interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "doRequest", reflect.TypeOf((*MockInstance)(nil).doRequest), ctx, url)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "doRequest", reflect.TypeOf((*MockInstance)(nil).doRequest), ctx, w, url)
 }

--- a/pkg/plugins/jaeger/instance/instance_test.go
+++ b/pkg/plugins/jaeger/instance/instance_test.go
@@ -26,7 +26,7 @@ func TestDoRequest(t *testing.T) {
 		// This is used to test when no context is passed to the function. This should never happen, but we want to make
 		// sure that the function does not panic.
 		//nolint:staticcheck
-		_, err := i.doRequest(nil, "/")
+		err := i.doRequest(nil, nil, "/")
 		require.Error(t, err)
 	})
 
@@ -35,7 +35,7 @@ func TestDoRequest(t *testing.T) {
 		defer ts.Close()
 
 		i := &instance{name: "jaeger", client: ts.Client(), address: ""}
-		_, err := i.doRequest(context.Background(), "/")
+		err := i.doRequest(context.Background(), nil, "/")
 		require.Error(t, err)
 	})
 
@@ -48,9 +48,10 @@ func TestDoRequest(t *testing.T) {
 		defer ts.Close()
 
 		i := &instance{name: "jaeger", client: ts.Client(), address: ts.URL}
-		res, err := i.doRequest(context.Background(), "/")
+		w := httptest.NewRecorder()
+		err := i.doRequest(context.Background(), w, "/")
 		require.NoError(t, err)
-		require.Equal(t, []byte(`{"key": "value"}`), res)
+		require.Equal(t, []byte(`{"key": "value"}`), w.Body.Bytes())
 	})
 
 	t.Run("should return error", func(t *testing.T) {
@@ -62,7 +63,7 @@ func TestDoRequest(t *testing.T) {
 		defer ts.Close()
 
 		i := &instance{name: "jaeger", client: ts.Client(), address: ts.URL}
-		_, err := i.doRequest(context.Background(), "/")
+		err := i.doRequest(context.Background(), nil, "/")
 		require.Error(t, err)
 		require.Equal(t, "error message", err.Error())
 	})
@@ -76,7 +77,7 @@ func TestDoRequest(t *testing.T) {
 		defer ts.Close()
 
 		i := &instance{name: "jaeger", client: ts.Client(), address: ts.URL}
-		_, err := i.doRequest(context.Background(), "/")
+		err := i.doRequest(context.Background(), nil, "/")
 		require.Error(t, err)
 	})
 }
@@ -91,9 +92,10 @@ func TestGetServices(t *testing.T) {
 		defer ts.Close()
 
 		i := &instance{name: "jaeger", client: ts.Client(), address: ts.URL}
-		res, err := i.GetServices(context.Background())
+		w := httptest.NewRecorder()
+		err := i.GetServices(context.Background(), w)
 		require.NoError(t, err)
-		require.Equal(t, []byte(`{"key": "value"}`), res)
+		require.Equal(t, []byte(`{"key": "value"}`), w.Body.Bytes())
 	})
 }
 
@@ -107,9 +109,10 @@ func TestGetOperations(t *testing.T) {
 		defer ts.Close()
 
 		i := &instance{name: "jaeger", client: ts.Client(), address: ts.URL}
-		res, err := i.GetOperations(context.Background(), "service")
+		w := httptest.NewRecorder()
+		err := i.GetOperations(context.Background(), w, "service")
 		require.NoError(t, err)
-		require.Equal(t, []byte(`{"key": "value"}`), res)
+		require.Equal(t, []byte(`{"key": "value"}`), w.Body.Bytes())
 	})
 }
 
@@ -123,9 +126,10 @@ func TestGetTraces(t *testing.T) {
 		defer ts.Close()
 
 		i := &instance{name: "jaeger", client: ts.Client(), address: ts.URL}
-		res, err := i.GetTraces(context.Background(), "", "", "", "operation", "service", "", 0, 0)
+		w := httptest.NewRecorder()
+		err := i.GetTraces(context.Background(), w, "", "", "", "operation", "service", "", 0, 0)
 		require.NoError(t, err)
-		require.Equal(t, []byte(`{"key": "value"}`), res)
+		require.Equal(t, []byte(`{"key": "value"}`), w.Body.Bytes())
 	})
 }
 
@@ -139,9 +143,10 @@ func TestGetTrace(t *testing.T) {
 		defer ts.Close()
 
 		i := &instance{name: "jaeger", client: ts.Client(), address: ts.URL}
-		res, err := i.GetTrace(context.Background(), "")
+		w := httptest.NewRecorder()
+		err := i.GetTrace(context.Background(), w, "")
 		require.NoError(t, err)
-		require.Equal(t, []byte(`{"key": "value"}`), res)
+		require.Equal(t, []byte(`{"key": "value"}`), w.Body.Bytes())
 	})
 }
 
@@ -155,9 +160,10 @@ func TestGetMetrics(t *testing.T) {
 		defer ts.Close()
 
 		i := &instance{name: "jaeger", client: ts.Client(), address: ts.URL}
-		res, err := i.GetMetrics(context.Background(), "", "", "", "", "", "", []string{"kind1", "kind2"}, 0, 0)
+		w := httptest.NewRecorder()
+		err := i.GetMetrics(context.Background(), w, "", "", "", "", "", "", []string{"kind1", "kind2"}, 0, 0)
 		require.NoError(t, err)
-		require.Equal(t, []byte(`{"key": "value"}`), res)
+		require.Equal(t, []byte(`{"key": "value"}`), w.Body.Bytes())
 	})
 }
 

--- a/pkg/plugins/jaeger/router.go
+++ b/pkg/plugins/jaeger/router.go
@@ -12,7 +12,6 @@ import (
 	"github.com/kobsio/kobs/pkg/utils/middleware/pluginproxy"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/go-chi/render"
 	"go.uber.org/zap"
 )
 
@@ -50,15 +49,12 @@ func (router *Router) getServices(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := i.GetServices(r.Context())
+	err := i.GetServices(r.Context(), w)
 	if err != nil {
 		log.Error(r.Context(), "Failed to get services", zap.Error(err))
 		errresponse.Render(w, r, http.StatusInternalServerError, "Failed to get services")
 		return
 	}
-
-	render.SetContentType(render.ContentTypeJSON)
-	render.Data(w, r, body)
 }
 
 func (router *Router) getOperations(w http.ResponseWriter, r *http.Request) {
@@ -74,15 +70,12 @@ func (router *Router) getOperations(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := i.GetOperations(r.Context(), service)
+	err := i.GetOperations(r.Context(), w, service)
 	if err != nil {
 		log.Error(r.Context(), "Failed to get operations", zap.Error(err))
 		errresponse.Render(w, r, http.StatusInternalServerError, "Failed to get operations")
 		return
 	}
-
-	render.SetContentType(render.ContentTypeJSON)
-	render.Data(w, r, body)
 }
 
 func (router *Router) getTraces(w http.ResponseWriter, r *http.Request) {
@@ -119,15 +112,12 @@ func (router *Router) getTraces(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := i.GetTraces(r.Context(), limit, maxDuration, minDuration, operation, service, tags, parsedTimeStart, parsedTimeEnd)
+	err = i.GetTraces(r.Context(), w, limit, maxDuration, minDuration, operation, service, tags, parsedTimeStart, parsedTimeEnd)
 	if err != nil {
 		log.Error(r.Context(), "Failed to get traces", zap.Error(err))
 		errresponse.Render(w, r, http.StatusInternalServerError, "Failed to get traces")
 		return
 	}
-
-	render.SetContentType(render.ContentTypeJSON)
-	render.Data(w, r, body)
 }
 
 func (router *Router) getTrace(w http.ResponseWriter, r *http.Request) {
@@ -143,15 +133,12 @@ func (router *Router) getTrace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := i.GetTrace(r.Context(), traceID)
+	err := i.GetTrace(r.Context(), w, traceID)
 	if err != nil {
 		log.Error(r.Context(), "Failed to get trace", zap.Error(err))
 		errresponse.Render(w, r, http.StatusInternalServerError, "Failed to get trace")
 		return
 	}
-
-	render.SetContentType(render.ContentTypeJSON)
-	render.Data(w, r, body)
 }
 
 func (router *Router) getMetrics(w http.ResponseWriter, r *http.Request) {
@@ -189,15 +176,12 @@ func (router *Router) getMetrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := i.GetMetrics(r.Context(), metric, service, groupByOperation, quantile, ratePer, step, spanKinds, parsedTimeStart, parsedTimeEnd)
+	err = i.GetMetrics(r.Context(), w, metric, service, groupByOperation, quantile, ratePer, step, spanKinds, parsedTimeStart, parsedTimeEnd)
 	if err != nil {
 		log.Error(r.Context(), "Failed to get metrics", zap.Error(err))
 		errresponse.Render(w, r, http.StatusInternalServerError, "Failed to get metrics")
 		return
 	}
-
-	render.SetContentType(render.ContentTypeJSON)
-	render.Data(w, r, body)
 }
 
 func Mount(instances []plugin.Instance, clustersClient clusters.Client) (chi.Router, error) {

--- a/pkg/plugins/jaeger/router_test.go
+++ b/pkg/plugins/jaeger/router_test.go
@@ -74,7 +74,7 @@ func TestGetServices(t *testing.T) {
 	t.Run("should fail when instance returns an error", func(t *testing.T) {
 		i, router := newRouter(t)
 		i.EXPECT().GetName().Return("jaeger")
-		i.EXPECT().GetServices(gomock.Any()).Return(nil, fmt.Errorf("unexpected error"))
+		i.EXPECT().GetServices(gomock.Any(), gomock.Any()).Return(fmt.Errorf("unexpected error"))
 
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/services", nil)
 		req.Header.Set("x-kobs-plugin", "jaeger")
@@ -89,7 +89,7 @@ func TestGetServices(t *testing.T) {
 	t.Run("should return services", func(t *testing.T) {
 		i, router := newRouter(t)
 		i.EXPECT().GetName().Return("jaeger")
-		i.EXPECT().GetServices(gomock.Any()).Return([]byte(`{"key": "value"}`), nil)
+		i.EXPECT().GetServices(gomock.Any(), gomock.Any()).Return(nil)
 
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/services", nil)
 		req.Header.Set("x-kobs-plugin", "jaeger")
@@ -98,7 +98,6 @@ func TestGetServices(t *testing.T) {
 		router.getServices(w, req)
 
 		utils.AssertStatusEq(t, w, http.StatusOK)
-		utils.AssertJSONEq(t, w, `{"key": "value"}`)
 	})
 }
 
@@ -128,7 +127,7 @@ func TestGetOperations(t *testing.T) {
 	t.Run("should fail when instance returns an error", func(t *testing.T) {
 		i, router := newRouter(t)
 		i.EXPECT().GetName().Return("jaeger")
-		i.EXPECT().GetOperations(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("unexpected error"))
+		i.EXPECT().GetOperations(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("unexpected error"))
 
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/operations", nil)
 		req.Header.Set("x-kobs-plugin", "jaeger")
@@ -143,7 +142,7 @@ func TestGetOperations(t *testing.T) {
 	t.Run("should return operations", func(t *testing.T) {
 		i, router := newRouter(t)
 		i.EXPECT().GetName().Return("jaeger")
-		i.EXPECT().GetOperations(gomock.Any(), gomock.Any()).Return([]byte(`{"key": "value"}`), nil)
+		i.EXPECT().GetOperations(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/operations", nil)
 		req.Header.Set("x-kobs-plugin", "jaeger")
@@ -152,7 +151,6 @@ func TestGetOperations(t *testing.T) {
 		router.getOperations(w, req)
 
 		utils.AssertStatusEq(t, w, http.StatusOK)
-		utils.AssertJSONEq(t, w, `{"key": "value"}`)
 	})
 }
 
@@ -210,7 +208,7 @@ func TestGetTraces(t *testing.T) {
 	t.Run("should fail when instance returns an error", func(t *testing.T) {
 		i, router := newRouter(t)
 		i.EXPECT().GetName().Return("jaeger")
-		i.EXPECT().GetTraces(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("unexpected error"))
+		i.EXPECT().GetTraces(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("unexpected error"))
 
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/traces?timeStart=0&timeEnd=0", nil)
 		req.Header.Set("x-kobs-plugin", "jaeger")
@@ -225,7 +223,7 @@ func TestGetTraces(t *testing.T) {
 	t.Run("should return traces", func(t *testing.T) {
 		i, router := newRouter(t)
 		i.EXPECT().GetName().Return("jaeger")
-		i.EXPECT().GetTraces(gomock.Any(), "", "", "", "myoperation", "myservice", "", int64(0), int64(0)).Return([]byte(`{"data": [{"traceID": "f821489350cd7465fcc727e92e32a237"}]}`), nil)
+		i.EXPECT().GetTraces(gomock.Any(), gomock.Any(), "", "", "", "myoperation", "myservice", "", int64(0), int64(0)).Return(nil)
 
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/traces?operation=myoperation&service=myservice&timeStart=0&timeEnd=0", nil)
 		req.Header.Set("x-kobs-plugin", "jaeger")
@@ -234,7 +232,6 @@ func TestGetTraces(t *testing.T) {
 		router.getTraces(w, req)
 
 		utils.AssertStatusEq(t, w, http.StatusOK)
-		utils.AssertJSONEq(t, w, `{"data": [{"traceID": "f821489350cd7465fcc727e92e32a237"}]}`)
 	})
 }
 
@@ -264,7 +261,7 @@ func TestGetTrace(t *testing.T) {
 	t.Run("should fail when instance returns an error", func(t *testing.T) {
 		i, router := newRouter(t)
 		i.EXPECT().GetName().Return("jaeger")
-		i.EXPECT().GetTrace(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("unexpected error"))
+		i.EXPECT().GetTrace(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("unexpected error"))
 
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/trace", nil)
 		req.Header.Set("x-kobs-plugin", "jaeger")
@@ -279,7 +276,7 @@ func TestGetTrace(t *testing.T) {
 	t.Run("should return trace", func(t *testing.T) {
 		i, router := newRouter(t)
 		i.EXPECT().GetName().Return("jaeger")
-		i.EXPECT().GetTrace(gomock.Any(), gomock.Any()).Return([]byte(`{"key": "value"}`), nil)
+		i.EXPECT().GetTrace(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/trace", nil)
 		req.Header.Set("x-kobs-plugin", "jaeger")
@@ -288,7 +285,6 @@ func TestGetTrace(t *testing.T) {
 		router.getTrace(w, req)
 
 		utils.AssertStatusEq(t, w, http.StatusOK)
-		utils.AssertJSONEq(t, w, `{"key": "value"}`)
 	})
 }
 
@@ -346,7 +342,7 @@ func TestGetMetrics(t *testing.T) {
 	t.Run("should fail when instance returns an error", func(t *testing.T) {
 		i, router := newRouter(t)
 		i.EXPECT().GetName().Return("jaeger")
-		i.EXPECT().GetMetrics(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("unexpected error"))
+		i.EXPECT().GetMetrics(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("unexpected error"))
 
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/metrics?timeStart=0&timeEnd=0", nil)
 		req.Header.Set("x-kobs-plugin", "jaeger")
@@ -361,7 +357,7 @@ func TestGetMetrics(t *testing.T) {
 	t.Run("should return metrics", func(t *testing.T) {
 		i, router := newRouter(t)
 		i.EXPECT().GetName().Return("jaeger")
-		i.EXPECT().GetMetrics(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]byte(`{"key": "value"}`), nil)
+		i.EXPECT().GetMetrics(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/metrics?timeStart=0&timeEnd=0", nil)
 		req.Header.Set("x-kobs-plugin", "jaeger")
@@ -370,7 +366,6 @@ func TestGetMetrics(t *testing.T) {
 		router.getMetrics(w, req)
 
 		utils.AssertStatusEq(t, w, http.StatusOK)
-		utils.AssertJSONEq(t, w, `{"key": "value"}`)
 	})
 }
 


### PR DESCRIPTION
As mentioned in #590, we are now directly copying the response from Jaeger instead of reading it first.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
