### PR TITLE
[tests] Improve db test performance

### DIFF
--- a/pkg/hub/db/db.go
+++ b/pkg/hub/db/db.go
@@ -104,8 +104,18 @@ func NewClient(config Config) (Client, error) {
 	}, nil
 }
 
+// Returns the collection with given name
+// uses specified "kobs.db.name" value from cxt if given  as db or "kobs" as default
+func (c *client) coll(ctx context.Context, collection string) *mongo.Collection {
+	dbName := ctx.Value("kobs.db.name")
+	if dbName == nil {
+		dbName = "kobs"
+	}
+	return c.db.Database(dbName.(string)).Collection(collection)
+}
+
 func (c *client) save(ctx context.Context, collection string, models []mongo.WriteModel, cluster string, updatedAt int64) error {
-	_, err := c.db.Database("kobs").Collection(collection).BulkWrite(ctx, models)
+	_, err := c.coll(ctx, collection).BulkWrite(ctx, models)
 	if err != nil {
 		return err
 	}
@@ -115,7 +125,7 @@ func (c *client) save(ctx context.Context, collection string, models []mongo.Wri
 		filter = bson.D{{Key: "$and", Value: bson.A{bson.D{{Key: "cluster", Value: bson.D{{Key: "$eq", Value: cluster}}}}, filter}}}
 	}
 
-	_, err = c.db.Database("kobs").Collection(collection).DeleteMany(ctx, filter)
+	_, err = c.coll(ctx, collection).DeleteMany(ctx, filter)
 	if err != nil {
 		return err
 	}
@@ -132,7 +142,7 @@ func (c *client) CreateIndexes(ctx context.Context) error {
 	defer span.End()
 
 	// Create TTL index for sessions collection, which will delete all inactive sessions which are older than 7 days (168h).
-	_, err := c.db.Database("kobs").Collection("sessions").Indexes().CreateOne(
+	_, err := c.coll(ctx, "sessions").Indexes().CreateOne(
 		ctx,
 		mongo.IndexModel{
 			Keys:    bson.D{{Key: "updatedAt", Value: 1}},
@@ -271,7 +281,7 @@ func (c *client) SaveApplication(ctx context.Context, application *applicationv1
 	upsert := true
 	application.UpdatedAt = time.Now().Unix()
 
-	_, err := c.db.Database("kobs").Collection("applications").ReplaceOne(ctx, bson.D{{Key: "_id", Value: application.ID}}, application, &options.ReplaceOptions{Upsert: &upsert})
+	_, err := c.coll(ctx, "applications").ReplaceOne(ctx, bson.D{{Key: "_id", Value: application.ID}}, application, &options.ReplaceOptions{Upsert: &upsert})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -342,7 +352,7 @@ func (c *client) SaveTeam(ctx context.Context, team *teamv1.TeamSpec) error {
 	upsert := true
 	team.UpdatedAt = time.Now().Unix()
 
-	_, err := c.db.Database("kobs").Collection("teams").ReplaceOne(ctx, bson.D{{Key: "_id", Value: team.ID}}, team, &options.ReplaceOptions{Upsert: &upsert})
+	_, err := c.coll(ctx, "teams").ReplaceOne(ctx, bson.D{{Key: "_id", Value: team.ID}}, team, &options.ReplaceOptions{Upsert: &upsert})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -386,7 +396,7 @@ func (c *client) SaveUser(ctx context.Context, user *userv1.UserSpec) error {
 	upsert := true
 	user.UpdatedAt = time.Now().Unix()
 
-	_, err := c.db.Database("kobs").Collection("users").ReplaceOne(ctx, bson.D{{Key: "_id", Value: user.ID}}, user, &options.ReplaceOptions{Upsert: &upsert})
+	_, err := c.coll(ctx, "users").ReplaceOne(ctx, bson.D{{Key: "_id", Value: user.ID}}, user, &options.ReplaceOptions{Upsert: &upsert})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -466,14 +476,14 @@ func (c *client) SaveTopology(ctx context.Context, cluster string, applications 
 		return nil
 	}
 
-	_, err := c.db.Database("kobs").Collection("topology").BulkWrite(ctx, models)
+	_, err := c.coll(ctx, "topology").BulkWrite(ctx, models)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 
-	_, err = c.db.Database("kobs").Collection("topology").DeleteMany(ctx, bson.D{{Key: "$and", Value: bson.A{bson.D{{Key: "sourceCluster", Value: bson.D{{Key: "$eq", Value: cluster}}}}, bson.D{{Key: "updatedAt", Value: bson.D{{Key: "$lt", Value: updatedAt}}}}}}})
+	_, err = c.coll(ctx, "topology").DeleteMany(ctx, bson.D{{Key: "$and", Value: bson.A{bson.D{{Key: "sourceCluster", Value: bson.D{{Key: "$eq", Value: cluster}}}}, bson.D{{Key: "updatedAt", Value: bson.D{{Key: "$lt", Value: updatedAt}}}}}}})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -489,7 +499,7 @@ func (c *client) GetPlugins(ctx context.Context) ([]plugin.Instance, error) {
 
 	var plugins []plugin.Instance
 
-	cursor, err := c.db.Database("kobs").Collection("plugins").Find(ctx, bson.D{}, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
+	cursor, err := c.coll(ctx, "plugins").Find(ctx, bson.D{}, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -512,7 +522,7 @@ func (c *client) GetNamespaces(ctx context.Context) ([]Namespace, error) {
 
 	var namespaces []Namespace
 
-	cursor, err := c.db.Database("kobs").Collection("namespaces").Find(ctx, bson.D{}, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
+	cursor, err := c.coll(ctx, "namespaces").Find(ctx, bson.D{}, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -542,7 +552,7 @@ func (c *client) GetNamespacesByClusters(ctx context.Context, clusters []string)
 
 	var namespaces []Namespace
 
-	cursor, err := c.db.Database("kobs").Collection("namespaces").Find(ctx, filter, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
+	cursor, err := c.coll(ctx, "namespaces").Find(ctx, filter, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -565,7 +575,7 @@ func (c *client) GetCRDs(ctx context.Context) ([]kubernetes.CRD, error) {
 
 	var crds []kubernetes.CRD
 
-	cursor, err := c.db.Database("kobs").Collection("crds").Find(ctx, bson.D{}, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
+	cursor, err := c.coll(ctx, "crds").Find(ctx, bson.D{}, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -589,7 +599,7 @@ func (c *client) GetCRDByID(ctx context.Context, id string) (*kubernetes.CRD, er
 
 	var crd kubernetes.CRD
 
-	result := c.db.Database("kobs").Collection("crds").FindOne(ctx, bson.D{{Key: "_id", Value: id}})
+	result := c.coll(ctx, "crds").FindOne(ctx, bson.D{{Key: "_id", Value: id}})
 	if err := result.Err(); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -612,7 +622,7 @@ func (c *client) GetApplications(ctx context.Context) ([]applicationv1.Applicati
 
 	var applications []applicationv1.ApplicationSpec
 
-	cursor, err := c.db.Database("kobs").Collection("applications").Find(ctx, bson.D{}, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
+	cursor, err := c.coll(ctx, "applications").Find(ctx, bson.D{}, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -664,7 +674,7 @@ func (c *client) GetApplicationsByFilter(ctx context.Context, teams, clusters, n
 
 	var applications []applicationv1.ApplicationSpec
 
-	cursor, err := c.db.Database("kobs").Collection("applications").Find(ctx, filter, options.Find().SetSort(bson.M{"name": 1}).SetLimit(int64(limit)).SetSkip(int64(offset)))
+	cursor, err := c.coll(ctx, "applications").Find(ctx, filter, options.Find().SetSort(bson.M{"name": 1}).SetLimit(int64(limit)).SetSkip(int64(offset)))
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -712,7 +722,7 @@ func (c *client) GetApplicationsByFilterCount(ctx context.Context, teams, cluste
 		filter["tags"] = bson.M{"$in": tags}
 	}
 
-	count, err := c.db.Database("kobs").Collection("applications").CountDocuments(ctx, filter)
+	count, err := c.coll(ctx, "applications").CountDocuments(ctx, filter)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -739,7 +749,7 @@ func (c *client) GetApplicationsByGroup(ctx context.Context, teams, groups []str
 
 	var applications []ApplicationGroup
 
-	cursor, err := c.db.Database("kobs").Collection("applications").Aggregate(ctx, mongo.Pipeline{
+	cursor, err := c.coll(ctx, "applications").Aggregate(ctx, mongo.Pipeline{
 		bson.D{{Key: "$match", Value: bson.D{{Key: "teams", Value: bson.D{{Key: "$in", Value: teams}}}}}},
 		bson.D{
 			{Key: "$group",
@@ -780,7 +790,7 @@ func (c *client) GetApplicationByID(ctx context.Context, id string) (*applicatio
 
 	var application applicationv1.ApplicationSpec
 
-	result := c.db.Database("kobs").Collection("applications").FindOne(ctx, bson.D{{Key: "_id", Value: id}})
+	result := c.coll(ctx, "applications").FindOne(ctx, bson.D{{Key: "_id", Value: id}})
 	if err := result.Err(); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -813,7 +823,7 @@ func (c *client) GetDashboards(ctx context.Context, clusters, namespaces []strin
 
 	var dashboards []dashboardv1.DashboardSpec
 
-	cursor, err := c.db.Database("kobs").Collection("dashboards").Find(ctx, filter, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
+	cursor, err := c.coll(ctx, "dashboards").Find(ctx, filter, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -837,7 +847,7 @@ func (c *client) GetDashboardByID(ctx context.Context, id string) (*dashboardv1.
 
 	var dashboard dashboardv1.DashboardSpec
 
-	result := c.db.Database("kobs").Collection("dashboards").FindOne(ctx, bson.D{{Key: "_id", Value: id}})
+	result := c.coll(ctx, "dashboards").FindOne(ctx, bson.D{{Key: "_id", Value: id}})
 	if err := result.Err(); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -865,7 +875,7 @@ func (c *client) GetTeams(ctx context.Context, searchTerm string) ([]teamv1.Team
 		filter = bson.D{{Key: "_id", Value: bson.M{"$regex": primitive.Regex{Pattern: searchTerm, Options: "i"}}}}
 	}
 
-	cursor, err := c.db.Database("kobs").Collection("teams").Find(ctx, filter, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
+	cursor, err := c.coll(ctx, "teams").Find(ctx, filter, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -898,7 +908,7 @@ func (c *client) GetTeamsByIDs(ctx context.Context, ids []string, searchTerm str
 		filter = bson.D{{Key: "$and", Value: bson.A{bson.D{{Key: "_id", Value: bson.D{{Key: "$in", Value: ids}}}}, bson.D{{Key: "_id", Value: bson.M{"$regex": primitive.Regex{Pattern: searchTerm, Options: "i"}}}}}}}
 	}
 
-	cursor, err := c.db.Database("kobs").Collection("teams").Find(ctx, filter, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
+	cursor, err := c.coll(ctx, "teams").Find(ctx, filter, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -922,7 +932,7 @@ func (c *client) GetTeamByID(ctx context.Context, id string) (*teamv1.TeamSpec, 
 
 	var team teamv1.TeamSpec
 
-	result := c.db.Database("kobs").Collection("teams").FindOne(ctx, bson.D{{Key: "_id", Value: id}})
+	result := c.coll(ctx, "teams").FindOne(ctx, bson.D{{Key: "_id", Value: id}})
 	if err := result.Err(); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -945,7 +955,7 @@ func (c *client) GetUsers(ctx context.Context) ([]userv1.UserSpec, error) {
 
 	var users []userv1.UserSpec
 
-	cursor, err := c.db.Database("kobs").Collection("users").Find(ctx, bson.D{}, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
+	cursor, err := c.coll(ctx, "users").Find(ctx, bson.D{}, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -969,7 +979,7 @@ func (c *client) GetUserByID(ctx context.Context, id string) (*userv1.UserSpec, 
 
 	var user userv1.UserSpec
 
-	result := c.db.Database("kobs").Collection("users").FindOne(ctx, bson.D{{Key: "_id", Value: id}})
+	result := c.coll(ctx, "users").FindOne(ctx, bson.D{{Key: "_id", Value: id}})
 	if err := result.Err(); err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			return nil, nil
@@ -995,7 +1005,7 @@ func (c *client) GetTags(ctx context.Context) ([]Tag, error) {
 
 	var tags []Tag
 
-	cursor, err := c.db.Database("kobs").Collection("tags").Find(ctx, bson.D{}, options.Find().SetSort(bson.D{{Key: "tag", Value: 1}}))
+	cursor, err := c.coll(ctx, "tags").Find(ctx, bson.D{}, options.Find().SetSort(bson.D{{Key: "tag", Value: 1}}))
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -1024,7 +1034,7 @@ func (c *client) GetTopologyByIDs(ctx context.Context, field string, ids []strin
 
 	var topology []Topology
 
-	cursor, err := c.db.Database("kobs").Collection("topology").Find(ctx, bson.D{{Key: field, Value: bson.D{{Key: "$in", Value: ids}}}})
+	cursor, err := c.coll(ctx, "topology").Find(ctx, bson.D{{Key: field, Value: bson.D{{Key: "$in", Value: ids}}}})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/pkg/hub/db/db.go
+++ b/pkg/hub/db/db.go
@@ -31,6 +31,12 @@ type Config struct {
 	URI string `json:"uri" env:"URI" default:"mongodb://localhost:27017" help:"The connection uri for MongoDB"`
 }
 
+type key int
+
+const (
+	kobsDbName key = iota
+)
+
 // Client is the interface with all the methods to interact with the db.
 type Client interface {
 	DB() *mongo.Client
@@ -107,7 +113,7 @@ func NewClient(config Config) (Client, error) {
 // Returns the collection with given name
 // uses specified "kobs.db.name" value from cxt if given  as db or "kobs" as default
 func (c *client) coll(ctx context.Context, collection string) *mongo.Collection {
-	dbName := ctx.Value("kobs.db.name")
+	dbName := ctx.Value(kobsDbName)
 	if dbName == nil {
 		dbName = "kobs"
 	}

--- a/pkg/hub/db/db_test.go
+++ b/pkg/hub/db/db_test.go
@@ -35,7 +35,7 @@ func setupDatabase(t *testing.T) (string, *gnomock.Container) {
 
 func ctx(t *testing.T) context.Context {
 	dbName := strings.ReplaceAll(t.Name(), "/", "_")
-	return context.WithValue(context.Background(), "kobs.db.name", dbName)
+	return context.WithValue(context.Background(), kobsDbName, dbName)
 }
 
 func TestDB(t *testing.T) {

--- a/pkg/hub/db/db_test.go
+++ b/pkg/hub/db/db_test.go
@@ -14,6 +14,7 @@ import (
 	teamv1 "github.com/kobsio/kobs/pkg/cluster/kubernetes/apis/team/v1"
 	userv1 "github.com/kobsio/kobs/pkg/cluster/kubernetes/apis/user/v1"
 	"github.com/kobsio/kobs/pkg/plugins/plugin"
+
 	"github.com/orlangure/gnomock"
 	"github.com/orlangure/gnomock/preset/mongo"
 	"github.com/stretchr/testify/require"

--- a/pkg/hub/db/db_test.go
+++ b/pkg/hub/db/db_test.go
@@ -79,7 +79,7 @@ func TestDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 2, len(storedPlugins1))
 
-		time.Sleep(550 * time.Millisecond)
+		time.Sleep(1 * time.Second)
 
 		err = c.SavePlugins(ctx(t), "test-cluster", plugins[0:1])
 		require.NoError(t, err)
@@ -98,7 +98,7 @@ func TestDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 2, len(storedNamespaces1))
 
-		time.Sleep(550 * time.Millisecond)
+		time.Sleep(1 * time.Second)
 
 		namespaces2 := []string{"default"}
 		err = c.SaveNamespaces(ctx(t), "test-cluster", namespaces2)
@@ -122,7 +122,7 @@ func TestDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 2, len(storedCRDs1))
 
-		time.Sleep(550 * time.Millisecond)
+		time.Sleep(1 * time.Second)
 
 		err = c.SaveCRDs(ctx(t), crds1[0:1])
 		require.NoError(t, err)
@@ -152,7 +152,7 @@ func TestDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 2, len(storedApplications1))
 
-		time.Sleep(550 * time.Millisecond)
+		time.Sleep(1 * time.Second)
 
 		err = c.SaveApplications(ctx(t), "test-cluster", applications[0:1])
 		require.NoError(t, err)
@@ -180,7 +180,7 @@ func TestDB(t *testing.T) {
 		require.Equal(t, application.Namespace, storedApplication1.Namespace)
 		require.Equal(t, application.Name, storedApplication1.Name)
 
-		time.Sleep(550 * time.Millisecond)
+		time.Sleep(1 * time.Second)
 
 		application.Name = "application2"
 		err = c.SaveApplication(ctx(t), &application)
@@ -218,7 +218,7 @@ func TestDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, len(storedDashboards2))
 
-		time.Sleep(550 * time.Millisecond)
+		time.Sleep(1 * time.Second)
 
 		err = c.SaveDashboards(ctx(t), "test-cluster", dashboards[0:1])
 		require.NoError(t, err)
@@ -248,7 +248,7 @@ func TestDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 2, len(storedTeams1))
 
-		time.Sleep(550 * time.Millisecond)
+		time.Sleep(1 * time.Second)
 
 		err = c.SaveTeams(ctx(t), "test-cluster", teams[0:1])
 		require.NoError(t, err)
@@ -276,7 +276,7 @@ func TestDB(t *testing.T) {
 		require.Equal(t, team.Namespace, storedTeam1.Namespace)
 		require.Equal(t, team.Name, storedTeam1.Name)
 
-		time.Sleep(550 * time.Millisecond)
+		time.Sleep(1 * time.Second)
 
 		team.Name = "team2"
 		err = c.SaveTeam(ctx(t), &team)
@@ -310,7 +310,7 @@ func TestDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 2, len(storedUsers1))
 
-		time.Sleep(550 * time.Millisecond)
+		time.Sleep(1 * time.Second)
 
 		err = c.SaveUsers(ctx(t), "test-cluster", users[0:1])
 		require.NoError(t, err)
@@ -338,7 +338,7 @@ func TestDB(t *testing.T) {
 		require.Equal(t, user.Namespace, storedUser1.Namespace)
 		require.Equal(t, user.Name, storedUser1.Name)
 
-		time.Sleep(550 * time.Millisecond)
+		time.Sleep(1 * time.Second)
 
 		user.Name = "user2"
 		err = c.SaveUser(ctx(t), &user)
@@ -454,12 +454,12 @@ func TestDB(t *testing.T) {
 			{ID: "cluster/test-cluster1/namespace/default/application4", Cluster: "test-cluster2", Namespace: "default", Name: "application4", Teams: []string{"team1", "team2", "team3"}, Tags: []string{"monitoring", "observability"}, Topology: applicationv1.Topology{External: false}},
 		}
 		applications2 := []applicationv1.ApplicationSpec{
-			{ID: "cluster/test-cluster1/namespace/default/application5", Cluster: "test-cluster2", Namespace: "default", Name: "application5", Teams: []string{}, Tags: []string{"monitoring", "observability"}, Topology: applicationv1.Topology{External: false}},
-			{ID: "cluster/test-cluster1/namespace/kube-system/application6", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application6", Teams: []string{"team1"}, Tags: []string{"core", "provider"}, Topology: applicationv1.Topology{External: false}},
-			{ID: "cluster/test-cluster1/namespace/kube-system/application7", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application7", Teams: []string{}, Tags: []string{"core", "provider"}, Topology: applicationv1.Topology{External: false}},
-			{ID: "cluster/test-cluster1/namespace/kube-system/application8", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application8", Teams: []string{"team3"}, Tags: []string{"core", "provider"}, Topology: applicationv1.Topology{External: false}},
-			{ID: "cluster/test-cluster1/namespace/kube-system/application9", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application9", Teams: []string{"team1"}, Tags: []string{"core", "provider"}, Topology: applicationv1.Topology{External: false}},
-			{ID: "cluster/test-cluster1/namespace/kube-system/application10", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application10", Teams: []string{}, Tags: []string{"core", "provider", "logging"}, Topology: applicationv1.Topology{External: true}},
+			{ID: "cluster/test-cluster2/namespace/default/application5", Cluster: "test-cluster2", Namespace: "default", Name: "application5", Teams: []string{}, Tags: []string{"monitoring", "observability"}, Topology: applicationv1.Topology{External: false}},
+			{ID: "cluster/test-cluster2/namespace/kube-system/application6", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application6", Teams: []string{"team1"}, Tags: []string{"core", "provider"}, Topology: applicationv1.Topology{External: false}},
+			{ID: "cluster/test-cluster2/namespace/kube-system/application7", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application7", Teams: []string{}, Tags: []string{"core", "provider"}, Topology: applicationv1.Topology{External: false}},
+			{ID: "cluster/test-cluster2/namespace/kube-system/application8", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application8", Teams: []string{"team3"}, Tags: []string{"core", "provider"}, Topology: applicationv1.Topology{External: false}},
+			{ID: "cluster/test-cluster2/namespace/kube-system/application9", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application9", Teams: []string{"team1"}, Tags: []string{"core", "provider"}, Topology: applicationv1.Topology{External: false}},
+			{ID: "cluster/test-cluster2/namespace/kube-system/application10", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application10", Teams: []string{}, Tags: []string{"core", "provider", "logging"}, Topology: applicationv1.Topology{External: true}},
 		}
 
 		err := c.SaveApplications(ctx(t), "test-cluster1", applications1)

--- a/pkg/hub/db/db_test.go
+++ b/pkg/hub/db/db_test.go
@@ -3,7 +3,6 @@ package db
 import (
 	"context"
 	"fmt"
-	"github.com/kobsio/kobs/pkg/plugins/plugin"
 	"os"
 	"strings"
 	"testing"
@@ -14,6 +13,7 @@ import (
 	dashboardv1 "github.com/kobsio/kobs/pkg/cluster/kubernetes/apis/dashboard/v1"
 	teamv1 "github.com/kobsio/kobs/pkg/cluster/kubernetes/apis/team/v1"
 	userv1 "github.com/kobsio/kobs/pkg/cluster/kubernetes/apis/user/v1"
+	"github.com/kobsio/kobs/pkg/plugins/plugin"
 	"github.com/orlangure/gnomock"
 	"github.com/orlangure/gnomock/preset/mongo"
 	"github.com/stretchr/testify/require"
@@ -79,7 +79,7 @@ func TestDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 2, len(storedPlugins1))
 
-		time.Sleep(2 * time.Second)
+		time.Sleep(550 * time.Millisecond)
 
 		err = c.SavePlugins(ctx(t), "test-cluster", plugins[0:1])
 		require.NoError(t, err)
@@ -98,7 +98,7 @@ func TestDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 2, len(storedNamespaces1))
 
-		time.Sleep(2 * time.Second)
+		time.Sleep(550 * time.Millisecond)
 
 		namespaces2 := []string{"default"}
 		err = c.SaveNamespaces(ctx(t), "test-cluster", namespaces2)
@@ -122,7 +122,7 @@ func TestDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 2, len(storedCRDs1))
 
-		time.Sleep(2 * time.Second)
+		time.Sleep(550 * time.Millisecond)
 
 		err = c.SaveCRDs(ctx(t), crds1[0:1])
 		require.NoError(t, err)
@@ -152,7 +152,7 @@ func TestDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 2, len(storedApplications1))
 
-		time.Sleep(2 * time.Second)
+		time.Sleep(550 * time.Millisecond)
 
 		err = c.SaveApplications(ctx(t), "test-cluster", applications[0:1])
 		require.NoError(t, err)
@@ -180,7 +180,7 @@ func TestDB(t *testing.T) {
 		require.Equal(t, application.Namespace, storedApplication1.Namespace)
 		require.Equal(t, application.Name, storedApplication1.Name)
 
-		time.Sleep(2 * time.Second)
+		time.Sleep(550 * time.Millisecond)
 
 		application.Name = "application2"
 		err = c.SaveApplication(ctx(t), &application)
@@ -218,7 +218,7 @@ func TestDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, len(storedDashboards2))
 
-		time.Sleep(2 * time.Second)
+		time.Sleep(550 * time.Millisecond)
 
 		err = c.SaveDashboards(ctx(t), "test-cluster", dashboards[0:1])
 		require.NoError(t, err)
@@ -248,7 +248,7 @@ func TestDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 2, len(storedTeams1))
 
-		time.Sleep(2 * time.Second)
+		time.Sleep(550 * time.Millisecond)
 
 		err = c.SaveTeams(ctx(t), "test-cluster", teams[0:1])
 		require.NoError(t, err)
@@ -276,7 +276,7 @@ func TestDB(t *testing.T) {
 		require.Equal(t, team.Namespace, storedTeam1.Namespace)
 		require.Equal(t, team.Name, storedTeam1.Name)
 
-		time.Sleep(2 * time.Second)
+		time.Sleep(550 * time.Millisecond)
 
 		team.Name = "team2"
 		err = c.SaveTeam(ctx(t), &team)
@@ -310,7 +310,7 @@ func TestDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 2, len(storedUsers1))
 
-		time.Sleep(2 * time.Second)
+		time.Sleep(550 * time.Millisecond)
 
 		err = c.SaveUsers(ctx(t), "test-cluster", users[0:1])
 		require.NoError(t, err)
@@ -338,7 +338,7 @@ func TestDB(t *testing.T) {
 		require.Equal(t, user.Namespace, storedUser1.Namespace)
 		require.Equal(t, user.Name, storedUser1.Name)
 
-		time.Sleep(2 * time.Second)
+		time.Sleep(550 * time.Millisecond)
 
 		user.Name = "user2"
 		err = c.SaveUser(ctx(t), &user)

--- a/pkg/hub/db/db_test.go
+++ b/pkg/hub/db/db_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"github.com/kobsio/kobs/pkg/plugins/plugin"
 	"os"
 	"strings"
 	"testing"
@@ -13,8 +14,6 @@ import (
 	dashboardv1 "github.com/kobsio/kobs/pkg/cluster/kubernetes/apis/dashboard/v1"
 	teamv1 "github.com/kobsio/kobs/pkg/cluster/kubernetes/apis/team/v1"
 	userv1 "github.com/kobsio/kobs/pkg/cluster/kubernetes/apis/user/v1"
-	"github.com/kobsio/kobs/pkg/plugins/plugin"
-
 	"github.com/orlangure/gnomock"
 	"github.com/orlangure/gnomock/preset/mongo"
 	"github.com/stretchr/testify/require"
@@ -39,784 +38,704 @@ func ctx(t *testing.T) context.Context {
 	return context.WithValue(context.Background(), "kobs.db.name", dbName)
 }
 
-func TestNewClient(t *testing.T) {
-	c1, err1 := NewClient(Config{URI: ""})
-	require.Error(t, err1)
-	require.Empty(t, c1)
-
+func TestDB(t *testing.T) {
 	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-
-	c2, err2 := NewClient(Config{URI: uri})
-	require.NoError(t, err2)
-	require.NotEmpty(t, c2)
-}
-
-func TestCreateIndexes(t *testing.T) {
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
-
-	err := c.CreateIndexes(ctx(t))
-	require.NoError(t, err)
-}
-
-func TestSaveAndGetPlugins(t *testing.T) {
-	plugins := []plugin.Instance{{
-		Name: "test-cluster",
-		Type: "prometheus",
-	}, {
-		Name: "test-cluster",
-		Type: "klogs",
-	}}
-
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
-
-	err := c.SavePlugins(ctx(t), "test-cluster", plugins)
-	require.NoError(t, err)
-
-	storedPlugins1, err := c.GetPlugins(ctx(t))
-	require.NoError(t, err)
-	require.Equal(t, 2, len(storedPlugins1))
-
-	time.Sleep(2 * time.Second)
-
-	err = c.SavePlugins(ctx(t), "test-cluster", plugins[0:1])
-	require.NoError(t, err)
-
-	storedPlugins2, err := c.GetPlugins(ctx(t))
-	require.NoError(t, err)
-	require.Equal(t, 1, len(storedPlugins2))
-}
-
-func TestSaveAndGetNamespaces(t *testing.T) {
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
-
-	namespaces1 := []string{"default", "kube-system"}
-	err := c.SaveNamespaces(ctx(t), "test-cluster", namespaces1)
-	require.NoError(t, err)
-
-	storedNamespaces1, err := c.GetNamespaces(ctx(t))
-	require.NoError(t, err)
-	require.Equal(t, 2, len(storedNamespaces1))
-
-	time.Sleep(2 * time.Second)
-
-	namespaces2 := []string{"default"}
-	err = c.SaveNamespaces(ctx(t), "test-cluster", namespaces2)
-	require.NoError(t, err)
-
-	storedNamespaces2, err := c.GetNamespaces(ctx(t))
-	require.NoError(t, err)
-	require.Equal(t, 1, len(storedNamespaces2))
-}
-
-func TestSaveAndGetCRDs(t *testing.T) {
-	crds1 := []kubernetes.CRD{
-		{ID: "resource1.path1/v1", Resource: "resource1", Path: "path1/v1"},
-		{ID: "resource2.path2/v2", Resource: "resource2", Path: "path2/v2"},
-	}
-
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
-
-	err := c.SaveCRDs(ctx(t), crds1)
-	require.NoError(t, err)
-
-	storedCRDs1, err := c.GetCRDs(ctx(t))
-	require.NoError(t, err)
-	require.Equal(t, 2, len(storedCRDs1))
-
-	time.Sleep(2 * time.Second)
-
-	err = c.SaveCRDs(ctx(t), crds1[0:1])
-	require.NoError(t, err)
-
-	storedCRDs2, err := c.GetCRDs(ctx(t))
-	require.NoError(t, err)
-	require.Equal(t, 2, len(storedCRDs2))
-}
-
-func TestSaveAndGetApplications(t *testing.T) {
-	applications := []applicationv1.ApplicationSpec{{
-		ID:        "/cluster/test-cluster/namespace/default/name/application1",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "application1",
-	}, {
-		ID:        "/cluster/test-cluster/namespace/default/name/application2",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "application2",
-	}}
-
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
-
-	err := c.SaveApplications(ctx(t), "test-cluster", applications)
-	require.NoError(t, err)
-
-	storedApplications1, err := c.GetApplications(ctx(t))
-	require.NoError(t, err)
-	require.Equal(t, 2, len(storedApplications1))
-
-	time.Sleep(2 * time.Second)
-
-	err = c.SaveApplications(ctx(t), "test-cluster", applications[0:1])
-	require.NoError(t, err)
-
-	storedApplications2, err := c.GetApplications(ctx(t))
-	require.NoError(t, err)
-	require.Equal(t, 1, len(storedApplications2))
-}
-
-func TestSaveAndGetApplication(t *testing.T) {
-	application := applicationv1.ApplicationSpec{
-		ID:        "/cluster/test-cluster/namespace/default/name/application1",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "application1",
-	}
-
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
-
-	err := c.SaveApplication(ctx(t), &application)
-	require.NoError(t, err)
-
-	storedApplication1, err := c.GetApplicationByID(ctx(t), application.ID)
-	require.NoError(t, err)
-	require.Equal(t, application.ID, storedApplication1.ID)
-	require.Equal(t, application.Cluster, storedApplication1.Cluster)
-	require.Equal(t, application.Namespace, storedApplication1.Namespace)
-	require.Equal(t, application.Name, storedApplication1.Name)
-
-	time.Sleep(2 * time.Second)
-
-	application.Name = "application2"
-	err = c.SaveApplication(ctx(t), &application)
-	require.NoError(t, err)
-
-	storedApplication2, err := c.GetApplicationByID(ctx(t), application.ID)
-	require.NoError(t, err)
-	require.Equal(t, application.ID, storedApplication2.ID)
-	require.Equal(t, application.Cluster, storedApplication2.Cluster)
-	require.Equal(t, application.Namespace, storedApplication2.Namespace)
-	require.Equal(t, application.Name, storedApplication2.Name)
-}
-
-func TestSaveAndGetDashboards(t *testing.T) {
-	dashboards := []dashboardv1.DashboardSpec{{
-		ID:        "/cluster/test-cluster/namespace/default/name/dashboard1",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "dashboard1",
-	}, {
-		ID:        "/cluster/test-cluster/namespace/default/name/dashboard2",
-		Cluster:   "test-cluster",
-		Namespace: "kube-system",
-		Name:      "dashboard2",
-	}}
-
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
-
-	err := c.SaveDashboards(ctx(t), "test-cluster", dashboards)
-	require.NoError(t, err)
-
-	storedDashboards1, err := c.GetDashboards(ctx(t), nil, nil)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(storedDashboards1))
-
-	storedDashboards2, err := c.GetDashboards(ctx(t), []string{"test-cluster"}, []string{"default"})
-	require.NoError(t, err)
-	require.Equal(t, 1, len(storedDashboards2))
-
-	time.Sleep(2 * time.Second)
-
-	err = c.SaveDashboards(ctx(t), "test-cluster", dashboards[0:1])
-	require.NoError(t, err)
-
-	storedDashboards3, err := c.GetDashboards(ctx(t), nil, nil)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(storedDashboards3))
-}
-
-func TestSaveAndGetTeams(t *testing.T) {
-	teams := []teamv1.TeamSpec{{
-		ID:        "/cluster/test-cluster/namespace/default/name/team1",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "team1",
-	}, {
-		ID:        "/cluster/test-cluster/namespace/default/name/team2",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "team2",
-	}}
-
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
-
-	err := c.SaveTeams(ctx(t), "test-cluster", teams)
-	require.NoError(t, err)
-
-	storedTeams1, err := c.GetTeams(ctx(t), "")
-	require.NoError(t, err)
-	require.Equal(t, 2, len(storedTeams1))
-
-	time.Sleep(2 * time.Second)
-
-	err = c.SaveTeams(ctx(t), "test-cluster", teams[0:1])
-	require.NoError(t, err)
-
-	storedTeams2, err := c.GetTeams(ctx(t), "")
-	require.NoError(t, err)
-	require.Equal(t, 1, len(storedTeams2))
-}
-
-func TestSaveAndGetTeam(t *testing.T) {
-	team := teamv1.TeamSpec{
-		ID:        "/cluster/test-cluster/namespace/default/name/team1",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "team1",
-	}
-
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
-
-	err := c.SaveTeam(ctx(t), &team)
-	require.NoError(t, err)
-
-	storedTeam1, err := c.GetTeamByID(ctx(t), team.ID)
-	require.NoError(t, err)
-	require.Equal(t, team.ID, storedTeam1.ID)
-	require.Equal(t, team.Cluster, storedTeam1.Cluster)
-	require.Equal(t, team.Namespace, storedTeam1.Namespace)
-	require.Equal(t, team.Name, storedTeam1.Name)
-
-	time.Sleep(2 * time.Second)
-
-	team.Name = "team2"
-	err = c.SaveTeam(ctx(t), &team)
-	require.NoError(t, err)
-
-	storedTeam2, err := c.GetTeamByID(ctx(t), team.ID)
-	require.NoError(t, err)
-	require.Equal(t, team.ID, storedTeam2.ID)
-	require.Equal(t, team.Cluster, storedTeam2.Cluster)
-	require.Equal(t, team.Namespace, storedTeam2.Namespace)
-	require.Equal(t, team.Name, storedTeam2.Name)
-}
-
-func TestSaveAndGetUsers(t *testing.T) {
-	users := []userv1.UserSpec{{
-		ID:        "/cluster/test-cluster/namespace/default/name/user1",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "user1",
-	}, {
-		ID:        "/cluster/test-cluster/namespace/default/name/user2",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "user2",
-	}}
-
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
-
-	err := c.SaveUsers(ctx(t), "test-cluster", users)
-	require.NoError(t, err)
-
-	storedUsers1, err := c.GetUsers(ctx(t))
-	require.NoError(t, err)
-	require.Equal(t, 2, len(storedUsers1))
-
-	time.Sleep(2 * time.Second)
-
-	err = c.SaveUsers(ctx(t), "test-cluster", users[0:1])
-	require.NoError(t, err)
-
-	storedUsers2, err := c.GetUsers(ctx(t))
-	require.NoError(t, err)
-	require.Equal(t, 1, len(storedUsers2))
-}
-
-func TestSaveAndGetUser(t *testing.T) {
-	user := userv1.UserSpec{
-		ID:        "/cluster/test-cluster/namespace/default/name/user1",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "user1",
-	}
-
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
-
-	err := c.SaveUser(ctx(t), &user)
-	require.NoError(t, err)
-
-	storedUser1, err := c.GetUserByID(ctx(t), user.ID)
-	require.NoError(t, err)
-	require.Equal(t, user.ID, storedUser1.ID)
-	require.Equal(t, user.Cluster, storedUser1.Cluster)
-	require.Equal(t, user.Namespace, storedUser1.Namespace)
-	require.Equal(t, user.Name, storedUser1.Name)
-
-	time.Sleep(2 * time.Second)
-
-	user.Name = "user2"
-	err = c.SaveUser(ctx(t), &user)
-	require.NoError(t, err)
-
-	storedUser2, err := c.GetUserByID(ctx(t), user.ID)
-	require.NoError(t, err)
-	require.Equal(t, user.ID, storedUser2.ID)
-	require.Equal(t, user.Cluster, storedUser2.Cluster)
-	require.Equal(t, user.Namespace, storedUser2.Namespace)
-	require.Equal(t, user.Name, storedUser2.Name)
-}
-
-func TestSaveAndGetTags(t *testing.T) {
-	applications := []applicationv1.ApplicationSpec{{
-		ID:        "/cluster/test-cluster/namespace/default/name/application1",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "application1",
-		Tags:      []string{"tag1", "tag2", "tag3"},
-	}, {
-		ID:        "/cluster/test-cluster/namespace/default/name/application2",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "application2",
-		Tags:      []string{"tag3", "tag4", "tag5"},
-	}}
-
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
-
-	err := c.SaveTags(ctx(t), applications)
-	require.NoError(t, err)
-
-	storedTags1, err := c.GetTags(ctx(t))
-	require.NoError(t, err)
-	require.Equal(t, 5, len(storedTags1))
-}
-
-func TestSaveAndGetTopology(t *testing.T) {
-	applications := []applicationv1.ApplicationSpec{{
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "application1",
-		Topology: applicationv1.Topology{
-			Dependencies: []applicationv1.Dependency{{
-				Cluster:   "test-cluster",
-				Namespace: "default",
-				Name:      "application2",
-			}},
-		},
-	}, {
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "application2",
-	}}
-
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
-
-	err := c.SaveTopology(ctx(t), "test-cluster", applications)
-	require.NoError(t, err)
-
-	storedTopology1, err := c.GetTopologyByIDs(ctx(t), "targetID", []string{"/cluster/test-cluster/namespace/default/name/application2"})
-	require.NoError(t, err)
-	require.Equal(t, 1, len(storedTopology1))
-
-	storedTopology2, err := c.GetTopologyByIDs(ctx(t), "sourceID", []string{"/cluster/test-cluster/namespace/default/name/application1"})
-	require.NoError(t, err)
-	require.Equal(t, 1, len(storedTopology2))
-}
-
-func TestGetNamespacesByClusters(t *testing.T) {
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
-
-	err := c.SaveNamespaces(ctx(t), "test-cluster1", []string{"default", "kube-system"})
-	require.NoError(t, err)
-	err = c.SaveNamespaces(ctx(t), "test-cluster2", []string{"default", "kube-system", "istio-system"})
-	require.NoError(t, err)
-
-	storedNamespaces1, err := c.GetNamespacesByClusters(ctx(t), []string{"test-cluster1"})
-	require.NoError(t, err)
-	require.Equal(t, 2, len(storedNamespaces1))
-
-	storedNamespaces2, err := c.GetNamespacesByClusters(ctx(t), []string{"test-cluster1", "test-cluster2"})
-	require.NoError(t, err)
-	require.Equal(t, 5, len(storedNamespaces2))
-
-	storedNamespaces3, err := c.GetNamespacesByClusters(ctx(t), []string{})
-	require.NoError(t, err)
-	require.Equal(t, 5, len(storedNamespaces3))
-
-	storedNamespaces4, err := c.GetNamespacesByClusters(ctx(t), nil)
-	require.NoError(t, err)
-	require.Equal(t, 5, len(storedNamespaces4))
-}
-
-func TestGetCRDByID(t *testing.T) {
-	crds := []kubernetes.CRD{
-		{ID: "resource1.path1/v1", Resource: "resource1", Path: "path1/v1"},
-		{ID: "resource2.path2/v2", Resource: "resource2", Path: "path2/v2"},
-	}
-
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
-
-	err := c.SaveCRDs(ctx(t), crds)
-	require.NoError(t, err)
-
-	crd1, err := c.GetCRDByID(ctx(t), "resource1.path1/v1")
-	require.NoError(t, err)
-	require.NotNil(t, crd1)
-
-	crd2, err := c.GetCRDByID(ctx(t), "resource3.path3/v3")
-	require.Error(t, err)
-	require.Nil(t, crd2)
-}
-
-func TestGetApplicationsByFilter(t *testing.T) {
-	applications1 := []applicationv1.ApplicationSpec{
-		{ID: "cluster/test-cluster1/namespace/default/application1", Cluster: "test-cluster1", Namespace: "default", Name: "application1", Teams: []string{"team1"}, Tags: []string{"monitoring", "observability"}, Topology: applicationv1.Topology{External: false}},
-		{ID: "cluster/test-cluster1/namespace/default/application2", Cluster: "test-cluster1", Namespace: "default", Name: "application2", Teams: []string{"team1", "team2"}, Tags: []string{"monitoring", "observability"}, Topology: applicationv1.Topology{External: false}},
-		{ID: "cluster/test-cluster1/namespace/default/application3", Cluster: "test-cluster1", Namespace: "default", Name: "application3", Teams: []string{"team3"}, Tags: []string{}, Topology: applicationv1.Topology{External: true}},
-		{ID: "cluster/test-cluster1/namespace/default/application4", Cluster: "test-cluster2", Namespace: "default", Name: "application4", Teams: []string{"team1", "team2", "team3"}, Tags: []string{"monitoring", "observability"}, Topology: applicationv1.Topology{External: false}},
-	}
-	applications2 := []applicationv1.ApplicationSpec{
-		{ID: "cluster/test-cluster1/namespace/default/application5", Cluster: "test-cluster2", Namespace: "default", Name: "application5", Teams: []string{}, Tags: []string{"monitoring", "observability"}, Topology: applicationv1.Topology{External: false}},
-		{ID: "cluster/test-cluster1/namespace/kube-system/application6", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application6", Teams: []string{"team1"}, Tags: []string{"core", "provider"}, Topology: applicationv1.Topology{External: false}},
-		{ID: "cluster/test-cluster1/namespace/kube-system/application7", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application7", Teams: []string{}, Tags: []string{"core", "provider"}, Topology: applicationv1.Topology{External: false}},
-		{ID: "cluster/test-cluster1/namespace/kube-system/application8", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application8", Teams: []string{"team3"}, Tags: []string{"core", "provider"}, Topology: applicationv1.Topology{External: false}},
-		{ID: "cluster/test-cluster1/namespace/kube-system/application9", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application9", Teams: []string{"team1"}, Tags: []string{"core", "provider"}, Topology: applicationv1.Topology{External: false}},
-		{ID: "cluster/test-cluster1/namespace/kube-system/application10", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application10", Teams: []string{}, Tags: []string{"core", "provider", "logging"}, Topology: applicationv1.Topology{External: true}},
-	}
-
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
-
-	err := c.SaveApplications(ctx(t), "test-cluster1", applications1)
-	require.NoError(t, err)
-	err = c.SaveApplications(ctx(t), "test-cluster2", applications2)
-	require.NoError(t, err)
-
-	getApplicationsNames := func(storedApplications []applicationv1.ApplicationSpec) []string {
-		var names []string
-		for _, a := range storedApplications {
-			names = append(names, a.Name)
+	defer func(cs *gnomock.Container) {
+		err := gnomock.Stop(cs)
+		if err != nil {
+			t.Error(err)
 		}
-		return names
-	}
+	}(container)
+	c, _ := NewClient(Config{URI: uri})
 
-	ctx := ctx(t)
-	for _, tt := range []struct {
-		name                 string
-		teams                []string
-		clusters             []string
-		namespaces           []string
-		tags                 []string
-		searchTerm           string
-		limit                int
-		offset               int
-		expectedError        bool
-		expectedApplications []string
-		expectedCount        int
-	}{
-		{name: "searchTerm can not be compiled to regexp", teams: nil, clusters: nil, namespaces: nil, tags: nil, searchTerm: "*", limit: 100, offset: 0, expectedError: true, expectedApplications: nil, expectedCount: 0},
-		{name: "no filters", teams: nil, clusters: nil, namespaces: nil, tags: nil, searchTerm: "", limit: 100, offset: 0, expectedError: false, expectedApplications: []string{"application1", "application10", "application2", "application3", "application4", "application5", "application6", "application7", "application8", "application9"}, expectedCount: 10},
-		{name: "no filters but limit", teams: nil, clusters: nil, namespaces: nil, tags: nil, searchTerm: "", limit: 5, offset: 0, expectedError: false, expectedApplications: []string{"application1", "application10", "application2", "application3", "application4"}, expectedCount: 10},
-		{name: "no filters but limit and offset", teams: nil, clusters: nil, namespaces: nil, tags: nil, searchTerm: "", limit: 5, offset: 5, expectedError: false, expectedApplications: []string{"application5", "application6", "application7", "application8", "application9"}, expectedCount: 10},
-		{name: "only searchTerm", teams: nil, clusters: nil, namespaces: nil, tags: nil, searchTerm: "application1", limit: 100, offset: 0, expectedError: false, expectedApplications: []string{"application1", "application10"}, expectedCount: 2},
-		{name: "filter by team", teams: []string{"team2"}, clusters: nil, namespaces: nil, tags: nil, searchTerm: "", limit: 100, offset: 0, expectedError: false, expectedApplications: []string{"application2", "application4"}, expectedCount: 2},
-		{name: "filter by teams", teams: []string{"team1", "team3"}, clusters: nil, namespaces: nil, tags: nil, searchTerm: "", limit: 100, offset: 0, expectedError: false, expectedApplications: []string{"application1", "application2", "application3", "application4", "application6", "application8", "application9"}, expectedCount: 7},
-		{name: "filter by cluster and namespace", teams: nil, clusters: []string{"test-cluster1", "test-cluster2"}, namespaces: []string{"default"}, tags: nil, searchTerm: "", limit: 100, offset: 0, expectedError: false, expectedApplications: []string{"application1", "application2", "application3", "application4", "application5"}, expectedCount: 5},
-		{name: "filter by tags", teams: nil, clusters: nil, namespaces: nil, tags: []string{"logging"}, searchTerm: "", limit: 100, offset: 0, expectedError: false, expectedApplications: []string{"application10"}, expectedCount: 1},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			storedApplications, err := c.GetApplicationsByFilter(ctx, tt.teams, tt.clusters, tt.namespaces, tt.tags, tt.searchTerm, tt.limit, tt.offset)
-			if tt.expectedError {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
+	t.Run("NewClient", func(t *testing.T) {
+		c1, err1 := NewClient(Config{URI: ""})
+		require.Error(t, err1)
+		require.Empty(t, c1)
+
+		c2, err2 := NewClient(Config{URI: uri})
+		require.NoError(t, err2)
+		require.NotEmpty(t, c2)
+	})
+
+	t.Run("CreateIndexes", func(t *testing.T) {
+		err := c.CreateIndexes(ctx(t))
+		require.NoError(t, err)
+	})
+
+	t.Run("SaveAndGetPlugins", func(t *testing.T) {
+		plugins := []plugin.Instance{{
+			Name: "test-cluster",
+			Type: "prometheus",
+		}, {
+			Name: "test-cluster",
+			Type: "klogs",
+		}}
+
+		err := c.SavePlugins(ctx(t), "test-cluster", plugins)
+		require.NoError(t, err)
+
+		storedPlugins1, err := c.GetPlugins(ctx(t))
+		require.NoError(t, err)
+		require.Equal(t, 2, len(storedPlugins1))
+
+		time.Sleep(2 * time.Second)
+
+		err = c.SavePlugins(ctx(t), "test-cluster", plugins[0:1])
+		require.NoError(t, err)
+
+		storedPlugins2, err := c.GetPlugins(ctx(t))
+		require.NoError(t, err)
+		require.Equal(t, 1, len(storedPlugins2))
+	})
+
+	t.Run("SaveAndGetNamespaces", func(t *testing.T) {
+		namespaces1 := []string{"default", "kube-system"}
+		err := c.SaveNamespaces(ctx(t), "test-cluster", namespaces1)
+		require.NoError(t, err)
+
+		storedNamespaces1, err := c.GetNamespaces(ctx(t))
+		require.NoError(t, err)
+		require.Equal(t, 2, len(storedNamespaces1))
+
+		time.Sleep(2 * time.Second)
+
+		namespaces2 := []string{"default"}
+		err = c.SaveNamespaces(ctx(t), "test-cluster", namespaces2)
+		require.NoError(t, err)
+
+		storedNamespaces2, err := c.GetNamespaces(ctx(t))
+		require.NoError(t, err)
+		require.Equal(t, 1, len(storedNamespaces2))
+	})
+
+	t.Run("SaveAndGetCRDs", func(t *testing.T) {
+		crds1 := []kubernetes.CRD{
+			{ID: "resource1.path1/v1", Resource: "resource1", Path: "path1/v1"},
+			{ID: "resource2.path2/v2", Resource: "resource2", Path: "path2/v2"},
+		}
+
+		err := c.SaveCRDs(ctx(t), crds1)
+		require.NoError(t, err)
+
+		storedCRDs1, err := c.GetCRDs(ctx(t))
+		require.NoError(t, err)
+		require.Equal(t, 2, len(storedCRDs1))
+
+		time.Sleep(2 * time.Second)
+
+		err = c.SaveCRDs(ctx(t), crds1[0:1])
+		require.NoError(t, err)
+
+		storedCRDs2, err := c.GetCRDs(ctx(t))
+		require.NoError(t, err)
+		require.Equal(t, 2, len(storedCRDs2))
+	})
+
+	t.Run("SaveAndGetApplications", func(t *testing.T) {
+		applications := []applicationv1.ApplicationSpec{{
+			ID:        "/cluster/test-cluster/namespace/default/name/application1",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "application1",
+		}, {
+			ID:        "/cluster/test-cluster/namespace/default/name/application2",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "application2",
+		}}
+
+		err := c.SaveApplications(ctx(t), "test-cluster", applications)
+		require.NoError(t, err)
+
+		storedApplications1, err := c.GetApplications(ctx(t))
+		require.NoError(t, err)
+		require.Equal(t, 2, len(storedApplications1))
+
+		time.Sleep(2 * time.Second)
+
+		err = c.SaveApplications(ctx(t), "test-cluster", applications[0:1])
+		require.NoError(t, err)
+
+		storedApplications2, err := c.GetApplications(ctx(t))
+		require.NoError(t, err)
+		require.Equal(t, 1, len(storedApplications2))
+	})
+
+	t.Run("SaveAndGetApplication", func(t *testing.T) {
+		application := applicationv1.ApplicationSpec{
+			ID:        "/cluster/test-cluster/namespace/default/name/application1",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "application1",
+		}
+
+		err := c.SaveApplication(ctx(t), &application)
+		require.NoError(t, err)
+
+		storedApplication1, err := c.GetApplicationByID(ctx(t), application.ID)
+		require.NoError(t, err)
+		require.Equal(t, application.ID, storedApplication1.ID)
+		require.Equal(t, application.Cluster, storedApplication1.Cluster)
+		require.Equal(t, application.Namespace, storedApplication1.Namespace)
+		require.Equal(t, application.Name, storedApplication1.Name)
+
+		time.Sleep(2 * time.Second)
+
+		application.Name = "application2"
+		err = c.SaveApplication(ctx(t), &application)
+		require.NoError(t, err)
+
+		storedApplication2, err := c.GetApplicationByID(ctx(t), application.ID)
+		require.NoError(t, err)
+		require.Equal(t, application.ID, storedApplication2.ID)
+		require.Equal(t, application.Cluster, storedApplication2.Cluster)
+		require.Equal(t, application.Namespace, storedApplication2.Namespace)
+		require.Equal(t, application.Name, storedApplication2.Name)
+	})
+
+	t.Run("SaveAndGetDashboards", func(t *testing.T) {
+		dashboards := []dashboardv1.DashboardSpec{{
+			ID:        "/cluster/test-cluster/namespace/default/name/dashboard1",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "dashboard1",
+		}, {
+			ID:        "/cluster/test-cluster/namespace/default/name/dashboard2",
+			Cluster:   "test-cluster",
+			Namespace: "kube-system",
+			Name:      "dashboard2",
+		}}
+
+		err := c.SaveDashboards(ctx(t), "test-cluster", dashboards)
+		require.NoError(t, err)
+
+		storedDashboards1, err := c.GetDashboards(ctx(t), nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(storedDashboards1))
+
+		storedDashboards2, err := c.GetDashboards(ctx(t), []string{"test-cluster"}, []string{"default"})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(storedDashboards2))
+
+		time.Sleep(2 * time.Second)
+
+		err = c.SaveDashboards(ctx(t), "test-cluster", dashboards[0:1])
+		require.NoError(t, err)
+
+		storedDashboards3, err := c.GetDashboards(ctx(t), nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(storedDashboards3))
+	})
+
+	t.Run("SaveAndGetTeams", func(t *testing.T) {
+		teams := []teamv1.TeamSpec{{
+			ID:        "/cluster/test-cluster/namespace/default/name/team1",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "team1",
+		}, {
+			ID:        "/cluster/test-cluster/namespace/default/name/team2",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "team2",
+		}}
+
+		err := c.SaveTeams(ctx(t), "test-cluster", teams)
+		require.NoError(t, err)
+
+		storedTeams1, err := c.GetTeams(ctx(t), "")
+		require.NoError(t, err)
+		require.Equal(t, 2, len(storedTeams1))
+
+		time.Sleep(2 * time.Second)
+
+		err = c.SaveTeams(ctx(t), "test-cluster", teams[0:1])
+		require.NoError(t, err)
+
+		storedTeams2, err := c.GetTeams(ctx(t), "")
+		require.NoError(t, err)
+		require.Equal(t, 1, len(storedTeams2))
+	})
+
+	t.Run("SaveAndGetTeam", func(t *testing.T) {
+		team := teamv1.TeamSpec{
+			ID:        "/cluster/test-cluster/namespace/default/name/team1",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "team1",
+		}
+
+		err := c.SaveTeam(ctx(t), &team)
+		require.NoError(t, err)
+
+		storedTeam1, err := c.GetTeamByID(ctx(t), team.ID)
+		require.NoError(t, err)
+		require.Equal(t, team.ID, storedTeam1.ID)
+		require.Equal(t, team.Cluster, storedTeam1.Cluster)
+		require.Equal(t, team.Namespace, storedTeam1.Namespace)
+		require.Equal(t, team.Name, storedTeam1.Name)
+
+		time.Sleep(2 * time.Second)
+
+		team.Name = "team2"
+		err = c.SaveTeam(ctx(t), &team)
+		require.NoError(t, err)
+
+		storedTeam2, err := c.GetTeamByID(ctx(t), team.ID)
+		require.NoError(t, err)
+		require.Equal(t, team.ID, storedTeam2.ID)
+		require.Equal(t, team.Cluster, storedTeam2.Cluster)
+		require.Equal(t, team.Namespace, storedTeam2.Namespace)
+		require.Equal(t, team.Name, storedTeam2.Name)
+	})
+
+	t.Run("SaveAndGetUsers", func(t *testing.T) {
+		users := []userv1.UserSpec{{
+			ID:        "/cluster/test-cluster/namespace/default/name/user1",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "user1",
+		}, {
+			ID:        "/cluster/test-cluster/namespace/default/name/user2",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "user2",
+		}}
+
+		err := c.SaveUsers(ctx(t), "test-cluster", users)
+		require.NoError(t, err)
+
+		storedUsers1, err := c.GetUsers(ctx(t))
+		require.NoError(t, err)
+		require.Equal(t, 2, len(storedUsers1))
+
+		time.Sleep(2 * time.Second)
+
+		err = c.SaveUsers(ctx(t), "test-cluster", users[0:1])
+		require.NoError(t, err)
+
+		storedUsers2, err := c.GetUsers(ctx(t))
+		require.NoError(t, err)
+		require.Equal(t, 1, len(storedUsers2))
+	})
+
+	t.Run("SaveAndGetUser", func(t *testing.T) {
+		user := userv1.UserSpec{
+			ID:        "/cluster/test-cluster/namespace/default/name/user1",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "user1",
+		}
+
+		err := c.SaveUser(ctx(t), &user)
+		require.NoError(t, err)
+
+		storedUser1, err := c.GetUserByID(ctx(t), user.ID)
+		require.NoError(t, err)
+		require.Equal(t, user.ID, storedUser1.ID)
+		require.Equal(t, user.Cluster, storedUser1.Cluster)
+		require.Equal(t, user.Namespace, storedUser1.Namespace)
+		require.Equal(t, user.Name, storedUser1.Name)
+
+		time.Sleep(2 * time.Second)
+
+		user.Name = "user2"
+		err = c.SaveUser(ctx(t), &user)
+		require.NoError(t, err)
+
+		storedUser2, err := c.GetUserByID(ctx(t), user.ID)
+		require.NoError(t, err)
+		require.Equal(t, user.ID, storedUser2.ID)
+		require.Equal(t, user.Cluster, storedUser2.Cluster)
+		require.Equal(t, user.Namespace, storedUser2.Namespace)
+		require.Equal(t, user.Name, storedUser2.Name)
+	})
+
+	t.Run("SaveAndGetTags", func(t *testing.T) {
+		applications := []applicationv1.ApplicationSpec{{
+			ID:        "/cluster/test-cluster/namespace/default/name/application1",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "application1",
+			Tags:      []string{"tag1", "tag2", "tag3"},
+		}, {
+			ID:        "/cluster/test-cluster/namespace/default/name/application2",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "application2",
+			Tags:      []string{"tag3", "tag4", "tag5"},
+		}}
+
+		err := c.SaveTags(ctx(t), applications)
+		require.NoError(t, err)
+
+		storedTags1, err := c.GetTags(ctx(t))
+		require.NoError(t, err)
+		require.Equal(t, 5, len(storedTags1))
+	})
+
+	t.Run("SaveAndGetTopology", func(t *testing.T) {
+		applications := []applicationv1.ApplicationSpec{{
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "application1",
+			Topology: applicationv1.Topology{
+				Dependencies: []applicationv1.Dependency{{
+					Cluster:   "test-cluster",
+					Namespace: "default",
+					Name:      "application2",
+				}},
+			},
+		}, {
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "application2",
+		}}
+
+		err := c.SaveTopology(ctx(t), "test-cluster", applications)
+		require.NoError(t, err)
+
+		storedTopology1, err := c.GetTopologyByIDs(ctx(t), "targetID", []string{"/cluster/test-cluster/namespace/default/name/application2"})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(storedTopology1))
+
+		storedTopology2, err := c.GetTopologyByIDs(ctx(t), "sourceID", []string{"/cluster/test-cluster/namespace/default/name/application1"})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(storedTopology2))
+	})
+
+	t.Run("GetNamespacesByClusters", func(t *testing.T) {
+		err := c.SaveNamespaces(ctx(t), "test-cluster1", []string{"default", "kube-system"})
+		require.NoError(t, err)
+		err = c.SaveNamespaces(ctx(t), "test-cluster2", []string{"default", "kube-system", "istio-system"})
+		require.NoError(t, err)
+
+		storedNamespaces1, err := c.GetNamespacesByClusters(ctx(t), []string{"test-cluster1"})
+		require.NoError(t, err)
+		require.Equal(t, 2, len(storedNamespaces1))
+
+		storedNamespaces2, err := c.GetNamespacesByClusters(ctx(t), []string{"test-cluster1", "test-cluster2"})
+		require.NoError(t, err)
+		require.Equal(t, 5, len(storedNamespaces2))
+
+		storedNamespaces3, err := c.GetNamespacesByClusters(ctx(t), []string{})
+		require.NoError(t, err)
+		require.Equal(t, 5, len(storedNamespaces3))
+
+		storedNamespaces4, err := c.GetNamespacesByClusters(ctx(t), nil)
+		require.NoError(t, err)
+		require.Equal(t, 5, len(storedNamespaces4))
+	})
+
+	t.Run("GetCRDByID", func(t *testing.T) {
+		crds := []kubernetes.CRD{
+			{ID: "resource1.path1/v1", Resource: "resource1", Path: "path1/v1"},
+			{ID: "resource2.path2/v2", Resource: "resource2", Path: "path2/v2"},
+		}
+
+		err := c.SaveCRDs(ctx(t), crds)
+		require.NoError(t, err)
+
+		crd1, err := c.GetCRDByID(ctx(t), "resource1.path1/v1")
+		require.NoError(t, err)
+		require.NotNil(t, crd1)
+
+		crd2, err := c.GetCRDByID(ctx(t), "resource3.path3/v3")
+		require.Error(t, err)
+		require.Nil(t, crd2)
+	})
+
+	t.Run("GetApplicationsByFilter", func(t *testing.T) {
+		applications1 := []applicationv1.ApplicationSpec{
+			{ID: "cluster/test-cluster1/namespace/default/application1", Cluster: "test-cluster1", Namespace: "default", Name: "application1", Teams: []string{"team1"}, Tags: []string{"monitoring", "observability"}, Topology: applicationv1.Topology{External: false}},
+			{ID: "cluster/test-cluster1/namespace/default/application2", Cluster: "test-cluster1", Namespace: "default", Name: "application2", Teams: []string{"team1", "team2"}, Tags: []string{"monitoring", "observability"}, Topology: applicationv1.Topology{External: false}},
+			{ID: "cluster/test-cluster1/namespace/default/application3", Cluster: "test-cluster1", Namespace: "default", Name: "application3", Teams: []string{"team3"}, Tags: []string{}, Topology: applicationv1.Topology{External: true}},
+			{ID: "cluster/test-cluster1/namespace/default/application4", Cluster: "test-cluster2", Namespace: "default", Name: "application4", Teams: []string{"team1", "team2", "team3"}, Tags: []string{"monitoring", "observability"}, Topology: applicationv1.Topology{External: false}},
+		}
+		applications2 := []applicationv1.ApplicationSpec{
+			{ID: "cluster/test-cluster1/namespace/default/application5", Cluster: "test-cluster2", Namespace: "default", Name: "application5", Teams: []string{}, Tags: []string{"monitoring", "observability"}, Topology: applicationv1.Topology{External: false}},
+			{ID: "cluster/test-cluster1/namespace/kube-system/application6", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application6", Teams: []string{"team1"}, Tags: []string{"core", "provider"}, Topology: applicationv1.Topology{External: false}},
+			{ID: "cluster/test-cluster1/namespace/kube-system/application7", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application7", Teams: []string{}, Tags: []string{"core", "provider"}, Topology: applicationv1.Topology{External: false}},
+			{ID: "cluster/test-cluster1/namespace/kube-system/application8", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application8", Teams: []string{"team3"}, Tags: []string{"core", "provider"}, Topology: applicationv1.Topology{External: false}},
+			{ID: "cluster/test-cluster1/namespace/kube-system/application9", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application9", Teams: []string{"team1"}, Tags: []string{"core", "provider"}, Topology: applicationv1.Topology{External: false}},
+			{ID: "cluster/test-cluster1/namespace/kube-system/application10", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application10", Teams: []string{}, Tags: []string{"core", "provider", "logging"}, Topology: applicationv1.Topology{External: true}},
+		}
+
+		err := c.SaveApplications(ctx(t), "test-cluster1", applications1)
+		require.NoError(t, err)
+		err = c.SaveApplications(ctx(t), "test-cluster2", applications2)
+		require.NoError(t, err)
+
+		getApplicationsNames := func(storedApplications []applicationv1.ApplicationSpec) []string {
+			var names []string
+			for _, a := range storedApplications {
+				names = append(names, a.Name)
 			}
-			require.Equal(t, tt.expectedApplications, getApplicationsNames(storedApplications))
+			return names
+		}
 
-			count, err := c.GetApplicationsByFilterCount(ctx, tt.teams, tt.clusters, tt.namespaces, tt.tags, tt.searchTerm)
-			if tt.expectedError {
-				require.Error(t, err)
-			} else {
+		ctx := ctx(t)
+		for _, tt := range []struct {
+			name                 string
+			teams                []string
+			clusters             []string
+			namespaces           []string
+			tags                 []string
+			searchTerm           string
+			limit                int
+			offset               int
+			expectedError        bool
+			expectedApplications []string
+			expectedCount        int
+		}{
+			{name: "searchTerm can not be compiled to regexp", teams: nil, clusters: nil, namespaces: nil, tags: nil, searchTerm: "*", limit: 100, offset: 0, expectedError: true, expectedApplications: nil, expectedCount: 0},
+			{name: "no filters", teams: nil, clusters: nil, namespaces: nil, tags: nil, searchTerm: "", limit: 100, offset: 0, expectedError: false, expectedApplications: []string{"application1", "application10", "application2", "application3", "application4", "application5", "application6", "application7", "application8", "application9"}, expectedCount: 10},
+			{name: "no filters but limit", teams: nil, clusters: nil, namespaces: nil, tags: nil, searchTerm: "", limit: 5, offset: 0, expectedError: false, expectedApplications: []string{"application1", "application10", "application2", "application3", "application4"}, expectedCount: 10},
+			{name: "no filters but limit and offset", teams: nil, clusters: nil, namespaces: nil, tags: nil, searchTerm: "", limit: 5, offset: 5, expectedError: false, expectedApplications: []string{"application5", "application6", "application7", "application8", "application9"}, expectedCount: 10},
+			{name: "only searchTerm", teams: nil, clusters: nil, namespaces: nil, tags: nil, searchTerm: "application1", limit: 100, offset: 0, expectedError: false, expectedApplications: []string{"application1", "application10"}, expectedCount: 2},
+			{name: "filter by team", teams: []string{"team2"}, clusters: nil, namespaces: nil, tags: nil, searchTerm: "", limit: 100, offset: 0, expectedError: false, expectedApplications: []string{"application2", "application4"}, expectedCount: 2},
+			{name: "filter by teams", teams: []string{"team1", "team3"}, clusters: nil, namespaces: nil, tags: nil, searchTerm: "", limit: 100, offset: 0, expectedError: false, expectedApplications: []string{"application1", "application2", "application3", "application4", "application6", "application8", "application9"}, expectedCount: 7},
+			{name: "filter by cluster and namespace", teams: nil, clusters: []string{"test-cluster1", "test-cluster2"}, namespaces: []string{"default"}, tags: nil, searchTerm: "", limit: 100, offset: 0, expectedError: false, expectedApplications: []string{"application1", "application2", "application3", "application4", "application5"}, expectedCount: 5},
+			{name: "filter by tags", teams: nil, clusters: nil, namespaces: nil, tags: []string{"logging"}, searchTerm: "", limit: 100, offset: 0, expectedError: false, expectedApplications: []string{"application10"}, expectedCount: 1},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				storedApplications, err := c.GetApplicationsByFilter(ctx, tt.teams, tt.clusters, tt.namespaces, tt.tags, tt.searchTerm, tt.limit, tt.offset)
+				if tt.expectedError {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+				require.Equal(t, tt.expectedApplications, getApplicationsNames(storedApplications))
+
+				count, err := c.GetApplicationsByFilterCount(ctx, tt.teams, tt.clusters, tt.namespaces, tt.tags, tt.searchTerm)
+				if tt.expectedError {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+				require.Equal(t, tt.expectedCount, count)
+			})
+		}
+	})
+
+	t.Run("GetApplicationsByGroup", func(t *testing.T) {
+		applications1 := []applicationv1.ApplicationSpec{
+			{ID: "1", Cluster: "test-cluster1", Namespace: "default", Name: "application1", Teams: []string{"team1"}},
+			{ID: "2", Cluster: "test-cluster1", Namespace: "default", Name: "application2", Teams: []string{"team1"}},
+			{ID: "3", Cluster: "test-cluster1", Namespace: "kube-system", Name: "application3", Teams: []string{"team1"}},
+			{ID: "4", Cluster: "test-cluster1", Namespace: "kube-system", Name: "application4", Teams: []string{"team1"}},
+		}
+		applications2 := []applicationv1.ApplicationSpec{
+			{ID: "5", Cluster: "test-cluster2", Namespace: "default", Name: "application1", Teams: []string{"team1"}},
+			{ID: "6", Cluster: "test-cluster2", Namespace: "default", Name: "application2", Teams: []string{"team1"}},
+			{ID: "7", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application3", Teams: []string{"team1"}},
+			{ID: "8", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application4", Teams: []string{"team1"}},
+			{ID: "9", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application5", Teams: []string{"team1"}},
+			{ID: "10", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application6", Teams: []string{"team1"}},
+		}
+
+		err := c.SaveApplications(ctx(t), "test-cluster1", applications1)
+		require.NoError(t, err)
+		err = c.SaveApplications(ctx(t), "test-cluster2", applications2)
+		require.NoError(t, err)
+
+		ctx := ctx(t)
+		for _, tt := range []struct {
+			name           string
+			teams          []string
+			groups         []string
+			expectedGroups []ApplicationGroup
+		}{
+			{name: "require groups and teams", teams: nil, groups: nil, expectedGroups: nil},
+			{name: "team must be in group", teams: []string{"team2"}, groups: []string{"name", "namespace"}, expectedGroups: nil},
+			{name: "return groups", teams: []string{"team1"}, groups: []string{"name", "namespace"}, expectedGroups: []ApplicationGroup{
+				{ID: ApplicationGroupID{Cluster: "", Namespace: "default", Name: "application1"}, Clusters: []string{"test-cluster1", "test-cluster2"}, Namespaces: []string{"default", "default"}, Names: []string{"application1", "application1"}, Description: "", Teams: []string{"team1"}},
+				{ID: ApplicationGroupID{Cluster: "", Namespace: "default", Name: "application2"}, Clusters: []string{"test-cluster1", "test-cluster2"}, Namespaces: []string{"default", "default"}, Names: []string{"application2", "application2"}, Description: "", Teams: []string{"team1"}},
+				{ID: ApplicationGroupID{Cluster: "", Namespace: "kube-system", Name: "application3"}, Clusters: []string{"test-cluster1", "test-cluster2"}, Namespaces: []string{"kube-system", "kube-system"}, Names: []string{"application3", "application3"}, Description: "", Teams: []string{"team1"}},
+				{ID: ApplicationGroupID{Cluster: "", Namespace: "kube-system", Name: "application4"}, Clusters: []string{"test-cluster1", "test-cluster2"}, Namespaces: []string{"kube-system", "kube-system"}, Names: []string{"application4", "application4"}, Description: "", Teams: []string{"team1"}},
+				{ID: ApplicationGroupID{Cluster: "", Namespace: "kube-system", Name: "application5"}, Clusters: []string{"test-cluster2"}, Namespaces: []string{"kube-system"}, Names: []string{"application5"}, Description: "", Teams: []string{"team1"}},
+				{ID: ApplicationGroupID{Cluster: "", Namespace: "kube-system", Name: "application6"}, Clusters: []string{"test-cluster2"}, Namespaces: []string{"kube-system"}, Names: []string{"application6"}, Description: "", Teams: []string{"team1"}},
+			}},
+			{name: "return groups for multiple teams", teams: []string{"team1", "team2"}, groups: []string{"name", "namespace"}, expectedGroups: []ApplicationGroup{
+				{ID: ApplicationGroupID{Cluster: "", Namespace: "default", Name: "application1"}, Clusters: []string{"test-cluster1", "test-cluster2"}, Namespaces: []string{"default", "default"}, Names: []string{"application1", "application1"}, Description: "", Teams: []string{"team1"}},
+				{ID: ApplicationGroupID{Cluster: "", Namespace: "default", Name: "application2"}, Clusters: []string{"test-cluster1", "test-cluster2"}, Namespaces: []string{"default", "default"}, Names: []string{"application2", "application2"}, Description: "", Teams: []string{"team1"}},
+				{ID: ApplicationGroupID{Cluster: "", Namespace: "kube-system", Name: "application3"}, Clusters: []string{"test-cluster1", "test-cluster2"}, Namespaces: []string{"kube-system", "kube-system"}, Names: []string{"application3", "application3"}, Description: "", Teams: []string{"team1"}},
+				{ID: ApplicationGroupID{Cluster: "", Namespace: "kube-system", Name: "application4"}, Clusters: []string{"test-cluster1", "test-cluster2"}, Namespaces: []string{"kube-system", "kube-system"}, Names: []string{"application4", "application4"}, Description: "", Teams: []string{"team1"}},
+				{ID: ApplicationGroupID{Cluster: "", Namespace: "kube-system", Name: "application5"}, Clusters: []string{"test-cluster2"}, Namespaces: []string{"kube-system"}, Names: []string{"application5"}, Description: "", Teams: []string{"team1"}},
+				{ID: ApplicationGroupID{Cluster: "", Namespace: "kube-system", Name: "application6"}, Clusters: []string{"test-cluster2"}, Namespaces: []string{"kube-system"}, Names: []string{"application6"}, Description: "", Teams: []string{"team1"}},
+			}},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				storedGroups, err := c.GetApplicationsByGroup(ctx, tt.teams, tt.groups)
 				require.NoError(t, err)
-			}
-			require.Equal(t, tt.expectedCount, count)
-		})
-	}
-}
+				require.Equal(t, tt.expectedGroups, storedGroups)
+			})
+		}
+	})
 
-func TestGetApplicationsByGroup(t *testing.T) {
-	applications1 := []applicationv1.ApplicationSpec{
-		{ID: "1", Cluster: "test-cluster1", Namespace: "default", Name: "application1", Teams: []string{"team1"}},
-		{ID: "2", Cluster: "test-cluster1", Namespace: "default", Name: "application2", Teams: []string{"team1"}},
-		{ID: "3", Cluster: "test-cluster1", Namespace: "kube-system", Name: "application3", Teams: []string{"team1"}},
-		{ID: "4", Cluster: "test-cluster1", Namespace: "kube-system", Name: "application4", Teams: []string{"team1"}},
-	}
-	applications2 := []applicationv1.ApplicationSpec{
-		{ID: "5", Cluster: "test-cluster2", Namespace: "default", Name: "application1", Teams: []string{"team1"}},
-		{ID: "6", Cluster: "test-cluster2", Namespace: "default", Name: "application2", Teams: []string{"team1"}},
-		{ID: "7", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application3", Teams: []string{"team1"}},
-		{ID: "8", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application4", Teams: []string{"team1"}},
-		{ID: "9", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application5", Teams: []string{"team1"}},
-		{ID: "10", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application6", Teams: []string{"team1"}},
-	}
+	t.Run("GetApplicationByID", func(t *testing.T) {
+		applications := []applicationv1.ApplicationSpec{{
+			ID:        "/cluster/test-cluster/namespace/default/name/application1",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "application1",
+		}, {
+			ID:        "/cluster/test-cluster/namespace/default/name/application2",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "application2",
+		}}
 
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
+		err := c.SaveApplications(ctx(t), "test-cluster", applications)
+		require.NoError(t, err)
 
-	err := c.SaveApplications(ctx(t), "test-cluster1", applications1)
-	require.NoError(t, err)
-	err = c.SaveApplications(ctx(t), "test-cluster2", applications2)
-	require.NoError(t, err)
+		storedApplication1, err := c.GetApplicationByID(ctx(t), "/cluster/test-cluster/namespace/default/name/application1")
+		require.NoError(t, err)
+		require.NotNil(t, storedApplication1)
 
-	ctx := ctx(t)
-	for _, tt := range []struct {
-		name           string
-		teams          []string
-		groups         []string
-		expectedGroups []ApplicationGroup
-	}{
-		{name: "require groups and teams", teams: nil, groups: nil, expectedGroups: nil},
-		{name: "team must be in group", teams: []string{"team2"}, groups: []string{"name", "namespace"}, expectedGroups: nil},
-		{name: "return groups", teams: []string{"team1"}, groups: []string{"name", "namespace"}, expectedGroups: []ApplicationGroup{
-			{ID: ApplicationGroupID{Cluster: "", Namespace: "default", Name: "application1"}, Clusters: []string{"test-cluster1", "test-cluster2"}, Namespaces: []string{"default", "default"}, Names: []string{"application1", "application1"}, Description: "", Teams: []string{"team1"}},
-			{ID: ApplicationGroupID{Cluster: "", Namespace: "default", Name: "application2"}, Clusters: []string{"test-cluster1", "test-cluster2"}, Namespaces: []string{"default", "default"}, Names: []string{"application2", "application2"}, Description: "", Teams: []string{"team1"}},
-			{ID: ApplicationGroupID{Cluster: "", Namespace: "kube-system", Name: "application3"}, Clusters: []string{"test-cluster1", "test-cluster2"}, Namespaces: []string{"kube-system", "kube-system"}, Names: []string{"application3", "application3"}, Description: "", Teams: []string{"team1"}},
-			{ID: ApplicationGroupID{Cluster: "", Namespace: "kube-system", Name: "application4"}, Clusters: []string{"test-cluster1", "test-cluster2"}, Namespaces: []string{"kube-system", "kube-system"}, Names: []string{"application4", "application4"}, Description: "", Teams: []string{"team1"}},
-			{ID: ApplicationGroupID{Cluster: "", Namespace: "kube-system", Name: "application5"}, Clusters: []string{"test-cluster2"}, Namespaces: []string{"kube-system"}, Names: []string{"application5"}, Description: "", Teams: []string{"team1"}},
-			{ID: ApplicationGroupID{Cluster: "", Namespace: "kube-system", Name: "application6"}, Clusters: []string{"test-cluster2"}, Namespaces: []string{"kube-system"}, Names: []string{"application6"}, Description: "", Teams: []string{"team1"}},
-		}},
-		{name: "return groups for multiple teams", teams: []string{"team1", "team2"}, groups: []string{"name", "namespace"}, expectedGroups: []ApplicationGroup{
-			{ID: ApplicationGroupID{Cluster: "", Namespace: "default", Name: "application1"}, Clusters: []string{"test-cluster1", "test-cluster2"}, Namespaces: []string{"default", "default"}, Names: []string{"application1", "application1"}, Description: "", Teams: []string{"team1"}},
-			{ID: ApplicationGroupID{Cluster: "", Namespace: "default", Name: "application2"}, Clusters: []string{"test-cluster1", "test-cluster2"}, Namespaces: []string{"default", "default"}, Names: []string{"application2", "application2"}, Description: "", Teams: []string{"team1"}},
-			{ID: ApplicationGroupID{Cluster: "", Namespace: "kube-system", Name: "application3"}, Clusters: []string{"test-cluster1", "test-cluster2"}, Namespaces: []string{"kube-system", "kube-system"}, Names: []string{"application3", "application3"}, Description: "", Teams: []string{"team1"}},
-			{ID: ApplicationGroupID{Cluster: "", Namespace: "kube-system", Name: "application4"}, Clusters: []string{"test-cluster1", "test-cluster2"}, Namespaces: []string{"kube-system", "kube-system"}, Names: []string{"application4", "application4"}, Description: "", Teams: []string{"team1"}},
-			{ID: ApplicationGroupID{Cluster: "", Namespace: "kube-system", Name: "application5"}, Clusters: []string{"test-cluster2"}, Namespaces: []string{"kube-system"}, Names: []string{"application5"}, Description: "", Teams: []string{"team1"}},
-			{ID: ApplicationGroupID{Cluster: "", Namespace: "kube-system", Name: "application6"}, Clusters: []string{"test-cluster2"}, Namespaces: []string{"kube-system"}, Names: []string{"application6"}, Description: "", Teams: []string{"team1"}},
-		}},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			storedGroups, err := c.GetApplicationsByGroup(ctx, tt.teams, tt.groups)
-			require.NoError(t, err)
-			require.Equal(t, tt.expectedGroups, storedGroups)
-		})
-	}
-}
+		storedApplication2, err := c.GetApplicationByID(ctx(t), "/cluster/test-cluster/namespace/default/name/application3")
+		require.Error(t, err)
+		require.Nil(t, storedApplication2)
+	})
 
-func TestGetApplicationByID(t *testing.T) {
-	applications := []applicationv1.ApplicationSpec{{
-		ID:        "/cluster/test-cluster/namespace/default/name/application1",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "application1",
-	}, {
-		ID:        "/cluster/test-cluster/namespace/default/name/application2",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "application2",
-	}}
+	t.Run("GetDashboardByID", func(t *testing.T) {
+		dashboards := []dashboardv1.DashboardSpec{{
+			ID:        "/cluster/test-cluster/namespace/default/name/dashboard1",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "dashboard1",
+		}, {
+			ID:        "/cluster/test-cluster/namespace/default/name/dashboard2",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "dashboard2",
+		}}
 
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
+		err := c.SaveDashboards(ctx(t), "test-cluster", dashboards)
+		require.NoError(t, err)
 
-	err := c.SaveApplications(ctx(t), "test-cluster", applications)
-	require.NoError(t, err)
+		storedDashboard1, err := c.GetDashboardByID(ctx(t), "/cluster/test-cluster/namespace/default/name/dashboard1")
+		require.NoError(t, err)
+		require.NotNil(t, storedDashboard1)
 
-	storedApplication1, err := c.GetApplicationByID(ctx(t), "/cluster/test-cluster/namespace/default/name/application1")
-	require.NoError(t, err)
-	require.NotNil(t, storedApplication1)
+		storedDashboard2, err := c.GetDashboardByID(ctx(t), "/cluster/test-cluster/namespace/default/name/dashboard3")
+		require.Error(t, err)
+		require.Nil(t, storedDashboard2)
+	})
 
-	storedApplication2, err := c.GetApplicationByID(ctx(t), "/cluster/test-cluster/namespace/default/name/application3")
-	require.Error(t, err)
-	require.Nil(t, storedApplication2)
-}
+	t.Run("GetTeamsByIDs", func(t *testing.T) {
+		teams := []teamv1.TeamSpec{{
+			ID:        "team1@kobs.io",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "team1",
+		}, {
+			ID:        "team2@kobs.io",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "team2",
+		}, {
+			ID:        "team3@kobs.io",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "team3",
+		}, {
+			ID:        "team3@kobs.io",
+			Cluster:   "stage-de1",
+			Namespace: "default",
+			Name:      "team3",
+		}}
 
-func TestGetDashboardByID(t *testing.T) {
-	dashboards := []dashboardv1.DashboardSpec{{
-		ID:        "/cluster/test-cluster/namespace/default/name/dashboard1",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "dashboard1",
-	}, {
-		ID:        "/cluster/test-cluster/namespace/default/name/dashboard2",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "dashboard2",
-	}}
+		err := c.SaveTeams(ctx(t), "test-cluster", teams)
+		require.NoError(t, err)
 
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
+		storedTeams1, err := c.GetTeamsByIDs(ctx(t), []string{"team1@kobs.io"}, "")
+		require.NoError(t, err)
+		require.Equal(t, 1, len(storedTeams1))
 
-	err := c.SaveDashboards(ctx(t), "test-cluster", dashboards)
-	require.NoError(t, err)
+		storedTeams2, err := c.GetTeamsByIDs(ctx(t), []string{"team1@kobs.io", "team2@kobs.io"}, "")
+		require.NoError(t, err)
+		require.Equal(t, 2, len(storedTeams2))
 
-	storedDashboard1, err := c.GetDashboardByID(ctx(t), "/cluster/test-cluster/namespace/default/name/dashboard1")
-	require.NoError(t, err)
-	require.NotNil(t, storedDashboard1)
+		storedTeams3, err := c.GetTeamsByIDs(ctx(t), []string{}, "")
+		require.NoError(t, err)
+		require.Equal(t, 0, len(storedTeams3))
 
-	storedDashboard2, err := c.GetDashboardByID(ctx(t), "/cluster/test-cluster/namespace/default/name/dashboard3")
-	require.Error(t, err)
-	require.Nil(t, storedDashboard2)
-}
+		storedTeams4, err := c.GetTeamsByIDs(ctx(t), nil, "")
+		require.NoError(t, err)
+		require.Equal(t, 0, len(storedTeams4))
 
-func TestGetTeamsByIDs(t *testing.T) {
-	teams := []teamv1.TeamSpec{{
-		ID:        "team1@kobs.io",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "team1",
-	}, {
-		ID:        "team2@kobs.io",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "team2",
-	}, {
-		ID:        "team3@kobs.io",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "team3",
-	}, {
-		ID:        "team3@kobs.io",
-		Cluster:   "stage-de1",
-		Namespace: "default",
-		Name:      "team3",
-	}}
+		storedTeams5, err := c.GetTeamsByIDs(ctx(t), []string{"team3@kobs.io"}, "")
+		require.NoError(t, err)
+		require.Equal(t, 1, len(storedTeams5))
 
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
+		storedTeams6, err := c.GetTeamsByIDs(ctx(t), []string{"team1@kobs.io", "team2@kobs.io"}, "team2")
+		require.NoError(t, err)
+		require.Equal(t, 1, len(storedTeams6))
+	})
 
-	err := c.SaveTeams(ctx(t), "test-cluster", teams)
-	require.NoError(t, err)
+	t.Run("GetTeamByID", func(t *testing.T) {
+		teams := []teamv1.TeamSpec{{
+			ID:        "team1@kobs.io",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "team1",
+			Dashboards: []dashboardv1.Reference{
+				{Cluster: "test-cluster", Namespace: "default", Name: "dashboard1", Title: "Dashboard 1"},
+			},
+		}, {
+			ID:        "team2@kobs.io",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "team2",
+			Dashboards: []dashboardv1.Reference{
+				{Cluster: "test-cluster", Namespace: "default", Name: "dashboard1", Title: "Dashboard 1"},
+			},
+		}, {
+			ID:        "team3@kobs.io",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "team3",
+			Dashboards: []dashboardv1.Reference{
+				{Cluster: "test-cluster", Namespace: "default", Name: "dashboard1", Title: "Dashboard 1"},
+			},
+		}}
 
-	storedTeams1, err := c.GetTeamsByIDs(ctx(t), []string{"team1@kobs.io"}, "")
-	require.NoError(t, err)
-	require.Equal(t, 1, len(storedTeams1))
+		err := c.SaveTeams(ctx(t), "test-cluster", teams)
+		require.NoError(t, err)
 
-	storedTeams2, err := c.GetTeamsByIDs(ctx(t), []string{"team1@kobs.io", "team2@kobs.io"}, "")
-	require.NoError(t, err)
-	require.Equal(t, 2, len(storedTeams2))
+		storedTeam1, err := c.GetTeamByID(ctx(t), "team1@kobs.io")
+		require.NoError(t, err)
+		require.NotNil(t, storedTeam1)
 
-	storedTeams3, err := c.GetTeamsByIDs(ctx(t), []string{}, "")
-	require.NoError(t, err)
-	require.Equal(t, 0, len(storedTeams3))
+		storedTeam2, err := c.GetTeamByID(ctx(t), "team4@kobs.io")
+		require.Error(t, err)
+		require.Nil(t, storedTeam2)
+	})
 
-	storedTeams4, err := c.GetTeamsByIDs(ctx(t), nil, "")
-	require.NoError(t, err)
-	require.Equal(t, 0, len(storedTeams4))
+	t.Run("GetGetUserByID", func(t *testing.T) {
+		users := []userv1.UserSpec{{
+			ID:        "user1@kobs.io",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "user1",
+		}, {
+			ID:        "user2@kobs.io",
+			Cluster:   "test-cluster",
+			Namespace: "default",
+			Name:      "user2",
+		}}
 
-	storedTeams5, err := c.GetTeamsByIDs(ctx(t), []string{"team3@kobs.io"}, "")
-	require.NoError(t, err)
-	require.Equal(t, 1, len(storedTeams5))
+		err := c.SaveUsers(ctx(t), "test-cluster", users)
+		require.NoError(t, err)
 
-	storedTeams6, err := c.GetTeamsByIDs(ctx(t), []string{"team1@kobs.io", "team2@kobs.io"}, "team2")
-	require.NoError(t, err)
-	require.Equal(t, 1, len(storedTeams6))
-}
+		storedUser1, err := c.GetUserByID(ctx(t), "user1@kobs.io")
+		require.NoError(t, err)
+		require.NotNil(t, storedUser1)
 
-func TestGetTeamByID(t *testing.T) {
-	teams := []teamv1.TeamSpec{{
-		ID:        "team1@kobs.io",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "team1",
-		Dashboards: []dashboardv1.Reference{
-			{Cluster: "test-cluster", Namespace: "default", Name: "dashboard1", Title: "Dashboard 1"},
-		},
-	}, {
-		ID:        "team2@kobs.io",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "team2",
-		Dashboards: []dashboardv1.Reference{
-			{Cluster: "test-cluster", Namespace: "default", Name: "dashboard1", Title: "Dashboard 1"},
-		},
-	}, {
-		ID:        "team3@kobs.io",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "team3",
-		Dashboards: []dashboardv1.Reference{
-			{Cluster: "test-cluster", Namespace: "default", Name: "dashboard1", Title: "Dashboard 1"},
-		},
-	}}
-
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
-
-	err := c.SaveTeams(ctx(t), "test-cluster", teams)
-	require.NoError(t, err)
-
-	storedTeam1, err := c.GetTeamByID(ctx(t), "team1@kobs.io")
-	require.NoError(t, err)
-	require.NotNil(t, storedTeam1)
-
-	storedTeam2, err := c.GetTeamByID(ctx(t), "team4@kobs.io")
-	require.Error(t, err)
-	require.Nil(t, storedTeam2)
-}
-
-func TestGetGetUserByID(t *testing.T) {
-	users := []userv1.UserSpec{{
-		ID:        "user1@kobs.io",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "user1",
-	}, {
-		ID:        "user2@kobs.io",
-		Cluster:   "test-cluster",
-		Namespace: "default",
-		Name:      "user2",
-	}}
-
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
-
-	err := c.SaveUsers(ctx(t), "test-cluster", users)
-	require.NoError(t, err)
-
-	storedUser1, err := c.GetUserByID(ctx(t), "user1@kobs.io")
-	require.NoError(t, err)
-	require.NotNil(t, storedUser1)
-
-	storedUser2, err := c.GetUserByID(ctx(t), "user4@kobs.io")
-	require.NoError(t, err)
-	require.Nil(t, storedUser2)
+		storedUser2, err := c.GetUserByID(ctx(t), "user4@kobs.io")
+		require.NoError(t, err)
+		require.Nil(t, storedUser2)
+	})
 }

--- a/pkg/hub/db/sessions.go
+++ b/pkg/hub/db/sessions.go
@@ -45,7 +45,7 @@ func (c *client) CreateSession(ctx context.Context, user authContext.User) (*Ses
 	span.SetAttributes(attribute.Key("userID").String(user.ID))
 	defer span.End()
 
-	_, err := c.db.Database("kobs").Collection("sessions").InsertOne(ctx, session)
+	_, err := c.coll(ctx, "sessions").InsertOne(ctx, session)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -61,7 +61,7 @@ func (c *client) GetSession(ctx context.Context, sessionID primitive.ObjectID) (
 	span.SetAttributes(attribute.Key("sessionID").String(sessionID.String()))
 	defer span.End()
 
-	res := c.db.Database("kobs").Collection("sessions").FindOne(ctx, bson.D{{Key: "_id", Value: sessionID}})
+	res := c.coll(ctx, "sessions").FindOne(ctx, bson.D{{Key: "_id", Value: sessionID}})
 	if res.Err() != nil {
 		span.RecordError(res.Err())
 		span.SetStatus(codes.Error, res.Err().Error())
@@ -87,7 +87,7 @@ func (c *client) GetAndUpdateSession(ctx context.Context, sessionID primitive.Ob
 	span.SetAttributes(attribute.Key("sessionID").String(sessionID.String()))
 	defer span.End()
 
-	res := c.db.Database("kobs").Collection("sessions").FindOneAndUpdate(ctx, bson.D{{Key: "_id", Value: sessionID}}, bson.D{{Key: "$set", Value: bson.D{{Key: "updatedAt", Value: time.Now()}}}})
+	res := c.coll(ctx, "sessions").FindOneAndUpdate(ctx, bson.D{{Key: "_id", Value: sessionID}}, bson.D{{Key: "$set", Value: bson.D{{Key: "updatedAt", Value: time.Now()}}}})
 	if res.Err() != nil {
 		span.RecordError(res.Err())
 		span.SetStatus(codes.Error, res.Err().Error())
@@ -113,7 +113,7 @@ func (c *client) DeleteSession(ctx context.Context, sessionID primitive.ObjectID
 	span.SetAttributes(attribute.Key("sessionID").String(sessionID.String()))
 	defer span.End()
 
-	res, err := c.db.Database("kobs").Collection("sessions").DeleteOne(ctx, bson.D{{Key: "_id", Value: sessionID}})
+	res, err := c.coll(ctx, "sessions").DeleteOne(ctx, bson.D{{Key: "_id", Value: sessionID}})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/pkg/hub/db/sessions_test.go
+++ b/pkg/hub/db/sessions_test.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"context"
 	"testing"
 
 	authContext "github.com/kobsio/kobs/pkg/hub/auth/context"
@@ -16,7 +15,7 @@ func TestCreateSession(t *testing.T) {
 	defer gnomock.Stop(container)
 	c, _ := NewClient(Config{URI: uri})
 
-	session, err := c.CreateSession(context.Background(), authContext.User{ID: "userid"})
+	session, err := c.CreateSession(ctx(t), authContext.User{ID: "userid"})
 	require.NoError(t, err)
 	require.NotNil(t, session)
 }
@@ -26,19 +25,20 @@ func TestGetSession(t *testing.T) {
 	defer gnomock.Stop(container)
 	c, _ := NewClient(Config{URI: uri})
 
-	session, err := c.CreateSession(context.Background(), authContext.User{ID: "userid"})
+	session, err := c.CreateSession(ctx(t), authContext.User{ID: "userid"})
 	require.NoError(t, err)
 	require.NotNil(t, session)
 
+	ctx := ctx(t)
 	t.Run("should return session", func(t *testing.T) {
-		actualSession, err := c.GetSession(context.Background(), session.ID)
+		actualSession, err := c.GetSession(ctx, session.ID)
 		require.NoError(t, err)
 		require.Equal(t, session.ID, actualSession.ID)
 		require.Equal(t, session.User.ID, actualSession.User.ID)
 	})
 
 	t.Run("should fail to return session, when session does not exists", func(t *testing.T) {
-		_, err := c.GetSession(context.Background(), primitive.NewObjectID())
+		_, err := c.GetSession(ctx, primitive.NewObjectID())
 		require.Error(t, err)
 		require.Equal(t, ErrSessionNotFound, err)
 	})
@@ -49,19 +49,20 @@ func TestGetAndUpdateSession(t *testing.T) {
 	defer gnomock.Stop(container)
 	c, _ := NewClient(Config{URI: uri})
 
-	session, err := c.CreateSession(context.Background(), authContext.User{ID: "userid"})
+	session, err := c.CreateSession(ctx(t), authContext.User{ID: "userid"})
 	require.NoError(t, err)
 	require.NotNil(t, session)
 
+	ctx := ctx(t)
 	t.Run("should return and update session", func(t *testing.T) {
-		actualSession, err := c.GetAndUpdateSession(context.Background(), session.ID)
+		actualSession, err := c.GetAndUpdateSession(ctx, session.ID)
 		require.NoError(t, err)
 		require.Equal(t, session.ID, actualSession.ID)
 		require.Equal(t, session.User.ID, actualSession.User.ID)
 	})
 
 	t.Run("should fail to update session, when session does not exists", func(t *testing.T) {
-		_, err := c.GetAndUpdateSession(context.Background(), primitive.NewObjectID())
+		_, err := c.GetAndUpdateSession(ctx, primitive.NewObjectID())
 		require.Error(t, err)
 		require.Equal(t, ErrSessionNotFound, err)
 	})
@@ -72,17 +73,18 @@ func TestDeleteSession(t *testing.T) {
 	defer gnomock.Stop(container)
 	c, _ := NewClient(Config{URI: uri})
 
-	session, err := c.CreateSession(context.Background(), authContext.User{ID: "userid"})
+	session, err := c.CreateSession(ctx(t), authContext.User{ID: "userid"})
 	require.NoError(t, err)
 	require.NotNil(t, session)
 
+	ctx := ctx(t)
 	t.Run("should delete session", func(t *testing.T) {
-		err := c.DeleteSession(context.Background(), session.ID)
+		err := c.DeleteSession(ctx, session.ID)
 		require.NoError(t, err)
 	})
 
 	t.Run("should fail to delete session, when session does not exists", func(t *testing.T) {
-		err := c.DeleteSession(context.Background(), primitive.NewObjectID())
+		err := c.DeleteSession(ctx, primitive.NewObjectID())
 		require.Error(t, err)
 		require.Equal(t, ErrSessionNotFound, err)
 	})

--- a/pkg/hub/db/sessions_test.go
+++ b/pkg/hub/db/sessions_test.go
@@ -10,82 +10,77 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-func TestCreateSession(t *testing.T) {
+func TestSessions(t *testing.T) {
 	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
+	defer func(cs *gnomock.Container) {
+		err := gnomock.Stop(cs)
+		if err != nil {
+			t.Error(err)
+		}
+	}(container)
 	c, _ := NewClient(Config{URI: uri})
 
-	session, err := c.CreateSession(ctx(t), authContext.User{ID: "userid"})
-	require.NoError(t, err)
-	require.NotNil(t, session)
-}
-
-func TestGetSession(t *testing.T) {
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
-
-	session, err := c.CreateSession(ctx(t), authContext.User{ID: "userid"})
-	require.NoError(t, err)
-	require.NotNil(t, session)
-
-	ctx := ctx(t)
-	t.Run("should return session", func(t *testing.T) {
-		actualSession, err := c.GetSession(ctx, session.ID)
+	t.Run("CreateSession", func(t *testing.T) {
+		session, err := c.CreateSession(ctx(t), authContext.User{ID: "userid"})
 		require.NoError(t, err)
-		require.Equal(t, session.ID, actualSession.ID)
-		require.Equal(t, session.User.ID, actualSession.User.ID)
+		require.NotNil(t, session)
 	})
 
-	t.Run("should fail to return session, when session does not exists", func(t *testing.T) {
-		_, err := c.GetSession(ctx, primitive.NewObjectID())
-		require.Error(t, err)
-		require.Equal(t, ErrSessionNotFound, err)
-	})
-}
-
-func TestGetAndUpdateSession(t *testing.T) {
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
-
-	session, err := c.CreateSession(ctx(t), authContext.User{ID: "userid"})
-	require.NoError(t, err)
-	require.NotNil(t, session)
-
-	ctx := ctx(t)
-	t.Run("should return and update session", func(t *testing.T) {
-		actualSession, err := c.GetAndUpdateSession(ctx, session.ID)
+	t.Run("GetSession", func(t *testing.T) {
+		session, err := c.CreateSession(ctx(t), authContext.User{ID: "userid"})
 		require.NoError(t, err)
-		require.Equal(t, session.ID, actualSession.ID)
-		require.Equal(t, session.User.ID, actualSession.User.ID)
+		require.NotNil(t, session)
+
+		ctx := ctx(t)
+		t.Run("should return session", func(t *testing.T) {
+			actualSession, err := c.GetSession(ctx, session.ID)
+			require.NoError(t, err)
+			require.Equal(t, session.ID, actualSession.ID)
+			require.Equal(t, session.User.ID, actualSession.User.ID)
+		})
+
+		t.Run("should fail to return session, when session does not exists", func(t *testing.T) {
+			_, err := c.GetSession(ctx, primitive.NewObjectID())
+			require.Error(t, err)
+			require.Equal(t, ErrSessionNotFound, err)
+		})
 	})
 
-	t.Run("should fail to update session, when session does not exists", func(t *testing.T) {
-		_, err := c.GetAndUpdateSession(ctx, primitive.NewObjectID())
-		require.Error(t, err)
-		require.Equal(t, ErrSessionNotFound, err)
-	})
-}
-
-func TestDeleteSession(t *testing.T) {
-	uri, container := setupDatabase(t)
-	defer gnomock.Stop(container)
-	c, _ := NewClient(Config{URI: uri})
-
-	session, err := c.CreateSession(ctx(t), authContext.User{ID: "userid"})
-	require.NoError(t, err)
-	require.NotNil(t, session)
-
-	ctx := ctx(t)
-	t.Run("should delete session", func(t *testing.T) {
-		err := c.DeleteSession(ctx, session.ID)
+	t.Run("GetAndUpdateSession", func(t *testing.T) {
+		session, err := c.CreateSession(ctx(t), authContext.User{ID: "userid"})
 		require.NoError(t, err)
+		require.NotNil(t, session)
+
+		ctx := ctx(t)
+		t.Run("should return and update session", func(t *testing.T) {
+			actualSession, err := c.GetAndUpdateSession(ctx, session.ID)
+			require.NoError(t, err)
+			require.Equal(t, session.ID, actualSession.ID)
+			require.Equal(t, session.User.ID, actualSession.User.ID)
+		})
+
+		t.Run("should fail to update session, when session does not exists", func(t *testing.T) {
+			_, err := c.GetAndUpdateSession(ctx, primitive.NewObjectID())
+			require.Error(t, err)
+			require.Equal(t, ErrSessionNotFound, err)
+		})
 	})
 
-	t.Run("should fail to delete session, when session does not exists", func(t *testing.T) {
-		err := c.DeleteSession(ctx, primitive.NewObjectID())
-		require.Error(t, err)
-		require.Equal(t, ErrSessionNotFound, err)
+	t.Run("DeleteSession", func(t *testing.T) {
+		session, err := c.CreateSession(ctx(t), authContext.User{ID: "userid"})
+		require.NoError(t, err)
+		require.NotNil(t, session)
+
+		ctx := ctx(t)
+		t.Run("should delete session", func(t *testing.T) {
+			err := c.DeleteSession(ctx, session.ID)
+			require.NoError(t, err)
+		})
+
+		t.Run("should fail to delete session, when session does not exists", func(t *testing.T) {
+			err := c.DeleteSession(ctx, primitive.NewObjectID())
+			require.Error(t, err)
+			require.Equal(t, ErrSessionNotFound, err)
+		})
 	})
 }


### PR DESCRIPTION
Separate db tests by using different databases instead of starting a new test container for each.
This also runs the tests in parallel.
I also reduced the 2 sec sleep to 1s, which should be big enough for a different updatedAt.

On my machine the changes reduced the test execution of `db_test.go` from >1:40min to ~14sec.

<details>
<summary>before</summary>
<img width="933" alt="Bildschirmfoto 2023-11-16 um 11 10 47" src="https://github.com/kobsio/kobs/assets/318533/0f0ab11d-3097-402c-b644-363bfec47073">
</details>
<details>
<summary>after</summary>
<img width="941" alt="Bildschirmfoto 2023-11-16 um 11 47 07" src="https://github.com/kobsio/kobs/assets/318533/8e68fd9e-a719-4a14-8a43-b9e6dcabe1bd">
</details>

**Hint:** ignore whitespace changes ([link](https://github.com/kobsio/kobs/pull/605/files?diff=split&w=1)) to get a better diff.


- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
