### PR TITLE
[runbooks] Add Common Field

### DIFF
--- a/app/packages/runbooks/src/components/DetailsPage.tsx
+++ b/app/packages/runbooks/src/components/DetailsPage.tsx
@@ -116,15 +116,29 @@ export const Runbook: FunctionComponent<{
             </CardContent>
           </Card>
 
-          <Card sx={{ mb: 6 }}>
-            <CardContent>
-              <Typography variant="h6" pb={2}>
-                Runbook
-              </Typography>
+          {data.common && (
+            <Card sx={{ mb: 6 }}>
+              <CardContent>
+                <Typography variant="h6" pb={2}>
+                  Common
+                </Typography>
 
-              <TechDocsMarkdown markdown={data.runbook} times={times} setTimes={setTimes} />
-            </CardContent>
-          </Card>
+                <TechDocsMarkdown markdown={data.common} times={times} setTimes={setTimes} />
+              </CardContent>
+            </Card>
+          )}
+
+          {data.runbook && (
+            <Card sx={{ mb: 6 }}>
+              <CardContent>
+                <Typography variant="h6" pb={2}>
+                  Runbook
+                </Typography>
+
+                <TechDocsMarkdown markdown={data.runbook} times={times} setTimes={setTimes} />
+              </CardContent>
+            </Card>
+          )}
         </>
       )}
     </UseQueryWrapper>

--- a/app/packages/runbooks/src/components/ListPage.tsx
+++ b/app/packages/runbooks/src/components/ListPage.tsx
@@ -114,15 +114,29 @@ const RunbookDetails: FunctionComponent<{
         </CardContent>
       </Card>
 
-      <Card sx={{ mb: 6 }}>
-        <CardContent>
-          <Typography variant="h6" pb={2}>
-            Runbook
-          </Typography>
+      {runbook.common && (
+        <Card sx={{ mb: 6 }}>
+          <CardContent>
+            <Typography variant="h6" pb={2}>
+              Common
+            </Typography>
 
-          <TechDocsMarkdown markdown={runbook.runbook} times={times} setTimes={setTimes} />
-        </CardContent>
-      </Card>
+            <TechDocsMarkdown markdown={runbook.common} times={times} setTimes={setTimes} />
+          </CardContent>
+        </Card>
+      )}
+
+      {runbook.runbook && (
+        <Card sx={{ mb: 6 }}>
+          <CardContent>
+            <Typography variant="h6" pb={2}>
+              Runbook
+            </Typography>
+
+            <TechDocsMarkdown markdown={runbook.runbook} times={times} setTimes={setTimes} />
+          </CardContent>
+        </Card>
+      )}
     </DetailsDrawer>
   );
 };

--- a/app/packages/runbooks/src/components/RunbooksPage.test.tsx
+++ b/app/packages/runbooks/src/components/RunbooksPage.test.tsx
@@ -28,6 +28,7 @@ describe('RunbooksPage', () => {
       getSpy.mockResolvedValue([
         {
           alert: 'test1',
+          common: 'Comman Actions',
           expr: 'vector(1)',
           group: 'testgroup1',
           id: '/group/test/alert/test1',
@@ -37,6 +38,7 @@ describe('RunbooksPage', () => {
         },
         {
           alert: 'test2',
+          common: 'Comman Actions',
           expr: 'vector(2)',
           group: 'testgroup2',
           id: '/group/test/alert/test2',
@@ -49,6 +51,7 @@ describe('RunbooksPage', () => {
       getSpy.mockResolvedValue([
         {
           alert: 'test1',
+          common: 'Comman Actions',
           expr: 'vector(1)',
           group: 'testgroup1',
           id: '/group/test/alert/test1',
@@ -95,6 +98,7 @@ describe('RunbooksPage', () => {
     expect(await waitFor(() => screen.getByText('Message 2'))).toBeInTheDocument();
 
     await userEvent.click(screen.getByText(/test1/));
+    expect(await waitFor(() => screen.getByText('Comman Actions'))).toBeInTheDocument();
     expect(await waitFor(() => screen.getByText('Runbook 1'))).toBeInTheDocument();
   });
 
@@ -109,6 +113,7 @@ describe('RunbooksPage', () => {
     expect(await waitFor(() => screen.getByText('testgroup1'))).toBeInTheDocument();
     expect(await waitFor(() => screen.getByText('warning'))).toBeInTheDocument();
     expect(await waitFor(() => screen.getByText('Message 1'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('Comman Actions'))).toBeInTheDocument();
     expect(await waitFor(() => screen.getByText('Runbook 1'))).toBeInTheDocument();
   });
 });

--- a/app/packages/runbooks/src/components/RunbooksPanel.test.tsx
+++ b/app/packages/runbooks/src/components/RunbooksPanel.test.tsx
@@ -27,6 +27,7 @@ describe('RunbooksPanel', () => {
       getSpy.mockResolvedValue([
         {
           alert: 'test1',
+          common: 'Comman Actions',
           expr: 'vector(1)',
           group: 'testgroup1',
           id: '/group/test/alert/test1',
@@ -36,6 +37,7 @@ describe('RunbooksPanel', () => {
         },
         {
           alert: 'test2',
+          common: 'Comman Actions',
           expr: 'vector(2)',
           group: 'testgroup2',
           id: '/group/test/alert/test2',
@@ -48,6 +50,7 @@ describe('RunbooksPanel', () => {
       getSpy.mockResolvedValue([
         {
           alert: 'test1',
+          common: 'Comman Actions',
           expr: 'vector(1)',
           group: 'testgroup1',
           id: '/group/test/alert/test1',
@@ -107,6 +110,7 @@ describe('RunbooksPanel', () => {
     expect(await waitFor(() => screen.getByText('Message 2'))).toBeInTheDocument();
 
     await userEvent.click(screen.getByText(/test1/));
+    expect(await waitFor(() => screen.getByText('Comman Actions'))).toBeInTheDocument();
     expect(await waitFor(() => screen.getByText('Runbook 1'))).toBeInTheDocument();
   });
 
@@ -117,6 +121,7 @@ describe('RunbooksPanel', () => {
     expect(await waitFor(() => screen.getByText('testgroup1'))).toBeInTheDocument();
     expect(await waitFor(() => screen.getByText('warning'))).toBeInTheDocument();
     expect(await waitFor(() => screen.getByText('Message 1'))).toBeInTheDocument();
+    expect(await waitFor(() => screen.getByText('Comman Actions'))).toBeInTheDocument();
     expect(await waitFor(() => screen.getByText('Runbook 1'))).toBeInTheDocument();
   });
 });

--- a/app/packages/runbooks/src/utils/utils.ts
+++ b/app/packages/runbooks/src/utils/utils.ts
@@ -11,6 +11,7 @@ export const example = `plugin:
 
 export interface IRunbook {
   alert: string;
+  common: string;
   expr: string;
   group: string;
   id: string;

--- a/docs/plugins/runbooks.md
+++ b/docs/plugins/runbooks.md
@@ -149,3 +149,22 @@ spec:
                           'y': 0
               ```
 ```
+
+To add some common instructions to all alerts in an alert group you can add a `kobs.io/<ALERTGROUP>` annotation, e.g.:
+
+```yaml
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  name: clickhouse-alert-rules
+  namespace: monitoring
+  aanotation:
+    kobs.io/ClickHouseOperatorRules: |
+      Here you can add some common actions which are visible within all alerts in the ClickHouseOperatorRules alert group.
+spec:
+  groups:
+    - name: ClickHouseOperatorRules
+      rules:
+        - alert: ClickHouseServerDown
+```

--- a/pkg/plugins/runbooks/instance/instance.go
+++ b/pkg/plugins/runbooks/instance/instance.go
@@ -90,6 +90,13 @@ func (i *instance) SyncRunbooks(ctx context.Context) error {
 				for _, prometheusRule := range prometheusRuleList.Items {
 					for _, ruleGroup := range prometheusRule.Spec.Groups {
 						for _, rule := range ruleGroup.Rules {
+							var common string
+							if prometheusRule.Metadata.Annotations != nil {
+								if value, ok := prometheusRule.Metadata.Annotations[fmt.Sprintf("kobs.io/%s", ruleGroup.Name)]; ok {
+									common = value
+								}
+							}
+
 							runbook := Runbook{
 								ID:        fmt.Sprintf("/group/%s/alert/%s", ruleGroup.Name, rule.Alert),
 								Alert:     rule.Alert,
@@ -97,6 +104,7 @@ func (i *instance) SyncRunbooks(ctx context.Context) error {
 								Expr:      rule.Expr,
 								Severity:  rule.Labels["severity"],
 								Message:   rule.Annotations["message"],
+								Common:    common,
 								Runbook:   rule.Annotations["runbook"],
 								UpdatedAt: updatedAt,
 							}

--- a/pkg/plugins/runbooks/instance/instance_test.go
+++ b/pkg/plugins/runbooks/instance/instance_test.go
@@ -46,6 +46,11 @@ func TestSyncAndGetRunbooks(t *testing.T) {
 	mockClusters.EXPECT().GetClusters().Return([]cluster.Client{mockCluster})
 	mockCluster.EXPECT().Request(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]any{
 		"items": []map[string]any{{
+			"metadata": map[string]any{
+				"annotations": map[string]any{
+					"kobs.io/test": "Common actions",
+				},
+			},
 			"spec": map[string]any{
 				"groups": []map[string]any{{
 					"name": "test",
@@ -87,6 +92,7 @@ func TestSyncAndGetRunbooks(t *testing.T) {
 	require.Equal(t, "vector(1)", runbooks1[0].Expr)
 	require.Equal(t, "info", runbooks1[0].Severity)
 	require.Equal(t, "Test alert message", runbooks1[0].Message)
+	require.Equal(t, "Common actions", runbooks1[0].Common)
 	require.Equal(t, "Test runbook", runbooks1[0].Runbook)
 
 	runbooks2, err := i.GetRunbooks(context.Background(), "", "test", "test")
@@ -97,6 +103,7 @@ func TestSyncAndGetRunbooks(t *testing.T) {
 	require.Equal(t, "vector(1)", runbooks2[0].Expr)
 	require.Equal(t, "info", runbooks2[0].Severity)
 	require.Equal(t, "Test alert message", runbooks2[0].Message)
+	require.Equal(t, "Common actions", runbooks2[0].Common)
 	require.Equal(t, "Test runbook", runbooks2[0].Runbook)
 
 	runbooks3, err := i.GetRunbooks(context.Background(), "", "", "test")
@@ -107,6 +114,7 @@ func TestSyncAndGetRunbooks(t *testing.T) {
 	require.Equal(t, "vector(1)", runbooks3[0].Expr)
 	require.Equal(t, "info", runbooks3[0].Severity)
 	require.Equal(t, "Test alert message", runbooks3[0].Message)
+	require.Equal(t, "Common actions", runbooks3[0].Common)
 	require.Equal(t, "Test runbook", runbooks3[0].Runbook)
 
 	runbooks4, err := i.GetRunbooks(context.Background(), "test", "", "")
@@ -117,6 +125,7 @@ func TestSyncAndGetRunbooks(t *testing.T) {
 	require.Equal(t, "vector(1)", runbooks4[0].Expr)
 	require.Equal(t, "info", runbooks4[0].Severity)
 	require.Equal(t, "Test alert message", runbooks4[0].Message)
+	require.Equal(t, "Common actions", runbooks4[0].Common)
 	require.Equal(t, "Test runbook", runbooks4[0].Runbook)
 }
 

--- a/pkg/plugins/runbooks/instance/types.go
+++ b/pkg/plugins/runbooks/instance/types.go
@@ -8,6 +8,9 @@ type PrometheusRuleList struct {
 }
 
 type PrometheusRule struct {
+	Metadata struct {
+		Annotations map[string]string `json:"annotations,omitempty"`
+	} `json:"metadata"`
 	Spec PrometheusRuleSpec `json:"spec"`
 }
 
@@ -35,6 +38,7 @@ type Runbook struct {
 	Expr      string `json:"expr" bson:"expr"`
 	Message   string `json:"message" bson:"message"`
 	Severity  string `json:"severity" bson:"severity"`
+	Common    string `json:"common" bson:"common"`
 	Runbook   string `json:"runbook" bson:"runbook"`
 	UpdatedAt int64  `json:"updatedAt" bson:"updatedAt"`
 }


### PR DESCRIPTION
Add a new "common" field to the runbooks, which allows a user to specify some common actions for an alert group in the Custom Resources via a "kobs.io/<ALERTGROUP>" annotation.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
