### PR TITLE
[mongodb] Fix Collection Filter and Pagination

### DIFF
--- a/app/packages/mongodb/src/components/Collections.tsx
+++ b/app/packages/mongodb/src/components/Collections.tsx
@@ -254,8 +254,10 @@ const CollectionList: FunctionComponent<{ collections: string[]; instance: IPlug
 
   const handleClear = () => {
     setFilter('');
-    setOptions({ filter: filter, page: 1, perPage: options.perPage });
+    setOptions({ filter: '', page: 1, perPage: options.perPage });
   };
+
+  console.log(options);
 
   return (
     <>
@@ -285,12 +287,15 @@ const CollectionList: FunctionComponent<{ collections: string[]; instance: IPlug
       </Box>
 
       <List disablePadding={true}>
-        {collections.map((collection, index) => (
-          <Fragment key={collection}>
-            <CollectionListItem instance={instance} collection={collection} />
-            {index + 1 !== collections.length && <Divider component="li" />}
-          </Fragment>
-        ))}
+        {collections
+          .filter((collection) => collection.includes(options.filter))
+          .slice((options.page - 1) * options.perPage, options.page * options.perPage)
+          .map((collection, index) => (
+            <Fragment key={collection}>
+              <CollectionListItem instance={instance} collection={collection} />
+              {index + 1 !== collections.length && <Divider component="li" />}
+            </Fragment>
+          ))}
       </List>
 
       <Pagination
@@ -313,12 +318,13 @@ export const Collections: FunctionComponent<{ description?: string; instance: IP
   const { isError, isLoading, error, data, refetch } = useQuery<string[], APIError>(
     ['mongodb/collections', instance],
     async () => {
-      return apiContext.client.get<string[]>(`/api/plugins/mongodb/collections`, {
+      const collections = await apiContext.client.get<string[]>(`/api/plugins/mongodb/collections`, {
         headers: {
           'x-kobs-cluster': instance.cluster,
           'x-kobs-plugin': instance.name,
         },
       });
+      return collections.sort();
     },
   );
 


### PR DESCRIPTION
The pagination and filter on the collections page was not working, because we forgot to add the `filter` and `slice` (for pagination) to the array of collections. This should now be fixed, so that a user can view all collections and filter them.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
