### PR TITLE
[velero] Create Backups from Schedules

### DIFF
--- a/pkg/plugins/velero/router.go
+++ b/pkg/plugins/velero/router.go
@@ -1,6 +1,7 @@
 package velero
 
 import (
+	"encoding/json"
 	"net/http"
 	"time"
 
@@ -9,10 +10,13 @@ import (
 	"github.com/kobsio/kobs/pkg/utils/middleware/errresponse"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/builder"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/downloadrequest"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
+	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func createScheme() *runtime.Scheme {
@@ -52,6 +56,37 @@ func (router *Router) logs(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (router *Router) backupFromSchedule(w http.ResponseWriter, r *http.Request) {
+	schedule := new(velerov1api.Schedule)
+
+	err := json.NewDecoder(r.Body).Decode(schedule)
+	if err != nil {
+		log.Error(r.Context(), "Failed to decode request body", zap.Error(err))
+		errresponse.Render(w, r, http.StatusBadRequest, "Failed to decode request body")
+		return
+	}
+
+	backupBuilder := builder.ForBackup(schedule.Namespace, schedule.TimestampedName(time.Now().UTC())).FromSchedule(schedule)
+	backup := backupBuilder.ObjectMeta(builder.WithLabelsMap(schedule.Labels)).Result()
+
+	client, err := router.kubernetesClient.GetClient(r.Context(), createScheme())
+	if err != nil {
+		log.Error(r.Context(), "Failed to create Kubernetes client", zap.Error(err))
+		errresponse.Render(w, r, http.StatusBadRequest, "Failed to create Kubernetes client")
+		return
+	}
+
+	err = client.Create(r.Context(), backup, &kbclient.CreateOptions{})
+	if err != nil {
+		log.Error(r.Context(), "Failed to create backup", zap.Error(err))
+		errresponse.Render(w, r, http.StatusBadRequest, "Failed to create backup")
+		return
+	}
+
+	render.Status(r, http.StatusNoContent)
+	render.JSON(w, r, nil)
+}
+
 func Mount(kubernetesClient kubernetes.Client) (chi.Router, error) {
 	router := Router{
 		chi.NewRouter(),
@@ -59,6 +94,7 @@ func Mount(kubernetesClient kubernetes.Client) (chi.Router, error) {
 	}
 
 	router.Get("/logs", router.logs)
+	router.Post("/backup", router.backupFromSchedule)
 
 	return router, nil
 }


### PR DESCRIPTION
It is now possible to create a Velero backup from a schedule, similar to how it can be done via the `--from-schedule` flag in the Velero CLI.

For that a new button was added to the Velero schedules resources table (`PlayArrow` icon), which triggers an API call to the new `/backup` API endpoint. This endpoint implements a similar logic as the Velero CLI to create the backup from the selected schedule.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
