### PR TITLE
[runbooks] Improve Sync

### DIFF
--- a/app/packages/runbooks/src/components/RunbooksPanel.tsx
+++ b/app/packages/runbooks/src/components/RunbooksPanel.tsx
@@ -32,6 +32,7 @@ const RunbooksPanel: FunctionComponent<IPluginPanelProps<IOptions>> = ({
         <Runbooks
           instance={instance}
           options={{ ...options, ...page }}
+          times={times}
           setPage={(page, perPage) => setPage({ page: page, perPage: perPage })}
         />
       </PluginPanel>

--- a/pkg/plugins/runbooks/instance/helpers.go
+++ b/pkg/plugins/runbooks/instance/helpers.go
@@ -1,0 +1,12 @@
+package instance
+
+// appendIfMissing appends a runbook to the list of runbooks when it is not already in the list.
+func appendIfMissing(items []Runbook, item Runbook) []Runbook {
+	for _, ele := range items {
+		if ele.ID == item.ID {
+			return items
+		}
+	}
+
+	return append(items, item)
+}

--- a/pkg/plugins/runbooks/instance/helpers_test.go
+++ b/pkg/plugins/runbooks/instance/helpers_test.go
@@ -1,0 +1,25 @@
+package instance
+
+import "testing"
+
+func TestAppendIfMissing(t *testing.T) {
+	items := []Runbook{
+		{ID: "1"},
+		{ID: "2"},
+		{ID: "3"},
+	}
+
+	item := Runbook{
+		ID: "4",
+	}
+
+	items = appendIfMissing(items, item)
+	if len(items) != 4 {
+		t.Errorf("Expected length of items to be 4, got %d", len(items))
+	}
+
+	items = appendIfMissing(items, item)
+	if len(items) != 4 {
+		t.Errorf("Expected length of items to be 4, got %d", len(items))
+	}
+}


### PR DESCRIPTION
We are now only adding runbooks in the sync process when they are not already present in another cluster, so that changes which are made in one cluster for testing not overwritten by the same runbook in another cluster.

We also automatically updating the runbooks in the frontend when a user clicks on the sync button, so that the current version is shown and not an old one after the sync.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
