### PR TITLE
[core] Add Annotations and Labels to VirtualService

### DIFF
--- a/deploy/helm/kobs/Chart.yaml
+++ b/deploy/helm/kobs/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kobs
 description: Kubernetes Observability Platform
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: v0.12.0

--- a/deploy/helm/kobs/templates/cluster/virtualservice.yaml
+++ b/deploy/helm/kobs/templates/cluster/virtualservice.yaml
@@ -7,6 +7,13 @@ metadata:
   labels:
     {{- include "kobs.labels" . | nindent 4 }}
     app.kubernetes.io/component: cluster
+    {{- with .Values.cluster.istio.virtualService.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.cluster.virtualService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.cluster.istio.virtualService.hosts }}
   hosts:

--- a/deploy/helm/kobs/templates/hub/virtualservice.yaml
+++ b/deploy/helm/kobs/templates/hub/virtualservice.yaml
@@ -7,6 +7,13 @@ metadata:
   labels:
     {{- include "kobs.labels" . | nindent 4 }}
     app.kubernetes.io/component: hub
+    {{- with .Values.hub.istio.virtualService.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.hub.virtualService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.hub.istio.virtualService.hosts }}
   hosts:
@@ -29,6 +36,10 @@ spec:
             port:
               number: 15220
       timeout: {{ .Values.hub.istio.virtualService.timeout }}
+      {{- with .Values.hub.istio.virtualService.headers }}
+      headers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     - route:
         - destination:
             host: {{ include "kobs.fullname" . }}-hub.{{ .Release.Namespace }}.svc.cluster.local

--- a/deploy/helm/kobs/values.yaml
+++ b/deploy/helm/kobs/values.yaml
@@ -342,6 +342,9 @@ hub:
     virtualService:
       enabled: false
 
+      annotations: {}
+      labels: {}
+
       gateways: []
         # - gateway
 
@@ -770,6 +773,9 @@ cluster:
     ##
     virtualService:
       enabled: false
+
+      annotations: {}
+      labels: {}
 
       gateways: []
         # - gateway

--- a/docs/getting-started/installation/helm.md
+++ b/docs/getting-started/installation/helm.md
@@ -72,6 +72,8 @@ helm upgrade --install kobs kobs/kobs
 | `hub.ingress.hosts` | Hosts to use for the ingress. | `[]` |
 | `hub.ingress.tls` | TLS configuration for the ingress. | `[]` |
 | `hub.istio.virtualService.enabled` | Specifies whether a VirtualService should be created. | `false` |
+| `hub.istio.virtualService.annotations` | Annotations to add to the VirtualService. | `{}` |
+| `hub.istio.virtualService.labels` | Labels to add to the VirtualService. | `{}` |
 | `hub.istio.virtualService.gateways` | A list of gateways for the VirtualService. | `[]` |
 | `hub.istio.virtualService.hosts` | A list of hosts for the VirtualService. | `[]` |
 | `hub.istio.virtualService.timeout` | Timeout for API requests. | `300s` |
@@ -141,6 +143,8 @@ helm upgrade --install kobs kobs/kobs
 | `cluster.ingress.hosts` | Hosts to use for the ingress. | `[]` |
 | `cluster.ingress.tls` | TLS configuration for the ingress. | `[]` |
 | `cluster.istio.virtualService.enabled` | Specifies whether a VirtualService should be created. | `false` |
+| `cluster.istio.virtualService.annotations` | Annotations to add to the VirtualService. | `{}` |
+| `cluster.istio.virtualService.labels` | Labels to add to the VirtualService. | `{}` |
 | `cluster.istio.virtualService.gateways` | A list of gateways for the VirtualService. | `[]` |
 | `cluster.istio.virtualService.hosts` | A list of hosts for the VirtualService. | `[]` |
 | `cluster.istio.virtualService.timeout` | Timeout for API requests. | `300s` |


### PR DESCRIPTION
It is now possible to add custom annotations and labels to a VirtualService in the Helm chart.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [x] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [x] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
