### PR TITLE
[core] Add Options to set Headers to VirtualService

### DIFF
--- a/deploy/helm/kobs/Chart.yaml
+++ b/deploy/helm/kobs/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kobs
 description: Kubernetes Observability Platform
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: v0.12.0

--- a/deploy/helm/kobs/templates/cluster/virtualservice.yaml
+++ b/deploy/helm/kobs/templates/cluster/virtualservice.yaml
@@ -26,5 +26,9 @@ spec:
             port:
               number: 15221
       timeout: {{ .Values.cluster.istio.virtualService.timeout }}
+      {{- with .Values.cluster.istio.virtualService.headers }}
+      headers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/kobs/templates/hub/virtualservice.yaml
+++ b/deploy/helm/kobs/templates/hub/virtualservice.yaml
@@ -35,5 +35,9 @@ spec:
             port:
               number: 15219
       timeout: 60s
+      {{- with .Values.hub.istio.virtualService.headers }}
+      headers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/kobs/values.yaml
+++ b/deploy/helm/kobs/values.yaml
@@ -350,6 +350,10 @@ hub:
 
       timeout: 300s
 
+      ## Set, add or remove headers in the VirtualService.
+      ##
+      headers: {}
+
       ## You can also add your own routes to the VirtualService.
       ##
       additionalRoutes: []
@@ -774,6 +778,10 @@ cluster:
         # - chart-example.local
 
       timeout: 300s
+
+      ## Set, add or remove headers in the VirtualService.
+      ##
+      headers: {}
 
       ## You can also add your own routes to the VirtualService.
       ##

--- a/docs/getting-started/installation/helm.md
+++ b/docs/getting-started/installation/helm.md
@@ -75,6 +75,7 @@ helm upgrade --install kobs kobs/kobs
 | `hub.istio.virtualService.gateways` | A list of gateways for the VirtualService. | `[]` |
 | `hub.istio.virtualService.hosts` | A list of hosts for the VirtualService. | `[]` |
 | `hub.istio.virtualService.timeout` | Timeout for API requests. | `300s` |
+| `hub.istio.virtualService.headers` | Modify the headers in the VirtualService. | `{}` |
 | `hub.istio.virtualService.additionalRoutes` | A list of additional routes for the VirtualService. | `[]` |
 | `hub.serviceMonitor.enabled` | Create a Service Monitor for kobs. | `false` |
 | `hub.serviceMonitor.interval` | Interval at which metrics should be scraped. Fallback to the Prometheus default unless specified. | |
@@ -143,6 +144,7 @@ helm upgrade --install kobs kobs/kobs
 | `cluster.istio.virtualService.gateways` | A list of gateways for the VirtualService. | `[]` |
 | `cluster.istio.virtualService.hosts` | A list of hosts for the VirtualService. | `[]` |
 | `cluster.istio.virtualService.timeout` | Timeout for API requests. | `300s` |
+| `cluster.istio.virtualService.headers` | Modify the headers in the VirtualService. | `{}` |
 | `cluster.istio.virtualService.additionalRoutes` | A list of additional routes for the VirtualService. | `[]` |
 | `cluster.serviceMonitor.enabled` | Create a Service Monitor for kobs. | `false` |
 | `cluster.serviceMonitor.interval` | Interval at which metrics should be scraped. Fallback to the Prometheus default unless specified. | |


### PR DESCRIPTION
It is now possible to set headers to the VirtualServices created by the Helm chart.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [x] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
