### PR TITLE
[sessions] Session cleanup

### DIFF
--- a/.run/cluster.run.xml
+++ b/.run/cluster.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="cluster" type="GoApplicationRunConfiguration" factoryName="Go Application">
+    <module name="kobs" />
+    <working_directory value="$PROJECT_DIR$" />
+    <parameters value="cluster" />
+    <kind value="PACKAGE" />
+    <package value="github.com/kobsio/kobs/cmd/kobs" />
+    <directory value="$PROJECT_DIR$" />
+    <filePath value="$PROJECT_DIR$/cmd/kobs/main.go" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/hub.run.xml
+++ b/.run/hub.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="hub" type="GoApplicationRunConfiguration" factoryName="Go Application">
+    <module name="kobs" />
+    <working_directory value="$PROJECT_DIR$" />
+    <parameters value="hub" />
+    <kind value="PACKAGE" />
+    <package value="github.com/kobsio/kobs/cmd/kobs" />
+    <directory value="$PROJECT_DIR$" />
+    <filePath value="$PROJECT_DIR$/cmd/kobs/main.go" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/start all.run.xml
+++ b/.run/start all.run.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="start all" type="CompoundRunConfigurationType">
+    <toRun name="start cluster" type="GoApplicationRunConfiguration" />
+    <toRun name="hub" type="GoApplicationRunConfiguration" />
+    <toRun name="start watcher" type="GoApplicationRunConfiguration" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/watcher.run.xml
+++ b/.run/watcher.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="watcher" type="GoApplicationRunConfiguration" factoryName="Go Application">
+    <module name="kobs" />
+    <working_directory value="$PROJECT_DIR$" />
+    <parameters value="watcher" />
+    <kind value="PACKAGE" />
+    <package value="github.com/kobsio/kobs/cmd/kobs" />
+    <directory value="$PROJECT_DIR$" />
+    <filePath value="$PROJECT_DIR$/cmd/kobs/main.go" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,7 +165,11 @@ The frontend lives in the [`plugins/app`](./plugins/app) folder. The shared Reac
 - `yarn workspace @kobsio/app build`: Build the React UI.
 - `yarn workspace @kobsio/app start`: Start development server for the React UI. The development server is served on port `3000`.
 
-We are using [ESLint](https://eslint.org) and [Prettier](https://prettier.io) for linting and automatic code formation. When you are using [VS Code](https://code.visualstudio.com) you can also use the `launch.json` file from the `.vscode` folder for debugging the React UI.
+We are using [ESLint](https://eslint.org) and [Prettier](https://prettier.io) for linting and automatic code formation.
+
+When you are using [VS Code](https://code.visualstudio.com) you can also use the `launch.json` file from the `.vscode` folder for debugging the React UI.
+
+For [Intellj](https://www.jetbrains.com/idea/) users the `.run` folder contains shared run configurations.
 
 #### Plugins
 

--- a/cmd/kobs/hub/hub.go
+++ b/cmd/kobs/hub/hub.go
@@ -83,6 +83,12 @@ func (r *Cmd) Run(plugins []plugins.Plugin) error {
 		return err
 	}
 
+	err = dbClient.CreateIndexes(context.Background())
+	if err != nil {
+		log.Error(context.Background(), "Could not create indexes", zap.Error(err))
+		return err
+	}
+
 	pluginsClient, err := hubPlugins.NewClient(plugins, cfg.Hub.Plugins, clustersClient, dbClient)
 	if err != nil {
 		log.Error(context.Background(), "Could not create plugins client", zap.Error(err))
@@ -115,7 +121,7 @@ func (r *Cmd) Run(plugins []plugins.Plugin) error {
 	done := make(chan os.Signal, 1)
 	signal.Notify(done, os.Interrupt, syscall.SIGTERM)
 
-	log.Debug(context.Background(), "Start listining for SIGINT and SIGTERM signal")
+	log.Debug(context.Background(), "Start listening for SIGINT and SIGTERM signal")
 	<-done
 	log.Info(context.Background(), "Shutdown kobs hub...")
 

--- a/pkg/hub/db/db_mock.go
+++ b/pkg/hub/db/db_mock.go
@@ -43,6 +43,20 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+// CreateIndexes mocks base method.
+func (m *MockClient) CreateIndexes(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateIndexes", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateIndexes indicates an expected call of CreateIndexes.
+func (mr *MockClientMockRecorder) CreateIndexes(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateIndexes", reflect.TypeOf((*MockClient)(nil).CreateIndexes), ctx)
+}
+
 // CreateSession mocks base method.
 func (m *MockClient) CreateSession(ctx context.Context, user context0.User) (*Session, error) {
 	m.ctrl.T.Helper()

--- a/pkg/hub/db/db_test.go
+++ b/pkg/hub/db/db_test.go
@@ -46,6 +46,15 @@ func TestNewClient(t *testing.T) {
 	require.NotEmpty(t, c2)
 }
 
+func TestCreateIndexes(t *testing.T) {
+	uri, container := setupDatabase(t)
+	defer gnomock.Stop(container)
+	c, _ := NewClient(Config{URI: uri})
+
+	err := c.CreateIndexes(context.Background())
+	require.NoError(t, err)
+}
+
 func TestSaveAndGetPlugins(t *testing.T) {
 	plugins := []plugin.Instance{{
 		Name: "test-cluster",

--- a/pkg/plugins/prometheus/instance/instance_mock.go
+++ b/pkg/plugins/prometheus/instance/instance_mock.go
@@ -6,11 +6,10 @@ package instance
 
 import (
 	context "context"
+	http "net/http"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
-	model "github.com/prometheus/common/model"
 )
 
 // MockInstance is a mock of Instance interface.
@@ -51,22 +50,6 @@ func (mr *MockInstanceMockRecorder) GetInstant(ctx, queries, timeEnd interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstant", reflect.TypeOf((*MockInstance)(nil).GetInstant), ctx, queries, timeEnd)
 }
 
-// GetLabels mocks base method.
-func (m *MockInstance) GetLabels(ctx context.Context, matches []string, timeStart, timeEnd int64) ([]string, v1.Warnings, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLabels", ctx, matches, timeStart, timeEnd)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(v1.Warnings)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// GetLabels indicates an expected call of GetLabels.
-func (mr *MockInstanceMockRecorder) GetLabels(ctx, matches, timeStart, timeEnd interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLabels", reflect.TypeOf((*MockInstance)(nil).GetLabels), ctx, matches, timeStart, timeEnd)
-}
-
 // GetName mocks base method.
 func (m *MockInstance) GetName() string {
 	m.ctrl.T.Helper()
@@ -96,22 +79,6 @@ func (mr *MockInstanceMockRecorder) GetRange(ctx, queries, resolution, timeStart
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRange", reflect.TypeOf((*MockInstance)(nil).GetRange), ctx, queries, resolution, timeStart, timeEnd)
 }
 
-// GetSeries mocks base method.
-func (m *MockInstance) GetSeries(ctx context.Context, matches []string, timeStart, timeEnd int64) ([]model.LabelSet, v1.Warnings, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSeries", ctx, matches, timeStart, timeEnd)
-	ret0, _ := ret[0].([]model.LabelSet)
-	ret1, _ := ret[1].(v1.Warnings)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// GetSeries indicates an expected call of GetSeries.
-func (mr *MockInstanceMockRecorder) GetSeries(ctx, matches, timeStart, timeEnd interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSeries", reflect.TypeOf((*MockInstance)(nil).GetSeries), ctx, matches, timeStart, timeEnd)
-}
-
 // GetVariable mocks base method.
 func (m *MockInstance) GetVariable(ctx context.Context, label, query, queryType string, timeStart, timeEnd int64) ([]string, error) {
 	m.ctrl.T.Helper()
@@ -125,4 +92,16 @@ func (m *MockInstance) GetVariable(ctx context.Context, label, query, queryType 
 func (mr *MockInstanceMockRecorder) GetVariable(ctx, label, query, queryType, timeStart, timeEnd interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVariable", reflect.TypeOf((*MockInstance)(nil).GetVariable), ctx, label, query, queryType, timeStart, timeEnd)
+}
+
+// Proxy mocks base method.
+func (m *MockInstance) Proxy(w http.ResponseWriter, r *http.Request) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Proxy", w, r)
+}
+
+// Proxy indicates an expected call of Proxy.
+func (mr *MockInstanceMockRecorder) Proxy(w, r interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Proxy", reflect.TypeOf((*MockInstance)(nil).Proxy), w, r)
 }

--- a/pkg/plugins/sonarqube/instance/instance_mock.go
+++ b/pkg/plugins/sonarqube/instance/instance_mock.go
@@ -64,16 +64,16 @@ func (mr *MockInstanceMockRecorder) GetProjectMeasures(ctx, project, metricKeys 
 }
 
 // GetProjects mocks base method.
-func (m *MockInstance) GetProjects(ctx context.Context, query, pageSize, pageNumber string) (*ResponseProjects, error) {
+func (m *MockInstance) GetProjects(ctx context.Context, query, page, perPage string) (*ResponseProjects, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProjects", ctx, query, pageSize, pageNumber)
+	ret := m.ctrl.Call(m, "GetProjects", ctx, query, page, perPage)
 	ret0, _ := ret[0].(*ResponseProjects)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetProjects indicates an expected call of GetProjects.
-func (mr *MockInstanceMockRecorder) GetProjects(ctx, query, pageSize, pageNumber interface{}) *gomock.Call {
+func (mr *MockInstanceMockRecorder) GetProjects(ctx, query, page, perPage interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjects", reflect.TypeOf((*MockInstance)(nil).GetProjects), ctx, query, pageSize, pageNumber)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjects", reflect.TypeOf((*MockInstance)(nil).GetProjects), ctx, query, page, perPage)
 }


### PR DESCRIPTION
<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->
Added cleanup of inactive sessions after 7 days (168h) which is the upper limit of the session cookie lifetime

* Create a TTL index on the updatedAt field
* Change type of createdAt and updatedAt to Date (required for TTL index)

=> the session cleanup will only work for sessions create/touch after this change. 
=> older sessions need to dropped manually

see: https://www.mongodb.com/docs/manual/core/index-ttl/

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
