### PR TITLE
[plugin-klogs] feat: adds button to remove column from Documents table

### DIFF
--- a/app/packages/klogs/src/components/Logs.test.tsx
+++ b/app/packages/klogs/src/components/Logs.test.tsx
@@ -46,7 +46,7 @@ describe('Logs', () => {
       },
     ];
 
-    const iconName = 'RemoveCircleOutlineIcon';
+    const iconName = 'TableChartIcon';
 
     const setup = (
       documents: Record<string, string>[],

--- a/app/packages/klogs/src/components/Logs.test.tsx
+++ b/app/packages/klogs/src/components/Logs.test.tsx
@@ -1,90 +1,93 @@
-import {render, screen} from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {vi} from 'vitest';
+import { vi } from 'vitest';
 
-import {Documents, LogsDownload} from './Logs';
+import { Documents, LogsDownload } from './Logs';
 
 describe('Logs', () => {
-    describe('LogsDownload', () => {
-        const documents = [
-            {
-                log: '{"namespace": "foo"}',
-                namespace: 'foo',
-                timestamp: new Date(2000, 2, 2).toISOString(),
-            },
-        ];
+  describe('LogsDownload', () => {
+    const documents = [
+      {
+        log: '{"namespace": "foo"}',
+        namespace: 'foo',
+        timestamp: new Date(2000, 2, 2).toISOString(),
+      },
+    ];
 
-        it('can download logs', async () => {
-            const download = vi.fn();
-            render(<LogsDownload documents={documents} download={download} fields={[]}/>);
+    it('can download logs', async () => {
+      const download = vi.fn();
+      render(<LogsDownload documents={documents} download={download} fields={[]} />);
 
-            const openMenu = screen.getByLabelText('open menu');
-            await userEvent.click(openMenu);
-            const downloadJSON = screen.getByLabelText('Download Logs');
-            await userEvent.click(downloadJSON);
-            expect(download).toHaveBeenCalledWith('{"namespace": "foo"}', 'kobs-export-logs.log');
-        });
-
-        it('can download csv', async () => {
-            const download = vi.fn();
-            render(<LogsDownload documents={documents} download={download} fields={['namespace']}/>);
-
-            const openMenu = screen.getByLabelText('open menu');
-            await userEvent.click(openMenu);
-            const downloadCSV = screen.getByLabelText('Download CSV');
-            await userEvent.click(downloadCSV);
-            expect(download).toHaveBeenCalledWith('2000-03-02 00:00:00;foo\r\n', 'kobs-export-logs.csv');
-        });
+      const openMenu = screen.getByLabelText('open menu');
+      await userEvent.click(openMenu);
+      const downloadJSON = screen.getByLabelText('Download Logs');
+      await userEvent.click(downloadJSON);
+      expect(download).toHaveBeenCalledWith('{"namespace": "foo"}', 'kobs-export-logs.log');
     });
 
+    it('can download csv', async () => {
+      const download = vi.fn();
+      render(<LogsDownload documents={documents} download={download} fields={['namespace']} />);
 
-    describe('Documents', () => {
-        const documents = [
-            {
-                log: '{"namespace": "foo"}',
-                namespace: 'foo',
-                timestamp: new Date(2000, 2, 2).toISOString(),
-            },
-        ];
-
-        const iconName = 'RemoveCircleOutlineIcon';
-
-        const setup = (
-            documents: Record<string, string>[],
-            selectedFields: string[],
-            selectField?: (field: string) => void,
-        ) => {
-            return (<Documents
-                documents={documents}
-                fields={[
-                    {name: 'log', type: 'string'},
-                    {name: 'namespace', type: 'string'},
-                    {name: 'timestamp', type: 'string'},
-                ]}
-                order={'descending'}
-                orderBy={'timestamp'}
-                selectField={selectField}
-                selectedFields={selectedFields}
-            />);
-        }
-
-        it('show documents with column remove button', async () => {
-            const removeFieldMock = vi.fn();
-            const selectedFields = ['log', 'namespace', 'timestamp'];
-            render(setup(documents, selectedFields, removeFieldMock));
-
-            let removeColumnIcons = screen.getAllByTestId(iconName);
-            expect(removeColumnIcons.length).toBe(selectedFields.length);
-            expect(screen.getByText('Time')).toBeInTheDocument();
-            expect(screen.getByText('log')).toBeInTheDocument();
-            expect(screen.getByText('namespace')).toBeInTheDocument();
-            expect(screen.getByText('timestamp')).toBeInTheDocument();
-
-            const element = document.querySelector(`button > svg[data-testid="${iconName}"]`);
-            await userEvent.click(element!);
-
-            // check to be called -> first button -> first column, which is 'log'
-            expect(removeFieldMock).toBeCalledWith("log");
-        });
+      const openMenu = screen.getByLabelText('open menu');
+      await userEvent.click(openMenu);
+      const downloadCSV = screen.getByLabelText('Download CSV');
+      await userEvent.click(downloadCSV);
+      expect(download).toHaveBeenCalledWith('2000-03-02 00:00:00;foo\r\n', 'kobs-export-logs.csv');
     });
+  });
+
+  describe('Documents', () => {
+    const documents = [
+      {
+        log: '{"namespace": "foo"}',
+        namespace: 'foo',
+        timestamp: new Date(2000, 2, 2).toISOString(),
+      },
+    ];
+
+    const iconName = 'RemoveCircleOutlineIcon';
+
+    const setup = (
+      documents: Record<string, string>[],
+      selectedFields: string[],
+      selectField?: (field: string) => void,
+    ) => {
+      return (
+        <Documents
+          documents={documents}
+          fields={[
+            { name: 'log', type: 'string' },
+            { name: 'namespace', type: 'string' },
+            { name: 'timestamp', type: 'string' },
+          ]}
+          order={'descending'}
+          orderBy={'timestamp'}
+          selectField={selectField}
+          selectedFields={selectedFields}
+        />
+      );
+    };
+
+    it('show documents with column remove button', async () => {
+      const removeFieldMock = vi.fn();
+      const selectedFields = ['log', 'namespace', 'timestamp'];
+      render(setup(documents, selectedFields, removeFieldMock));
+
+      const removeColumnIcons = screen.getAllByTestId(iconName);
+      expect(removeColumnIcons.length).toBe(selectedFields.length);
+      expect(screen.getByText('Time')).toBeInTheDocument();
+      expect(screen.getByText('log')).toBeInTheDocument();
+      expect(screen.getByText('namespace')).toBeInTheDocument();
+      expect(screen.getByText('timestamp')).toBeInTheDocument();
+
+      const element = document.querySelector(`button > svg[data-testid="${iconName}"]`);
+      expect(element).not.toBeNull();
+      /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
+      await userEvent.click(element!);
+
+      // check to be called -> first button -> first column, which is 'log'
+      expect(removeFieldMock).toBeCalledWith('log');
+    });
+  });
 });

--- a/app/packages/klogs/src/components/Logs.tsx
+++ b/app/packages/klogs/src/components/Logs.tsx
@@ -16,7 +16,6 @@ import {
   KeyboardArrowRight,
   ListAlt,
   MoreVert,
-  RemoveCircleOutline,
   SavedSearch,
   TableChart,
   ZoomIn,
@@ -532,7 +531,7 @@ export const Documents: FunctionComponent<{
                       sx={{ m: 0 }}
                       onClick={() => selectField?.(field)}
                     >
-                      <RemoveCircleOutline fontSize="small" />
+                      <TableChart sx={{ fontSize: 16 }} />
                     </IconButton>
                   </TableCell>
                 ))}

--- a/app/packages/klogs/src/components/Logs.tsx
+++ b/app/packages/klogs/src/components/Logs.tsx
@@ -526,13 +526,13 @@ const Documents: FunctionComponent<{
                       {field}
                     </TableSortLabel>
                     <IconButton
-                      edge="end"
-                      color="inherit"
-                      size={"small"}
+                      edge='end'
+                      color='inherit'
+                      size={'small'}
                       sx={{ m: 0 }}
                       onClick={() => selectField?.(field)}
                     >
-                      <RemoveCircleOutline fontSize="small"/>
+                      <RemoveCircleOutline fontSize='small' />
                     </IconButton>
                   </TableCell>
                 ))}

--- a/app/packages/klogs/src/components/Logs.tsx
+++ b/app/packages/klogs/src/components/Logs.tsx
@@ -481,9 +481,9 @@ const Document: FunctionComponent<{
 /**
  * The `Documents` component is used to render the documents in a table. The table will show the timestamp of each log
  * line and a preview of the most important fields. If the user select a list of fields these fields will be shown
- * insteand of the preview.
+ * instead of the preview.
  */
-const Documents: FunctionComponent<{
+export const Documents: FunctionComponent<{
   addFilter?: (filter: string) => void;
   changeOrder?: (orderBy: string) => void;
   documents: Record<string, string>[];

--- a/app/packages/klogs/src/components/Logs.tsx
+++ b/app/packages/klogs/src/components/Logs.tsx
@@ -526,13 +526,13 @@ const Documents: FunctionComponent<{
                       {field}
                     </TableSortLabel>
                     <IconButton
-                      edge='end'
-                      color='inherit'
+                      edge="end"
+                      color="inherit"
                       size={'small'}
                       sx={{ m: 0 }}
                       onClick={() => selectField?.(field)}
                     >
-                      <RemoveCircleOutline fontSize='small' />
+                      <RemoveCircleOutline fontSize="small" />
                     </IconButton>
                   </TableCell>
                 ))}

--- a/app/packages/klogs/src/components/Logs.tsx
+++ b/app/packages/klogs/src/components/Logs.tsx
@@ -16,6 +16,7 @@ import {
   KeyboardArrowRight,
   ListAlt,
   MoreVert,
+  RemoveCircleOutline,
   SavedSearch,
   TableChart,
   ZoomIn,
@@ -524,6 +525,15 @@ const Documents: FunctionComponent<{
                     >
                       {field}
                     </TableSortLabel>
+                    <IconButton
+                      edge="end"
+                      color="inherit"
+                      size={"small"}
+                      sx={{ m: 0 }}
+                      onClick={() => selectField?.(field)}
+                    >
+                      <RemoveCircleOutline fontSize="small"/>
+                    </IconButton>
                   </TableCell>
                 ))}
               </>

--- a/app/packages/klogs/src/components/Logs.tsx
+++ b/app/packages/klogs/src/components/Logs.tsx
@@ -529,6 +529,7 @@ export const Documents: FunctionComponent<{
                       color="inherit"
                       size={'small'}
                       sx={{ m: 0 }}
+                      aria-label="toggle field column"
                       onClick={() => selectField?.(field)}
                     >
                       <TableChart sx={{ fontSize: 16 }} />


### PR DESCRIPTION
<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

Added a button remove columns directly from the Documents table header. This eases the work quite a lot, for example:

- when you have 3+ "custom" (not Time or Log) columns open, you do not need to scroll through all of the properties of a "log line" (Document)

- when you aggregate logs where certain properties are not set (or you aggregate them from different services etc.), removing the column as it is from the Document table header is quite convenient ;) 

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
