### PR TITLE
[db] Use UnixMilli() instead of Unix() for createdAt / updatedAt

### DIFF
--- a/pkg/hub/db/db.go
+++ b/pkg/hub/db/db.go
@@ -174,7 +174,7 @@ func (c *client) SavePlugins(ctx context.Context, cluster string, plugins []plug
 	defer span.End()
 
 	var models []mongo.WriteModel
-	updatedAt := time.Now().Unix()
+	updatedAt := time.Now().UnixMilli()
 
 	for _, p := range plugins {
 		p.ID = fmt.Sprintf("/cluster/%s/type/%s/name/%s", cluster, p.Type, p.Name)
@@ -203,7 +203,7 @@ func (c *client) SaveNamespaces(ctx context.Context, cluster string, namespaces 
 	defer span.End()
 
 	var models []mongo.WriteModel
-	updatedAt := time.Now().Unix()
+	updatedAt := time.Now().UnixMilli()
 
 	for _, n := range namespaces {
 		namespace := Namespace{
@@ -236,14 +236,14 @@ func (c *client) SaveCRDs(ctx context.Context, crds []kubernetes.CRD) error {
 
 	var models []mongo.WriteModel
 	updatedAtTime := time.Now()
-	updatedAt := updatedAtTime.Unix()
+	updatedAt := updatedAtTime.UnixMilli()
 
 	for _, crd := range crds {
 		crd.UpdatedAt = updatedAt
 		models = append(models, mongo.NewReplaceOneModel().SetFilter(bson.D{{Key: "_id", Value: crd.ID}}).SetReplacement(crd).SetUpsert(true))
 	}
 
-	err := c.save(ctx, "crds", models, "", updatedAtTime.Add(time.Duration(-72*time.Hour)).Unix())
+	err := c.save(ctx, "crds", models, "", updatedAtTime.Add(time.Duration(-72*time.Hour)).UnixMilli())
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -263,7 +263,7 @@ func (c *client) SaveApplications(ctx context.Context, cluster string, applicati
 	defer span.End()
 
 	var models []mongo.WriteModel
-	updatedAt := time.Now().Unix()
+	updatedAt := time.Now().UnixMilli()
 
 	for _, a := range applications {
 		a.UpdatedAt = updatedAt
@@ -285,7 +285,7 @@ func (c *client) SaveApplication(ctx context.Context, application *applicationv1
 	defer span.End()
 
 	upsert := true
-	application.UpdatedAt = time.Now().Unix()
+	application.UpdatedAt = time.Now().UnixMilli()
 
 	_, err := c.coll(ctx, "applications").ReplaceOne(ctx, bson.D{{Key: "_id", Value: application.ID}}, application, &options.ReplaceOptions{Upsert: &upsert})
 	if err != nil {
@@ -307,7 +307,7 @@ func (c *client) SaveDashboards(ctx context.Context, cluster string, dashboards 
 	defer span.End()
 
 	var models []mongo.WriteModel
-	updatedAt := time.Now().Unix()
+	updatedAt := time.Now().UnixMilli()
 
 	for _, d := range dashboards {
 		d.UpdatedAt = updatedAt
@@ -334,7 +334,7 @@ func (c *client) SaveTeams(ctx context.Context, cluster string, teams []teamv1.T
 	defer span.End()
 
 	var models []mongo.WriteModel
-	updatedAt := time.Now().Unix()
+	updatedAt := time.Now().UnixMilli()
 
 	for _, t := range teams {
 		t.UpdatedAt = updatedAt
@@ -356,7 +356,7 @@ func (c *client) SaveTeam(ctx context.Context, team *teamv1.TeamSpec) error {
 	defer span.End()
 
 	upsert := true
-	team.UpdatedAt = time.Now().Unix()
+	team.UpdatedAt = time.Now().UnixMilli()
 
 	_, err := c.coll(ctx, "teams").ReplaceOne(ctx, bson.D{{Key: "_id", Value: team.ID}}, team, &options.ReplaceOptions{Upsert: &upsert})
 	if err != nil {
@@ -378,7 +378,7 @@ func (c *client) SaveUsers(ctx context.Context, cluster string, users []userv1.U
 	defer span.End()
 
 	var models []mongo.WriteModel
-	updatedAt := time.Now().Unix()
+	updatedAt := time.Now().UnixMilli()
 
 	for _, u := range users {
 		u.UpdatedAt = updatedAt
@@ -400,7 +400,7 @@ func (c *client) SaveUser(ctx context.Context, user *userv1.UserSpec) error {
 	defer span.End()
 
 	upsert := true
-	user.UpdatedAt = time.Now().Unix()
+	user.UpdatedAt = time.Now().UnixMilli()
 
 	_, err := c.coll(ctx, "users").ReplaceOne(ctx, bson.D{{Key: "_id", Value: user.ID}}, user, &options.ReplaceOptions{Upsert: &upsert})
 	if err != nil {
@@ -418,7 +418,7 @@ func (c *client) SaveTags(ctx context.Context, applications []applicationv1.Appl
 
 	var models []mongo.WriteModel
 	updatedAtTime := time.Now()
-	updatedAt := updatedAtTime.Unix()
+	updatedAt := updatedAtTime.UnixMilli()
 
 	for _, a := range applications {
 		for _, t := range a.Tags {
@@ -436,7 +436,7 @@ func (c *client) SaveTags(ctx context.Context, applications []applicationv1.Appl
 		return nil
 	}
 
-	err := c.save(ctx, "tags", models, "", updatedAtTime.Add(time.Duration(-72*time.Hour)).Unix())
+	err := c.save(ctx, "tags", models, "", updatedAtTime.Add(time.Duration(-72*time.Hour)).UnixMilli())
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -452,7 +452,7 @@ func (c *client) SaveTopology(ctx context.Context, cluster string, applications 
 	defer span.End()
 
 	var models []mongo.WriteModel
-	updatedAt := time.Now().Unix()
+	updatedAt := time.Now().UnixMilli()
 
 	for _, a := range applications {
 		for _, dependency := range a.Topology.Dependencies {

--- a/pkg/hub/db/db_test.go
+++ b/pkg/hub/db/db_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/kobsio/kobs/pkg/cluster/kubernetes"
 	applicationv1 "github.com/kobsio/kobs/pkg/cluster/kubernetes/apis/application/v1"
@@ -80,8 +79,6 @@ func TestDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 2, len(storedPlugins1))
 
-		time.Sleep(1 * time.Second)
-
 		err = c.SavePlugins(ctx(t), "test-cluster", plugins[0:1])
 		require.NoError(t, err)
 
@@ -98,8 +95,6 @@ func TestDB(t *testing.T) {
 		storedNamespaces1, err := c.GetNamespaces(ctx(t))
 		require.NoError(t, err)
 		require.Equal(t, 2, len(storedNamespaces1))
-
-		time.Sleep(1 * time.Second)
 
 		namespaces2 := []string{"default"}
 		err = c.SaveNamespaces(ctx(t), "test-cluster", namespaces2)
@@ -122,8 +117,6 @@ func TestDB(t *testing.T) {
 		storedCRDs1, err := c.GetCRDs(ctx(t))
 		require.NoError(t, err)
 		require.Equal(t, 2, len(storedCRDs1))
-
-		time.Sleep(1 * time.Second)
 
 		err = c.SaveCRDs(ctx(t), crds1[0:1])
 		require.NoError(t, err)
@@ -153,8 +146,6 @@ func TestDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 2, len(storedApplications1))
 
-		time.Sleep(1 * time.Second)
-
 		err = c.SaveApplications(ctx(t), "test-cluster", applications[0:1])
 		require.NoError(t, err)
 
@@ -180,8 +171,6 @@ func TestDB(t *testing.T) {
 		require.Equal(t, application.Cluster, storedApplication1.Cluster)
 		require.Equal(t, application.Namespace, storedApplication1.Namespace)
 		require.Equal(t, application.Name, storedApplication1.Name)
-
-		time.Sleep(1 * time.Second)
 
 		application.Name = "application2"
 		err = c.SaveApplication(ctx(t), &application)
@@ -219,8 +208,6 @@ func TestDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, len(storedDashboards2))
 
-		time.Sleep(1 * time.Second)
-
 		err = c.SaveDashboards(ctx(t), "test-cluster", dashboards[0:1])
 		require.NoError(t, err)
 
@@ -249,8 +236,6 @@ func TestDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 2, len(storedTeams1))
 
-		time.Sleep(1 * time.Second)
-
 		err = c.SaveTeams(ctx(t), "test-cluster", teams[0:1])
 		require.NoError(t, err)
 
@@ -276,8 +261,6 @@ func TestDB(t *testing.T) {
 		require.Equal(t, team.Cluster, storedTeam1.Cluster)
 		require.Equal(t, team.Namespace, storedTeam1.Namespace)
 		require.Equal(t, team.Name, storedTeam1.Name)
-
-		time.Sleep(1 * time.Second)
 
 		team.Name = "team2"
 		err = c.SaveTeam(ctx(t), &team)
@@ -311,8 +294,6 @@ func TestDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 2, len(storedUsers1))
 
-		time.Sleep(1 * time.Second)
-
 		err = c.SaveUsers(ctx(t), "test-cluster", users[0:1])
 		require.NoError(t, err)
 
@@ -338,8 +319,6 @@ func TestDB(t *testing.T) {
 		require.Equal(t, user.Cluster, storedUser1.Cluster)
 		require.Equal(t, user.Namespace, storedUser1.Namespace)
 		require.Equal(t, user.Name, storedUser1.Name)
-
-		time.Sleep(1 * time.Second)
 
 		user.Name = "user2"
 		err = c.SaveUser(ctx(t), &user)
@@ -452,9 +431,9 @@ func TestDB(t *testing.T) {
 			{ID: "cluster/test-cluster1/namespace/default/application1", Cluster: "test-cluster1", Namespace: "default", Name: "application1", Teams: []string{"team1"}, Tags: []string{"monitoring", "observability"}, Topology: applicationv1.Topology{External: false}},
 			{ID: "cluster/test-cluster1/namespace/default/application2", Cluster: "test-cluster1", Namespace: "default", Name: "application2", Teams: []string{"team1", "team2"}, Tags: []string{"monitoring", "observability"}, Topology: applicationv1.Topology{External: false}},
 			{ID: "cluster/test-cluster1/namespace/default/application3", Cluster: "test-cluster1", Namespace: "default", Name: "application3", Teams: []string{"team3"}, Tags: []string{}, Topology: applicationv1.Topology{External: true}},
-			{ID: "cluster/test-cluster1/namespace/default/application4", Cluster: "test-cluster2", Namespace: "default", Name: "application4", Teams: []string{"team1", "team2", "team3"}, Tags: []string{"monitoring", "observability"}, Topology: applicationv1.Topology{External: false}},
 		}
 		applications2 := []applicationv1.ApplicationSpec{
+			{ID: "cluster/test-cluster2/namespace/default/application4", Cluster: "test-cluster2", Namespace: "default", Name: "application4", Teams: []string{"team1", "team2", "team3"}, Tags: []string{"monitoring", "observability"}, Topology: applicationv1.Topology{External: false}},
 			{ID: "cluster/test-cluster2/namespace/default/application5", Cluster: "test-cluster2", Namespace: "default", Name: "application5", Teams: []string{}, Tags: []string{"monitoring", "observability"}, Topology: applicationv1.Topology{External: false}},
 			{ID: "cluster/test-cluster2/namespace/kube-system/application6", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application6", Teams: []string{"team1"}, Tags: []string{"core", "provider"}, Topology: applicationv1.Topology{External: false}},
 			{ID: "cluster/test-cluster2/namespace/kube-system/application7", Cluster: "test-cluster2", Namespace: "kube-system", Name: "application7", Teams: []string{}, Tags: []string{"core", "provider"}, Topology: applicationv1.Topology{External: false}},


### PR DESCRIPTION
Use UnixMilli() instead of Unix() for createdAt / updatedAt
The increased precision avoids the need of time.Sleep() in tests

This further reduces the test execution time. For db_test.go down to ~4.5s on my machine.

<img width="933" alt="Bildschirmfoto 2023-11-16 um 12 47 27" src="https://github.com/kobsio/kobs/assets/318533/6e6703a2-6d4d-47bd-84ce-f557cfc669be">

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
