### PR TITLE
[klogs] Fix Exists Filter

### DIFF
--- a/app/packages/klogs/src/components/Logs.tsx
+++ b/app/packages/klogs/src/components/Logs.tsx
@@ -340,11 +340,11 @@ const DocumentDetailsTable: FunctionComponent<{
                         </IconButton>
                       </Tooltip>
 
-                      <Tooltip title={`add filter: _exists_ ${key}`}>
+                      <Tooltip title={`add filter: _and_ _exists_ ${key}`}>
                         <IconButton
                           aria-label="add EXISTS field filter"
                           size="small"
-                          onClick={() => addFilter(`_exists_ ${key}`)}
+                          onClick={() => addFilter(`_and_ _exists_ ${key}`)}
                         >
                           <SavedSearch sx={{ fontSize: 16 }} />
                         </IconButton>

--- a/app/packages/klogs/src/components/Logs.tsx
+++ b/app/packages/klogs/src/components/Logs.tsx
@@ -340,7 +340,7 @@ const DocumentDetailsTable: FunctionComponent<{
                         </IconButton>
                       </Tooltip>
 
-                      <Tooltip title={`add filter: _and_ _exists_ ${key}`}>
+                      <Tooltip title={`add filter: _exists_ ${key}`}>
                         <IconButton
                           aria-label="add EXISTS field filter"
                           size="small"


### PR DESCRIPTION
When a user used the exists filter in the logs table it only added `_exists_ field` to the query, but it should add `_and_ _exists_ field` to the query, so that the new query is valid and can be run directly. This commit fixes the issue.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
