### PR TITLE
[techdocs] Fix Heading

### DIFF
--- a/app/packages/techdocs/src/utils/renderers.tsx
+++ b/app/packages/techdocs/src/utils/renderers.tsx
@@ -75,7 +75,7 @@ export const renderHeading = ({ ...props }: any): ReactElement => {
   const children = Children.toArray(props.children);
   const text = children.reduce(flatten, '');
   const slug = text.toLowerCase().replace(/\W/g, '-');
-  return createElement('h' + props.level, { id: slug }, props.children);
+  return createElement(props.node.tagName, { id: slug }, props.children);
 };
 
 /**


### PR DESCRIPTION
Fix the `renderHeading` function, which was still using the `level` property which isn't available anymore. We are now using the `node.tagName` property to render the element.

<!--
  Keep PR title verbose enough and add prefix telling about what plugin it touches e.g "[prometheus]" or "[core]" when it touches other parts of the app.

  If you add a breaking change within your PR you should add ":warning:" to the title, e.g. ":warning: [core] My breaking change"
-->

<!--
  Description of what have been changed. Please also reference an issue, when available.
-->

<!--
  Place an '[x]' (no spaces) in all applicable fields.

  The changelog entry format looks as follow:
    - [#<PR-ID>](<PR-URL>): [<PLUGIN>] ...
-->

- [ ] I adjusted the corresponding [documentation](https://github.com/kobsio/kobs/tree/main/docs) for this change.
- [ ] I adjusted the [values.yaml](https://github.com/kobsio/kobs/blob/main/deploy/helm/kobs/values.yaml) and the [documentation for all values](https://github.com/kobsio/kobs/blob/main/docs/getting-started/installation/helm.md).
