### PR TITLE
[mongodb] Revert Dependency Update

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8237,15 +8237,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/bson": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
-      "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
-      "peer": true,
-      "engines": {
-        "node": ">=14.20.1"
-      }
-    },
     "node_modules/btoa": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
@@ -10361,20 +10352,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ejson-shell-parser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ejson-shell-parser/-/ejson-shell-parser-2.0.1.tgz",
-      "integrity": "sha512-ZTDIeoRBWSrGgHMYlBn4PymQdtNCsnFUK/cSVwZREPNC3Mr+E3arO08DapVjBVDGTE08kkpqRll1Y+lwe5ZvCQ==",
-      "dependencies": {
-        "acorn": "^8.1.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "bson": "^4.6.3 || ^5 || ^6"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -37166,8 +37143,8 @@
       "name": "@kobsio/mongodb",
       "version": "0.0.0",
       "dependencies": {
-        "bson": "^6.3.0",
-        "ejson-shell-parser": "^2.0.1"
+        "bson": "^5.5.0",
+        "ejson-shell-parser": "^v1.2.4"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.2",
@@ -37336,6 +37313,17 @@
       "integrity": "sha512-balJfqwwTBddxfnidJZagCBPP/f48zj9Sdp3OJswREOgsJzHiQSaOIAtApSgDQFYgHqAvFkp53AFSqjMDZoTFw==",
       "engines": {
         "node": ">=16.20.1"
+      }
+    },
+    "packages/mongodb/node_modules/ejson-shell-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/ejson-shell-parser/-/ejson-shell-parser-1.2.4.tgz",
+      "integrity": "sha512-bweqlPb9ChFu25I4IOc4kevGfHhXS+r/PyFTqdLYNerB4J52UIxrvYX+4lyer0PQuWvn3WoFO/KLMbMiYo+8PA==",
+      "dependencies": {
+        "acorn": "^8.1.0"
+      },
+      "peerDependencies": {
+        "bson": "^4.6.3 || ^5.0.0"
       }
     },
     "packages/mongodb/node_modules/estree-walker": {

--- a/app/packages/mongodb/package.json
+++ b/app/packages/mongodb/package.json
@@ -53,7 +53,7 @@
     "vitest": "^1.3.1"
   },
   "dependencies": {
-    "bson": "^6.3.0",
-    "ejson-shell-parser": "^2.0.1"
+    "bson": "^5.5.0",
+    "ejson-shell-parser": "^v1.2.4"
   }
 }


### PR DESCRIPTION
This commit reverts the dependency update for the MongoDB plugin, so that the plugin can be used with MongoDB version 5.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
