### PR TITLE
[klogs] Add Settings Config

### DIFF
--- a/docs/plugins/klogs.md
+++ b/docs/plugins/klogs.md
@@ -20,6 +20,7 @@ The klogs plugin can be used within the `hub` or `cluster`. To use the klogs plu
 | options.connMaxLifetime | string | ClickHouse maximum connection lifetime. The default value is `1h`. | No |
 | options.maxIdleConns | number | ClickHouse maximum number of idle connections. The default value is `5`. | No |
 | options.maxOpenConns | number | ClickHouse maximum number of open connections. The default value is `10`. | No |
+| options.settings | map<string, any> | Additional settings which should be applyed to the ClickHouse connection. | No |
 | options.materializedColumns | []string | A list of materialized columns. See [kobsio/klogs](https://github.com/kobsio/klogs#configuration) for more information. | No |
 
 ```yaml
@@ -35,6 +36,9 @@ plugins:
       connMaxLifetime:
       maxIdleConns:
       maxOpenConns:
+      settings:
+        # e.g.
+        # receive_timeout: 600
       materializedColumns:
 ```
 

--- a/pkg/plugins/klogs/instance/instance.go
+++ b/pkg/plugins/klogs/instance/instance.go
@@ -23,15 +23,16 @@ var defaultFieldsSQL = []string{"timestamp", "cluster", "namespace", "app", "pod
 
 // Config is the structure of the configuration for a single klogs instance.
 type Config struct {
-	Address             string   `json:"address"`
-	Database            string   `json:"database"`
-	Username            string   `json:"username"`
-	Password            string   `json:"password"`
-	DialTimeout         string   `json:"dialTimeout"`
-	ConnMaxLifetime     string   `json:"connMaxLifetime"`
-	MaxIdleConns        int      `json:"maxIdleConns"`
-	MaxOpenConns        int      `json:"maxOpenConns"`
-	MaterializedColumns []string `json:"materializedColumns"`
+	Address             string         `json:"address"`
+	Database            string         `json:"database"`
+	Username            string         `json:"username"`
+	Password            string         `json:"password"`
+	DialTimeout         string         `json:"dialTimeout"`
+	ConnMaxLifetime     string         `json:"connMaxLifetime"`
+	MaxIdleConns        int            `json:"maxIdleConns"`
+	MaxOpenConns        int            `json:"maxOpenConns"`
+	MaterializedColumns []string       `json:"materializedColumns"`
+	Settings            map[string]any `json:"settings"`
 }
 
 type Instance interface {
@@ -219,6 +220,7 @@ func newQuerierFromConfig(config Config) Querier {
 			Password: config.Password,
 		},
 		DialTimeout: parsedDialTimeout,
+		Settings:    config.Settings,
 	})
 	client.SetMaxIdleConns(config.MaxIdleConns)
 	client.SetMaxOpenConns(config.MaxOpenConns)


### PR DESCRIPTION
It is now possible to provide additional settings for the connection to ClickHouse in the klogs plugin via the new "settings" option, e.g.

```yaml
- name: klogs
  type: klogs
  options:
    address: localhost:9000
    database: logs
    settings:
      receive_timeout: 30
```


<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
