### PR TITLE
[velero] UI Improvements

### DIFF
--- a/app/packages/azure/src/components/CostManagement.tsx
+++ b/app/packages/azure/src/components/CostManagement.tsx
@@ -86,8 +86,6 @@ const CostManagementPieChart: FunctionComponent<{ properties: ICostProperties }>
                   height={chartSize.height}
                   width={chartSize.width}
                   legendData={({ datum }: { datum: IPieDatum }) => {
-                    console.log(datum);
-
                     return {
                       color: datum.color,
                       label: datum.x,

--- a/app/packages/datadog/src/components/Metrics.tsx
+++ b/app/packages/datadog/src/components/Metrics.tsx
@@ -324,8 +324,6 @@ export const Metrics: FunctionComponent<{
     },
   );
 
-  console.log(data);
-
   return (
     <PluginPanel title={title} description={description}>
       <UseQueryWrapper

--- a/app/packages/velero/src/components/ResourceDetails.tsx
+++ b/app/packages/velero/src/components/ResourceDetails.tsx
@@ -1,13 +1,34 @@
 import {
   APIContext,
   APIError,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
   DetailsDrawer,
   Editor,
   IAPIContext,
   IPluginInstance,
+  ToolbarItem,
   UseQueryWrapper,
+  formatTimestamp,
 } from '@kobsio/core';
-import { Box, Card, CardContent, Tab, Tabs } from '@mui/material';
+import {
+  Box,
+  Card,
+  CardContent,
+  Tab,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tabs,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import yaml from 'js-yaml';
 import { FunctionComponent, useContext, useState } from 'react';
@@ -22,6 +43,7 @@ const ResourceDetailsLogs: FunctionComponent<{
   veleroResource: IVeleroResource;
 }> = ({ instance, veleroResource, cluster, namespace, name }) => {
   const apiContext = useContext<IAPIContext>(APIContext);
+  const [view, setView] = useState<'table' | 'plain'>('table');
 
   const { isError, isLoading, error, data, refetch } = useQuery<string, APIError>(
     ['velero/logs', instance, veleroResource, cluster, namespace, name],
@@ -53,7 +75,59 @@ const ResourceDetailsLogs: FunctionComponent<{
     >
       {data ? (
         <Card>
-          <CardContent style={{ overflowX: 'scroll', whiteSpace: 'pre', width: '100%' }}>{data}</CardContent>
+          <CardContent>
+            <ToolbarItem>
+              <ToggleButtonGroup
+                sx={{ mb: 6 }}
+                size="small"
+                value={view}
+                exclusive={true}
+                onChange={(_, value) => setView(value)}
+              >
+                <ToggleButton sx={{ px: 4 }} value="table">
+                  Table
+                </ToggleButton>
+                <ToggleButton sx={{ px: 4 }} value="plain">
+                  Plain
+                </ToggleButton>
+              </ToggleButtonGroup>
+            </ToolbarItem>
+
+            {view === 'table' ? (
+              <TableContainer>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Time</TableCell>
+                      <TableCell>Level</TableCell>
+                      <TableCell>Message</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {data.split('\n').map((line, index) => {
+                      if (line === '') {
+                        return null;
+                      }
+
+                      const parsedLine = JSON.parse(line);
+
+                      return (
+                        <TableRow key={index}>
+                          <TableCell sx={{ whiteSpace: 'nowrap' }}>
+                            {formatTimestamp(Math.floor(new Date(parsedLine.time).getTime() / 1000))}
+                          </TableCell>
+                          <TableCell>{parsedLine.level}</TableCell>
+                          <TableCell>{parsedLine.msg}</TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            ) : (
+              <div style={{ overflowX: 'scroll', whiteSpace: 'pre', width: '100%' }}>{data}</div>
+            )}
+          </CardContent>
         </Card>
       ) : null}
     </UseQueryWrapper>
@@ -79,7 +153,7 @@ const ResourceDetails: FunctionComponent<{
   resource: string;
   veleroResource: IVeleroResource;
 }> = ({ instance, veleroResource, cluster, namespace, name, manifest, resource, path, refetch, onClose, open }) => {
-  const [activeTab, setActiveTab] = useState<string>('yaml');
+  const [activeTab, setActiveTab] = useState<string>('details');
 
   return (
     <DetailsDrawer
@@ -91,9 +165,172 @@ const ResourceDetails: FunctionComponent<{
     >
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
         <Tabs variant="scrollable" scrollButtons={false} value={activeTab} onChange={(_, value) => setActiveTab(value)}>
+          <Tab key="details" label="Details" value="details" />
           <Tab key="yaml" label="Yaml" value="yaml" />
-          <Tab key="logs" label="Logs" value="logs" />
+          {veleroResource.type === 'backups' || veleroResource.type === 'restores' ? (
+            <Tab key="logs" label="Logs" value="logs" />
+          ) : null}
         </Tabs>
+      </Box>
+
+      <Box key="details" hidden={activeTab !== 'details'} py={6}>
+        {activeTab === 'details' && (
+          <>
+            {veleroResource.type === 'backups' && (
+              <Card sx={{ mb: 6 }}>
+                <CardContent>
+                  <Typography variant="h6" pb={2}>
+                    Info
+                  </Typography>
+                  <DescriptionList>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Status</DescriptionListTerm>
+                      <DescriptionListDescription>{manifest.status?.phase ?? '-'}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Errors</DescriptionListTerm>
+                      <DescriptionListDescription>{manifest.status?.errors ?? '0'}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Warnings</DescriptionListTerm>
+                      <DescriptionListDescription>{manifest.status?.warnings ?? '0'}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Created</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {manifest.metadata?.creationTimestamp
+                          ? formatTimestamp(Math.floor(new Date(manifest.metadata.creationTimestamp).getTime() / 1000))
+                          : '-'}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Expiration</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {manifest.status?.expiration
+                          ? formatTimestamp(Math.floor(new Date(manifest.status.expiration).getTime() / 1000))
+                          : '-'}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Location</DescriptionListTerm>
+                      <DescriptionListDescription>{manifest.spec?.storageLocation ?? '-'}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    {manifest.status?.failureReason && (
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>Failure</DescriptionListTerm>
+                        <DescriptionListDescription>{manifest.status?.failureReason}</DescriptionListDescription>
+                      </DescriptionListGroup>
+                    )}
+                  </DescriptionList>
+                </CardContent>
+              </Card>
+            )}
+
+            {veleroResource.type === 'restores' && (
+              <Card sx={{ mb: 6 }}>
+                <CardContent>
+                  <Typography variant="h6" pb={2}>
+                    Info
+                  </Typography>
+                  <DescriptionList>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Backup</DescriptionListTerm>
+                      <DescriptionListDescription>{manifest.spec?.backupName ?? '-'}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Status</DescriptionListTerm>
+                      <DescriptionListDescription>{manifest.status?.phase ?? '-'}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Errors</DescriptionListTerm>
+                      <DescriptionListDescription>{manifest.status?.errors ?? '0'}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Warnings</DescriptionListTerm>
+                      <DescriptionListDescription>{manifest.status?.warnings ?? '0'}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Started</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {manifest.status?.startTimestamp
+                          ? formatTimestamp(Math.floor(new Date(manifest.status.startTimestamp).getTime() / 1000))
+                          : '-'}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Expiration</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {manifest.status?.expiration
+                          ? formatTimestamp(Math.floor(new Date(manifest.status.expiration).getTime() / 1000))
+                          : '-'}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Created</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {manifest.metadata?.creationTimestamp
+                          ? formatTimestamp(Math.floor(new Date(manifest.metadata.creationTimestamp).getTime() / 1000))
+                          : '-'}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    {manifest.status?.failureReason && (
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>Failure</DescriptionListTerm>
+                        <DescriptionListDescription>{manifest.status?.failureReason}</DescriptionListDescription>
+                      </DescriptionListGroup>
+                    )}
+                  </DescriptionList>
+                </CardContent>
+              </Card>
+            )}
+
+            {veleroResource.type === 'schedules' && (
+              <Card sx={{ mb: 6 }}>
+                <CardContent>
+                  <Typography variant="h6" pb={2}>
+                    Info
+                  </Typography>
+                  <DescriptionList>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Status</DescriptionListTerm>
+                      <DescriptionListDescription>{manifest.status?.phase ?? '-'}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Created</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {manifest.metadata?.creationTimestamp
+                          ? formatTimestamp(Math.floor(new Date(manifest.metadata.creationTimestamp).getTime() / 1000))
+                          : '-'}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Schedule</DescriptionListTerm>
+                      <DescriptionListDescription>{manifest.spec?.schedule ?? '-'}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>TTL</DescriptionListTerm>
+                      <DescriptionListDescription>{manifest.spec?.ttl ?? '-'}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Last Backup</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {manifest.status?.lastBackup
+                          ? formatTimestamp(Math.floor(new Date(manifest.status.lastBackup).getTime() / 1000))
+                          : '-'}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Paused</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {manifest.spec?.paused === true ? 'True' : 'False'}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  </DescriptionList>
+                </CardContent>
+              </Card>
+            )}
+          </>
+        )}
       </Box>
 
       <Box key="yaml" hidden={activeTab !== 'yaml'} py={6}>

--- a/app/packages/velero/src/components/Resources.tsx
+++ b/app/packages/velero/src/components/Resources.tsx
@@ -7,6 +7,7 @@ import {
   ITimes,
   UseQueryWrapper,
 } from '@kobsio/core';
+import { Square } from '@mui/icons-material';
 import {
   Alert,
   AlertTitle,
@@ -144,6 +145,46 @@ const getErrors = (resource: IResourceResponse): string[] => {
 };
 
 /**
+ * `generateStatusColor` generates the color to identify the status of the Velero resource.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const generateStatusColor = (veleroResource: IVeleroResource, manifest: any): 'error' | 'warning' | 'success' => {
+  if (veleroResource.type === 'backups') {
+    if (manifest?.status?.phase !== 'Completed' || (manifest?.status?.errors && manifest?.status?.errors > 0)) {
+      return 'error';
+    }
+
+    if (manifest?.status?.errors && manifest?.status?.warnings > 0) {
+      return 'warning';
+    }
+
+    return 'success';
+  }
+
+  if (veleroResource.type === 'restores') {
+    if (manifest?.status?.phase !== 'Completed' || (manifest?.status?.errors && manifest?.status?.errors > 0)) {
+      return 'error';
+    }
+
+    if (manifest?.status?.errors && manifest?.status?.warnings > 0) {
+      return 'warning';
+    }
+
+    return 'success';
+  }
+
+  if (veleroResource.type === 'schedules') {
+    if (manifest?.spec?.paused === true) {
+      return 'warning';
+    }
+
+    return 'success';
+  }
+
+  return 'success';
+};
+
+/**
  * The `ResourceRow` component is used to render a single row in the table of resources. When a user clicks on the row
  * we also show a drawer with some details of the resource and mark the corresponding row as selected.
  *
@@ -168,6 +209,9 @@ const ResourceRow: FunctionComponent<{
             {cell}
           </TableCell>
         ))}
+        <TableCell>
+          <Square color={generateStatusColor(veleroResource, row.manifest)} />
+        </TableCell>
       </TableRow>
 
       {open && (
@@ -258,6 +302,7 @@ const Resource: FunctionComponent<{
               {veleroResource.columns.map((column) => (
                 <TableCell key={column.title}>{column.title}</TableCell>
               ))}
+              <TableCell />
             </TableRow>
           </TableHead>
           <TableBody>

--- a/app/packages/velero/src/utils/utils.ts
+++ b/app/packages/velero/src/utils/utils.ts
@@ -50,7 +50,7 @@ export const veleroResources: Record<TVeleroType, IVeleroResource> = {
         type: 'number',
       },
       {
-        jsonPath: '$.spec.warnings',
+        jsonPath: '$.status.warnings',
         title: 'Warnings',
         type: 'number',
       },
@@ -145,7 +145,7 @@ export const veleroResources: Record<TVeleroType, IVeleroResource> = {
       },
       {
         jsonPath: '$.spec.paused',
-        title: 'TTL',
+        title: 'Paused',
         type: 'boolean',
       },
     ],


### PR DESCRIPTION
This commit contains some improvements for the UI of the Velero plugin. These improvements are:

- Add status indication in the table for the Velero resources
- Add details tab in the details drawer of the Velero resources, which shows the information from the table + some additional fields from the CR
- Add table view for logs, which allows users to see all log lines in a table. A user can also switch to the known plain text view via a toggle button

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
