### PR TITLE
[prometheus] Fix Query Form

### DIFF
--- a/app/packages/prometheus/src/components/PrometheusPage.tsx
+++ b/app/packages/prometheus/src/components/PrometheusPage.tsx
@@ -16,6 +16,7 @@ import {
   getStateHistory,
   addStateHistoryItems,
   Editor,
+  useLatest,
 } from '@kobsio/core';
 import { Add, ManageSearch, Remove } from '@mui/icons-material';
 import {
@@ -321,6 +322,7 @@ const PrometheusToolbar: FunctionComponent<{
   setOptions: (options: IOptions) => void;
 }> = ({ instance, options, setOptions }) => {
   const [queries, setQueries] = useState<string[]>(options.queries);
+  const latestQueries = useLatest(queries);
 
   /**
    * `addQuery` adds a new PromQL query to our list of queries. In the UI we will add a new editor field which can then
@@ -346,7 +348,7 @@ const PrometheusToolbar: FunctionComponent<{
    * `changeQuery` changes the value of the query with the provided `index` to the provided `value`.
    */
   const changeQuery = (index: number, value: string) => {
-    const tmpQueries = [...queries];
+    const tmpQueries = [...latestQueries.current];
     tmpQueries[index] = value;
     setQueries(tmpQueries);
   };


### PR DESCRIPTION
The query form wasn't working sometimes, e.g. queries could not be removed or deleted queries where readded when another query was edited. This is now fixed by always using the latest queries via the "useLatest" hook.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
